### PR TITLE
node-pty@1.1.0-beta43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "native-is-elevated": "0.8.0",
         "native-keymap": "^3.3.5",
         "native-watchdog": "^1.4.1",
-        "node-pty": "^1.1.0-beta42",
+        "node-pty": "^1.1.0-beta43",
         "open": "^10.1.2",
         "tas-client": "0.3.1",
         "undici": "^7.9.0",
@@ -12810,9 +12810,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta42",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta42.tgz",
-      "integrity": "sha512-59KoV6xxhJciRVpo4lQ9wnP38SPaBlXgwszYS8nlHAHrt02d14peg+kHtJ4AOtyLWiCf8WPCeJNbxBkiA7Oy7Q==",
+      "version": "1.1.0-beta43",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta43.tgz",
+      "integrity": "sha512-CYyIQogRs97Rfjo0WKyku8V56Bm4WyWUijrbWDs5LJ+ZmsUW2gqbVAEpD+1gtA7dEZ6v1A08GzfqsDuIl/eRqw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "native-is-elevated": "0.8.0",
     "native-keymap": "^3.3.5",
     "native-watchdog": "^1.4.1",
-    "node-pty": "^1.1.0-beta42",
+    "node-pty": "^1.1.0-beta43",
     "open": "^10.1.2",
     "tas-client": "0.3.1",
     "undici": "^7.9.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -38,7 +38,7 @@
         "kerberos": "2.1.1",
         "minimist": "^1.2.8",
         "native-watchdog": "^1.4.1",
-        "node-pty": "^1.1.0-beta42",
+        "node-pty": "^1.1.0-beta43",
         "tas-client": "0.3.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta42",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta42.tgz",
-      "integrity": "sha512-59KoV6xxhJciRVpo4lQ9wnP38SPaBlXgwszYS8nlHAHrt02d14peg+kHtJ4AOtyLWiCf8WPCeJNbxBkiA7Oy7Q==",
+      "version": "1.1.0-beta43",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta43.tgz",
+      "integrity": "sha512-CYyIQogRs97Rfjo0WKyku8V56Bm4WyWUijrbWDs5LJ+ZmsUW2gqbVAEpD+1gtA7dEZ6v1A08GzfqsDuIl/eRqw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -33,7 +33,7 @@
     "kerberos": "2.1.1",
     "minimist": "^1.2.8",
     "native-watchdog": "^1.4.1",
-    "node-pty": "^1.1.0-beta42",
+    "node-pty": "^1.1.0-beta43",
     "tas-client": "0.3.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",


### PR DESCRIPTION
Brings in further improvements to handling of write backpressure. After this we no longer throttle at all which means that for older versions of bash at least on macOS interleaving is possible, but pasting and sending should be near instantaneous for any reasonable amount of text. I measured zsh injesting 5mb of data in ~14 seconds.

See:

- microsoft/node-pty#835
- microsoft/node-pty#837
- microsoft/node-pty#839

Part of #246204, #283056

cc @anthonykim1 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
