### PR TITLE
feat: improve fuzzy scoring for exact substring matches

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -797,8 +797,7 @@ export function fuzzyScore(pattern: string, patternLow: string, patternStart: nu
 	// Add 1 penalty for each skipped character in the word only if
 	// the pattern doesn't exist as a contiguous substring within the word
 	const skippedCharsCount = maxMatchColumn - patternLen;
-	const subPattern = patternLow.substring(patternStart, patternLen);
-	if (wordLow.indexOf(subPattern, wordStart) === -1) {
+	if (wordLow.indexOf(patternLow, wordStart) === -1) {
 		result[0] -= skippedCharsCount;
 	}
 

--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -794,9 +794,13 @@ export function fuzzyScore(pattern: string, patternLow: string, patternStart: nu
 		result[0] += 2;
 	}
 
-	// Add 1 penalty for each skipped character in the word
+	// Add 1 penalty for each skipped character in the word only if
+	// the pattern doesn't exist as a contiguous substring within the word
 	const skippedCharsCount = maxMatchColumn - patternLen;
-	result[0] -= skippedCharsCount;
+	const subPattern = patternLow.substring(patternStart, patternLen);
+	if (wordLow.indexOf(subPattern, wordStart) === -1) {
+		result[0] -= skippedCharsCount;
+	}
 
 	return result;
 }

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -631,4 +631,8 @@ suite('Filters', () => {
 		assertMatches('i', 'machine/{id}', 'machine/{^id}', fuzzyScore);
 		assertMatches('ok', 'obobobf{ok}/user', '^obobobf{o^k}/user', fuzzyScore);
 	});
+
+	test('Exact substring match should score higher than fuzzy match #285449', function () {
+		assertTopScore(fuzzyScore, 'joint', 1, 'john.is.not.here', 'he.has.a.joint.account');
+	});
 });


### PR DESCRIPTION
Fixes #284229

Previously, the fuzzy scoring algorithm applied a penalty for every character skipped before the match started. This caused exact substring matches that appeared deep within a long string (e.g., matching "joint" in "github.copilot.chat.advanced.inlineEdits.jointCompletionsProvider") to be ranked lower than weaker fuzzy matches that appeared earlier (e.g., "json.maxItemsComputed").

This change modifies `fuzzyScore` to skip this penalty if the search pattern exists as a contiguous substring within the target word. 
