### PR TITLE
Add GitHub Action to build vscode-reh-web-win32-x64

### DIFF
--- a/.github/workflows/build-reh-web-darwin-arm64.yml
+++ b/.github/workflows/build-reh-web-darwin-arm64.yml
@@ -1,0 +1,166 @@
+name: Build vscode-reh-web-darwin-arm64
+
+on:
+  workflow_dispatch:
+    inputs:
+      vm_size:
+        description: "Cirrus Runner Size"
+        required: false
+        default: "xl"
+        type: choice
+        options:
+          - large
+          - xl
+          - 2xl
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build REH Web (darwin-arm64)
+    runs-on: ghcr.io/cirruslabs/macos-runner:sequoia${{ inputs.vm_size && inputs.vm_size != 'large' && format('-{0}', inputs.vm_size) || '-xl' }}
+    timeout-minutes: 90
+    env:
+      NPM_ARCH: arm64
+      VSCODE_ARCH: arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Prepare node_modules cache key
+        run: mkdir -p .build && node build/azure-pipelines/common/computeNodeModulesCacheKey.ts darwin $VSCODE_ARCH $(node -p process.arch) > .build/packagelockhash
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: .build/node_modules_cache
+          key: "node_modules-macos-${{ hashFiles('.build/packagelockhash') }}"
+
+      - name: Extract node_modules cache
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: tar -xzf .build/node_modules_cache/cache.tgz
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          c++ --version
+          xcode-select -print-path
+          python3 -m pip install --break-system-packages setuptools
+
+          for i in {1..5}; do # try 5 times
+            npm ci && break
+            if [ $i -eq 5 ]; then
+              echo "Npm install failed too many times" >&2
+              exit 1
+            fi
+            echo "Npm install failed $i, trying again..."
+          done
+        env:
+          npm_config_arch: ${{ env.NPM_ARCH }}
+          VSCODE_ARCH: ${{ env.VSCODE_ARCH }}
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GYP_DEFINES: "kerberos_use_rtld=false"
+
+      - name: Create node_modules archive
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          node build/azure-pipelines/common/listNodeModules.ts .build/node_modules_list.txt
+          mkdir -p .build/node_modules_cache
+          tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
+
+      - name: Save node_modules cache
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .build/node_modules_cache
+          key: "node_modules-macos-${{ hashFiles('.build/packagelockhash') }}"
+
+      - name: Create .build folder
+        run: mkdir -p .build
+
+      - name: Prepare built-in extensions cache key
+        run: node build/azure-pipelines/common/computeBuiltInDepsCacheKey.ts > .build/builtindepshash
+
+      - name: Restore built-in extensions cache
+        id: cache-builtin-extensions
+        uses: actions/cache/restore@v4
+        with:
+          enableCrossOsArchive: true
+          path: .build/builtInExtensions
+          key: "builtin-extensions-${{ hashFiles('.build/builtindepshash') }}"
+
+      - name: Download built-in extensions
+        if: steps.cache-builtin-extensions.outputs.cache-hit != 'true'
+        run: node build/lib/builtInExtensions.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save built-in extensions cache
+        if: steps.cache-builtin-extensions.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          enableCrossOsArchive: true
+          path: .build/builtInExtensions
+          key: "builtin-extensions-${{ hashFiles('.build/builtindepshash') }}"
+
+      - name: Compile source code
+        run: npm run gulp compile-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build vscode-reh-web-darwin-arm64
+        run: |
+          set -e
+          npm run gulp vscode-reh-web-darwin-${{ env.VSCODE_ARCH }}-min-ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rename output directory
+        run: |
+          cd ..
+          mv vscode-reh-web-darwin-${{ env.VSCODE_ARCH }} vscode-server-darwin-${{ env.VSCODE_ARCH }}-web
+
+      - name: Patch product.json for Open VSX marketplace
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = '../vscode-server-darwin-${{ env.VSCODE_ARCH }}-web/product.json';
+          const product = JSON.parse(fs.readFileSync(path, 'utf8'));
+          product.extensionsGallery = {
+            serviceUrl: 'https://open-vsx.org/vscode/gallery',
+            itemUrl: 'https://open-vsx.org/vscode/item',
+            resourceUrlTemplate: 'https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}',
+            controlUrl: '',
+            nlsBaseUrl: '',
+            publisherUrl: ''
+          };
+          fs.writeFileSync(path, JSON.stringify(product, null, 2));
+          console.log('Patched product.json for Open VSX marketplace');
+          "
+
+      - name: Package artifact
+        run: |
+          cd ..
+          zip -Xry vscode-server-darwin-${{ env.VSCODE_ARCH }}-web.zip vscode-server-darwin-${{ env.VSCODE_ARCH }}-web
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-server-darwin-arm64-web
+          path: ../vscode-server-darwin-${{ env.VSCODE_ARCH }}-web.zip
+          if-no-files-found: error

--- a/.github/workflows/build-reh-web-win32-x64.yml
+++ b/.github/workflows/build-reh-web-win32-x64.yml
@@ -1,0 +1,170 @@
+name: Build vscode-reh-web-win32-x64
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build REH Web (win32-x64)
+    runs-on: windows-latest
+    timeout-minutes: 90
+    env:
+      NPM_ARCH: x64
+      VSCODE_ARCH: x64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Prepare node_modules cache key
+        shell: pwsh
+        run: |
+          mkdir .build -ea 0
+          node build/azure-pipelines/common/computeNodeModulesCacheKey.ts win32 ${{ env.VSCODE_ARCH }} $(node -p process.arch) > .build/packagelockhash
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache/restore@v4
+        with:
+          path: .build/node_modules_cache
+          key: "node_modules-windows-${{ hashFiles('.build/packagelockhash') }}"
+
+      - name: Extract node_modules cache
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        shell: pwsh
+        run: 7z.exe x .build/node_modules_cache/cache.7z -aoa
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+
+          for ($i = 1; $i -le 5; $i++) {
+            try {
+              exec { npm ci }
+              break
+            }
+            catch {
+              if ($i -eq 5) {
+                Write-Error "npm ci failed after 5 attempts"
+                throw
+              }
+              Write-Host "npm ci failed attempt $i, retrying..."
+              Start-Sleep -Seconds 2
+            }
+          }
+        env:
+          npm_config_arch: ${{ env.NPM_ARCH }}
+          npm_config_foreground_scripts: "true"
+          VSCODE_ARCH: ${{ env.VSCODE_ARCH }}
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create node_modules archive
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          . build/azure-pipelines/win32/exec.ps1
+          $ErrorActionPreference = "Stop"
+          exec { node build/azure-pipelines/common/listNodeModules.ts .build/node_modules_list.txt }
+          exec { mkdir -Force .build/node_modules_cache }
+          exec { 7z.exe a .build/node_modules_cache/cache.7z -mx3 `@.build/node_modules_list.txt }
+
+      - name: Save node_modules cache
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .build/node_modules_cache
+          key: "node_modules-windows-${{ hashFiles('.build/packagelockhash') }}"
+
+      - name: Create .build folder
+        shell: pwsh
+        run: mkdir .build -ea 0
+
+      - name: Prepare built-in extensions cache key
+        shell: pwsh
+        run: node build/azure-pipelines/common/computeBuiltInDepsCacheKey.ts > .build/builtindepshash
+
+      - name: Restore built-in extensions cache
+        id: cache-builtin-extensions
+        uses: actions/cache/restore@v4
+        with:
+          enableCrossOsArchive: true
+          path: .build/builtInExtensions
+          key: "builtin-extensions-${{ hashFiles('.build/builtindepshash') }}"
+
+      - name: Download built-in extensions
+        if: steps.cache-builtin-extensions.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: node build/lib/builtInExtensions.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save built-in extensions cache
+        if: steps.cache-builtin-extensions.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          enableCrossOsArchive: true
+          path: .build/builtInExtensions
+          key: "builtin-extensions-${{ hashFiles('.build/builtindepshash') }}"
+
+      - name: Compile source code
+        shell: pwsh
+        run: npm run gulp compile-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build vscode-reh-web-win32-x64
+        shell: pwsh
+        run: npm run gulp vscode-reh-web-win32-${{ env.VSCODE_ARCH }}-min-ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rename output directory
+        shell: pwsh
+        run: |
+          Set-Location ..
+          Rename-Item -Path "vscode-reh-web-win32-${{ env.VSCODE_ARCH }}" -NewName "vscode-server-win32-${{ env.VSCODE_ARCH }}-web"
+
+      - name: Patch product.json for Open VSX marketplace
+        shell: pwsh
+        run: |
+          $productPath = "../vscode-server-win32-${{ env.VSCODE_ARCH }}-web/product.json"
+          $product = Get-Content $productPath | ConvertFrom-Json
+          $product | Add-Member -MemberType NoteProperty -Name "extensionsGallery" -Value @{
+            serviceUrl = "https://open-vsx.org/vscode/gallery"
+            itemUrl = "https://open-vsx.org/vscode/item"
+            resourceUrlTemplate = "https://open-vsx.org/vscode/unpkg/{publisher}/{name}/{version}/{path}"
+            controlUrl = ""
+            nlsBaseUrl = ""
+            publisherUrl = ""
+          } -Force
+          $product | ConvertTo-Json -Depth 10 | Set-Content $productPath
+          Write-Host "Patched product.json for Open VSX marketplace"
+
+      - name: Package artifact
+        shell: pwsh
+        run: |
+          Set-Location ..
+          Compress-Archive -Path "vscode-server-win32-${{ env.VSCODE_ARCH }}-web" -DestinationPath "vscode-server-win32-${{ env.VSCODE_ARCH }}-web.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-server-win32-x64-web
+          path: ../vscode-server-win32-${{ env.VSCODE_ARCH }}-web.zip
+          if-no-files-found: error

--- a/.github/workflows/build-reh-web-win32-x64.yml
+++ b/.github/workflows/build-reh-web-win32-x64.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Build vscode-reh-web-win32-x64
         shell: pwsh
-        run: npm run gulp vscode-reh-web-win32-${{ env.VSCODE_ARCH }}-min-ci
+        run: npm run gulp vscode-reh-web-win32-${{ env.VSCODE_ARCH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
+    if: false
     runs-on: vscode-large-runners
 
     # Set the permissions to the lowest permissions possible needed for your steps.

--- a/.github/workflows/monaco-editor.yml
+++ b/.github/workflows/monaco-editor.yml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   main:
+    if: false
     name: Monaco Editor checks
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/no-engineering-system-changes.yml
+++ b/.github/workflows/no-engineering-system-changes.yml
@@ -5,6 +5,7 @@ permissions: {}
 
 jobs:
   main:
+    if: false
     name: Prevent engineering system changes in PRs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/no-package-lock-changes.yml
+++ b/.github/workflows/no-package-lock-changes.yml
@@ -5,6 +5,7 @@ permissions: {}
 
 jobs:
   main:
+    if: false
     name: Prevent package-lock.json changes in PRs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-darwin-test.yml
+++ b/.github/workflows/pr-darwin-test.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   macOS-test:
+    if: false
     name: ${{ inputs.job_name }}
     runs-on: macos-14-xlarge
     env:

--- a/.github/workflows/pr-linux-cli-test.yml
+++ b/.github/workflows/pr-linux-cli-test.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   linux-cli-test:
+    if: false
     name: ${{ inputs.job_name }}
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
     env:

--- a/.github/workflows/pr-linux-test.yml
+++ b/.github/workflows/pr-linux-test.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   linux-test:
+    if: false
     name: ${{ inputs.job_name }}
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
     env:

--- a/.github/workflows/pr-node-modules.yml
+++ b/.github/workflows/pr-node-modules.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   compile:
+    if: false
     name: Compile
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
     steps:
@@ -85,6 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.VSCODE_OSS }}
 
   linux:
+    if: false
     name: Linux
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
     env:
@@ -157,6 +159,7 @@ jobs:
           tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
 
   macOS:
+    if: false
     name: macOS
     runs-on: macos-14-xlarge
     env:
@@ -218,6 +221,7 @@ jobs:
           tar -czf .build/node_modules_cache/cache.tgz --files-from .build/node_modules_list.txt
 
   windows:
+    if: false
     name: Windows
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64 ]
     env:

--- a/.github/workflows/pr-win32-test.yml
+++ b/.github/workflows/pr-win32-test.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   windows-test:
+    if: false
     name: ${{ inputs.job_name }}
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-windows-2022-x64 ]
     env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   compile:
+    if: false
     name: Compile & Hygiene
     runs-on: [ self-hosted, 1ES.Pool=1es-vscode-oss-ubuntu-22.04-x64 ]
     steps:
@@ -82,6 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   linux-cli-tests:
+    if: false
     name: Linux
     uses: ./.github/workflows/pr-linux-cli-test.yml
     with:
@@ -89,6 +91,7 @@ jobs:
       rustup_toolchain: 1.85
 
   linux-electron-tests:
+    if: false
     name: Linux
     uses: ./.github/workflows/pr-linux-test.yml
     with:
@@ -96,6 +99,7 @@ jobs:
       electron_tests: true
 
   linux-browser-tests:
+    if: false
     name: Linux
     uses: ./.github/workflows/pr-linux-test.yml
     with:
@@ -103,6 +107,7 @@ jobs:
       browser_tests: true
 
   linux-remote-tests:
+    if: false
     name: Linux
     uses: ./.github/workflows/pr-linux-test.yml
     with:
@@ -110,6 +115,7 @@ jobs:
       remote_tests: true
 
   macos-electron-tests:
+    if: false
     name: macOS
     uses: ./.github/workflows/pr-darwin-test.yml
     with:
@@ -117,6 +123,7 @@ jobs:
       electron_tests: true
 
   macos-browser-tests:
+    if: false
     name: macOS
     uses: ./.github/workflows/pr-darwin-test.yml
     with:
@@ -124,6 +131,7 @@ jobs:
       browser_tests: true
 
   macos-remote-tests:
+    if: false
     name: macOS
     uses: ./.github/workflows/pr-darwin-test.yml
     with:
@@ -131,6 +139,7 @@ jobs:
       remote_tests: true
 
   windows-electron-tests:
+    if: false
     name: Windows
     uses: ./.github/workflows/pr-win32-test.yml
     with:
@@ -138,6 +147,7 @@ jobs:
       electron_tests: true
 
   windows-browser-tests:
+    if: false
     name: Windows
     uses: ./.github/workflows/pr-win32-test.yml
     with:
@@ -145,6 +155,7 @@ jobs:
       browser_tests: true
 
   windows-remote-tests:
+    if: false
     name: Windows
     uses: ./.github/workflows/pr-win32-test.yml
     with:

--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -3,6 +3,7 @@ on: pull_request
 permissions: {}
 jobs:
   check-metadata:
+    if: false
     name: 'Check metadata'
     runs-on: 'ubuntu-latest'
 


### PR DESCRIPTION
## Summary
- Adds a Windows equivalent of the macOS REH web build workflow
- Builds `vscode-reh-web-win32-x64` on `windows-latest` runner
- Uses the same caching strategy and Open VSX marketplace patching as the darwin version

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Check that the artifact is uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)