### PR TITLE
fix: Correct typo 'occured' to 'occurred' in parcelWatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "name": "Microsoft Corporation"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
   "main": "./out/main.js",
   "type": "module",
   "private": true,

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -169,8 +169,8 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// Parcel internally uses 50ms as delay, so we use 75ms,
 	// to schedule sufficiently after Parcel.
 	//
-	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+		// Note: since Parcel 2.0.7, the very first event is
+		// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//


### PR DESCRIPTION
Simple typo fix in comment.