### PR TITLE
Enable skip confirmation on permanent file deletion

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -163,7 +163,7 @@ async function deleteFiles(explorerService: IExplorerService, workingCopyFileSer
 		distinctElements.length > 1 ? nls.localize('restorePlural', "You can restore these files using the Undo command.") : nls.localize('restore', "You can restore this file using the Undo command.");
 
 	// Check if we need to ask for confirmation at all
-	if (skipConfirm || (useTrash && configurationService.getValue<boolean>(CONFIRM_DELETE_SETTING_KEY) === false)) {
+	if (skipConfirm || configurationService.getValue<boolean>(CONFIRM_DELETE_SETTING_KEY) === false) {
 		confirmation = { confirmed: true };
 	}
 

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -483,7 +483,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.confirmDelete': {
 			'type': 'boolean',
-			'description': nls.localize('confirmDelete', "Controls whether the Explorer should ask for confirmation when deleting a file via the trash."),
+			'description': nls.localize('confirmDelete', "Controls whether the Explorer should ask for confirmation when deleting files and folders."),
 			'default': true
 		},
 		'explorer.enableUndo': {


### PR DESCRIPTION
Fixes #265748

We were limiting no-confirm option to `useTrash` scenario only, this change enables it for permanent delete as well. I think it's ok since the confirmation is on by default and permanent delete dialog does not have the check box to "not ask again", so the user has to take an explicit action of setting this option.

If this feels too dangerous, I can change it to add a new setting e.g. `explorer.confirmPermanentDelete` and gate it on that instead.
