### PR TITLE
Enable "secondary" buttons in all QuickInput locations except Input

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -36,12 +36,12 @@
 }
 
 /* give some space between input and action bar */
-.quick-input-inline-action-bar > .actions-container > .action-item:first-child {
+.quick-input-inline-action-bar .actions-container > .action-item:first-child {
 	margin-left: 5px;
 }
 
 /* center horizontally */
-.quick-input-inline-action-bar > .actions-container > .action-item {
+.quick-input-inline-action-bar .actions-container > .action-item {
 	margin-top: 2px;
 }
 
@@ -59,15 +59,15 @@
 	margin-right: 4px;
 }
 
-.quick-input-right-action-bar > .actions-container {
+.quick-input-right-action-bar .actions-container {
 	justify-content: flex-end;
 }
 
-.quick-input-right-action-bar > .actions-container > .action-item {
+.quick-input-right-action-bar .actions-container > .action-item {
 	margin-left: 4px;
 }
 
-.quick-input-inline-action-bar > .actions-container > .action-item {
+.quick-input-inline-action-bar .actions-container > .action-item {
 	margin-left: 4px;
 }
 

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -5,8 +5,7 @@
 
 import * as dom from '../../../base/browser/dom.js';
 import * as domStylesheetsJs from '../../../base/browser/domStylesheets.js';
-import { ActionBar } from '../../../base/browser/ui/actionbar/actionbar.js';
-import { ActionViewItem } from '../../../base/browser/ui/actionbar/actionViewItems.js';
+import { ToolBar } from '../../../base/browser/ui/toolbar/toolbar.js';
 import { Button } from '../../../base/browser/ui/button/button.js';
 import { CountBadge } from '../../../base/browser/ui/countBadge/countBadge.js';
 import { ProgressBar } from '../../../base/browser/ui/progressbar/progressbar.js';
@@ -23,6 +22,7 @@ import { QuickInputUI, Writeable, IQuickInputStyles, IQuickInputOptions, QuickPi
 import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
+import { IContextMenuService } from '../../contextview/browser/contextView.js';
 import { QuickInputList } from './quickInputList.js';
 import { IContextKey, IContextKeyService } from '../../contextkey/common/contextkey.js';
 import './quickInputActions.js';
@@ -88,7 +88,8 @@ export class QuickInputController extends Disposable {
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IStorageService private readonly storageService: IStorageService
+		@IStorageService private readonly storageService: IStorageService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService
 	) {
 		super();
 
@@ -146,19 +147,23 @@ export class QuickInputController extends Disposable {
 
 		const titleBar = dom.append(container, $('.quick-input-titlebar'));
 
-		const leftActionBar = this._register(new ActionBar(titleBar, {
+		const leftActionBar = this._register(new ToolBar(titleBar, this.contextMenuService, {
 			hoverDelegate: this.options.hoverDelegate,
-			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle)
+			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle),
+			icon: true,
+			label: false
 		}));
-		leftActionBar.domNode.classList.add('quick-input-left-action-bar');
+		leftActionBar.getElement().classList.add('quick-input-left-action-bar');
 
 		const title = dom.append(titleBar, $('.quick-input-title'));
 
-		const rightActionBar = this._register(new ActionBar(titleBar, {
+		const rightActionBar = this._register(new ToolBar(titleBar, this.contextMenuService, {
 			hoverDelegate: this.options.hoverDelegate,
-			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle)
+			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle),
+			icon: true,
+			label: false
 		}));
-		rightActionBar.domNode.classList.add('quick-input-right-action-bar');
+		rightActionBar.getElement().classList.add('quick-input-right-action-bar');
 
 		const headerContainer = dom.append(container, $('.quick-input-header'));
 
@@ -190,11 +195,13 @@ export class QuickInputController extends Disposable {
 		countContainer.setAttribute('aria-live', 'polite');
 		const count = this._register(new CountBadge(countContainer, { countFormat: localize({ key: 'quickInput.countSelected', comment: ['This tells the user how many items are selected in a list of items to select from. The items can be anything.'] }, "{0} Selected") }, this.styles.countBadge));
 
-		const inlineActionBar = this._register(new ActionBar(headerContainer, {
+		const inlineActionBar = this._register(new ToolBar(headerContainer, this.contextMenuService, {
 			hoverDelegate: this.options.hoverDelegate,
-			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle)
+			actionViewItemProvider: createToggleActionViewItemProvider(this.styles.toggle),
+			icon: true,
+			label: false
 		}));
-		inlineActionBar.domNode.classList.add('quick-input-inline-action-bar');
+		inlineActionBar.getElement().classList.add('quick-input-inline-action-bar');
 
 		const okContainer = dom.append(headerContainer, $('.quick-input-action'));
 		const ok = this._register(new Button(okContainer, this.styles.button));
@@ -349,7 +356,7 @@ export class QuickInputController extends Disposable {
 				{
 					node: titleBar,
 					includeChildren: true,
-					excludeNodes: [leftActionBar.domNode, rightActionBar.domNode]
+					excludeNodes: [leftActionBar.getElement(), rightActionBar.getElement()]
 				},
 				{
 					node: headerContainer,
@@ -660,13 +667,13 @@ export class QuickInputController extends Disposable {
 		oldController?.didHide();
 
 		this.setEnabled(true);
-		ui.leftActionBar.clear();
+		ui.leftActionBar.setActions([]);
 		ui.title.textContent = '';
 		ui.description1.textContent = '';
 		ui.description2.textContent = '';
 		dom.reset(ui.widget);
-		ui.rightActionBar.clear();
-		ui.inlineActionBar.clear();
+		ui.rightActionBar.setActions([]);
+		ui.inlineActionBar.setActions([]);
 		ui.checkAll.checked = false;
 		// ui.inputBox.value = ''; Avoid triggering an event.
 		ui.inputBox.placeholder = '';
@@ -731,11 +738,17 @@ export class QuickInputController extends Disposable {
 		if (enabled !== this.enabled) {
 			this.enabled = enabled;
 			const ui = this.getUI();
-			for (const item of ui.leftActionBar.viewItems) {
-				(item as ActionViewItem).action.enabled = enabled;
+			for (let i = 0; i < ui.leftActionBar.getItemsLength(); i++) {
+				const action = ui.leftActionBar.getItemAction(i);
+				if (action) {
+					action.enabled = enabled;
+				}
 			}
-			for (const item of ui.rightActionBar.viewItems) {
-				(item as ActionViewItem).action.enabled = enabled;
+			for (let i = 0; i < ui.rightActionBar.getItemsLength(); i++) {
+				const action = ui.rightActionBar.getItemAction(i);
+				if (action) {
+					action.enabled = enabled;
+				}
 			}
 			if (enabled) {
 				ui.checkAll.enable();

--- a/src/vs/platform/quickinput/browser/quickInputUtils.ts
+++ b/src/vs/platform/quickinput/browser/quickInputUtils.ts
@@ -53,7 +53,7 @@ class QuickInputToggleButtonAction implements IAction {
 		className: string | undefined,
 		public enabled: boolean,
 		private _checked: boolean,
-		public run: () => unknown
+		private _run: () => unknown
 	) {
 		this.class = className;
 	}
@@ -65,7 +65,12 @@ class QuickInputToggleButtonAction implements IAction {
 	set checked(value: boolean) {
 		this._checked = value;
 		// Toggles behave like buttons. When clicked, they run... the only difference is that their checked state also changes.
-		this.run();
+		this._run();
+	}
+
+	run() {
+		this._checked = !this._checked;
+		return this._run();
 	}
 }
 
@@ -102,6 +107,35 @@ export function quickInputButtonToAction(button: IQuickInputButton, id: string, 
 		};
 
 	return action;
+}
+
+export function quickInputButtonsToActionArrays(
+	buttons: readonly IQuickInputButton[],
+	idPrefix: string,
+	onTrigger: (button: IQuickInputButton) => unknown
+): { primary: IAction[]; secondary: IAction[] } {
+	const primary: IAction[] = [];
+	const secondary: IAction[] = [];
+
+	buttons.forEach((button, index) => {
+		const action = quickInputButtonToAction(
+			button,
+			`${idPrefix}-${index}`,
+			async () => onTrigger(button)
+		);
+
+		if (button.label) {
+			action.label = button.label;
+		}
+
+		if (button.secondary) {
+			secondary.push(action);
+		} else {
+			primary.push(action);
+		}
+	});
+
+	return { primary, secondary };
 }
 
 export function renderQuickInputDescription(description: string, container: HTMLElement, actionHandler: { callback: (content: string) => void; disposables: DisposableStore }) {

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -819,6 +819,16 @@ export interface IQuickInputButton {
 	 * when the button is clicked.
 	 */
 	readonly toggle?: { checked: boolean };
+	/**
+	 * Optional label for the button. When used with secondary actions, this label appears in the overflow menu.
+	 */
+	label?: string;
+	/**
+	 * When true, the button will be rendered as a secondary action in the toolbar overflow menu.
+	 * By default, buttons are rendered as primary actions.
+	 * @note This does not currently apply to buttons in the Input location
+	 */
+	secondary?: boolean;
 }
 
 export interface IQuickInputButtonWithToggle extends IQuickInputButton {

--- a/src/vs/platform/quickinput/test/browser/quickInputUtils.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickInputUtils.test.ts
@@ -1,0 +1,266 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../base/common/uri.js';
+import { IQuickInputButton } from '../../common/quickInput.js';
+import { quickInputButtonToAction, quickInputButtonsToActionArrays } from '../../browser/quickInputUtils.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+
+suite('QuickInputUtils', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('quickInputButtonToAction', () => {
+		test('should convert simple button to action', () => {
+			const button: IQuickInputButton = {
+				iconPath: { dark: URI.file('/path/to/icon.svg') },
+				tooltip: 'Test Tooltip'
+			};
+
+			let runCalled = false;
+			const action = quickInputButtonToAction(button, 'test-id', () => {
+				runCalled = true;
+			});
+
+			assert.strictEqual(action.id, 'test-id');
+			assert.strictEqual(action.tooltip, 'Test Tooltip');
+			assert.strictEqual(action.enabled, true);
+			assert.ok(action.class);
+
+			action.run();
+			assert.strictEqual(runCalled, true);
+		});
+
+		test('should handle button with iconClass', () => {
+			const button: IQuickInputButton = {
+				iconClass: 'custom-icon-class',
+				tooltip: 'Test'
+			};
+
+			const action = quickInputButtonToAction(button, 'test-id', () => { });
+
+			assert.ok(action.class?.includes('custom-icon-class'));
+		});
+
+		test('should handle alwaysVisible button', () => {
+			const button: IQuickInputButton = {
+				iconClass: 'icon-class',
+				tooltip: 'Test',
+				alwaysVisible: true
+			};
+
+			const action = quickInputButtonToAction(button, 'test-id', () => { });
+
+			assert.ok(action.class?.includes('always-visible'));
+			assert.ok(action.class?.includes('icon-class'));
+		});
+
+		test('should handle alwaysVisible without iconClass', () => {
+			const button: IQuickInputButton = {
+				tooltip: 'Test',
+				alwaysVisible: true
+			};
+
+			const action = quickInputButtonToAction(button, 'test-id', () => { });
+
+			assert.strictEqual(action.class, 'always-visible');
+		});
+
+		test('should handle toggle button', () => {
+			const toggle = {
+				checked: false
+			};
+			const button: IQuickInputButton = {
+				iconClass: 'toggle-icon',
+				tooltip: 'Toggle Test',
+				toggle
+			};
+
+			let runCalled = false;
+			const action = quickInputButtonToAction(button, 'toggle-id', () => {
+				runCalled = true;
+			});
+
+			assert.strictEqual(action.id, 'toggle-id');
+			// For toggle buttons, tooltip is used as label
+			assert.strictEqual(action.label, 'Toggle Test');
+			assert.strictEqual(action.tooltip, '');
+			assert.notStrictEqual(action.checked, undefined);
+
+			// Initial state
+			assert.strictEqual(action.checked, false);
+			assert.strictEqual(toggle.checked, false);
+
+			// Run the action
+			action.run();
+			assert.strictEqual(runCalled, true);
+
+			// Toggle state should be flipped
+			assert.strictEqual(action.checked, true);
+			assert.strictEqual(toggle.checked, true);
+		});
+
+		test('should handle toggle button with initial checked state', () => {
+			const toggle = {
+				checked: true
+			};
+			const button: IQuickInputButton = {
+				iconClass: 'toggle-icon',
+				tooltip: 'Toggle Test',
+				toggle
+			};
+
+			const action = quickInputButtonToAction(button, 'toggle-id', () => { });
+
+			assert.strictEqual(action.checked, true);
+			assert.strictEqual(toggle.checked, true);
+
+			// Run should flip the state
+			action.run();
+
+			assert.strictEqual(action.checked, false);
+			assert.strictEqual(toggle.checked, false);
+		});
+
+		test('should use empty string for tooltip when not provided', () => {
+			const button: IQuickInputButton = {
+				iconClass: 'icon'
+			};
+
+			const action = quickInputButtonToAction(button, 'test-id', () => { });
+
+			assert.strictEqual(action.tooltip, '');
+		});
+
+		test('should handle button with label', () => {
+			const button: IQuickInputButton = {
+				iconClass: 'icon',
+				tooltip: 'Test',
+				label: 'Button Label'
+			};
+
+			const action = quickInputButtonToAction(button, 'test-id', () => { });
+
+			// The label property exists on the button but the action's label is initially empty
+			assert.strictEqual(action.label, '');
+		});
+	});
+
+	suite('quickInputButtonsToActionArrays', () => {
+		test('should convert empty array', () => {
+			const buttons: IQuickInputButton[] = [];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'prefix', () => { });
+
+			assert.strictEqual(result.primary.length, 0);
+			assert.strictEqual(result.secondary.length, 0);
+		});
+
+		test('should convert primary buttons', () => {
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Button 1' },
+				{ iconClass: 'icon2', tooltip: 'Button 2' }
+			];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'test', () => { });
+
+			assert.strictEqual(result.primary.length, 2);
+			assert.strictEqual(result.secondary.length, 0);
+			assert.strictEqual(result.primary[0].id, 'test-0');
+			assert.strictEqual(result.primary[1].id, 'test-1');
+		});
+
+		test('should convert secondary buttons', () => {
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Button 1', secondary: true },
+				{ iconClass: 'icon2', tooltip: 'Button 2', secondary: true }
+			];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'test', () => { });
+
+			assert.strictEqual(result.primary.length, 0);
+			assert.strictEqual(result.secondary.length, 2);
+			assert.strictEqual(result.secondary[0].id, 'test-0');
+			assert.strictEqual(result.secondary[1].id, 'test-1');
+		});
+
+		test('should convert mixed primary and secondary buttons', () => {
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Primary 1' },
+				{ iconClass: 'icon2', tooltip: 'Secondary 1', secondary: true },
+				{ iconClass: 'icon3', tooltip: 'Primary 2' },
+				{ iconClass: 'icon4', tooltip: 'Secondary 2', secondary: true }
+			];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'test', () => { });
+
+			assert.strictEqual(result.primary.length, 2);
+			assert.strictEqual(result.secondary.length, 2);
+			assert.strictEqual(result.primary[0].id, 'test-0');
+			assert.strictEqual(result.primary[1].id, 'test-2');
+			assert.strictEqual(result.secondary[0].id, 'test-1');
+			assert.strictEqual(result.secondary[1].id, 'test-3');
+		});
+
+		test('should apply label to actions', () => {
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Button 1', label: 'Label 1' },
+				{ iconClass: 'icon2', tooltip: 'Button 2' }
+			];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'test', () => { });
+
+			assert.strictEqual(result.primary[0].label, 'Label 1');
+			assert.strictEqual(result.primary[1].label, '');
+		});
+
+		test('should trigger callback with correct button', () => {
+			const button1: IQuickInputButton = { iconClass: 'icon1', tooltip: 'Button 1' };
+			const button2: IQuickInputButton = { iconClass: 'icon2', tooltip: 'Button 2' };
+			const buttons = [button1, button2];
+
+			const triggeredButtons: IQuickInputButton[] = [];
+			const result = quickInputButtonsToActionArrays(buttons, 'test', (button) => {
+				triggeredButtons.push(button);
+			});
+
+			result.primary[0].run();
+			assert.strictEqual(triggeredButtons.length, 1);
+			assert.strictEqual(triggeredButtons[0], button1);
+
+			result.primary[1].run();
+			assert.strictEqual(triggeredButtons.length, 2);
+			assert.strictEqual(triggeredButtons[1], button2);
+		});
+
+		test('should handle toggle buttons in arrays', () => {
+			const toggle = { checked: false };
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Toggle', toggle },
+				{ iconClass: 'icon2', tooltip: 'Regular' }
+			];
+
+			const result = quickInputButtonsToActionArrays(buttons, 'test', () => { });
+
+			const toggleAction = result.primary[0];
+			assert.strictEqual(toggleAction.checked, false);
+			toggleAction.run();
+			assert.strictEqual(toggleAction.checked, true);
+			assert.strictEqual(toggle.checked, true);
+		});
+
+		test('should use correct id prefix', () => {
+			const buttons: IQuickInputButton[] = [
+				{ iconClass: 'icon1', tooltip: 'Button 1' }
+			];
+
+			const result1 = quickInputButtonsToActionArrays(buttons, 'custom-prefix', () => { });
+			assert.strictEqual(result1.primary[0].id, 'custom-prefix-0');
+
+			const result2 = quickInputButtonsToActionArrays(buttons, 'another', () => { });
+			assert.strictEqual(result2.primary[0].id, 'another-0');
+		});
+	});
+});


### PR DESCRIPTION
<img width="747" height="193" alt="Image" src="https://github.com/user-attachments/assets/41e2edc9-37a1-48cc-bdd4-e1b671f5b6f6" />

Input is a bit of a beast because of plumbing so I'm saving that for later.

This does two major things:
* replaces ActionBar usage with ToolBar (minus a few property renames I'm saving for another PR so this one isn't so big)
* Adds a `label` and `secondary` property to QuickInputButtons to allow the overflow for particular buttons

Fixes https://github.com/microsoft/vscode/issues/285213 (mostly, will create a new issue for input location when this goes in)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
