### PR TITLE
Show sidebar when hovering over activity bar

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -602,6 +602,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.activityBar.location.hide', "Hide the Activity Bar in the Primary and Secondary Side Bars.")
 				],
 			},
+			'workbench.activityBar.hoverTrigger': {
+				'type': 'boolean',
+				'default': false,
+				'description': localize('workbench.activityBar.hoverTrigger', "Controls whether hovering over the Activity Bar opens the Primary Side Bar.")
+			},
 			'workbench.activityBar.iconClickBehavior': {
 				'type': 'string',
 				'enum': ['toggle', 'focus'],


### PR DESCRIPTION
We made a few changes to the original feature request in order to improve the user experience, based on comments on the request as well as research into similar features. While the original request was to automatically hide the file explorer after a certain amount of time, we made the decision to instead automatically show the sidebar on mouse hoover, and have it collapse upon clicking inside the workbench window.