### PR TITLE
fix: HoverDelegateFactory may use a disposed InstantiationService

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -12,7 +12,7 @@ import { IDiffEditorOptions, IEditorOptions } from '../../common/config/editorOp
 import { InternalEditorAction } from '../../common/editorAction.js';
 import { IModelChangedEvent } from '../../common/editorCommon.js';
 import { ITextModel } from '../../common/model.js';
-import { StandaloneKeybindingService, updateConfigurationService } from './standaloneServices.js';
+import { StandaloneKeybindingService, StandaloneServices, updateConfigurationService } from './standaloneServices.js';
 import { IStandaloneThemeService } from '../common/standaloneTheme.js';
 import { IMenuItem, MenuId, MenuRegistry } from '../../../platform/actions/common/actions.js';
 import { CommandsRegistry, ICommandHandler, ICommandService } from '../../../platform/commands/common/commands.js';
@@ -296,7 +296,7 @@ export class StandaloneCodeEditor extends CodeEditorWidget implements IStandalon
 
 		createAriaDomNode(options.ariaContainerElement);
 
-		setHoverDelegateFactory((placement, enableInstantHover) => instantiationService.createInstance(WorkbenchHoverDelegate, placement, { instantHover: enableInstantHover }, {}));
+		setHoverDelegateFactory((placement, enableInstantHover) => StandaloneServices.initialize({}).createInstance(WorkbenchHoverDelegate, placement, { instantHover: enableInstantHover }, {}));
 		setBaseLayerHoverDelegate(hoverService);
 
 		markdownRendererService.setDefaultCodeBlockRenderer(instantiationService.createInstance(EditorMarkdownCodeBlockRenderer));


### PR DESCRIPTION
## Description

Currently, `getDefaultHoverDelegate` and `createInstantHoverDelegate` are still used in many places across the codebase. While `getDefaultHoverDelegate` returns a lazy-initialized `IScopedHoverDelegate`, `createInstantHoverDelegate` calls the internally captured `hoverDelegateFactory` set by `setHoverDelegateFactory` to create an `IScopedHoverDelegate`.

After the `StandaloneCodeEditor` (created via `monaco.editor.create`) calls `setHoverDelegateFactory` on initialization, the `StandaloneDiffEditor2` (created via `monaco.editor.createDiffEditor`) calls it a second time and overwrites it with a different `HoverDelegateFactory`. After the `StandaloneDiffEditor2` is disposed, the last `HoverDelegateFactory` it set still captures a disposed `InstantiationService`, which causes an error upon use.

Fixes https://github.com/microsoft/monaco-editor/issues/4612

## Reproduction

[Open in the Monaco Editor Playground](https://microsoft.github.io/monaco-editor/playground.html?source=v0.55.1#XQAAAALpBQAAAAAAAABBqQkHQ5NjdWHSdHiQNSdBTF4iAtMYwGafQ7gkkia-sjcCvr4qnFMzQvvPGdnVEjq3MWOfFoj3eaTRcTtVAnNHH2zn1sRO5FpWQjRsG8u_yk6NKMAe7DxTqvAGpF3XPskGTiZTjeHDIHgx7vAlC7paoJOC35uHtSxNn4N_M35Q1ZOGCcrPFPvW9AKvm0lqfbwxQxrwF08_f7OVWafgC_1gszVaDg0uItoLKulDnKjjqBsDuejdDNr2MiWnc_us1NGgpVJ8NfvNtwcKTZQJEOvgepiYTIvXeCepT0JoTbE60-INZb636kmhH1beh2-Or8hcG5-1dz6HqcLGR4Y8LD-ufnhME3MoYC653PQ0lddrS7oFf2pDQEhLwkIRVwm93HvRS-jtZvcyhKShgIrDjl41B3K3m_GVsKzh18rkts3DGxdcYYtrLECjvTbGY9MUAWbzlmMoWSAY1wZCzoUC3-ioI_z3A2RtnFyBBOJKKbJ_8hNFCblIEH9CADeYvjp-l-_yHvvRBnB8sRGcePYsPsLM4D1JzbllFhuV5kf7ky1zqZLq8LuxtED-SHaKY1aOcT37JCrbXH_Ht1-Q4ugN6lvKVFN1cfw6_9o3Gpo4fbXB88HxD0fDxMU_MOhQxCcF9RXeosUKfvM9tyIGPr1pi3lDxakazrDl1cbxH74tFylFdtK6NWG1NuYIJta8kCOzYlMIwTC8wCucL8bGV0JUty-BzZusBM9yFbMYBcH7ihozVXPQYcN8XYIYctKm_y_sqNIRe2UKjrR1jh5qkmnp3CJq1T_fv1VZcwIiv6EyF1CjlkN4tHJTcPckk9Bokpo8KJi1DZpDt9Bp6uPadx0mJfEypz3RTsAT2iznwT8yMak5EeTInfsyZQhdI8690Y8pEf_mksRt)

https://github.com/user-attachments/assets/fa7d6734-7da2-4f9b-915f-8d7e87c4da03


