### PR TITLE
Fix "add context" toolbar item slow to appear

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -1476,7 +1476,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this.tryUpdateWidgetController();
 
-		this.renderAttachedContext();
 		this._register(this._attachmentModel.onDidChange((e) => {
 			if (e.added.length > 0) {
 				this._indexOfLastAttachedContextDeletedWithKeyboard = -1;
@@ -1759,6 +1758,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this._onDidChangeHeight.fire();
 			}
 		}));
+		this.renderAttachedContext();
 	}
 
 	public toggleChatInputOverlay(editing: boolean): void {


### PR DESCRIPTION
We did the attachments layout before creating the toolbar, so its container would start hidden, then it wouldn't appear until some other random thing would trigger renderAttachedContext, generally the onDidFileIconThemeChange event which happened after some delay

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
