### PR TITLE
docs(agents): add extension development and testing guidelines

### DIFF
--- a/.github/instructions/extension-testing.instructions.md
+++ b/.github/instructions/extension-testing.instructions.md
@@ -1,0 +1,128 @@
+---
+description: Guidelines for writing and running extension tests in VS Code
+applyTo: extensions/**
+---
+
+# Extension Testing Guidelines
+
+## Test Location and Structure
+
+Extension tests live within each extension's `src/test/` directory. Follow patterns from `extensions/vscode-api-tests/` as the canonical example.
+
+## Running Extension Tests
+
+```bash
+# Run specific extension tests
+npm run test-extension -- -l <extension-name>
+
+# Run all API tests (integration)
+./scripts/test-integration.sh
+
+# Run with debugging
+./scripts/test-integration.sh  # then attach debugger
+```
+
+## Writing Tests
+
+### Basic Test Structure
+```typescript
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Feature Name', () => {
+    suiteSetup(async () => {
+        // One-time setup before all tests
+    });
+
+    suiteTeardown(async () => {
+        // Cleanup after all tests
+    });
+
+    test('should perform expected behavior', async () => {
+        // Arrange
+        const doc = await vscode.workspace.openTextDocument({
+            content: 'test',
+            language: 'plaintext'
+        });
+
+        // Act
+        const editor = await vscode.window.showTextDocument(doc);
+
+        // Assert
+        assert.strictEqual(editor.document.getText(), 'test');
+    });
+});
+```
+
+### Common Testing Patterns
+
+#### Working with Documents
+```typescript
+// Create a new document
+const doc = await vscode.workspace.openTextDocument({ content: '', language: 'typescript' });
+const editor = await vscode.window.showTextDocument(doc);
+
+// Edit document
+await editor.edit(builder => {
+    builder.insert(new vscode.Position(0, 0), 'new content');
+});
+```
+
+#### Testing Commands
+```typescript
+await vscode.commands.executeCommand('myExtension.myCommand');
+```
+
+#### Testing with Workspace Files
+Use `testWorkspace/` directory within your extension for test fixtures.
+
+#### Async/Await and Timeouts
+```typescript
+// Wait for something with timeout
+async function waitFor<T>(fn: () => T | undefined, timeout = 5000): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        const result = fn();
+        if (result !== undefined) return result;
+        await new Promise(r => setTimeout(r, 100));
+    }
+    throw new Error('Timeout waiting for condition');
+}
+```
+
+## Test Configuration
+
+### package.json Setup
+```json
+{
+    "scripts": {
+        "test": "node ./out/test/runTest.js"
+    },
+    "devDependencies": {
+        "@types/mocha": "^10.0.10",
+        "@vscode/test-electron": "^2.3.0"
+    }
+}
+```
+
+## Debugging Tests
+
+1. Use launch configurations in `.vscode/launch.json`
+2. Set `"extensionTestsPath"` to your test output directory
+3. Breakpoints work in TypeScript source when source maps are enabled
+
+## Best Practices
+
+1. **Isolate tests**: Each test should be independent
+2. **Clean up**: Close editors and delete temporary files in `teardown`
+3. **Use `strictEqual`**: Prefer `assert.strictEqual` over `assert.equal`
+4. **Async handling**: Always `await` async operations
+5. **Timeout handling**: Increase timeouts for slow operations
+6. **Avoid flakiness**: Don't depend on timing; use explicit waits
+
+## Common Pitfalls
+
+- **Not waiting for activation**: Extensions may need time to activate
+- **File system state**: Tests may fail if previous test left files open
+- **Parallel execution**: Tests run sequentially; don't assume parallel
+- **Platform differences**: Test on multiple platforms when possible

--- a/.github/prompts/extension-dev.prompt.md
+++ b/.github/prompts/extension-dev.prompt.md
@@ -1,0 +1,28 @@
+---
+description: 'Guide for developing and testing VS Code built-in extensions'
+---
+# Extension Development Guide
+
+When working on built-in extensions in the `extensions/` folder:
+
+## Structure
+- Extensions use standard VS Code extension structure with `package.json`, TypeScript sources, and contribution points
+- Entry point is typically `src/extension.ts` compiled to `out/main.js`
+- Use `enabledApiProposals` in package.json for proposed APIs
+
+## Testing Extensions
+1. Write tests in `src/test/` following patterns in `extensions/vscode-api-tests/`
+2. Use Mocha's `suite`/`test` structure
+3. Run with: `npm run test-extension -- -l <extension-name>`
+4. Integration tests run via `./scripts/test-integration.sh`
+
+## Key References
+- API test examples: `extensions/vscode-api-tests/src/singlefolder-tests/`
+- Language features: `extensions/typescript-language-features/`
+- Proposed APIs: `src/vscode-dts/vscode.proposed.*.d.ts`
+
+## Checklist
+- [ ] Tests pass locally
+- [ ] No TypeScript errors in extension
+- [ ] User strings localized
+- [ ] package.json contributions properly defined

--- a/.kilocode/rules/copilot-instructions.md
+++ b/.kilocode/rules/copilot-instructions.md
@@ -1,0 +1,1 @@
+../../.github/copilot-instructions.md

--- a/.kilocode/rules/instructions/disposable.instructions.md
+++ b/.kilocode/rules/instructions/disposable.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/disposable.instructions.md

--- a/.kilocode/rules/instructions/extension-testing.instructions.md
+++ b/.kilocode/rules/instructions/extension-testing.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/extension-testing.instructions.md

--- a/.kilocode/rules/instructions/learnings.instructions.md
+++ b/.kilocode/rules/instructions/learnings.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/learnings.instructions.md

--- a/.kilocode/rules/instructions/observables.instructions.md
+++ b/.kilocode/rules/instructions/observables.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/observables.instructions.md

--- a/.kilocode/rules/instructions/telemetry.instructions.md
+++ b/.kilocode/rules/instructions/telemetry.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/telemetry.instructions.md

--- a/.kilocode/rules/instructions/tree-widgets.instructions.md
+++ b/.kilocode/rules/instructions/tree-widgets.instructions.md
@@ -1,0 +1,1 @@
+../../../.github/instructions/tree-widgets.instructions.md

--- a/.kilocode/rules/prompts/extension-dev.prompt.md
+++ b/.kilocode/rules/prompts/extension-dev.prompt.md
@@ -1,0 +1,1 @@
+../../../.github/prompts/extension-dev.prompt.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,195 @@
 This file provides instructions for AI coding agents working with the VS Code codebase.
 
 For detailed project overview, architecture, coding guidelines, and validation steps, see the [Copilot Instructions](.github/copilot-instructions.md).
+
+## Repository Purpose
+
+This is a personal fork of VS Code used for contributing PRs to the official Microsoft vscode repository. All changes should follow Microsoft's contribution guidelines and coding standards to ensure PRs are accepted upstream.
+
+## Quick Reference
+
+### Before Making Any Changes
+1. **Check compilation**: Monitor the `VS Code - Build` watch task for TypeScript errors
+2. **Understand the layered architecture**: `base` → `platform` → `editor` → `workbench`
+3. **Find existing patterns**: Look at similar code before implementing new features
+
+### Code Style Essentials
+- **Tabs, not spaces** for indentation
+- **PascalCase** for types/enums, **camelCase** for functions/variables
+- **Single quotes** for code strings, **double quotes** for user-facing localized strings
+- **Arrow functions** preferred over anonymous functions
+- **Curly braces** always required around loop/conditional bodies
+- **No `any` or `unknown`** types unless absolutely necessary
+
+### Localization
+All user-visible strings must use `nls.localize()`:
+```typescript
+import * as nls from 'vs/nls';
+const message = nls.localize('myKey', "User visible message with {0} placeholder", value);
+```
+
+## Building and Testing
+
+### TypeScript Compilation
+- **NEVER** use `npm run compile` directly
+- Use the `VS Code - Build` watch task which runs `Core - Build` and `Ext - Build`
+- Fix ALL compilation errors before running tests or committing
+
+### Running Unit Tests
+```bash
+# All unit tests (runs in Electron)
+./scripts/test.sh
+
+# Filter by pattern
+./scripts/test.sh --grep "pattern"
+
+# Specific test file
+./scripts/test.sh --glob "**/myFile.test.js"
+
+# Debug mode (opens Electron with DevTools)
+./scripts/test.sh --debug --glob "**/myFile.test.js"
+
+# Browser-based tests (common/browser layers)
+npm run test-browser -- --browser chromium
+
+# Node-based tests
+npm run test-node -- --run src/vs/path/to/test.ts
+```
+
+### Running Integration Tests
+```bash
+# All integration tests
+./scripts/test-integration.sh
+
+# Web integration tests
+./scripts/test-web-integration.sh --browser chromium
+```
+
+### Layering Validation
+```bash
+npm run valid-layers-check
+```
+
+## Writing and Testing Extensions
+
+VS Code's built-in extensions live in the `extensions/` folder. This is "Inception-level" development—you're building extensions that ship with the editor you're also developing.
+
+### Extension Structure
+Each extension in `extensions/` follows standard VS Code extension conventions:
+```
+extensions/my-extension/
+├── package.json          # Extension manifest with contributions
+├── src/                  # TypeScript source files
+│   └── extension.ts      # Entry point
+├── tsconfig.json         # TypeScript config
+└── out/                  # Compiled output (generated)
+```
+
+### Key Extension Directories
+- `extensions/vscode-api-tests/` - API test extension (great reference for testing patterns)
+- `extensions/typescript-language-features/` - Full language support example
+- `extensions/git/` - Complex extension with proposed APIs
+- `extensions/extension-editing/` - Extension development tools
+
+### Testing Extensions
+
+#### API Tests (in `extensions/vscode-api-tests/`)
+These test the VS Code Extension API itself:
+```bash
+# Run API tests for single folder workspace
+./scripts/test-integration.sh  # Runs as part of integration suite
+
+# Run specific extension tests
+npm run test-extension -- -l vscode-api-tests
+```
+
+Test files location: `extensions/vscode-api-tests/src/singlefolder-tests/`
+
+#### Extension-Specific Tests
+For extensions like `typescript-language-features`:
+```bash
+# The integration script runs these automatically
+./scripts/test-integration.sh
+```
+
+#### Writing New Extension Tests
+1. Create test files in `src/test/` within your extension
+2. Follow patterns in `extensions/vscode-api-tests/src/singlefolder-tests/`
+3. Use Mocha's `describe`/`test` (or `it`) structure
+4. Tests run via `extensionTestsPath` parameter to VS Code
+
+Example test structure:
+```typescript
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('My Extension Tests', () => {
+    test('should do something', async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            content: 'test content',
+            language: 'plaintext'
+        });
+        assert.strictEqual(doc.getText(), 'test content');
+    });
+});
+```
+
+### Proposed APIs
+Built-in extensions can use proposed APIs by listing them in `package.json`:
+```json
+{
+  "enabledApiProposals": ["proposedApiName"]
+}
+```
+Proposed API definitions: `src/vscode-dts/vscode.proposed.*.d.ts`
+
+### Debugging Extensions
+1. Use the launch configurations in `.vscode/launch.json`
+2. Set breakpoints in extension TypeScript source
+3. Use "Extension Host" debug configuration
+
+## Contributing PR Checklist
+
+Before submitting a PR to upstream:
+- [ ] All TypeScript compilation errors fixed
+- [ ] Unit tests pass: `./scripts/test.sh`
+- [ ] Integration tests pass: `./scripts/test-integration.sh`
+- [ ] Layering check passes: `npm run valid-layers-check`
+- [ ] No lint errors: `npm run eslint`
+- [ ] New code has Microsoft copyright header
+- [ ] User-facing strings are localized with `nls.localize()`
+- [ ] New tests added for new functionality
+- [ ] Existing tests not broken
+
+## Architecture Quick Guide
+
+### Dependency Injection
+Services are injected via constructor decorators:
+```typescript
+class MyService {
+    constructor(
+        @IConfigurationService private configService: IConfigurationService,
+        @ILogService private logService: ILogService
+    ) {}
+}
+```
+
+### Contribution Pattern
+Features register via contribution points:
+```typescript
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+    .registerWorkbenchContribution(MyContribution, LifecyclePhase.Ready);
+```
+
+### Test File Location
+- Unit tests: Adjacent to source in `test/` folders (e.g., `src/vs/base/test/`)
+- Integration tests: `test/integration/` and extension test folders
+- Smoke tests: `test/smoke/`
+
+## Common Pitfalls
+
+1. **Wrong test suite**: Don't add tests to end of file; put them in the relevant `describe` block
+2. **Missing localization**: All user-visible strings need `nls.localize()`
+3. **Import duplication**: Reuse existing imports, don't duplicate
+4. **Temporary files**: Clean up any helper files created during development
+5. **Layer violations**: Respect the `base` → `platform` → `editor` → `workbench` hierarchy


### PR DESCRIPTION
Add comprehensive documentation for AI coding agents working with VS Code extensions, including:

- Extension testing guidelines with Mocha patterns, common testing patterns, and best practices for writing extension tests
- Extension development guide covering structure, testing, and key references
- Expanded AGENTS.md with quick reference, building/testing instructions, extension development workflows, and PR checklist
- Symlinks in .kilocode/rules/ to make GitHub instructions accessible for compatibility with multiple AI coding assistant tools

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
