### PR TITLE
Revert "Add editorBracketMatch-foreground color setting (#284031)"

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -203,7 +203,6 @@
 		"--vscode-editorBracketHighlight-unexpectedBracket-foreground",
 		"--vscode-editorBracketMatch-background",
 		"--vscode-editorBracketMatch-border",
-		"--vscode-editorBracketMatch-foreground",
 		"--vscode-editorBracketPairGuide-activeBackground1",
 		"--vscode-editorBracketPairGuide-activeBackground2",
 		"--vscode-editorBracketPairGuide-activeBackground3",

--- a/src/vs/editor/common/core/editorColorRegistry.ts
+++ b/src/vs/editor/common/core/editorColorRegistry.ts
@@ -55,7 +55,6 @@ export const editorCodeLensForeground = registerColor('editorCodeLens.foreground
 
 export const editorBracketMatchBackground = registerColor('editorBracketMatch.background', { dark: '#0064001a', light: '#0064001a', hcDark: '#0064001a', hcLight: '#0000' }, nls.localize('editorBracketMatchBackground', 'Background color behind matching brackets'));
 export const editorBracketMatchBorder = registerColor('editorBracketMatch.border', { dark: '#888', light: '#B9B9B9', hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('editorBracketMatchBorder', 'Color for matching brackets boxes'));
-export const editorBracketMatchForeground = registerColor('editorBracketMatch.foreground', null, nls.localize('editorBracketMatchForeground', 'Foreground color for matching brackets'));
 
 export const editorOverviewRulerBorder = registerColor('editorOverviewRuler.border', { dark: '#7f7f7f4d', light: '#7f7f7f4d', hcDark: '#7f7f7f4d', hcLight: '#666666' }, nls.localize('editorOverviewRulerBorder', 'Color of the overview ruler border.'));
 export const editorOverviewRulerBackground = registerColor('editorOverviewRuler.background', null, nls.localize('editorOverviewRulerBackground', 'Background color of the editor overview ruler.'));

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
@@ -21,8 +21,7 @@ import * as nls from '../../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { registerColor } from '../../../../platform/theme/common/colorRegistry.js';
-import { registerThemingParticipant, themeColorFromId } from '../../../../platform/theme/common/themeService.js';
-import { editorBracketMatchForeground } from '../../../common/core/editorColorRegistry.js';
+import { themeColorFromId } from '../../../../platform/theme/common/themeService.js';
 
 const overviewRulerBracketMatchForeground = registerColor('editorOverviewRuler.bracketMatchForeground', '#A0A0A0', nls.localize('overviewRulerBracketMatchForeground', 'Overview ruler marker color for matching brackets.'));
 
@@ -300,7 +299,7 @@ export class BracketMatchingController extends Disposable implements IEditorCont
 	private static readonly _DECORATION_OPTIONS_WITH_OVERVIEW_RULER = ModelDecorationOptions.register({
 		description: 'bracket-match-overview',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		inlineClassName: 'bracket-match',
+		className: 'bracket-match',
 		overviewRuler: {
 			color: themeColorFromId(overviewRulerBracketMatchForeground),
 			position: OverviewRulerLane.Center
@@ -310,7 +309,7 @@ export class BracketMatchingController extends Disposable implements IEditorCont
 	private static readonly _DECORATION_OPTIONS_WITHOUT_OVERVIEW_RULER = ModelDecorationOptions.register({
 		description: 'bracket-match-no-overview',
 		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		inlineClassName: 'bracket-match'
+		className: 'bracket-match'
 	});
 
 	private _updateBrackets(): void {
@@ -414,13 +413,4 @@ MenuRegistry.appendMenuItem(MenuId.MenubarGoMenu, {
 		title: nls.localize({ key: 'miGoToBracket', comment: ['&& denotes a mnemonic'] }, "Go to &&Bracket")
 	},
 	order: 2
-});
-
-// Theming participant to ensure bracket-match color overrides bracket pair colorization
-registerThemingParticipant((theme, collector) => {
-	const bracketMatchForeground = theme.getColor(editorBracketMatchForeground);
-	if (bracketMatchForeground) {
-		// Use higher specificity to override bracket pair colorization
-		collector.addRule(`.monaco-editor .bracket-match { color: ${bracketMatchForeground} !important; }`);
-	}
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/284444

This reverts commit 695f93c7588a42dc4c2981d395b6d766e5ab390a.