### PR TITLE
decorationsEnabled takes space even when set to never (#285320)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -134,6 +134,11 @@ export class TerminalViewPane extends ViewPane {
 
 	private _updateForShellIntegration(container: HTMLElement) {
 		container.classList.toggle('shell-integration', this._gutterDecorationsEnabled());
+
+		const decorationsEnabled = this._configurationService.getValue(TerminalSettingId.ShellIntegrationDecorationsEnabled);
+		if (decorationsEnabled === 'never') {
+			container.style.paddingLeft = '0px';
+		}
 	}
 
 	private _gutterDecorationsEnabled(): boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


I have not tested this, unfortunetly I got some issues on my machine. Could someone test it, how to reproduce stuff is written in #285323.