### PR TITLE
Support `# pragma` folding markers in C

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -93,8 +93,8 @@
 	"wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
 	"folding": {
 		"markers": {
-			"start": "^\\s*#pragma\\s+region\\b",
-			"end": "^\\s*#pragma\\s+endregion\\b"
+			"start": "^\\s*#\\s*pragma\\s+region\\b",
+			"end": "^\\s*#\\s*pragma\\s+endregion\\b"
 		}
 	},
 	"indentationRules": {


### PR DESCRIPTION
fixes #284917

* #284917

allows whitespace between `#` and `pragma`