### PR TITLE
Add inline reference handling for markdown conversion in RunSubagentTool

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/runSubagentTool.ts
@@ -305,7 +305,7 @@ function inlineReferenceToMarkdown(part: IChatContentInlineReference): string {
 	} else {
 		const range = isLocation(reference) ? reference.range : reference.location.range;
 		const uri = isLocation(reference) ? reference.uri : reference.location.uri;
-		const rangeFragment = range ? `${range.startLineNumber},${range.startColumn}` : undefined;
+		const rangeFragment = range ? `L${range.startLineNumber}-L${range.endLineNumber}` : undefined;
 		refUri = rangeFragment ? uri.with({ fragment: rangeFragment }) : uri;
 	}
 	let label: string;


### PR DESCRIPTION
Add inline reference handling for markdown conversion in RunSubagentTool. Fix #282509

CC: @roblourens 