### PR TITLE
Fix notebook background colors

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -52,6 +52,7 @@ import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IDefaultAccountService } from '../../../../../platform/defaultAccount/common/defaultAccount.js';
 import { IDefaultAccount } from '../../../../../base/common/defaultAccount.js';
+import { Schemas } from '../../../../../base/common/network.js';
 
 export class InlineCompletionsModel extends Disposable {
 	private readonly _source;
@@ -155,7 +156,7 @@ export class InlineCompletionsModel extends Disposable {
 		}));
 
 		{ // Determine editor type
-			const isNotebook = this.textModel.uri.scheme === 'vscode-notebook-cell';
+			const isNotebook = this.textModel.uri.scheme === Schemas.vscodeNotebookCell;
 			const [diffEditor] = this._codeEditorService.listDiffEditors()
 				.filter(d =>
 					d.getOriginalEditor().getId() === this._editor.getId() ||

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsModel.ts
@@ -8,6 +8,7 @@ import { derived, IObservable } from '../../../../../../base/common/observable.j
 import { setTimeout0 } from '../../../../../../base/common/platform.js';
 import { InlineCompletionsModel, isSuggestionInViewport } from '../../model/inlineCompletionsModel.js';
 import { InlineSuggestHint } from '../../model/inlineSuggestionItem.js';
+import { InlineCompletionEditorType } from '../../model/provideInlineCompletions.js';
 import { InlineCompletionViewData, InlineCompletionViewKind, InlineEditTabAction } from './inlineEditsViewInterface.js';
 import { InlineEditWithChanges } from './inlineEditWithChanges.js';
 
@@ -17,7 +18,7 @@ import { InlineEditWithChanges } from './inlineEditWithChanges.js';
 */
 export class ModelPerInlineEdit {
 
-	readonly isInDiffEditor: boolean;
+	readonly editorType: InlineCompletionEditorType;
 
 	readonly displayLocation: InlineSuggestHint | undefined;
 
@@ -32,7 +33,7 @@ export class ModelPerInlineEdit {
 		readonly inlineEdit: InlineEditWithChanges,
 		readonly tabAction: IObservable<InlineEditTabAction>,
 	) {
-		this.isInDiffEditor = this._model.isInDiffEditor;
+		this.editorType = this._model.editorType;
 
 		this.displayLocation = this.inlineEdit.inlineCompletion.hint;
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsView.ts
@@ -42,6 +42,7 @@ import { JumpToView } from './inlineEditsViews/jumpToView.js';
 import { StringEdit } from '../../../../../common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../../../common/core/ranges/offsetRange.js';
 import { getPositionOffsetTransformerFromTextModel } from '../../../../../common/core/text/getPositionOffsetTransformerFromTextModel.js';
+import { InlineCompletionEditorType } from '../../model/provideInlineCompletions.js';
 
 export class InlineEditsView extends Disposable {
 	private readonly _editorObs: ObservableCodeEditor;
@@ -85,7 +86,7 @@ export class InlineEditsView extends Disposable {
 			this._previewTextModel,
 			this._uiState.map(s => s && s.state?.kind === InlineCompletionViewKind.SideBySide ? ({
 				newTextLineCount: s.newTextLineCount,
-				isInDiffEditor: s.isInDiffEditor,
+				editorType: s.editorType,
 			}) : undefined),
 			this._tabAction,
 		));
@@ -95,7 +96,7 @@ export class InlineEditsView extends Disposable {
 			this._uiState.map(s => s && s.state?.kind === InlineCompletionViewKind.Deletion ? ({
 				originalRange: s.state.originalRange,
 				deletions: s.state.deletions,
-				inDiffEditor: s.isInDiffEditor,
+				editorType: s.editorType,
 			}) : undefined),
 			this._tabAction,
 		));
@@ -105,7 +106,7 @@ export class InlineEditsView extends Disposable {
 				lineNumber: s.state.lineNumber,
 				startColumn: s.state.column,
 				text: s.state.text,
-				inDiffEditor: s.isInDiffEditor,
+				editorType: s.editorType,
 			}) : undefined),
 			this._tabAction,
 		));
@@ -118,6 +119,7 @@ export class InlineEditsView extends Disposable {
 			this._editor,
 			this._model.map((m, reader) => this._uiState.read(reader)?.state?.kind === InlineCompletionViewKind.Custom ? m?.displayLocation : undefined),
 			this._tabAction,
+			this._uiState.map(s => s?.editorType ?? InlineCompletionEditorType.TextEditor),
 		));
 
 		this._showLongDistanceHint = this._editorObs.getOption(EditorOption.inlineSuggest).map(this, s => s.edits.showLongDistanceHint);
@@ -132,6 +134,7 @@ export class InlineEditsView extends Disposable {
 					newTextLineCount: s.newTextLineCount,
 					edit: s.edit,
 					diff: s.diff,
+					editorType: s.editorType,
 					model: this._simpleModel.read(reader)!,
 					inlineSuggestInfo: this._inlineSuggestInfo.read(reader)!,
 					nextCursorPosition: s.nextCursorPosition,
@@ -153,7 +156,7 @@ export class InlineEditsView extends Disposable {
 				diff: e.diff,
 				mode: e.state.kind,
 				modifiedCodeEditor: this._sideBySide.previewEditor,
-				isInDiffEditor: e.isInDiffEditor,
+				editorType: e.editorType,
 			};
 		});
 		this._inlineDiffView = this._register(new OriginalEditorInlineDiffView(this._editor, this._inlineDiffViewState, this._previewTextModel));
@@ -168,7 +171,7 @@ export class InlineEditsView extends Disposable {
 			equalsFn: equals.arrayC(equals.thisC())
 		}, reader => {
 			const s = this._uiState.read(reader);
-			return s?.state?.kind === InlineCompletionViewKind.WordReplacements ? s.state.replacements.map(replacement => new WordReplacementsViewData(replacement, s.state?.alternativeAction)) : [];
+			return s?.state?.kind === InlineCompletionViewKind.WordReplacements ? s.state.replacements.map(replacement => new WordReplacementsViewData(replacement, s.editorType, s.state?.alternativeAction)) : [];
 		});
 		this._wordReplacementViews = mapObservableArrayCached(this, wordReplacements, (viewData, store) => {
 			return store.add(this._instantiationService.createInstance(InlineEditsWordReplacementView, this._editorObs, viewData, this._tabAction));
@@ -181,7 +184,7 @@ export class InlineEditsView extends Disposable {
 				modifiedLines: s.state.modifiedLines,
 				replacements: s.state.replacements,
 			}) : undefined),
-			this._uiState.map(s => s?.isInDiffEditor ?? false),
+			this._uiState.map(s => s?.editorType ?? InlineCompletionEditorType.TextEditor),
 			this._tabAction,
 		));
 
@@ -301,7 +304,7 @@ export class InlineEditsView extends Disposable {
 		edit: InlineEditWithChanges;
 		newText: string;
 		newTextLineCount: number;
-		isInDiffEditor: boolean;
+		editorType: InlineCompletionEditorType;
 		longDistanceHint: ILongDistanceHint | undefined;
 		nextCursorPosition: Position | null;
 	} | undefined>(this, reader => {
@@ -374,7 +377,7 @@ export class InlineEditsView extends Disposable {
 			edit: inlineEdit,
 			newText: newText.getValue(),
 			newTextLineCount: inlineEdit.modifiedLineRange.length,
-			isInDiffEditor: model.isInDiffEditor,
+			editorType: model.editorType,
 			longDistanceHint,
 			nextCursorPosition: nextCursorPosition,
 		};
@@ -462,7 +465,7 @@ export class InlineEditsView extends Disposable {
 		const inner = diff.flatMap(d => d.innerChanges ?? []);
 		const isSingleInnerEdit = inner.length === 1;
 
-		if (!model.isInDiffEditor) {
+		if (model.editorType !== InlineCompletionEditorType.DiffEditor) {
 			if (
 				isSingleInnerEdit
 				&& this._useCodeShifting.read(reader) !== 'never'
@@ -503,7 +506,7 @@ export class InlineEditsView extends Disposable {
 		}
 
 		if (numOriginalLines > 0 && numModifiedLines > 0) {
-			if (numOriginalLines === 1 && numModifiedLines === 1 && !model.isInDiffEditor /* prefer side by side in diff editor */) {
+			if (numOriginalLines === 1 && numModifiedLines === 1 && model.editorType !== InlineCompletionEditorType.DiffEditor /* prefer side by side in diff editor */) {
 				return InlineCompletionViewKind.LineReplacement;
 			}
 
@@ -514,7 +517,7 @@ export class InlineEditsView extends Disposable {
 			return InlineCompletionViewKind.LineReplacement;
 		}
 
-		if (model.isInDiffEditor) {
+		if (model.editorType === InlineCompletionEditorType.DiffEditor) {
 			if (isDeletion(inner, inlineEdit, newText)) {
 				return InlineCompletionViewKind.Deletion;
 			}

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsCustomView.ts
@@ -6,8 +6,6 @@ import { n } from '../../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { autorun, constObservable, derived, derivedObservableWithCache, IObservable, IReader, observableValue } from '../../../../../../../base/common/observable.js';
-import { editorBackground } from '../../../../../../../platform/theme/common/colorRegistry.js';
-import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
 import { ICodeEditor } from '../../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
@@ -19,8 +17,9 @@ import { InlineCompletionHintStyle } from '../../../../../../common/languages.js
 import { ILanguageService } from '../../../../../../common/languages/language.js';
 import { LineTokens, TokenArray } from '../../../../../../common/tokens/lineTokens.js';
 import { InlineSuggestHint } from '../../../model/inlineSuggestionItem.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 import { IInlineEditsView, InlineEditClickEvent, InlineEditTabAction } from '../inlineEditsViewInterface.js';
-import { getEditorBlendedColor, INLINE_EDITS_BORDER_RADIUS, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorSecondaryBackground, inlineEditIndicatorSuccessfulBackground } from '../theme.js';
+import { getEditorBackgroundColor, getEditorBlendedColor, INLINE_EDITS_BORDER_RADIUS, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorSecondaryBackground, inlineEditIndicatorSuccessfulBackground } from '../theme.js';
 import { getContentRenderWidth, maxContentWidthInRange, rectToProps } from '../utils/utils.js';
 
 const MIN_END_OF_LINE_PADDING = 14;
@@ -47,6 +46,7 @@ export class InlineEditsCustomView extends Disposable implements IInlineEditsVie
 		private readonly _editor: ICodeEditor,
 		displayLocation: IObservable<InlineSuggestHint | undefined>,
 		tabAction: IObservable<InlineEditTabAction>,
+		editorType: IObservable<InlineCompletionEditorType>,
 		@IThemeService themeService: IThemeService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
@@ -63,7 +63,7 @@ export class InlineEditsCustomView extends Disposable implements IInlineEditsVie
 			}
 			return {
 				border: getEditorBlendedColor(border, themeService).read(reader).toString(),
-				background: asCssVariable(editorBackground)
+				background: getEditorBackgroundColor(editorType.read(reader))
 			};
 		});
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsDeletionView.ts
@@ -6,7 +6,6 @@ import { n } from '../../../../../../../base/browser/dom.js';
 import { Event } from '../../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { constObservable, derived, derivedObservableWithCache, IObservable } from '../../../../../../../base/common/observable.js';
-import { editorBackground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { ICodeEditor } from '../../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
@@ -18,8 +17,9 @@ import { Position } from '../../../../../../common/core/position.js';
 import { Range } from '../../../../../../common/core/range.js';
 import { IInlineEditsView, InlineEditTabAction } from '../inlineEditsViewInterface.js';
 import { InlineEditWithChanges } from '../inlineEditWithChanges.js';
-import { getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, originalBackgroundColor } from '../theme.js';
+import { getEditorBackgroundColor, getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, originalBackgroundColor } from '../theme.js';
 import { getPrefixTrim, mapOutFalsy, maxContentWidthInRange } from '../utils/utils.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 
 const HORIZONTAL_PADDING = 0;
 const VERTICAL_PADDING = 0;
@@ -45,7 +45,7 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 		private readonly _uiState: IObservable<{
 			originalRange: LineRange;
 			deletions: Range[];
-			inDiffEditor: boolean;
+			editorType: InlineCompletionEditorType;
 		} | undefined>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 	) {
@@ -159,16 +159,16 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 			return rect.intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER));
 		});
 
-		const separatorWidth = this._uiState.map(s => s?.inDiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
+		const separatorWidth = this._uiState.map(s => s?.editorType === InlineCompletionEditorType.DiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
 		const separatorRect = overlayRect.map(rect => rect.withMargin(separatorWidth, separatorWidth));
-
+		const editorBackground = getEditorBackgroundColor(this._uiState.map(s => s?.editorType ?? InlineCompletionEditorType.TextEditor).read(reader));
 		return [
 			n.div({
 				class: 'originalSeparatorDeletion',
 				style: {
 					...separatorRect.read(reader).toStyles(),
 					borderRadius: `${BORDER_RADIUS}px`,
-					border: `${BORDER_WIDTH + separatorWidth}px solid ${asCssVariable(editorBackground)}`,
+					border: `${BORDER_WIDTH + separatorWidth}px solid ${editorBackground}`,
 					boxSizing: 'border-box',
 				}
 			}),
@@ -186,7 +186,7 @@ export class InlineEditsDeletionView extends Disposable implements IInlineEditsV
 				class: 'originalOverlayHiderDeletion',
 				style: {
 					...overlayhider.read(reader).toStyles(),
-					backgroundColor: asCssVariable(editorBackground),
+					backgroundColor: editorBackground,
 				}
 			})
 		];

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsInsertionView.ts
@@ -7,7 +7,6 @@ import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { constObservable, derived, IObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
-import { editorBackground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { ICodeEditor } from '../../../../../../browser/editorBrowser.js';
 import { ObservableCodeEditor, observableCodeEditor } from '../../../../../../browser/observableCodeEditor.js';
@@ -21,9 +20,10 @@ import { ILanguageService } from '../../../../../../common/languages/language.js
 import { LineTokens, TokenArray } from '../../../../../../common/tokens/lineTokens.js';
 import { InlineDecoration, InlineDecorationType } from '../../../../../../common/viewModel/inlineDecorations.js';
 import { GhostText, GhostTextPart } from '../../../model/ghostText.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 import { GhostTextView, IGhostTextWidgetData } from '../../ghostText/ghostTextView.js';
 import { IInlineEditsView, InlineEditClickEvent, InlineEditTabAction } from '../inlineEditsViewInterface.js';
-import { getModifiedBorderColor, INLINE_EDITS_BORDER_RADIUS, modifiedBackgroundColor } from '../theme.js';
+import { getEditorBackgroundColor, getModifiedBorderColor, INLINE_EDITS_BORDER_RADIUS, modifiedBackgroundColor } from '../theme.js';
 import { getPrefixTrim, mapOutFalsy } from '../utils/utils.js';
 
 const BORDER_WIDTH = 1;
@@ -126,7 +126,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			lineNumber: number;
 			startColumn: number;
 			text: string;
-			inDiffEditor: boolean;
+			editorType: InlineCompletionEditorType;
 		} | undefined>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -272,17 +272,18 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 			layoutInfo.overlay.bottom
 		)).read(reader);
 
-		const separatorWidth = this._input.map(i => i?.inDiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
+		const separatorWidth = this._input.map(i => i?.editorType === InlineCompletionEditorType.DiffEditor ? WIDGET_SEPARATOR_DIFF_EDITOR_WIDTH : WIDGET_SEPARATOR_WIDTH).read(reader);
 		const overlayRect = overlayLayoutObs.map(l => l.overlay.withMargin(0, BORDER_WIDTH, 0, l.startsAtContentLeft ? 0 : BORDER_WIDTH).intersectHorizontal(new OffsetRange(overlayHider.left, Number.MAX_SAFE_INTEGER)));
 		const underlayRect = overlayRect.map(rect => rect.withMargin(separatorWidth, separatorWidth));
 
+		const editorBackground = getEditorBackgroundColor(this._input.read(undefined)?.editorType ?? InlineCompletionEditorType.TextEditor);
 		return [
 			n.div({
 				class: 'originalUnderlayInsertion',
 				style: {
 					...underlayRect.read(reader).toStyles(),
 					borderRadius: BORDER_RADIUS,
-					border: `${BORDER_WIDTH + separatorWidth}px solid ${asCssVariable(editorBackground)}`,
+					border: `${BORDER_WIDTH + separatorWidth}px solid ${editorBackground}`,
 					boxSizing: 'border-box',
 				}
 			}),
@@ -300,7 +301,7 @@ export class InlineEditsInsertionView extends Disposable implements IInlineEdits
 				class: 'originalOverlayHiderInsertion',
 				style: {
 					...overlayHider.toStyles(),
-					backgroundColor: asCssVariable(editorBackground),
+					backgroundColor: editorBackground,
 				}
 			})
 		];

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsLineReplacementView.ts
@@ -7,7 +7,7 @@ import { $, n } from '../../../../../../../base/browser/dom.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
 import { Disposable, toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { autorunDelta, constObservable, derived, IObservable } from '../../../../../../../base/common/observable.js';
-import { editorBackground, scrollbarShadow } from '../../../../../../../platform/theme/common/colorRegistry.js';
+import { scrollbarShadow } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
 import { IEditorMouseEvent, IViewZoneChangeAccessor } from '../../../../../../browser/editorBrowser.js';
@@ -23,8 +23,9 @@ import { OffsetRange } from '../../../../../../common/core/ranges/offsetRange.js
 import { ILanguageService } from '../../../../../../common/languages/language.js';
 import { LineTokens, TokenArray } from '../../../../../../common/tokens/lineTokens.js';
 import { InlineDecoration, InlineDecorationType } from '../../../../../../common/viewModel/inlineDecorations.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 import { IInlineEditsView, InlineEditClickEvent, InlineEditTabAction } from '../inlineEditsViewInterface.js';
-import { getEditorBlendedColor, getModifiedBorderColor, getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, modifiedChangedLineBackgroundColor, originalBackgroundColor } from '../theme.js';
+import { getEditorBackgroundColor, getEditorBlendedColor, getModifiedBorderColor, getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, modifiedChangedLineBackgroundColor, originalBackgroundColor } from '../theme.js';
 import { getEditorValidOverlayRect, getPrefixTrim, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class InlineEditsLineReplacementView extends Disposable implements IInlineEditsView {
@@ -55,7 +56,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 			modifiedLines: string[];
 			replacements: Replacement[];
 		} | undefined>,
-		private readonly _isInDiffEditor: IObservable<boolean>,
+		private readonly _editorType: IObservable<InlineCompletionEditorType>,
 		private readonly _tabAction: IObservable<InlineEditTabAction>,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IThemeService private readonly _themeService: IThemeService,
@@ -207,7 +208,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 				const layoutProps = layout.read(reader);
 				const contentLeft = this._editor.layoutInfoContentLeft.read(reader);
 
-				const separatorWidth = this._isInDiffEditor.read(reader) ? 3 : 1;
+				const separatorWidth = this._editorType.read(reader) === InlineCompletionEditorType.DiffEditor ? 3 : 1;
 
 				modifiedLineElements.lines.forEach((l, i) => {
 					l.style.width = `${layoutProps.lowerText.width}px`;
@@ -217,6 +218,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 
 				const modifiedBorderColor = getModifiedBorderColor(this._tabAction).read(reader);
 				const originalBorderColor = getOriginalBorderColor(this._tabAction).read(reader);
+				const editorBackground = getEditorBackgroundColor(this._editorType.read(reader));
 
 				return [
 					n.div({
@@ -234,7 +236,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 								...rectToProps(reader => layout.read(reader).background.translateX(-contentLeft).withMargin(separatorWidth)),
 								borderRadius: `${INLINE_EDITS_BORDER_RADIUS}px`,
 
-								border: `${separatorWidth + 1}px solid ${asCssVariable(editorBackground)}`,
+								border: `${separatorWidth + 1}px solid ${editorBackground}`,
 								boxSizing: 'border-box',
 								pointerEvents: 'none',
 							}
@@ -258,7 +260,7 @@ export class InlineEditsLineReplacementView extends Disposable implements IInlin
 								position: 'absolute',
 								...rectToProps(reader => layout.read(reader).lowerBackground.translateX(-contentLeft)),
 								borderRadius: `0 0 ${INLINE_EDITS_BORDER_RADIUS}px ${INLINE_EDITS_BORDER_RADIUS}px`,
-								background: asCssVariable(editorBackground),
+								background: editorBackground,
 								boxShadow: `${asCssVariable(scrollbarShadow)} 0 6px 6px -6px`,
 								border: `1px solid ${asCssVariable(modifiedBorderColor)}`,
 								boxSizing: 'border-box',

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/inlineEditsWordReplacementView.ts
@@ -14,7 +14,7 @@ import { OS } from '../../../../../../../base/common/platform.js';
 import { localize } from '../../../../../../../nls.js';
 import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
-import { editorBackground, editorHoverForeground } from '../../../../../../../platform/theme/common/colorRegistry.js';
+import { editorHoverForeground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { contrastBorder } from '../../../../../../../platform/theme/common/colors/baseColors.js';
 import { asCssVariable } from '../../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
@@ -30,13 +30,15 @@ import { ILanguageService } from '../../../../../../common/languages/language.js
 import { LineTokens, TokenArray } from '../../../../../../common/tokens/lineTokens.js';
 import { inlineSuggestCommitAlternativeActionId } from '../../../controller/commandIds.js';
 import { InlineSuggestAlternativeAction } from '../../../model/InlineSuggestAlternativeAction.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 import { IInlineEditsView, InlineEditClickEvent, InlineEditTabAction } from '../inlineEditsViewInterface.js';
-import { getModifiedBorderColor, getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorPrimaryBorder, inlineEditIndicatorPrimaryForeground, modifiedChangedTextOverlayColor, observeColor, originalChangedTextOverlayColor } from '../theme.js';
+import { getEditorBackgroundColor, getModifiedBorderColor, getOriginalBorderColor, INLINE_EDITS_BORDER_RADIUS, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorPrimaryBorder, inlineEditIndicatorPrimaryForeground, modifiedChangedTextOverlayColor, observeColor, originalChangedTextOverlayColor } from '../theme.js';
 import { getEditorValidOverlayRect, mapOutFalsy, rectToProps } from '../utils/utils.js';
 
 export class WordReplacementsViewData implements IEquatable<WordReplacementsViewData> {
 	constructor(
 		public readonly edit: TextReplacement,
+		public readonly editorType: InlineCompletionEditorType,
 		public readonly alternativeAction: InlineSuggestAlternativeAction | undefined,
 	) { }
 
@@ -205,11 +207,12 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 
 				const passiveStyles = {
 					borderColor: hcBorderColor ? hcBorderColor.toString() : observeColor(editorHoverForeground, this._themeService).map(c => c.transparent(0.2).toString()).read(reader),
-					backgroundColor: asCssVariable(editorBackground),
+					backgroundColor: getEditorBackgroundColor(this._viewData.editorType),
 					color: '',
 					opacity: '0.7',
 				};
 
+				const editorBackground = getEditorBackgroundColor(this._viewData.editorType);
 				const primaryActionStyles = derived(this, r => alternativeActionActive.read(r) ? primaryActiveStyles : primaryActiveStyles);
 				const secondaryActionStyles = derived(this, r => alternativeActionActive.read(r) ? secondaryActiveStyles : passiveStyles);
 				// TODO@benibenj clicking the arrow does not accept suggestion anymore
@@ -227,7 +230,7 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 							style: {
 								position: 'absolute',
 								...rectToProps(reader => layout.read(reader).lowerBackground.withMargin(BORDER_WIDTH, 2 * BORDER_WIDTH, BORDER_WIDTH, 0)),
-								background: asCssVariable(editorBackground),
+								background: editorBackground,
 								cursor: 'pointer',
 								pointerEvents: 'auto',
 							},
@@ -243,11 +246,11 @@ export class InlineEditsWordReplacementView extends Disposable implements IInlin
 								boxSizing: 'border-box',
 								borderRadius: `${INLINE_EDITS_BORDER_RADIUS}px`,
 
-								background: asCssVariable(editorBackground),
+								background: editorBackground,
 								display: 'flex',
 								justifyContent: 'left',
 
-								outline: `2px solid ${asCssVariable(editorBackground)}`,
+								outline: `2px solid ${editorBackground}`,
 							},
 							onmousedown: (e) => this._mouseDown(e),
 						}, [

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/longDistanceHint/inlineEditsLongDistanceHint.ts
@@ -28,13 +28,14 @@ import { Point } from '../../../../../../../common/core/2d/point.js';
 import { Size2D } from '../../../../../../../common/core/2d/size.js';
 import { IThemeService } from '../../../../../../../../platform/theme/common/themeService.js';
 import { IKeybindingService } from '../../../../../../../../platform/keybinding/common/keybinding.js';
-import { getEditorBlendedColor, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorSecondaryBackground, inlineEditIndicatorSuccessfulBackground, observeColor } from '../../theme.js';
-import { asCssVariable, descriptionForeground, editorBackground, editorWidgetBackground } from '../../../../../../../../platform/theme/common/colorRegistry.js';
+import { getEditorBackgroundColor, getEditorBlendedColor, inlineEditIndicatorPrimaryBackground, inlineEditIndicatorSecondaryBackground, inlineEditIndicatorSuccessfulBackground, observeColor } from '../../theme.js';
+import { asCssVariable, descriptionForeground, editorWidgetBackground } from '../../../../../../../../platform/theme/common/colorRegistry.js';
 import { editorWidgetBorder } from '../../../../../../../../platform/theme/common/colors/editorColors.js';
 import { ILongDistancePreviewProps, LongDistancePreviewEditor } from './longDistancePreviewEditor.js';
 import { InlineSuggestionGutterMenuData, SimpleInlineSuggestModel } from '../../components/gutterIndicatorView.js';
 import { jumpToNextInlineEditId } from '../../../../controller/commandIds.js';
 import { splitIntoContinuousLineRanges, WidgetLayoutConstants, WidgetOutline, WidgetPlacementContext } from './longDistnaceWidgetPlacement.js';
+import { InlineCompletionEditorType } from '../../../../model/provideInlineCompletions.js';
 
 const BORDER_RADIUS = 6;
 const MAX_WIDGET_WIDTH = { EMPTY_SPACE: 425, OVERLAY: 375 };
@@ -93,7 +94,7 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 
 			return {
 				border: borderColor.toString(),
-				background: asCssVariable(editorBackground)
+				background: getEditorBackgroundColor(this._viewState.map(s => s?.editorType ?? InlineCompletionEditorType.TextEditor).read(reader)),
 			};
 		});
 
@@ -388,7 +389,7 @@ export class InlineEditsLongDistanceHint extends Disposable implements IInlineEd
 				style: {
 					overflow: 'hidden',
 					padding: this._previewEditorLayoutInfo.map(i => i?.previewEditorMargin),
-					background: asCssVariable(editorBackground),
+					background: this._styles.map(s => s.background),
 					pointerEvents: 'none',
 				},
 			}, [
@@ -481,6 +482,7 @@ export interface ILongDistanceViewState {
 	edit: InlineEditWithChanges;
 	diff: DetailedLineRangeMapping[];
 	nextCursorPosition: Position | null;
+	editorType: InlineCompletionEditorType;
 
 	model: SimpleInlineSuggestModel;
 	inlineSuggestInfo: InlineSuggestionGutterMenuData;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/inlineEditsViews/originalEditorInlineDiffView.ts
@@ -17,12 +17,13 @@ import { EndOfLinePreference, IModelDeltaDecoration, InjectedTextCursorStops, IT
 import { ModelDecorationOptions } from '../../../../../../common/model/textModel.js';
 import { IInlineEditsView, InlineEditClickEvent } from '../inlineEditsViewInterface.js';
 import { classNames } from '../utils/utils.js';
+import { InlineCompletionEditorType } from '../../../model/provideInlineCompletions.js';
 
 export interface IOriginalEditorInlineDiffViewState {
 	diff: DetailedLineRangeMapping[];
 	modifiedText: AbstractText;
 	mode: 'insertionInline' | 'sideBySide' | 'deletion' | 'lineReplacement';
-	isInDiffEditor: boolean;
+	editorType: InlineCompletionEditorType;
 
 	modifiedCodeEditor: ICodeEditor;
 }
@@ -209,7 +210,7 @@ export class OriginalEditorInlineDiffView extends Disposable implements IInlineE
 				}
 			}
 
-			if (diff.isInDiffEditor) {
+			if (diff.editorType === InlineCompletionEditorType.DiffEditor) {
 				for (const m of diff.diff) {
 					if (!m.original.isEmpty) {
 						originalDecorations.push({

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/theme.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/theme.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from '../../../../../../base/common/assert.js';
 import { Color } from '../../../../../../base/common/color.js';
 import { BugIndicatingError } from '../../../../../../base/common/errors.js';
 import { IObservable, observableFromEventOpts } from '../../../../../../base/common/observable.js';
 import { localize } from '../../../../../../nls.js';
 import { buttonBackground, buttonForeground, buttonSecondaryBackground, buttonSecondaryForeground, diffInserted, diffInsertedLine, diffRemoved, editorBackground } from '../../../../../../platform/theme/common/colorRegistry.js';
-import { ColorIdentifier, darken, registerColor, transparent } from '../../../../../../platform/theme/common/colorUtils.js';
+import { asCssVariable, ColorIdentifier, darken, registerColor, transparent } from '../../../../../../platform/theme/common/colorUtils.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
+import { InlineCompletionEditorType } from '../../model/provideInlineCompletions.js';
 import { InlineEditTabAction } from './inlineEditsViewInterface.js';
 
 export const originalBackgroundColor = registerColor(
@@ -190,6 +192,22 @@ export function getEditorBlendedColor(colorIdentifier: ColorIdentifier | IObserv
 
 	return color.map((c, reader) => /** @description makeOpaque */ c.makeOpaque(backgroundColor.read(reader)));
 }
+
+export function getEditorBackgroundColor(editorType: InlineCompletionEditorType): string {
+	let color;
+	switch (editorType) {
+		case InlineCompletionEditorType.TextEditor:
+			color = editorBackground; break;
+		case InlineCompletionEditorType.DiffEditor:
+			color = editorBackground; break;
+		case InlineCompletionEditorType.Notebook:
+			color = 'notebook.cellEditorBackground'; break;
+		default:
+			assertNever(editorType, 'Not supported editor type yet');
+	}
+	return asCssVariable(color);
+}
+
 
 export function observeColor(colorIdentifier: ColorIdentifier, themeService: IThemeService): IObservable<Color> {
 	return observableFromEventOpts(


### PR DESCRIPTION
```Copilot Generated Description:``` Update the handling of background colors for different editor types, including notebooks, ensuring appropriate colors are applied based on the editor context.

fixes https://github.com/microsoft/vscode-copilot/issues/15247