### PR TITLE
Fix Ctrl+P text navigation in webview on macOS

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -29,6 +29,9 @@
 			navigator.userAgent.indexOf('Firefox') >= 0
 		);
 
+		const isMacOS = navigator.platform?.toUpperCase().includes('MAC') ||
+			navigator.userAgent?.toUpperCase().includes('MAC');
+
 		const searchParams = new URL(location.toString()).searchParams;
 		const ID = searchParams.get('id');
 		const webviewOrigin = searchParams.get('origin');
@@ -688,6 +691,9 @@
 		 * @return {boolean}
 		 */
 		function isPrint(e) {
+			if (isMacOS && e.ctrlKey && !e.metaKey) {
+				return false;
+			}
 			const hasMeta = e.ctrlKey || e.metaKey;
 			// 80: keyCode of "P"
 			return hasMeta && e.keyCode === 80;


### PR DESCRIPTION
## Summary

Fixes #264957

On macOS, Ctrl+P is a standard emacs-style shortcut for moving to the previous line in text input controls (similar to Ctrl+A for beginning of line, Ctrl+E for end of line, Ctrl+N for next line). Currently, this shortcut is incorrectly suppressed in webviews because the code treats it as the Print command, which is Windows-specific behavior.

## Changes

- Added macOS platform detection using navigator.platform and navigator.userAgent
- Modified the isPrint() function to return false for Ctrl+P on macOS when metaKey is not pressed
- On macOS, Cmd+P continues to correctly trigger the print behavior

## Testing

1. Create a VS Code extension with a webview containing a textarea or contenteditable control
2. Run the extension on macOS
3. Enter multiple lines of text in the control
4. Verify Ctrl+P moves the cursor to the previous line
5. Verify Ctrl+N moves the cursor to the next line
6. Verify Cmd+P still triggers the print/command palette behavior