### PR TITLE
Use a button instead of a toggle for the theme picker

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -18,7 +18,7 @@ import { Color } from '../../../../base/common/color.js';
 import { ColorScheme, isHighContrast } from '../../../../platform/theme/common/theme.js';
 import { colorThemeSchemaId } from '../../../services/themes/common/colorThemeSchema.js';
 import { isCancellationError, onUnexpectedError } from '../../../../base/common/errors.js';
-import { IQuickInputButton, IQuickInputService, IQuickInputToggle, IQuickPick, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputButton, IQuickInputService, IQuickPick, IQuickPickItem, QuickInputButtonLocation, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
 import { DEFAULT_PRODUCT_ICON_THEME_ID, ProductIconThemeData } from '../../../services/themes/browser/productIconThemeData.js';
 import { ThrottledDelayer } from '../../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
@@ -39,8 +39,6 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 
 import { mainWindow } from '../../../../base/browser/window.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
-import { Toggle } from '../../../../base/browser/ui/toggle/toggle.js';
-import { defaultToggleStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 
 export const manageExtensionIcon = registerIcon('theme-selection-manage-extension', Codicon.gear, localize('manageExtensionIcon', 'Icon for the \'Manage\' action in the theme selection quick pick.'));
@@ -286,8 +284,8 @@ interface InstalledThemesPickerOptions {
 	readonly marketplaceTag: string;
 	readonly title?: string;
 	readonly description?: string;
-	readonly toggles?: IQuickInputToggle[];
-	readonly onToggle?: (toggle: IQuickInputToggle, quickInput: IQuickPick<ThemeItem, { useSeparators: boolean }>) => Promise<void>;
+	readonly buttons?: IQuickInputButton[];
+	readonly onButton?: (button: IQuickInputButton, quickInput: IQuickPick<ThemeItem, { useSeparators: boolean }>) => Promise<void>;
 }
 
 class InstalledThemesPicker {
@@ -345,10 +343,8 @@ class InstalledThemesPicker {
 				quickpick.placeholder = this.options.placeholderMessage;
 				quickpick.activeItems = [picks[autoFocusIndex] as ThemeItem];
 				quickpick.canSelectMany = false;
-				quickpick.toggles = this.options.toggles;
-				quickpick.toggles?.forEach(toggle => {
-					disposables.add(toggle.onChange(() => this.options.onToggle?.(toggle, quickpick)));
-				});
+				quickpick.buttons = this.options.buttons ?? [];
+				disposables.add(quickpick.onDidTriggerButton(button => this.options.onButton?.(button, quickpick)));
 				quickpick.matchOnDescription = true;
 				disposables.add(quickpick.onDidAccept(async _ => {
 					isCompleted = true;
@@ -435,30 +431,21 @@ registerAction2(class extends Action2 {
 
 		const preferredColorScheme = themeService.getPreferredColorScheme();
 
-		let modeConfigureToggle;
-		if (preferredColorScheme) {
-			modeConfigureToggle = new Toggle({
-				title: localize('themes.configure.switchingEnabled', 'Detect system color mode enabled. Click to configure.'),
-				icon: Codicon.colorMode,
-				isChecked: false,
-				...defaultToggleStyles
-			});
-		} else {
-			modeConfigureToggle = new Toggle({
-				title: localize('themes.configure.switchingDisabled', 'Detect system color mode disabled. Click to configure.'),
-				icon: Codicon.colorMode,
-				isChecked: false,
-				...defaultToggleStyles
-			});
-		}
+		const modeConfigureButton: IQuickInputButton = {
+			tooltip: preferredColorScheme
+				? localize('themes.configure.switchingEnabled', 'Detect system color mode enabled. Click to configure.')
+				: localize('themes.configure.switchingDisabled', 'Detect system color mode disabled. Click to configure.'),
+			iconClass: ThemeIcon.asClassName(Codicon.colorMode),
+			location: QuickInputButtonLocation.Inline
+		};
 
 		const options = {
 			installMessage: localize('installColorThemes', "Install Additional Color Themes..."),
 			browseMessage: '$(plus) ' + localize('browseColorThemes', "Browse Additional Color Themes..."),
 			placeholderMessage: this.getTitle(preferredColorScheme),
 			marketplaceTag: 'category:themes',
-			toggles: [modeConfigureToggle],
-			onToggle: async (toggle, picker) => {
+			buttons: [modeConfigureButton],
+			onButton: async (_button, picker) => {
 				picker.hide();
 				await preferencesService.openSettings({ query: ThemeSettings.DETECT_COLOR_SCHEME });
 			}


### PR DESCRIPTION
Since it's just opening to settings, let's make it a button instead of a toggle. I also moved it from being an input button to an inline one which makes more sense since it takes you out of the picker.

Maybe worth considering in a follow up turning this into a toggle (using the new `.toggle` property on `IQuickInputButton`) and then having the toggle turn the detection mode on and off. Modifying the setting without having to go to the settings view.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="674" height="488" alt="image" src="https://github.com/user-attachments/assets/7a9bb4d9-fe2e-4759-a8fc-1126e83613cb" />

FYI @aeschli 