### PR TITLE
Move checkbox toggling to a command & support space bar toggling in Quick Tree

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputActions.ts
+++ b/src/vs/platform/quickinput/browser/quickInputActions.ts
@@ -255,6 +255,21 @@ registerQuickInputCommandAndKeybindingRule(
 
 //#endregion
 
+//#region Toggle Checkbox
+
+registerQuickPickCommandAndKeybindingRule(
+	{
+		id: 'quickInput.toggleCheckbox',
+		primary: KeyCode.Space,
+		handler: accessor => {
+			const quickInputService = accessor.get(IQuickInputService);
+			quickInputService.toggle();
+		}
+	}
+);
+
+//#endregion
+
 //#region Toggle Hover
 
 registerQuickPickCommandAndKeybindingRule(

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -802,8 +802,13 @@ export class QuickInputController extends Disposable {
 	}
 
 	toggle() {
-		if (this.isVisible() && this.controller instanceof QuickPick && this.controller.canSelectMany) {
+		if (!this.isVisible()) {
+			return;
+		}
+		if (this.controller instanceof QuickPick && this.controller.canSelectMany) {
 			this.getUI().list.toggleCheckbox();
+		} else if (this.controller instanceof QuickTree) {
+			this.getUI().tree.toggleCheckbox();
 		}
 	}
 

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -27,7 +27,6 @@ import { Emitter, Event, EventBufferer, IValueWithChangeEvent } from '../../../b
 import { IMatch } from '../../../base/common/filters.js';
 import { IMarkdownString } from '../../../base/common/htmlContent.js';
 import { IParsedLabelWithIcons, getCodiconAriaLabel, matchesFuzzyIconAware, parseLabelWithIcons } from '../../../base/common/iconLabels.js';
-import { KeyCode } from '../../../base/common/keyCodes.js';
 import { Lazy } from '../../../base/common/lazy.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { observableValue, observableValueOpts, transaction } from '../../../base/common/observable.js';
@@ -902,7 +901,6 @@ export class QuickInputList extends Disposable {
 	//#region register listeners
 
 	private _registerListeners() {
-		this._registerOnKeyDown();
 		this._registerOnContainerClick();
 		this._registerOnMouseMiddleClick();
 		this._registerOnTreeModelChanged();
@@ -911,20 +909,6 @@ export class QuickInputList extends Disposable {
 		this._registerHoverListeners();
 		this._registerSelectionChangeListener();
 		this._registerSeparatorActionShowingListeners();
-	}
-
-	private _registerOnKeyDown() {
-		// TODO: Should this be added at a higher level?
-		this._register(this._tree.onKeyDown(e => {
-			const event = new StandardKeyboardEvent(e);
-			switch (event.keyCode) {
-				case KeyCode.Space:
-					this.toggleCheckbox();
-					break;
-			}
-
-			this._onKeyDown.fire(event);
-		}));
 	}
 
 	private _registerOnContainerClick() {

--- a/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
@@ -379,7 +379,7 @@ export class QuickInputTreeController extends Disposable {
 
 	toggleCheckbox() {
 		for (const element of this.getActiveItems()) {
-			if (element.pickable !== false) {
+			if (element.pickable !== false && !element.disabled) {
 				this.updateCheckboxState(element, !(element.checked === true));
 			}
 		}

--- a/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
@@ -377,12 +377,12 @@ export class QuickInputTreeController extends Disposable {
 		return this._tree.getFocus().filter((item): item is IQuickTreeItem => item !== null);
 	}
 
-	check(element: IQuickTreeItem, checked: boolean | 'mixed') {
-		if (element.checked === checked) {
-			return;
+	toggleCheckbox() {
+		for (const element of this.getActiveItems()) {
+			if (element.pickable !== false) {
+				this.updateCheckboxState(element, !(element.checked === true));
+			}
 		}
-		element.checked = checked;
-		this._onDidCheckedLeafItemsChange.fire(this.getCheckedLeafItems());
 	}
 
 	checkAll(checked: boolean | 'mixed') {

--- a/src/vs/platform/quickinput/browser/tree/quickTree.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickTree.ts
@@ -91,9 +91,6 @@ export class QuickTree<T extends IQuickTreeItem> extends QuickInput implements I
 		return this.ui.tree.tree.getParentElement(element) as T ?? undefined;
 	}
 
-	setCheckboxState(element: T, checked: boolean | 'mixed'): void {
-		this.ui.tree.check(element, checked);
-	}
 	expand(element: T): void {
 		this.ui.tree.tree.expand(element);
 	}

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -1139,13 +1139,6 @@ export interface IQuickTree<T extends IQuickTreeItem> extends IQuickInput {
 	setItemTree(itemTree: T[]): void;
 
 	/**
-	 * Sets the checkbox state of an item.
-	 * @param element The item to update.
-	 * @param checked The new checkbox state.
-	 */
-	setCheckboxState(element: T, checked: boolean | 'mixed'): void;
-
-	/**
 	 * Expands an item.
 	 * @param element The item to expand.
 	 */


### PR DESCRIPTION
also cleans up an api on quick tree that wasn't used.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
