### PR TITLE
feat(chat): Allow resizing the Chat Sessions list width in 'Side by Side' orientation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatViewPane.css
@@ -8,6 +8,15 @@
 	display: flex;
 	flex-direction: column;
 
+	.chat-controls-wrapper {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		height: 100%;
+		min-height: 0;
+		min-width: 0;
+	}
+
 	.chat-controls-container {
 		display: flex;
 		flex-direction: column;
@@ -101,6 +110,11 @@
 	.agent-sessions-container {
 		border-bottom: 1px solid var(--vscode-panel-border);
 	}
+
+	/* Hide sash in stacked mode */
+	.agent-sessions-sash {
+		display: none;
+	}
 }
 
 /* Sessions control: side by side */
@@ -110,7 +124,20 @@
 		flex-direction: row;
 
 		.agent-sessions-container {
+			border-right: none; /* border handled by sash */
+			position: relative;
+			flex-shrink: 0;
+		}
+
+		.agent-sessions-sash {
+			right: 0;
+			cursor: ew-resize;
 			border-right: 1px solid var(--vscode-panel-border);
+		}
+
+		.agent-sessions-sash:hover,
+		.agent-sessions-sash.active {
+			border-right-color: var(--vscode-sash-hoverBorder);
 		}
 	}
 
@@ -118,8 +145,35 @@
 		flex-direction: row-reverse;
 
 		.agent-sessions-container {
+			border-left: none; /* border handled by sash */
+			position: relative;
+			flex-shrink: 0;
+		}
+
+		.agent-sessions-sash {
+			left: 0;
+			cursor: ew-resize;
 			border-left: 1px solid var(--vscode-panel-border);
 		}
+
+		.agent-sessions-sash:hover,
+		.agent-sessions-sash.active {
+			border-left-color: var(--vscode-sash-hoverBorder);
+		}
+	}
+
+	.agent-sessions-container {
+		height: 100%;
+		overflow: hidden;
+	}
+
+	.agent-sessions-sash {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 4px;
+		z-index: 10;
+		transition: border-color 0.1s ease-out;
 	}
 
 	.agent-sessions-link-container {


### PR DESCRIPTION
Fixes #285418
Fixes #281258

## Summary

This PR adds the ability to resize the Chat Sessions sidebar when using the "Side by Side" orientation.

## Changes

- Added a resize sash to the sessions sidebar container
- Implemented drag-to-resize functionality with min (150px) and max (600px) constraints
- Sidebar width is persisted in user profile storage (`chat.sessionsPanel.width`)
- Double-click on the sash resets the width to default (300px)
- Sash is hidden in stacked orientation mode
- Works correctly for both left and right panel positions

## Testing

1. Open Copilot Chat view
2. Enable "Side by Side" orientation in chat settings
3. Hover over the border between sessions list and chat area
4. Drag to resize the sessions sidebar
5. Verify the width is persisted after reloading

## Demo

https://github.com/user-attachments/assets/53d77270-a22e-4015-8ad7-3ae6516d484b