### PR TITLE
include uppercase `-I` in sed in-place option detection

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -271,7 +271,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			//   while processing the input.
 			// - `-f`/`--file`: Add the commands contained in the file script-file to the set of
 			//   commands to be run while processing the input.
-			// - `-i`/`--in-place`: This option specifies that files are to be edited in-place.
+			// - `-i`/`-I`/`--in-place`: This option specifies that files are to be edited in-place.
 			// - `w`/`W` commands: Write to files (blocked by `-i` check + agent typically won't use).
 			// - `s///e` flag: Executes substitution result as shell command
 			// - `s///w` flag: Write substitution result to file
@@ -279,7 +279,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			// - Note that `--sandbox` exists which blocks unsafe commands that could potentially be
 			//   leveraged to auto approve
 			sed: true,
-			'/^sed\\b.*(-[a-zA-Z]*(e|i|f)[a-zA-Z]*|--expression|--file|--in-place)\\b/': false,
+			'/^sed\\b.*(-[a-zA-Z]*(e|i|I|f)[a-zA-Z]*|--expression|--file|--in-place)\\b/': false,
 			'/^sed\\b.*(\/e|\/w|;W)/': false,
 
 			// sort

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -304,6 +304,7 @@ suite('RunInTerminalTool', () => {
 			'rg --hostname-bin hostname pattern .',
 			'sed -i "s/foo/bar/g" file.txt',
 			'sed -i.bak "s/foo/bar/" file.txt',
+			'sed -Ibak "s/foo/bar/" file.txt',
 			'sed --in-place "s/foo/bar/" file.txt',
 			'sed -e "s/a/b/" file.txt',
 			'sed -f script.sed file.txt',


### PR DESCRIPTION
include uppercase `-I` in sed in-place option detection

The `-I` option is available for `sed` on macOS and BSDs. 

- https://man.freebsd.org/cgi/man.cgi?sed
- https://ss64.com/mac/sed.html

Although There is no official macOS manual available online, you can check by executing `man sed` on macOS.

ProductName:		macOS
ProductVersion:		15.7.3
BuildVersion:		24G419

CC: @Tyriar 
