### PR TITLE
Separate 'as' keyword into its own scope keyword.control.as.php

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -982,8 +982,12 @@
 			"name": "keyword.operator.arithmetic.php"
 		},
 		{
-			"match": "(?i)(!|&&|\\|\\|)|\\b(and|or|xor|as)\\b",
+			"match": "(?i)(!|&&|\\|\\|)|\\b(and|or|xor)\\b",
 			"name": "keyword.operator.logical.php"
+		},
+		{ 
+		  "match": "(?i)\\bas\\b", 
+		  "name": "keyword.control.as.php" 
 		},
 		{
 			"include": "#function-call"


### PR DESCRIPTION
This pull request updates the PHP TextMate grammar to assign the as keyword to a dedicated scope (keyword.control.as.php) instead of grouping it under keyword.operator.logical.php.

Motivation  
Currently, as is highlighted as a logical operator together with and, or, xor, and !. In PHP, however, as is not an operator—it is a control keyword used in contexts such as foreach, catch, use ... as, and list(). Treating it as a control keyword improves semantic accuracy and consistency in syntax highlighting.

Changes

Removed as from the logical operator rule.
Added a new rule to match as and assign it to keyword.control.as.php.

Impact
```
foreach ($arr as $val) → as highlighted as keyword.control.as.php.

catch (Exception as $e) → as highlighted as keyword.control.as.php.
```

Benefits  
This change improves clarity for developers working with PHP in VS Code by aligning syntax highlighting with the actual semantics of the language. It also makes it easier for theme authors to style as consistently with other control keywords.
