### PR TITLE
fix: model name overflows out of bounds of the chat window

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -223,7 +223,6 @@
 	height: 22px;
 }
 
-
 /* Show toolbar on hover and last response. Also show when the item has keyboard focus (focus-within) or when the surrounding list row is marked focused (monaco list keyboard navigation). */
 .interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar,
 .interactive-item-container.interactive-response.chat-most-recent-response:not(.chat-response-loading) .chat-footer-toolbar,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -223,11 +223,6 @@
 	height: 22px;
 }
 
-.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
 
 /* Show toolbar on hover and last response. Also show when the item has keyboard focus (focus-within) or when the surrounding list row is marked focused (monaco list keyboard navigation). */
 .interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar,
@@ -256,6 +251,9 @@
 	color: var(--vscode-descriptionForeground);
 	line-height: 16px;
 	margin-left: auto;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .interactive-item-container .chat-footer-details.hidden {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -25,13 +25,7 @@
 	--vscode-chat-font-size-body-xxl: 1.538em;
 }
 
-.interactive-list
-	> .monaco-list
-	> .monaco-scrollable-element
-	> .monaco-list-rows
-	> .monaco-list-row
-	> .monaco-tl-row
-	> .monaco-tl-twistie {
+.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row > .monaco-tl-row > .monaco-tl-twistie {
 	/* Hide twisties from chat tree rows, but not from nested trees within a chat response */
 	display: none !important;
 }
@@ -86,11 +80,7 @@
 	overflow: hidden;
 }
 
-.interactive-item-container
-	.detail-container
-	.detail
-	.agentOrSlashCommandDetected
-	A {
+.interactive-item-container .detail-container .detail .agentOrSlashCommandDetected A {
 	cursor: pointer;
 	color: var(--vscode-textLink-foreground);
 }
@@ -127,7 +117,7 @@
 }
 
 .interactive-item-container .chat-animated-ellipsis::after {
-	content: "";
+	content: '';
 	white-space: nowrap;
 	overflow: hidden;
 	width: 3em;
@@ -170,37 +160,17 @@
 	font-size: 14px;
 }
 
-.monaco-list-row:not(.focused)
-	.interactive-item-container:not(:hover)
-	.header
-	.monaco-toolbar,
-.monaco-list:not(:focus-within)
-	.monaco-list-row
-	.interactive-item-container:not(:hover)
-	.header
-	.monaco-toolbar,
-.monaco-list-row:not(.focused)
-	.interactive-item-container:not(:hover)
-	.header
-	.monaco-toolbar
-	.action-label,
-.monaco-list:not(:focus-within)
-	.monaco-list-row
-	.interactive-item-container:not(:hover)
-	.header
-	.monaco-toolbar
-	.action-label {
+.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar,
+.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar,
+.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label,
+.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label {
 	/* Also apply this rule to the .action-label directly to work around a strange issue- when the
 	toolbar is hidden without that second rule, tabbing from the list container into a list item doesn't work
 	and the tab key doesn't do anything. */
 	display: none;
 }
 
-.interactive-item-container
-	.header
-	.monaco-toolbar
-	.monaco-action-bar
-	.actions-container {
+.interactive-item-container .header .monaco-toolbar .monaco-action-bar .actions-container {
 	gap: 4px;
 }
 
@@ -228,10 +198,7 @@
 	display: none !important;
 }
 
-.interactive-item-container
-	.chat-footer-toolbar
-	.monaco-action-bar
-	.actions-container {
+.interactive-item-container .chat-footer-toolbar .monaco-action-bar .actions-container {
 	gap: 4px;
 }
 
@@ -246,11 +213,8 @@
 	min-height: var(--chat-current-response-min-height);
 }
 
-.interactive-item-container.interactive-response:not(.chat-response-loading)
-	.chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(.chat-response-loading)
-	.chat-footer-toolbar
-	.chat-footer-details {
+.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
 	/* Complete response only */
 	display: block;
 	opacity: 0;
@@ -263,35 +227,13 @@
 }
 
 /* Show toolbar on hover and last response. Also show when the item has keyboard focus (focus-within) or when the surrounding list row is marked focused (monaco list keyboard navigation). */
-.interactive-item-container.interactive-response:not(
-		.chat-response-loading
-	):hover
-	.chat-footer-toolbar,
-.interactive-item-container.interactive-response.chat-most-recent-response:not(
-		.chat-response-loading
-	)
-	.chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(
-		.chat-response-loading
-	):hover
-	.chat-footer-toolbar
-	.chat-footer-details,
-.interactive-item-container.interactive-response:not(
-		.chat-response-loading
-	):focus-within
-	.chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(
-		.chat-response-loading
-	):focus-within
-	.chat-footer-toolbar
-	.chat-footer-details,
-.monaco-list-row.focused
-	.interactive-item-container.interactive-response:not(.chat-response-loading)
-	.chat-footer-toolbar,
-.monaco-list-row.focused
-	.interactive-item-container.interactive-response:not(.chat-response-loading)
-	.chat-footer-toolbar
-	.chat-footer-details {
+.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar,
+.interactive-item-container.interactive-response.chat-most-recent-response:not(.chat-response-loading) .chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar .chat-footer-details,
+.interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar .chat-footer-details,
+.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar,
+.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
 	opacity: 1;
 	visibility: visible;
 }
@@ -325,9 +267,7 @@
 	margin-bottom: 8px;
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown:not(:has(.chat-extensions-content-part)) {
+.interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {
 	.codicon {
 		font-size: inherit;
 	}
@@ -367,11 +307,7 @@
 	color: var(--vscode-textLink-foreground);
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown
-	.chat-extensions-content-part
-	a {
+.interactive-item-container .value .rendered-markdown .chat-extensions-content-part a {
 	color: inherit;
 }
 
@@ -407,14 +343,8 @@
 }
 
 .interactive-item-container .value > :last-child,
-.interactive-item-container
-	.value
-	> :last-child.rendered-markdown
-	> :last-child,
-.interactive-item-container.interactive-request
-	.value
-	.rendered-markdown
-	> :last-child {
+.interactive-item-container .value > :last-child.rendered-markdown > :last-child,
+.interactive-item-container.interactive-request .value .rendered-markdown > :last-child {
 	margin-bottom: 0px;
 }
 
@@ -431,6 +361,7 @@
 	font-weight: 600;
 	margin: 16px 0 8px 0;
 	font-family: var(--vscode-chat-font-family, inherit);
+
 }
 
 .interactive-item-container .value .rendered-markdown h2 {
@@ -447,10 +378,7 @@
 	font-family: var(--vscode-chat-font-family, inherit);
 }
 
-.interactive-item-container.editing-session
-	.value
-	.rendered-markdown
-	p:has(+ [data-code] > .chat-codeblock-pill-widget) {
+.interactive-item-container.editing-session .value .rendered-markdown p:has(+ [data-code] > .chat-codeblock-pill-widget) {
 	margin-bottom: 8px;
 }
 
@@ -461,10 +389,7 @@
 }
 
 /* Codicons next to text need to be aligned with the text */
-.interactive-item-container
-	.value
-	.rendered-markdown:not(:has(.chat-extensions-content-part))
-	.codicon {
+.interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) .codicon {
 	position: relative;
 	top: 2px;
 }
@@ -483,22 +408,18 @@
 	/* Code blocks at the beginning of an answer should not have a margin as it means it won't align with the agent icon*/
 	> div[data-code]:first-child {
 		margin-top: 0;
+
 	}
 
 	/* Override the top to avoid the toolbar getting clipped by overflow:hidden */
-	> div[data-code]:first-child
-		.interactive-result-code-block
-		.interactive-result-code-block-toolbar
-		> .monaco-action-bar,
-	> div[data-code]:first-child
-		.interactive-result-code-block
-		.interactive-result-code-block-toolbar
-		> .monaco-toolbar {
+	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar,
+	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
 		top: 6px;
 	}
 }
 
 .interactive-item-container .value.inline-progress {
+
 	.rendered-markdown {
 		display: inline-flex;
 	}
@@ -510,7 +431,7 @@
 	}
 
 	.rendered-markdown:last-of-type > P > SPAN:empty::after {
-		content: "";
+		content: '';
 		white-space: nowrap;
 		overflow: hidden;
 		width: 3em;
@@ -561,18 +482,8 @@
 
 		.message-wrapper {
 			/* This mask fades out the end of the second line of text so the "see more" message can be displayed over it. */
-			mask-image: linear-gradient(
-					to right,
-					rgba(0, 0, 0, 1) calc(100% - 95px),
-					rgba(0, 0, 0, 0) calc(100% - 72px)
-				),
-				linear-gradient(
-					to top,
-					rgba(0, 0, 0, 0) 0%,
-					rgba(0, 0, 0, 0) 20px,
-					rgba(0, 0, 0, 1) 2px,
-					rgba(0, 0, 0, 1) 100%
-				);
+			mask-image:
+				linear-gradient(to right, rgba(0, 0, 0, 1) calc(100% - 95px), rgba(0, 0, 0, 0) calc(100% - 72px)), linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 20px, rgba(0, 0, 0, 1) 2px, rgba(0, 0, 0, 1) 100%);
 			mask-repeat: no-repeat, no-repeat;
 			pointer-events: none;
 			max-height: 40px;
@@ -681,52 +592,24 @@
 
 /* NOTE- We want to dedent codeblocks in lists specifically to give them the full width. No more elegant way to do this, these values
 have to be updated for changes to the rules above, or to support more deeply nested lists. */
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ul
-	.interactive-result-code-block {
+.interactive-item-container .value .rendered-markdown ul .interactive-result-code-block {
 	margin-left: -24px;
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ul
-	ul
-	.interactive-result-code-block {
+.interactive-item-container .value .rendered-markdown ul ul .interactive-result-code-block {
 	margin-left: -48px;
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ol
-	.interactive-result-code-block {
+.interactive-item-container .value .rendered-markdown ol .interactive-result-code-block {
 	margin-left: -28px;
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ol
-	ol
-	.interactive-result-code-block {
+.interactive-item-container .value .rendered-markdown ol ol .interactive-result-code-block {
 	margin-left: -56px;
 }
 
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ol
-	ul
-	.interactive-result-code-block,
-.interactive-item-container
-	.value
-	.rendered-markdown
-	ul
-	ol
-	.interactive-result-code-block {
+.interactive-item-container .value .rendered-markdown ol ul .interactive-result-code-block,
+.interactive-item-container .value .rendered-markdown ul ol .interactive-result-code-block {
 	margin-left: -52px;
 }
 
@@ -738,6 +621,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-tool-hover,
 .interactive-item-container {
+
 	.monaco-tokenized-source,
 	code {
 		font-family: var(--monaco-monospace-font);
@@ -769,10 +653,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: 16px;
 }
 
-.interactive-item-container.interactive-item-compact
-	.header
-	.codicon-avatar
-	.codicon {
+.interactive-item-container.interactive-item-compact .header .codicon-avatar .codicon {
 	font-size: 12px;
 }
 
@@ -784,39 +665,24 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-height: 0;
 }
 
-.interactive-item-container.interactive-item-compact
-	.value
-	> .rendered-markdown
-	p {
+.interactive-item-container.interactive-item-compact .value > .rendered-markdown p {
 	margin: 0 0 8px 0;
 }
 
-.interactive-item-container.interactive-item-compact
-	.value
-	> .rendered-markdown
-	li
-	> p {
+.interactive-item-container.interactive-item-compact .value > .rendered-markdown li > p {
 	margin: 0;
 }
 
-.interactive-item-container.interactive-item-compact
-	.value
-	.rendered-markdown
-	h1 {
+.interactive-item-container.interactive-item-compact .value .rendered-markdown h1 {
+	margin: 8px 0;
+
+}
+
+.interactive-item-container.interactive-item-compact .value .rendered-markdown h2 {
 	margin: 8px 0;
 }
 
-.interactive-item-container.interactive-item-compact
-	.value
-	.rendered-markdown
-	h2 {
-	margin: 8px 0;
-}
-
-.interactive-item-container.interactive-item-compact
-	.value
-	.rendered-markdown
-	h3 {
+.interactive-item-container.interactive-item-compact .value .rendered-markdown h3 {
 	margin: 8px 0;
 }
 
@@ -835,9 +701,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-grow: 1;
 }
 
-.interactive-item-container.interactive-request.minimal
-	.rendered-markdown
-	.chat-animated-ellipsis {
+.interactive-item-container.interactive-request.minimal .rendered-markdown .chat-animated-ellipsis {
 	display: inline-flex;
 }
 
@@ -898,19 +762,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: 100%;
 }
 
-.interactive-input-part:has(
-		.chat-editing-session > .chat-editing-session-container
-	)
-	.chat-input-container,
-.interactive-input-part:has(
-		.chat-todo-list-widget-container > .chat-todo-list-widget.has-todos
-	)
-	.chat-input-container,
-.interactive-input-part:has(
-		.chat-input-widgets-container
-			> .chat-status-widget:not([style*="display: none"])
-	)
-	.chat-input-container {
+.interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,
+.interactive-input-part:has(.chat-todo-list-widget-container > .chat-todo-list-widget.has-todos) .chat-input-container,
+.interactive-input-part:has(.chat-input-widgets-container > .chat-status-widget:not([style*="display: none"])) .chat-input-container {
 	/* Remove top border radius when editing session, todo list, or status widget is present */
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
@@ -937,61 +791,31 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container:has(.chat-todo-list-widget.has-todos)
-	+ .chat-editing-session
-	.chat-editing-session-container {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container:has(.chat-todo-list-widget.has-todos) + .chat-editing-session .chat-editing-session-container {
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 }
 
-.interactive-session
-	.chat-editing-session
-	.monaco-list-row
-	.chat-collapsible-list-action-bar {
+.interactive-session .chat-editing-session .monaco-list-row .chat-collapsible-list-action-bar {
 	padding-left: 5px;
 	display: none;
 }
 
-.interactive-session
-	.chat-editing-session
-	.monaco-list-row:hover
-	.chat-collapsible-list-action-bar:not(.has-no-actions),
-.interactive-session
-	.chat-editing-session
-	.monaco-list-row.focused
-	.chat-collapsible-list-action-bar:not(.has-no-actions),
-.interactive-session
-	.chat-editing-session
-	.monaco-list-row.selected
-	.chat-collapsible-list-action-bar:not(.has-no-actions) {
+.interactive-session .chat-editing-session .monaco-list-row:hover .chat-collapsible-list-action-bar:not(.has-no-actions),
+.interactive-session .chat-editing-session .monaco-list-row.focused .chat-collapsible-list-action-bar:not(.has-no-actions),
+.interactive-session .chat-editing-session .monaco-list-row.selected .chat-collapsible-list-action-bar:not(.has-no-actions) {
 	display: inherit;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container.show-file-icons
-	.monaco-scrollable-element
-	.monaco-list-rows
-	.monaco-list-row {
+.interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
 	border-radius: 2px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container.show-file-icons
-	.chat-editing-session-list
-	.monaco-scrollable-element:has(.visible.scrollbar.vertical)
-	.monaco-list-row
-	.monaco-icon-label {
+.interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .chat-editing-session-list .monaco-scrollable-element:has(.visible.scrollbar.vertical) .monaco-list-row .monaco-icon-label {
 	padding-right: 12px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -1000,11 +824,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview
-	> .working-set-title {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview > .working-set-title {
 	color: var(--vscode-descriptionForeground);
 	font-size: 11px;
 	white-space: nowrap;
@@ -1013,78 +833,49 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	align-content: center;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview
-	> .working-set-title
-	.working-set-count.file-limit-reached {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview > .working-set-title .working-set-count.file-limit-reached {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
 /* Inline added/removed line count styling */
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview
-	.working-set-line-counts {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts {
 	display: inline-flex;
 	gap: 4px;
 	margin-left: 6px;
 	font-weight: 500;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview
-	.working-set-line-counts
-	.working-set-lines-added {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts .working-set-lines-added {
 	color: var(--vscode-chat-linesAddedForeground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.chat-editing-session-overview
-	.working-set-line-counts
-	.working-set-lines-removed {
+.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts .working-set-lines-removed {
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-list
-	.working-set-line-counts {
+.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts {
 	margin-left: 6px;
 	display: inline-flex;
 	gap: 4px;
 	font-size: 11px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-list
-	.working-set-line-counts
-	.working-set-lines-added {
+.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts .working-set-lines-added {
 	color: var(--vscode-chat-linesAddedForeground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-list
-	.working-set-line-counts
-	.working-set-lines-removed {
+.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts .working-set-lines-removed {
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
 .interactive-session .chat-editing-session .working-set-title {
+
 	.monaco-button {
 		padding: 4px 6px 4px 0px;
 		border-radius: 2px;
 		border: none;
 		background-color: unset;
-		color: var(--vscode-foreground);
+		color: var(--vscode-foreground)
 	}
 
 	.monaco-button:focus-visible {
@@ -1092,16 +883,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-container
-	.monaco-progress-container {
+
+.interactive-session .chat-editing-session .chat-editing-session-container .monaco-progress-container {
 	position: relative;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions,
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions,
 .interactive-session .chat-editing-session .chat-editing-session-actions {
 	display: flex;
 	flex-direction: row;
@@ -1110,9 +897,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	align-items: center;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions {
 	margin: 3px 0px;
 	overflow: hidden;
 }
@@ -1124,10 +909,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 11px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button:hover {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {
 	background-color: var(--vscode-button-hoverBackground);
 }
 
@@ -1138,10 +920,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button.codicon.codicon-close {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.codicon.codicon-close {
 	width: 17px;
 	height: 17px;
 	display: flex;
@@ -1156,10 +935,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button.secondary {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary {
 	color: var(--vscode-foreground);
 	background-color: transparent;
 	border: none;
@@ -1231,49 +1007,30 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 4px 3px 0 2px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-related-files
-	.monaco-button.secondary:first-child {
+.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary:first-child {
 	margin: 3px 0px 3px 3px;
 	flex-shrink: 0;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-related-files
-	.monaco-button.secondary.monaco-icon-label::before {
+.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary.monaco-icon-label::before {
 	display: inline-flex;
 	align-items: center;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-related-files
-	.monaco-button.secondary:only-child {
+.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary:only-child {
 	width: 100%;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-related-files
-	.monaco-button.secondary.disabled {
+.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary.disabled {
 	cursor: initial;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-related-files
-	.monaco-button.secondary
-	.codicon {
+.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary .codicon {
 	font-size: 12px;
 	margin-left: 4px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-actions
-	.monaco-button.secondary.monaco-text-button.codicon {
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button.codicon {
 	background-color: transparent;
 	border-color: transparent;
 	color: var(--vscode-foreground);
@@ -1283,99 +1040,56 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: inline-flex;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-actions
-	.monaco-button.secondary.monaco-text-button {
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button {
 	background-color: var(--vscode-button-secondaryBackground);
 	border: 1px solid var(--vscode-button-border);
 	color: var(--vscode-button-secondaryForeground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-actions
-	.monaco-button.secondary:hover {
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary:hover {
 	background-color: var(--vscode-button-secondaryHoverBackground);
 	color: var(--vscode-button-secondaryForeground);
 }
 
 /* The Add Files button is currently implemented as a secondary button but should not have the secondary button background */
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button.secondary:hover {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-actions
-	.monaco-button.secondary.monaco-text-button.codicon:not(.disabled):hover,
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button:hover {
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button.codicon:not(.disabled):hover,
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button,
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-actions
-	.monaco-button {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button,
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button {
 	overflow: hidden;
 	text-wrap: nowrap;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button {
 	align-items: center;
 	border-radius: 2px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button
-	.monaco-button,
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button
-	.monaco-button:hover {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button .monaco-button,
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button .monaco-button:hover {
 	border-right: 1px solid transparent;
 	background-color: unset;
 	padding: 0;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button
-	> .separator {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button > .separator {
 	border-right: 1px solid transparent;
 	padding: 0 1px;
 	height: 22px;
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button:hover
-	> .separator {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button:hover > .separator {
 	border-color: var(--vscode-input-border, transparent);
 }
 
-.interactive-session
-	.chat-editing-session
-	.chat-editing-session-toolbar-actions
-	.monaco-button-dropdown.sidebyside-button:hover {
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
@@ -1386,19 +1100,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Chat Todo List Widget Container - mirrors chat-editing-session styling */
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container {
 	margin-bottom: -4px;
 	/* reset the 4px gap of the container for editing sessions */
 	width: 100%;
 	position: relative;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget {
 	padding: 6px 3px 6px 3px;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-input-border, transparent);
@@ -1411,20 +1120,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-expand {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand {
 	width: 100%;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-expand
-	.monaco-button {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .monaco-button {
 	display: flex;
 	align-items: center;
 	gap: 4px;
@@ -1438,21 +1138,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-width: unset;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-expand
-	.monaco-button:focus:not(:focus-visible) {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .monaco-button:focus:not(:focus-visible) {
 	outline: none;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-expand
-	.todo-list-title-section {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .todo-list-title-section {
 	padding-left: 3px;
 	display: flex;
 	align-items: center;
@@ -1464,23 +1154,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	line-height: 16px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-expand
-	.todo-list-title-section
-	.codicon {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .todo-list-title-section .codicon {
 	font-size: 16px;
 	line-height: 16px;
 	flex-shrink: 0;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-clear-button-container {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container {
 	padding-right: 2px;
 	display: flex;
 	align-items: center;
@@ -1488,12 +1168,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	opacity: 1;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-clear-button-container
-	.monaco-button {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button {
 	background-color: transparent;
 	border-color: transparent;
 	color: var(--vscode-foreground);
@@ -1509,50 +1184,27 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-right: 1px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-clear-button-container
-	.monaco-button:hover {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-clear-button-container
-	.monaco-button:focus {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 1px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-clear-button-container
-	.monaco-button
-	.codicon {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button .codicon {
 	font-size: 10px;
 	color: var(--vscode-foreground);
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.expand-icon {
+
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .expand-icon {
 	flex-shrink: 0;
 	margin-right: 3px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-title {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-title {
 	font-weight: normal;
 	font-size: 11px;
 	display: flex;
@@ -1561,11 +1213,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	text-overflow: ellipsis;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list-container {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-container {
 	margin-top: 2px;
 	max-height: calc(6.5 * 21px);
 	/* 6.5 items to show half-line affordance */
@@ -1578,22 +1226,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	/* Half item height to show partial previous item */
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-list {
+
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 	scroll-snap-type: y proximity;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-item {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item {
 	display: flex;
 	align-items: center;
 	gap: 6px;
@@ -1605,38 +1246,22 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-item:focus {
+
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-item.focused {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item.focused {
 	background-color: var(--vscode-list-focusBackground);
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-item
-	> .todo-status-icon.codicon {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item > .todo-status-icon.codicon {
 	flex-shrink: 0;
 	font-size: 16px;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.todo-content {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-content {
 	flex-grow: 1;
 	overflow: hidden;
 	white-space: nowrap;
@@ -1644,13 +1269,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-width: 0;
 }
 
-.interactive-session
-	.interactive-input-part
-	> .chat-todo-list-widget-container
-	.chat-todo-list-widget
-	.monaco-scrollable-element
-	.monaco-list-rows
-	.monaco-list-row {
+.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
 	border-radius: 2px;
 }
 
@@ -1676,62 +1295,28 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-input-foreground);
 }
 
-.interactive-session
-	.chat-editor-container
-	.monaco-editor
-	.chat-prompt-spinner {
+.interactive-session .chat-editor-container .monaco-editor .chat-prompt-spinner {
 	transform-origin: 6px 6px;
 	font-size: 12px;
 }
 
-.interactive-session
-	.interactive-input-part
-	.chat-editor-container
-	.interactive-input-editor
-	.monaco-editor,
-.interactive-session
-	.interactive-input-part
-	.chat-editor-container
-	.interactive-input-editor
-	.monaco-editor
-	.monaco-editor-background {
+.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor,
+.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-input-background);
 }
 
-.interactive-session
-	.interactive-input-part.editing
-	.chat-input-container
-	.chat-editor-container
-	.monaco-editor,
-.interactive-session
-	.interactive-input-part.editing
-	.chat-input-container
-	.chat-editor-container
-	.monaco-editor
-	.monaco-editor-background,
-.interactive-session
-	.interactive-request.editing
-	.interactive-input-part
-	.chat-input-container
-	.chat-editor-container
-	.monaco-editor,
-.interactive-session
-	.interactive-request.editing
-	.interactive-input-part
-	.chat-input-container
-	.chat-editor-container
-	.monaco-editor
-	.monaco-editor-background {
+.interactive-session .interactive-input-part.editing .chat-input-container .chat-editor-container .monaco-editor,
+.interactive-session .interactive-input-part.editing .chat-input-container .chat-editor-container .monaco-editor .monaco-editor-background,
+.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container .chat-editor-container .monaco-editor,
+.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container .chat-editor-container .monaco-editor .monaco-editor-background {
 	background-color: transparent;
 }
 
 .interactive-session .interactive-input-part.editing .chat-input-container,
-.interactive-session
-	.interactive-request.editing
-	.interactive-input-part
-	.chat-input-container {
+.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container {
 	background-color: var(--vscode-chat-requestBubbleBackground);
 }
+
 
 .interactive-session .chat-editor-container .monaco-editor .cursors-layer {
 	padding-left: 4px;
@@ -1788,38 +1373,25 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-input-toolbars.scroll-top-decoration {
-	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset;
+	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset
 }
 
 .interactive-session .chat-input-toolbar .chat-modelPicker-item .action-label,
-.interactive-session
-	.chat-input-toolbar
-	.chat-sessionPicker-item
-	.action-label {
+.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label {
 	height: 16px;
 	padding: 3px 0px 3px 6px;
 	display: flex;
 	align-items: center;
 }
 
-.interactive-session
-	.chat-input-toolbar
-	.chat-modelPicker-item
-	.action-label
-	.codicon-chevron-down,
-.interactive-session
-	.chat-input-toolbar
-	.chat-sessionPicker-item
-	.action-label
-	.codicon-chevron-down {
+
+.interactive-session .chat-input-toolbar .chat-modelPicker-item .action-label .codicon-chevron-down,
+.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
 	font-size: 12px;
 	margin-left: 2px;
 }
 
-.interactive-session
-	.chat-input-toolbars
-	.monaco-action-bar
-	.actions-container {
+.interactive-session .chat-input-toolbars .monaco-action-bar .actions-container {
 	display: flex;
 	gap: 4px;
 }
@@ -1833,36 +1405,20 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-icon-foreground) !important;
 }
 
-.interactive-response
-	.interactive-result-code-block
-	.interactive-result-editor
-	.monaco-editor,
-.interactive-response
-	.interactive-result-code-block
-	.interactive-result-editor
-	.monaco-editor
-	.margin,
-.interactive-response
-	.interactive-result-code-block
-	.interactive-result-editor
-	.monaco-editor
-	.monaco-editor-background {
-	background-color: var(
-		--vscode-interactive-result-editor-background-color
-	) !important;
+.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor,
+.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .margin,
+.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .monaco-editor-background {
+	background-color: var(--vscode-interactive-result-editor-background-color) !important;
 }
 
 .interactive-item-compact .interactive-result-code-block {
 	margin: 0 0 8px 0;
 }
 
-.interactive-item-container
-	.interactive-result-code-block
-	.monaco-toolbar
-	.monaco-action-bar
-	.actions-container {
+.interactive-item-container .interactive-result-code-block .monaco-toolbar .monaco-action-bar .actions-container {
 	padding-inline-start: unset;
 }
+
 
 @keyframes kf-chat-editing-atomic-edit {
 	0% {
@@ -1894,7 +1450,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 @property --chat-editing-last-edit-shift {
-	syntax: "<percentage>";
+	syntax: '<percentage>';
 	initial-value: 100%;
 	inherits: false;
 }
@@ -1915,15 +1471,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .monaco-editor .chat-editing-last-edit-line {
 	--chat-editing-last-edit-shift: 100%;
-	background: linear-gradient(
-		45deg,
-		var(--vscode-editor-rangeHighlightBackground),
-		var(--chat-editing-last-edit-shift),
-		transparent
-	);
+	background: linear-gradient(45deg, var(--vscode-editor-rangeHighlightBackground), var(--chat-editing-last-edit-shift), transparent);
 	animation: 2.3s kf-chat-editing-last-edit-shift ease-in-out infinite;
 	animation-delay: 330ms;
 }
+
 
 .chat-notification-widget .chat-info-codicon,
 .chat-notification-widget .chat-error-codicon,
@@ -1933,11 +1485,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 8px;
 }
 
-.interactive-item-container
-	.value
-	.chat-notification-widget
-	.rendered-markdown
-	p {
+.interactive-item-container .value .chat-notification-widget .rendered-markdown p {
 	margin: 0;
 }
 
@@ -1947,10 +1495,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-response
-	.interactive-response-error-details
-	.rendered-markdown
-	:last-child {
+.interactive-response .interactive-response-error-details .rendered-markdown :last-child {
 	margin-bottom: 0px;
 }
 
@@ -1967,21 +1512,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-interactive-session-foreground);
 }
 
-.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-name-container.warning,
-.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-suffix-container.warning,
+.chat-attached-context .chat-attached-context-attachment .monaco-icon-name-container.warning,
+.chat-attached-context .chat-attached-context-attachment .monaco-icon-suffix-container.warning,
 .chat-used-context-list .monaco-icon-name-container.warning,
 .chat-used-context-list .monaco-icon-suffix-container.warning {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
-.chat-attached-context
-	.chat-attached-context-attachment.show-file-icons.warning,
-.chat-attached-context
-	.chat-attached-context-attachment.show-file-icons.partial-warning {
+.chat-attached-context .chat-attached-context-attachment.show-file-icons.warning,
+.chat-attached-context .chat-attached-context-attachment.show-file-icons.partial-warning {
 	border-color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
@@ -1990,7 +1529,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
  */
 .chat-attached-context-attachment .prompt-type {
 	opacity: 0.7;
-	font-size: 0.9em;
+	font-size: .9em;
 	margin-left: 0.5em;
 }
 
@@ -2002,11 +1541,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-notificationsErrorIcon-foreground);
 }
 
-.chat-attached-context-attachment
-	.monaco-icon-label
-	> .monaco-icon-label-container
-	> .monaco-icon-suffix-container
-	> .label-suffix {
+.chat-attached-context-attachment .monaco-icon-label > .monaco-icon-label-container > .monaco-icon-suffix-container > .label-suffix {
 	color: var(--vscode-peekViewTitleDescription-foreground);
 	opacity: 1;
 }
@@ -2045,7 +1580,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part.compact {
 	margin: 0;
-	padding: 8px 0 0 0;
+	padding: 8px 0 0 0
 }
 
 .action-item.chat-attachment-button .action-label,
@@ -2054,11 +1589,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 	font-size: 11px;
 	padding: 0 4px 0 0;
-	border: 1px solid
-		var(
-			--vscode-chat-requestBorder,
-			var(--vscode-input-background, transparent)
-		);
+	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
 	border-radius: 4px;
 	height: 18px;
 	max-width: 100%;
@@ -2069,10 +1600,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 0 4px;
 }
 
-.interactive-session
-	.interactive-list
-	.chat-attached-context
-	.chat-attached-context-attachment {
+.interactive-session .interactive-list .chat-attached-context .chat-attached-context-attachment {
 	font-family: var(--vscode-chat-font-family, inherit);
 	font-size: var(--vscode-chat-font-size-body-xs);
 }
@@ -2082,20 +1610,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: auto;
 }
 
-.interactive-session
-	.action-item.chat-attachment-button
-	.action-label:not(.has-label) {
+.interactive-session .action-item.chat-attachment-button .action-label:not(.has-label) {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	padding: 2px 4px 2px 4px;
 	height: fit-content;
 	gap: 0;
-	border: 1px solid
-		var(
-			--vscode-chat-requestBorder,
-			var(--vscode-input-background, transparent)
-		);
+	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
 	border-radius: 4px;
 	box-sizing: border-box;
 
@@ -2109,6 +1631,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .action-item.chat-mcp {
+
 	.chat-mcp-state-indicator {
 		position: absolute;
 		bottom: 0;
@@ -2133,15 +1656,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.action-item.chat-attached-context-attachment.chat-add-files
-	.action-label.codicon::before {
+.action-item.chat-attached-context-attachment.chat-add-files .action-label.codicon::before {
 	font: normal normal normal 16px/1 codicon;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-button {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button {
 	display: flex;
 	align-items: center;
 	margin-top: -2px;
@@ -2152,36 +1671,24 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 12px;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-button.codicon.codicon-plus {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
 	padding-left: 4px;
 	font-size: 11px;
 }
 
 .chat-related-files .monaco-button.codicon.codicon-add:hover,
 .action-item.chat-attached-context-attachment.chat-add-files:hover,
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-button:hover {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button:hover {
 	cursor: pointer;
 	background: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled
-	.monaco-button:hover {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .monaco-button:hover {
 	cursor: pointer;
 	background: transparent;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label-container {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label-container {
 	display: flex;
 
 	.monaco-icon-suffix-container {
@@ -2190,11 +1697,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label-container
-	.monaco-highlighted-label {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label-container .monaco-highlighted-label {
 	display: inline-flex;
 	align-items: center;
 	overflow: hidden;
@@ -2202,41 +1705,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	text-overflow: ellipsis;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label
-	.monaco-button.codicon.codicon-close,
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-button.codicon.codicon-close,
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label
-	.monaco-button.codicon.codicon-plus,
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-button.codicon.codicon-plus {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-close,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-close,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-plus,
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
 	color: var(--vscode-descriptionForeground);
 	cursor: pointer;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label
-	.codicon {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .codicon {
 	font-size: 14px;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label
-	.monaco-icon-label-iconpath.codicon {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-icon-label-iconpath.codicon {
 	padding-top: 2px;
 }
 
@@ -2262,55 +1743,35 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-wrap: wrap;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit
-	.chat-implicit-hint {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit .chat-implicit-hint {
 	opacity: 0.7;
-	font-size: 0.9em;
+	font-size: .9em;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled
-	.chat-implicit-hint {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .chat-implicit-hint {
 	font-style: italic;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled {
 	border-style: dashed;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled:focus {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled:focus {
 	outline: none;
 	border-color: var(--vscode-focusBorder);
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled
-	.monaco-icon-label
-	.label-name {
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .monaco-icon-label .label-name {
 	text-decoration: line-through;
 	font-style: italic;
 	opacity: 0.8;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label {
 	gap: 4px;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label::before {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label::before {
 	height: auto;
 	padding: 0;
 	line-height: 100% !important;
@@ -2321,18 +1782,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-repeat: no-repeat;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment
-	.monaco-icon-label.predefined-file-icon::before {
+.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label.predefined-file-icon::before {
 	padding: 0 0 0 2px;
 	align-content: center;
 }
 
-.interactive-session
-	.interactive-item-container.interactive-request
-	.chat-attached-context
-	.chat-attached-context-attachment {
+.interactive-session .interactive-item-container.interactive-request .chat-attached-context .chat-attached-context-attachment {
 	padding-right: 6px;
 }
 
@@ -2361,11 +1816,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-bottom: 4px;
 } */
 
-.interactive-session
-	.interactive-input-part
-	.interactive-input-followups
-	.interactive-session-followups
-	.monaco-button {
+.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups .monaco-button {
 	display: block;
 	color: var(--vscode-textLink-foreground);
 	font-size: 12px;
@@ -2378,21 +1829,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session
-	.interactive-input-part
-	.interactive-input-followups
-	.interactive-session-followups
-	code {
+.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups code {
 	font-family: var(--monaco-monospace-font);
 	font-size: 11px;
 }
 
-.interactive-session
-	.interactive-input-part
-	.interactive-input-followups
-	.interactive-session-followups
-	.monaco-button
-	.codicon-sparkle {
+.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups .monaco-button .codicon-sparkle {
 	float: left;
 }
 
@@ -2417,23 +1859,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin: 0 3px;
 }
 
-.quick-input-widget
-	.interactive-session
-	.interactive-input-part
-	.chat-input-toolbars
-	.monaco-toolbar,
-.quick-input-widget
-	.interactive-session
-	.interactive-input-part
-	.chat-input-toolbars
-	.actions-container {
+.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars .monaco-toolbar,
+.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars .actions-container {
 	height: initial;
 }
 
-.quick-input-widget
-	.interactive-session
-	.interactive-input-part
-	.chat-input-toolbars {
+.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars {
 	margin-bottom: 1px;
 	align-items: flex-end;
 }
@@ -2469,9 +1900,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* #endregion */
 
-.interactive-response-progress-tree
-	.monaco-list-row:not(.selected)
-	.monaco-tl-row:hover {
+.interactive-response-progress-tree .monaco-list-row:not(.selected) .monaco-tl-row:hover {
 	background-color: var(--vscode-list-hoverBackground);
 }
 
@@ -2483,10 +1912,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border-color: var(--vscode-focusBorder, transparent);
 }
 
-.interactive-item-container
-	.value
-	.interactive-response-placeholder-codicon
-	.codicon {
+.interactive-item-container .value .interactive-response-placeholder-codicon .codicon {
 	color: var(--vscode-editorGhostText-foreground);
 }
 
@@ -2516,6 +1942,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-chat-slashCommandBackground);
 	color: var(--vscode-chat-slashCommandForeground);
 }
+
 
 .interactive-item-container .chat-resource-widget,
 .interactive-item-container .chat-agent-widget .monaco-button {
@@ -2598,16 +2025,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		float: left;
 	}
 
-	.checkpoint-file-changes-summary-header
-		.chat-file-changes-label
-		.monaco-button {
+	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button {
 		width: 100%;
 	}
 
-	.checkpoint-file-changes-summary-header
-		.chat-file-changes-label
-		.monaco-button
-		.codicon {
+	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button .codicon {
 		font-size: 16px;
 	}
 
@@ -2644,12 +2066,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session
-	.checkpoint-file-changes-summary.chat-file-changes-collapsed
-	.chat-summary-list,
-.interactive-session
-	.chat-used-context.chat-used-context-collapsed
-	.chat-used-context-list {
+.interactive-session .checkpoint-file-changes-summary.chat-file-changes-collapsed .chat-summary-list,
+.interactive-session .chat-used-context.chat-used-context-collapsed .chat-used-context-list {
 	display: none;
 }
 
@@ -2681,12 +2099,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session-list {
+
 	.monaco-icon-label {
 		padding: 0px 3px;
 	}
 
 	.monaco-icon-label.excluded {
-		color: var(--vscode-notificationsWarningIcon-foreground);
+		color: var(--vscode-notificationsWarningIcon-foreground)
 	}
 }
 
@@ -2719,10 +2138,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-list-divider .chat-list-divider-line {
 	flex: 1;
 	height: 1px;
-	background-color: var(
-		--vscode-editorWidget-border,
-		var(--vscode-contrastBorder)
-	);
+	background-color: var(--vscode-editorWidget-border, var(--vscode-contrastBorder));
 	opacity: 0.5;
 }
 
@@ -2795,6 +2211,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-used-context-label .monaco-button:hover {
 	background-color: var(--vscode-list-hoverBackground);
 	color: var(--vscode-foreground);
+
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus,
@@ -2803,9 +2220,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus-visible,
-.interactive-session
-	.chat-used-context-label
-	.monaco-text-button:focus-visible {
+.interactive-session .chat-used-context-label .monaco-text-button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 }
 
@@ -2825,7 +2240,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	The working progress also can be replaced by a tool progress part. So align this padding so the text doesn't appear to shift. */
 	padding-top: 2px;
 
-	> .codicon[class*="codicon-"] {
+	> .codicon[class*='codicon-'] {
 		font-size: var(--vscode-chat-font-size-body-s);
 
 		&::before {
@@ -2874,9 +2289,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-item-container
-	.chat-confirmation-widget
-	.interactive-result-code-block,
+.interactive-item-container .chat-confirmation-widget .interactive-result-code-block,
 .interactive-item-container .chat-confirmation-widget .chat-attached-context {
 	margin-bottom: 8px;
 }
@@ -2913,9 +2326,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: block;
 }
 
-.chat-attached-context-hover
-	.chat-attached-context-image-container
-	.chat-attached-context-image {
+.chat-attached-context-hover .chat-attached-context-image-container .chat-attached-context-image {
 	width: 100%;
 	height: 100%;
 	object-fit: contain;
@@ -2924,6 +2335,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	max-width: 100%;
 	min-width: 200px;
 	min-height: 200px;
+
 }
 
 .chat-attached-context-hover .chat-attached-context-url {
@@ -2947,6 +2359,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-top: 2px;
 }
 
+
 .chat-attached-context-attachment .chat-attached-context-pill {
 	font-size: 12px;
 	display: inline-flex;
@@ -2961,7 +2374,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-attached-context-attachment .attachment-additional-info {
 	opacity: 0.7;
-	font-size: 0.9em;
+	font-size: .9em;
 }
 
 .chat-attached-context-attachment .chat-attached-context-pill-image {
@@ -2983,14 +2396,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: inline-block;
 }
 
-.chat-attached-context-attachment.show-file-icons.warning
-	.chat-attached-context-custom-text {
+.chat-attached-context-attachment.show-file-icons.warning .chat-attached-context-custom-text {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 	text-decoration: line-through;
 }
 
-.chat-attached-context-attachment.show-file-icons.partial-warning
-	.chat-attached-context-custom-text {
+.chat-attached-context-attachment.show-file-icons.partial-warning .chat-attached-context-custom-text {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
@@ -3052,25 +2463,22 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.hideSuggestTextIcons
-	.suggest-widget
-	.monaco-list
-	.monaco-list-row
-	.suggest-icon.codicon-symbol-text::before {
+.hideSuggestTextIcons .suggest-widget .monaco-list .monaco-list-row .suggest-icon.codicon-symbol-text::before {
 	display: none;
 }
 
 .interactive-session:not(.chat-widget > .interactive-session) {
+
 	.interactive-item-container {
 		padding: 5px 16px;
 	}
 
 	.interactive-item-container.interactive-request {
 		align-items: flex-end;
+
 	}
 
-	.interactive-item-container.interactive-request:not(.editing):hover
-		.request-hover {
+	.interactive-item-container.interactive-request:not(.editing):hover .request-hover {
 		opacity: 1 !important;
 	}
 
@@ -3097,35 +2505,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		margin-left: auto;
 	}
 
-	.interactive-item-container.interactive-request
-		.value
-		.rendered-markdown.clickable:hover {
+	.interactive-item-container.interactive-request .value .rendered-markdown.clickable:hover {
 		cursor: pointer;
 		background-color: var(--vscode-chat-requestBubbleHoverBackground);
 	}
 
-	.hc-black
-		.interactive-item-container.interactive-request
-		.value
-		.rendered-markdown,
-	.hc-light
-		.interactive-item-container.interactive-request
-		.value
-		.rendered-markdown {
+	.hc-black .interactive-item-container.interactive-request .value .rendered-markdown,
+	.hc-light .interactive-item-container.interactive-request .value .rendered-markdown {
 		border: 1px dotted var(--vscode-focusBorder);
 	}
 
-	.interactive-item-container.interactive-request
-		.value
-		.rendered-markdown
-		> :last-child {
+	.interactive-item-container.interactive-request .value .rendered-markdown > :last-child {
 		margin-bottom: 0px;
 	}
 
-	.interactive-item-container.interactive-request
-		.value
-		> .rendered-markdown
-		p {
+	.interactive-item-container.interactive-request .value > .rendered-markdown p {
 		width: fit-content;
 	}
 
@@ -3165,10 +2559,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		position: absolute;
 		overflow: hidden;
 		z-index: 100;
-		background-color: var(
-			--vscode-interactive-result-editor-background-color,
-			var(--vscode-editor-background)
-		);
+		background-color: var(--vscode-interactive-result-editor-background-color, var(--vscode-editor-background));
 		border: 1px solid var(--vscode-chat-requestBorder);
 		top: -13px;
 		right: 20px;
@@ -3199,6 +2590,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 
 	.request-hover:not(.expanded) .actions-container {
+
 		.action-label.codicon-discard,
 		.action-label.codicon-x,
 		.action-label.codicon-edit {
@@ -3210,6 +2602,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.request-hover:focus-within {
 		opacity: 1 !important;
 	}
+
 
 	.checkpoint-container,
 	.checkpoint-restore-container {
@@ -3249,8 +2642,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 
 		.monaco-toolbar .action-label {
-			border: 1px solid
-				var(--vscode-chat-requestBorder, var(--vscode-input-background));
+			border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background));
 			padding: 1px 5px;
 			background-color: var(--vscode-sideBar-background);
 		}
@@ -3275,30 +2667,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.checkpoint-container .monaco-toolbar:focus-within,
 	.checkpoint-restore-container .monaco-toolbar,
-	.interactive-item-container.interactive-request:not(.editing):hover
-		.checkpoint-container
-		.monaco-toolbar {
+	.interactive-item-container.interactive-request:not(.editing):hover .checkpoint-container .monaco-toolbar {
 		opacity: 1;
 	}
 
-	.interactive-item-container.interactive-request.editing
-		.checkpoint-container {
+	.interactive-item-container.interactive-request.editing .checkpoint-container {
 		display: none;
 	}
 
-	.interactive-list
-		> .monaco-list
-		> .monaco-scrollable-element
-		> .monaco-list-rows
-		> .monaco-list-row {
+	.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row {
 		overflow: visible !important;
 	}
 
-	.interactive-list
-		> .monaco-list
-		> .monaco-scrollable-element
-		> .monaco-list-rows
-		> .monaco-list-row.monaco-list-row.focused.request {
+	.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.monaco-list-row.focused.request {
 		outline: none !important;
 	}
 
@@ -3316,11 +2697,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 	}
 
-	.interactive-list
-		> .monaco-list:focus
-		> .monaco-scrollable-element
-		> .monaco-list-rows
-		> .monaco-list-row.focused.request {
+	.interactive-list > .monaco-list:focus > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.focused.request {
 		outline: none !important;
 
 		.interactive-item-container .value .rendered-markdown {
@@ -3344,20 +2721,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.interactive-request.editing {
 		padding: 0px;
 
-		.interactive-input-part
-			.chat-input-container
-			.interactive-input-editor
-			.monaco-editor
-			.native-edit-context {
+		.interactive-input-part .chat-input-container .interactive-input-editor .monaco-editor .native-edit-context {
 			opacity: 0;
 		}
 	}
 }
 
-.editor-instance
-	.interactive-session
-	.interactive-item-container.interactive-response
-	.checkpoint-restore-container {
+.editor-instance .interactive-session .interactive-item-container.interactive-response .checkpoint-restore-container {
+
 	.checkpoint-label-text,
 	.monaco-toolbar {
 		background-color: var(--vscode-editor-background);
@@ -3413,9 +2784,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: 1px;
 }
 
-.interactive-session
-	.chat-attached-context
-	.chat-attached-context-attachment.implicit.disabled:hover {
+
+.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled:hover {
 	cursor: pointer;
 	border-style: solid;
 	background-color: var(--vscode-toolbar-hoverBackground);
@@ -3476,12 +2846,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-shrink: 0;
 }
 
-.chat-welcome-view-suggested-prompt
-	> .chat-suggest-next-dropdown:hover
-	.dropdown-chevron,
-.chat-welcome-view-suggested-prompt
-	> .chat-suggest-next-dropdown:focus
-	.dropdown-chevron {
+.chat-welcome-view-suggested-prompt > .chat-suggest-next-dropdown:hover .dropdown-chevron,
+.chat-welcome-view-suggested-prompt > .chat-suggest-next-dropdown:focus .dropdown-chevron {
 	opacity: 1;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -221,6 +221,9 @@
 	visibility: hidden;
 	padding-top: 6px;
 	height: 22px;
+}
+
+.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -25,7 +25,13 @@
 	--vscode-chat-font-size-body-xxl: 1.538em;
 }
 
-.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row > .monaco-tl-row > .monaco-tl-twistie {
+.interactive-list
+	> .monaco-list
+	> .monaco-scrollable-element
+	> .monaco-list-rows
+	> .monaco-list-row
+	> .monaco-tl-row
+	> .monaco-tl-twistie {
 	/* Hide twisties from chat tree rows, but not from nested trees within a chat response */
 	display: none !important;
 }
@@ -80,7 +86,11 @@
 	overflow: hidden;
 }
 
-.interactive-item-container .detail-container .detail .agentOrSlashCommandDetected A {
+.interactive-item-container
+	.detail-container
+	.detail
+	.agentOrSlashCommandDetected
+	A {
 	cursor: pointer;
 	color: var(--vscode-textLink-foreground);
 }
@@ -117,7 +127,7 @@
 }
 
 .interactive-item-container .chat-animated-ellipsis::after {
-	content: '';
+	content: "";
 	white-space: nowrap;
 	overflow: hidden;
 	width: 3em;
@@ -160,17 +170,37 @@
 	font-size: 14px;
 }
 
-.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar,
-.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar,
-.monaco-list-row:not(.focused) .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label,
-.monaco-list:not(:focus-within) .monaco-list-row .interactive-item-container:not(:hover) .header .monaco-toolbar .action-label {
+.monaco-list-row:not(.focused)
+	.interactive-item-container:not(:hover)
+	.header
+	.monaco-toolbar,
+.monaco-list:not(:focus-within)
+	.monaco-list-row
+	.interactive-item-container:not(:hover)
+	.header
+	.monaco-toolbar,
+.monaco-list-row:not(.focused)
+	.interactive-item-container:not(:hover)
+	.header
+	.monaco-toolbar
+	.action-label,
+.monaco-list:not(:focus-within)
+	.monaco-list-row
+	.interactive-item-container:not(:hover)
+	.header
+	.monaco-toolbar
+	.action-label {
 	/* Also apply this rule to the .action-label directly to work around a strange issue- when the
 	toolbar is hidden without that second rule, tabbing from the list container into a list item doesn't work
 	and the tab key doesn't do anything. */
 	display: none;
 }
 
-.interactive-item-container .header .monaco-toolbar .monaco-action-bar .actions-container {
+.interactive-item-container
+	.header
+	.monaco-toolbar
+	.monaco-action-bar
+	.actions-container {
 	gap: 4px;
 }
 
@@ -198,7 +228,10 @@
 	display: none !important;
 }
 
-.interactive-item-container .chat-footer-toolbar .monaco-action-bar .actions-container {
+.interactive-item-container
+	.chat-footer-toolbar
+	.monaco-action-bar
+	.actions-container {
 	gap: 4px;
 }
 
@@ -213,24 +246,52 @@
 	min-height: var(--chat-current-response-min-height);
 }
 
-.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
+.interactive-item-container.interactive-response:not(.chat-response-loading)
+	.chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(.chat-response-loading)
+	.chat-footer-toolbar
+	.chat-footer-details {
 	/* Complete response only */
 	display: block;
 	opacity: 0;
 	visibility: hidden;
 	padding-top: 6px;
 	height: 22px;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 /* Show toolbar on hover and last response. Also show when the item has keyboard focus (focus-within) or when the surrounding list row is marked focused (monaco list keyboard navigation). */
-.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar,
-.interactive-item-container.interactive-response.chat-most-recent-response:not(.chat-response-loading) .chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(.chat-response-loading):hover .chat-footer-toolbar .chat-footer-details,
-.interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar,
-.interactive-item-container.interactive-response:not(.chat-response-loading):focus-within .chat-footer-toolbar .chat-footer-details,
-.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar,
-.monaco-list-row.focused .interactive-item-container.interactive-response:not(.chat-response-loading) .chat-footer-toolbar .chat-footer-details {
+.interactive-item-container.interactive-response:not(
+		.chat-response-loading
+	):hover
+	.chat-footer-toolbar,
+.interactive-item-container.interactive-response.chat-most-recent-response:not(
+		.chat-response-loading
+	)
+	.chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(
+		.chat-response-loading
+	):hover
+	.chat-footer-toolbar
+	.chat-footer-details,
+.interactive-item-container.interactive-response:not(
+		.chat-response-loading
+	):focus-within
+	.chat-footer-toolbar,
+.interactive-item-container.interactive-response:not(
+		.chat-response-loading
+	):focus-within
+	.chat-footer-toolbar
+	.chat-footer-details,
+.monaco-list-row.focused
+	.interactive-item-container.interactive-response:not(.chat-response-loading)
+	.chat-footer-toolbar,
+.monaco-list-row.focused
+	.interactive-item-container.interactive-response:not(.chat-response-loading)
+	.chat-footer-toolbar
+	.chat-footer-details {
 	opacity: 1;
 	visibility: visible;
 }
@@ -264,7 +325,9 @@
 	margin-bottom: 8px;
 }
 
-.interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {
+.interactive-item-container
+	.value
+	.rendered-markdown:not(:has(.chat-extensions-content-part)) {
 	.codicon {
 		font-size: inherit;
 	}
@@ -304,7 +367,11 @@
 	color: var(--vscode-textLink-foreground);
 }
 
-.interactive-item-container .value .rendered-markdown .chat-extensions-content-part a {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	.chat-extensions-content-part
+	a {
 	color: inherit;
 }
 
@@ -340,8 +407,14 @@
 }
 
 .interactive-item-container .value > :last-child,
-.interactive-item-container .value > :last-child.rendered-markdown > :last-child,
-.interactive-item-container.interactive-request .value .rendered-markdown > :last-child {
+.interactive-item-container
+	.value
+	> :last-child.rendered-markdown
+	> :last-child,
+.interactive-item-container.interactive-request
+	.value
+	.rendered-markdown
+	> :last-child {
 	margin-bottom: 0px;
 }
 
@@ -358,7 +431,6 @@
 	font-weight: 600;
 	margin: 16px 0 8px 0;
 	font-family: var(--vscode-chat-font-family, inherit);
-
 }
 
 .interactive-item-container .value .rendered-markdown h2 {
@@ -375,7 +447,10 @@
 	font-family: var(--vscode-chat-font-family, inherit);
 }
 
-.interactive-item-container.editing-session .value .rendered-markdown p:has(+ [data-code] > .chat-codeblock-pill-widget) {
+.interactive-item-container.editing-session
+	.value
+	.rendered-markdown
+	p:has(+ [data-code] > .chat-codeblock-pill-widget) {
 	margin-bottom: 8px;
 }
 
@@ -386,7 +461,10 @@
 }
 
 /* Codicons next to text need to be aligned with the text */
-.interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) .codicon {
+.interactive-item-container
+	.value
+	.rendered-markdown:not(:has(.chat-extensions-content-part))
+	.codicon {
 	position: relative;
 	top: 2px;
 }
@@ -405,18 +483,22 @@
 	/* Code blocks at the beginning of an answer should not have a margin as it means it won't align with the agent icon*/
 	> div[data-code]:first-child {
 		margin-top: 0;
-
 	}
 
 	/* Override the top to avoid the toolbar getting clipped by overflow:hidden */
-	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar,
-	> div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
+	> div[data-code]:first-child
+		.interactive-result-code-block
+		.interactive-result-code-block-toolbar
+		> .monaco-action-bar,
+	> div[data-code]:first-child
+		.interactive-result-code-block
+		.interactive-result-code-block-toolbar
+		> .monaco-toolbar {
 		top: 6px;
 	}
 }
 
 .interactive-item-container .value.inline-progress {
-
 	.rendered-markdown {
 		display: inline-flex;
 	}
@@ -428,7 +510,7 @@
 	}
 
 	.rendered-markdown:last-of-type > P > SPAN:empty::after {
-		content: '';
+		content: "";
 		white-space: nowrap;
 		overflow: hidden;
 		width: 3em;
@@ -479,8 +561,18 @@
 
 		.message-wrapper {
 			/* This mask fades out the end of the second line of text so the "see more" message can be displayed over it. */
-			mask-image:
-				linear-gradient(to right, rgba(0, 0, 0, 1) calc(100% - 95px), rgba(0, 0, 0, 0) calc(100% - 72px)), linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 20px, rgba(0, 0, 0, 1) 2px, rgba(0, 0, 0, 1) 100%);
+			mask-image: linear-gradient(
+					to right,
+					rgba(0, 0, 0, 1) calc(100% - 95px),
+					rgba(0, 0, 0, 0) calc(100% - 72px)
+				),
+				linear-gradient(
+					to top,
+					rgba(0, 0, 0, 0) 0%,
+					rgba(0, 0, 0, 0) 20px,
+					rgba(0, 0, 0, 1) 2px,
+					rgba(0, 0, 0, 1) 100%
+				);
 			mask-repeat: no-repeat, no-repeat;
 			pointer-events: none;
 			max-height: 40px;
@@ -589,24 +681,52 @@
 
 /* NOTE- We want to dedent codeblocks in lists specifically to give them the full width. No more elegant way to do this, these values
 have to be updated for changes to the rules above, or to support more deeply nested lists. */
-.interactive-item-container .value .rendered-markdown ul .interactive-result-code-block {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ul
+	.interactive-result-code-block {
 	margin-left: -24px;
 }
 
-.interactive-item-container .value .rendered-markdown ul ul .interactive-result-code-block {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ul
+	ul
+	.interactive-result-code-block {
 	margin-left: -48px;
 }
 
-.interactive-item-container .value .rendered-markdown ol .interactive-result-code-block {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ol
+	.interactive-result-code-block {
 	margin-left: -28px;
 }
 
-.interactive-item-container .value .rendered-markdown ol ol .interactive-result-code-block {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ol
+	ol
+	.interactive-result-code-block {
 	margin-left: -56px;
 }
 
-.interactive-item-container .value .rendered-markdown ol ul .interactive-result-code-block,
-.interactive-item-container .value .rendered-markdown ul ol .interactive-result-code-block {
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ol
+	ul
+	.interactive-result-code-block,
+.interactive-item-container
+	.value
+	.rendered-markdown
+	ul
+	ol
+	.interactive-result-code-block {
 	margin-left: -52px;
 }
 
@@ -618,7 +738,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-tool-hover,
 .interactive-item-container {
-
 	.monaco-tokenized-source,
 	code {
 		font-family: var(--monaco-monospace-font);
@@ -650,7 +769,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: 16px;
 }
 
-.interactive-item-container.interactive-item-compact .header .codicon-avatar .codicon {
+.interactive-item-container.interactive-item-compact
+	.header
+	.codicon-avatar
+	.codicon {
 	font-size: 12px;
 }
 
@@ -662,24 +784,39 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-height: 0;
 }
 
-.interactive-item-container.interactive-item-compact .value > .rendered-markdown p {
+.interactive-item-container.interactive-item-compact
+	.value
+	> .rendered-markdown
+	p {
 	margin: 0 0 8px 0;
 }
 
-.interactive-item-container.interactive-item-compact .value > .rendered-markdown li > p {
+.interactive-item-container.interactive-item-compact
+	.value
+	> .rendered-markdown
+	li
+	> p {
 	margin: 0;
 }
 
-.interactive-item-container.interactive-item-compact .value .rendered-markdown h1 {
-	margin: 8px 0;
-
-}
-
-.interactive-item-container.interactive-item-compact .value .rendered-markdown h2 {
+.interactive-item-container.interactive-item-compact
+	.value
+	.rendered-markdown
+	h1 {
 	margin: 8px 0;
 }
 
-.interactive-item-container.interactive-item-compact .value .rendered-markdown h3 {
+.interactive-item-container.interactive-item-compact
+	.value
+	.rendered-markdown
+	h2 {
+	margin: 8px 0;
+}
+
+.interactive-item-container.interactive-item-compact
+	.value
+	.rendered-markdown
+	h3 {
 	margin: 8px 0;
 }
 
@@ -698,7 +835,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-grow: 1;
 }
 
-.interactive-item-container.interactive-request.minimal .rendered-markdown .chat-animated-ellipsis {
+.interactive-item-container.interactive-request.minimal
+	.rendered-markdown
+	.chat-animated-ellipsis {
 	display: inline-flex;
 }
 
@@ -759,9 +898,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: 100%;
 }
 
-.interactive-input-part:has(.chat-editing-session > .chat-editing-session-container) .chat-input-container,
-.interactive-input-part:has(.chat-todo-list-widget-container > .chat-todo-list-widget.has-todos) .chat-input-container,
-.interactive-input-part:has(.chat-input-widgets-container > .chat-status-widget:not([style*="display: none"])) .chat-input-container {
+.interactive-input-part:has(
+		.chat-editing-session > .chat-editing-session-container
+	)
+	.chat-input-container,
+.interactive-input-part:has(
+		.chat-todo-list-widget-container > .chat-todo-list-widget.has-todos
+	)
+	.chat-input-container,
+.interactive-input-part:has(
+		.chat-input-widgets-container
+			> .chat-status-widget:not([style*="display: none"])
+	)
+	.chat-input-container {
 	/* Remove top border radius when editing session, todo list, or status widget is present */
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
@@ -788,31 +937,61 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container:has(.chat-todo-list-widget.has-todos) + .chat-editing-session .chat-editing-session-container {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container:has(.chat-todo-list-widget.has-todos)
+	+ .chat-editing-session
+	.chat-editing-session-container {
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 }
 
-.interactive-session .chat-editing-session .monaco-list-row .chat-collapsible-list-action-bar {
+.interactive-session
+	.chat-editing-session
+	.monaco-list-row
+	.chat-collapsible-list-action-bar {
 	padding-left: 5px;
 	display: none;
 }
 
-.interactive-session .chat-editing-session .monaco-list-row:hover .chat-collapsible-list-action-bar:not(.has-no-actions),
-.interactive-session .chat-editing-session .monaco-list-row.focused .chat-collapsible-list-action-bar:not(.has-no-actions),
-.interactive-session .chat-editing-session .monaco-list-row.selected .chat-collapsible-list-action-bar:not(.has-no-actions) {
+.interactive-session
+	.chat-editing-session
+	.monaco-list-row:hover
+	.chat-collapsible-list-action-bar:not(.has-no-actions),
+.interactive-session
+	.chat-editing-session
+	.monaco-list-row.focused
+	.chat-collapsible-list-action-bar:not(.has-no-actions),
+.interactive-session
+	.chat-editing-session
+	.monaco-list-row.selected
+	.chat-collapsible-list-action-bar:not(.has-no-actions) {
 	display: inherit;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container.show-file-icons
+	.monaco-scrollable-element
+	.monaco-list-rows
+	.monaco-list-row {
 	border-radius: 2px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .chat-editing-session-list .monaco-scrollable-element:has(.visible.scrollbar.vertical) .monaco-list-row .monaco-icon-label {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container.show-file-icons
+	.chat-editing-session-list
+	.monaco-scrollable-element:has(.visible.scrollbar.vertical)
+	.monaco-list-row
+	.monaco-icon-label {
 	padding-right: 12px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -821,7 +1000,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview > .working-set-title {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview
+	> .working-set-title {
 	color: var(--vscode-descriptionForeground);
 	font-size: 11px;
 	white-space: nowrap;
@@ -830,49 +1013,78 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	align-content: center;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview > .working-set-title .working-set-count.file-limit-reached {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview
+	> .working-set-title
+	.working-set-count.file-limit-reached {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
 /* Inline added/removed line count styling */
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview
+	.working-set-line-counts {
 	display: inline-flex;
 	gap: 4px;
 	margin-left: 6px;
 	font-weight: 500;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts .working-set-lines-added {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview
+	.working-set-line-counts
+	.working-set-lines-added {
 	color: var(--vscode-chat-linesAddedForeground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview .working-set-line-counts .working-set-lines-removed {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.chat-editing-session-overview
+	.working-set-line-counts
+	.working-set-lines-removed {
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-list
+	.working-set-line-counts {
 	margin-left: 6px;
 	display: inline-flex;
 	gap: 4px;
 	font-size: 11px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts .working-set-lines-added {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-list
+	.working-set-line-counts
+	.working-set-lines-added {
 	color: var(--vscode-chat-linesAddedForeground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts .working-set-lines-removed {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-list
+	.working-set-line-counts
+	.working-set-lines-removed {
 	color: var(--vscode-chat-linesRemovedForeground);
 }
 
 .interactive-session .chat-editing-session .working-set-title {
-
 	.monaco-button {
 		padding: 4px 6px 4px 0px;
 		border-radius: 2px;
 		border: none;
 		background-color: unset;
-		color: var(--vscode-foreground)
+		color: var(--vscode-foreground);
 	}
 
 	.monaco-button:focus-visible {
@@ -880,12 +1092,16 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-
-.interactive-session .chat-editing-session .chat-editing-session-container .monaco-progress-container {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-container
+	.monaco-progress-container {
 	position: relative;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions,
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions,
 .interactive-session .chat-editing-session .chat-editing-session-actions {
 	display: flex;
 	flex-direction: row;
@@ -894,7 +1110,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	align-items: center;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions {
 	margin: 3px 0px;
 	overflow: hidden;
 }
@@ -906,7 +1124,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 11px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button:hover {
 	background-color: var(--vscode-button-hoverBackground);
 }
 
@@ -917,7 +1138,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.codicon.codicon-close {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button.codicon.codicon-close {
 	width: 17px;
 	height: 17px;
 	display: flex;
@@ -932,7 +1156,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button.secondary {
 	color: var(--vscode-foreground);
 	background-color: transparent;
 	border: none;
@@ -1004,30 +1231,49 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 4px 3px 0 2px;
 }
 
-.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary:first-child {
+.interactive-session
+	.chat-editing-session
+	.chat-related-files
+	.monaco-button.secondary:first-child {
 	margin: 3px 0px 3px 3px;
 	flex-shrink: 0;
 }
 
-.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary.monaco-icon-label::before {
+.interactive-session
+	.chat-editing-session
+	.chat-related-files
+	.monaco-button.secondary.monaco-icon-label::before {
 	display: inline-flex;
 	align-items: center;
 }
 
-.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary:only-child {
+.interactive-session
+	.chat-editing-session
+	.chat-related-files
+	.monaco-button.secondary:only-child {
 	width: 100%;
 }
 
-.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary.disabled {
+.interactive-session
+	.chat-editing-session
+	.chat-related-files
+	.monaco-button.secondary.disabled {
 	cursor: initial;
 }
 
-.interactive-session .chat-editing-session .chat-related-files .monaco-button.secondary .codicon {
+.interactive-session
+	.chat-editing-session
+	.chat-related-files
+	.monaco-button.secondary
+	.codicon {
 	font-size: 12px;
 	margin-left: 4px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button.codicon {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-actions
+	.monaco-button.secondary.monaco-text-button.codicon {
 	background-color: transparent;
 	border-color: transparent;
 	color: var(--vscode-foreground);
@@ -1037,56 +1283,99 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: inline-flex;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-actions
+	.monaco-button.secondary.monaco-text-button {
 	background-color: var(--vscode-button-secondaryBackground);
 	border: 1px solid var(--vscode-button-border);
 	color: var(--vscode-button-secondaryForeground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-actions
+	.monaco-button.secondary:hover {
 	background-color: var(--vscode-button-secondaryHoverBackground);
 	color: var(--vscode-button-secondaryForeground);
 }
 
 /* The Add Files button is currently implemented as a secondary button but should not have the secondary button background */
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button.secondary:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.monaco-text-button.codicon:not(.disabled):hover,
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-actions
+	.monaco-button.secondary.monaco-text-button.codicon:not(.disabled):hover,
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button,
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button,
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-actions
+	.monaco-button {
 	overflow: hidden;
 	text-wrap: nowrap;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button {
 	align-items: center;
 	border-radius: 2px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button .monaco-button,
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button .monaco-button:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button
+	.monaco-button,
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button
+	.monaco-button:hover {
 	border-right: 1px solid transparent;
 	background-color: unset;
 	padding: 0;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button > .separator {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button
+	> .separator {
 	border-right: 1px solid transparent;
 	padding: 0 1px;
 	height: 22px;
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button:hover > .separator {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button:hover
+	> .separator {
 	border-color: var(--vscode-input-border, transparent);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button-dropdown.sidebyside-button:hover {
+.interactive-session
+	.chat-editing-session
+	.chat-editing-session-toolbar-actions
+	.monaco-button-dropdown.sidebyside-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
@@ -1097,14 +1386,19 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Chat Todo List Widget Container - mirrors chat-editing-session styling */
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container {
 	margin-bottom: -4px;
 	/* reset the 4px gap of the container for editing sessions */
 	width: 100%;
 	position: relative;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget {
 	padding: 6px 3px 6px 3px;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-input-border, transparent);
@@ -1117,11 +1411,20 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-expand {
 	width: 100%;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .monaco-button {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-expand
+	.monaco-button {
 	display: flex;
 	align-items: center;
 	gap: 4px;
@@ -1135,11 +1438,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-width: unset;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .monaco-button:focus:not(:focus-visible) {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-expand
+	.monaco-button:focus:not(:focus-visible) {
 	outline: none;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .todo-list-title-section {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-expand
+	.todo-list-title-section {
 	padding-left: 3px;
 	display: flex;
 	align-items: center;
@@ -1151,13 +1464,23 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	line-height: 16px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .todo-list-title-section .codicon {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-expand
+	.todo-list-title-section
+	.codicon {
 	font-size: 16px;
 	line-height: 16px;
 	flex-shrink: 0;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-clear-button-container {
 	padding-right: 2px;
 	display: flex;
 	align-items: center;
@@ -1165,7 +1488,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	opacity: 1;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-clear-button-container
+	.monaco-button {
 	background-color: transparent;
 	border-color: transparent;
 	color: var(--vscode-foreground);
@@ -1181,27 +1509,50 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-right: 1px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button:hover {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-clear-button-container
+	.monaco-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button:focus {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-clear-button-container
+	.monaco-button:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 1px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button .codicon {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-clear-button-container
+	.monaco-button
+	.codicon {
 	font-size: 10px;
 	color: var(--vscode-foreground);
 }
 
-
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .expand-icon {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.expand-icon {
 	flex-shrink: 0;
 	margin-right: 3px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-title {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-title {
 	font-weight: normal;
 	font-size: 11px;
 	display: flex;
@@ -1210,7 +1561,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	text-overflow: ellipsis;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-container {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list-container {
 	margin-top: 2px;
 	max-height: calc(6.5 * 21px);
 	/* 6.5 items to show half-line affordance */
@@ -1223,15 +1578,22 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	/* Half item height to show partial previous item */
 }
 
-
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-list {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 	scroll-snap-type: y proximity;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-item {
 	display: flex;
 	align-items: center;
 	gap: 6px;
@@ -1243,22 +1605,38 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: pointer;
 }
 
-
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item:focus {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-item:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item.focused {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-item.focused {
 	background-color: var(--vscode-list-focusBackground);
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-item > .todo-status-icon.codicon {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-item
+	> .todo-status-icon.codicon {
 	flex-shrink: 0;
 	font-size: 16px;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-content {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.todo-content {
 	flex-grow: 1;
 	overflow: hidden;
 	white-space: nowrap;
@@ -1266,7 +1644,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	min-width: 0;
 }
 
-.interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
+.interactive-session
+	.interactive-input-part
+	> .chat-todo-list-widget-container
+	.chat-todo-list-widget
+	.monaco-scrollable-element
+	.monaco-list-rows
+	.monaco-list-row {
 	border-radius: 2px;
 }
 
@@ -1292,28 +1676,62 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-input-foreground);
 }
 
-.interactive-session .chat-editor-container .monaco-editor .chat-prompt-spinner {
+.interactive-session
+	.chat-editor-container
+	.monaco-editor
+	.chat-prompt-spinner {
 	transform-origin: 6px 6px;
 	font-size: 12px;
 }
 
-.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor,
-.interactive-session .interactive-input-part .chat-editor-container .interactive-input-editor .monaco-editor .monaco-editor-background {
+.interactive-session
+	.interactive-input-part
+	.chat-editor-container
+	.interactive-input-editor
+	.monaco-editor,
+.interactive-session
+	.interactive-input-part
+	.chat-editor-container
+	.interactive-input-editor
+	.monaco-editor
+	.monaco-editor-background {
 	background-color: var(--vscode-input-background);
 }
 
-.interactive-session .interactive-input-part.editing .chat-input-container .chat-editor-container .monaco-editor,
-.interactive-session .interactive-input-part.editing .chat-input-container .chat-editor-container .monaco-editor .monaco-editor-background,
-.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container .chat-editor-container .monaco-editor,
-.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container .chat-editor-container .monaco-editor .monaco-editor-background {
+.interactive-session
+	.interactive-input-part.editing
+	.chat-input-container
+	.chat-editor-container
+	.monaco-editor,
+.interactive-session
+	.interactive-input-part.editing
+	.chat-input-container
+	.chat-editor-container
+	.monaco-editor
+	.monaco-editor-background,
+.interactive-session
+	.interactive-request.editing
+	.interactive-input-part
+	.chat-input-container
+	.chat-editor-container
+	.monaco-editor,
+.interactive-session
+	.interactive-request.editing
+	.interactive-input-part
+	.chat-input-container
+	.chat-editor-container
+	.monaco-editor
+	.monaco-editor-background {
 	background-color: transparent;
 }
 
 .interactive-session .interactive-input-part.editing .chat-input-container,
-.interactive-session .interactive-request.editing .interactive-input-part .chat-input-container {
+.interactive-session
+	.interactive-request.editing
+	.interactive-input-part
+	.chat-input-container {
 	background-color: var(--vscode-chat-requestBubbleBackground);
 }
-
 
 .interactive-session .chat-editor-container .monaco-editor .cursors-layer {
 	padding-left: 4px;
@@ -1370,25 +1788,38 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-input-toolbars.scroll-top-decoration {
-	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset
+	box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset;
 }
 
 .interactive-session .chat-input-toolbar .chat-modelPicker-item .action-label,
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label {
+.interactive-session
+	.chat-input-toolbar
+	.chat-sessionPicker-item
+	.action-label {
 	height: 16px;
 	padding: 3px 0px 3px 6px;
 	display: flex;
 	align-items: center;
 }
 
-
-.interactive-session .chat-input-toolbar .chat-modelPicker-item .action-label .codicon-chevron-down,
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
+.interactive-session
+	.chat-input-toolbar
+	.chat-modelPicker-item
+	.action-label
+	.codicon-chevron-down,
+.interactive-session
+	.chat-input-toolbar
+	.chat-sessionPicker-item
+	.action-label
+	.codicon-chevron-down {
 	font-size: 12px;
 	margin-left: 2px;
 }
 
-.interactive-session .chat-input-toolbars .monaco-action-bar .actions-container {
+.interactive-session
+	.chat-input-toolbars
+	.monaco-action-bar
+	.actions-container {
 	display: flex;
 	gap: 4px;
 }
@@ -1402,20 +1833,36 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-icon-foreground) !important;
 }
 
-.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor,
-.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .margin,
-.interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-interactive-result-editor-background-color) !important;
+.interactive-response
+	.interactive-result-code-block
+	.interactive-result-editor
+	.monaco-editor,
+.interactive-response
+	.interactive-result-code-block
+	.interactive-result-editor
+	.monaco-editor
+	.margin,
+.interactive-response
+	.interactive-result-code-block
+	.interactive-result-editor
+	.monaco-editor
+	.monaco-editor-background {
+	background-color: var(
+		--vscode-interactive-result-editor-background-color
+	) !important;
 }
 
 .interactive-item-compact .interactive-result-code-block {
 	margin: 0 0 8px 0;
 }
 
-.interactive-item-container .interactive-result-code-block .monaco-toolbar .monaco-action-bar .actions-container {
+.interactive-item-container
+	.interactive-result-code-block
+	.monaco-toolbar
+	.monaco-action-bar
+	.actions-container {
 	padding-inline-start: unset;
 }
-
 
 @keyframes kf-chat-editing-atomic-edit {
 	0% {
@@ -1447,7 +1894,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 @property --chat-editing-last-edit-shift {
-	syntax: '<percentage>';
+	syntax: "<percentage>";
 	initial-value: 100%;
 	inherits: false;
 }
@@ -1468,11 +1915,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .monaco-editor .chat-editing-last-edit-line {
 	--chat-editing-last-edit-shift: 100%;
-	background: linear-gradient(45deg, var(--vscode-editor-rangeHighlightBackground), var(--chat-editing-last-edit-shift), transparent);
+	background: linear-gradient(
+		45deg,
+		var(--vscode-editor-rangeHighlightBackground),
+		var(--chat-editing-last-edit-shift),
+		transparent
+	);
 	animation: 2.3s kf-chat-editing-last-edit-shift ease-in-out infinite;
 	animation-delay: 330ms;
 }
-
 
 .chat-notification-widget .chat-info-codicon,
 .chat-notification-widget .chat-error-codicon,
@@ -1482,7 +1933,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 8px;
 }
 
-.interactive-item-container .value .chat-notification-widget .rendered-markdown p {
+.interactive-item-container
+	.value
+	.chat-notification-widget
+	.rendered-markdown
+	p {
 	margin: 0;
 }
 
@@ -1492,7 +1947,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-response .interactive-response-error-details .rendered-markdown :last-child {
+.interactive-response
+	.interactive-response-error-details
+	.rendered-markdown
+	:last-child {
 	margin-bottom: 0px;
 }
 
@@ -1509,15 +1967,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-interactive-session-foreground);
 }
 
-.chat-attached-context .chat-attached-context-attachment .monaco-icon-name-container.warning,
-.chat-attached-context .chat-attached-context-attachment .monaco-icon-suffix-container.warning,
+.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-name-container.warning,
+.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-suffix-container.warning,
 .chat-used-context-list .monaco-icon-name-container.warning,
 .chat-used-context-list .monaco-icon-suffix-container.warning {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
-.chat-attached-context .chat-attached-context-attachment.show-file-icons.warning,
-.chat-attached-context .chat-attached-context-attachment.show-file-icons.partial-warning {
+.chat-attached-context
+	.chat-attached-context-attachment.show-file-icons.warning,
+.chat-attached-context
+	.chat-attached-context-attachment.show-file-icons.partial-warning {
 	border-color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
@@ -1526,7 +1990,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
  */
 .chat-attached-context-attachment .prompt-type {
 	opacity: 0.7;
-	font-size: .9em;
+	font-size: 0.9em;
 	margin-left: 0.5em;
 }
 
@@ -1538,7 +2002,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-notificationsErrorIcon-foreground);
 }
 
-.chat-attached-context-attachment .monaco-icon-label > .monaco-icon-label-container > .monaco-icon-suffix-container > .label-suffix {
+.chat-attached-context-attachment
+	.monaco-icon-label
+	> .monaco-icon-label-container
+	> .monaco-icon-suffix-container
+	> .label-suffix {
 	color: var(--vscode-peekViewTitleDescription-foreground);
 	opacity: 1;
 }
@@ -1577,7 +2045,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part.compact {
 	margin: 0;
-	padding: 8px 0 0 0
+	padding: 8px 0 0 0;
 }
 
 .action-item.chat-attachment-button .action-label,
@@ -1586,7 +2054,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 	font-size: 11px;
 	padding: 0 4px 0 0;
-	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
+	border: 1px solid
+		var(
+			--vscode-chat-requestBorder,
+			var(--vscode-input-background, transparent)
+		);
 	border-radius: 4px;
 	height: 18px;
 	max-width: 100%;
@@ -1597,7 +2069,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 0 4px;
 }
 
-.interactive-session .interactive-list .chat-attached-context .chat-attached-context-attachment {
+.interactive-session
+	.interactive-list
+	.chat-attached-context
+	.chat-attached-context-attachment {
 	font-family: var(--vscode-chat-font-family, inherit);
 	font-size: var(--vscode-chat-font-size-body-xs);
 }
@@ -1607,14 +2082,20 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: auto;
 }
 
-.interactive-session .action-item.chat-attachment-button .action-label:not(.has-label) {
+.interactive-session
+	.action-item.chat-attachment-button
+	.action-label:not(.has-label) {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	padding: 2px 4px 2px 4px;
 	height: fit-content;
 	gap: 0;
-	border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
+	border: 1px solid
+		var(
+			--vscode-chat-requestBorder,
+			var(--vscode-input-background, transparent)
+		);
 	border-radius: 4px;
 	box-sizing: border-box;
 
@@ -1628,7 +2109,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .action-item.chat-mcp {
-
 	.chat-mcp-state-indicator {
 		position: absolute;
 		bottom: 0;
@@ -1653,11 +2133,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.action-item.chat-attached-context-attachment.chat-add-files .action-label.codicon::before {
+.action-item.chat-attached-context-attachment.chat-add-files
+	.action-label.codicon::before {
 	font: normal normal normal 16px/1 codicon;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-button {
 	display: flex;
 	align-items: center;
 	margin-top: -2px;
@@ -1668,24 +2152,36 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 12px;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-button.codicon.codicon-plus {
 	padding-left: 4px;
 	font-size: 11px;
 }
 
 .chat-related-files .monaco-button.codicon.codicon-add:hover,
 .action-item.chat-attached-context-attachment.chat-add-files:hover,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button:hover {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-button:hover {
 	cursor: pointer;
 	background: var(--vscode-toolbar-hoverBackground);
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .monaco-button:hover {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled
+	.monaco-button:hover {
 	cursor: pointer;
 	background: transparent;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label-container {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label-container {
 	display: flex;
 
 	.monaco-icon-suffix-container {
@@ -1694,7 +2190,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label-container .monaco-highlighted-label {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label-container
+	.monaco-highlighted-label {
 	display: inline-flex;
 	align-items: center;
 	overflow: hidden;
@@ -1702,19 +2202,41 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	text-overflow: ellipsis;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-close,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-close,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-plus,
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-plus {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label
+	.monaco-button.codicon.codicon-close,
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-button.codicon.codicon-close,
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label
+	.monaco-button.codicon.codicon-plus,
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-button.codicon.codicon-plus {
 	color: var(--vscode-descriptionForeground);
 	cursor: pointer;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .codicon {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label
+	.codicon {
 	font-size: 14px;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-icon-label-iconpath.codicon {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label
+	.monaco-icon-label-iconpath.codicon {
 	padding-top: 2px;
 }
 
@@ -1740,35 +2262,55 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-wrap: wrap;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit .chat-implicit-hint {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit
+	.chat-implicit-hint {
 	opacity: 0.7;
-	font-size: .9em;
+	font-size: 0.9em;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .chat-implicit-hint {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled
+	.chat-implicit-hint {
 	font-style: italic;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled {
 	border-style: dashed;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled:focus {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled:focus {
 	outline: none;
 	border-color: var(--vscode-focusBorder);
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled .monaco-icon-label .label-name {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled
+	.monaco-icon-label
+	.label-name {
 	text-decoration: line-through;
 	font-style: italic;
 	opacity: 0.8;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label {
 	gap: 4px;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label::before {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label::before {
 	height: auto;
 	padding: 0;
 	line-height: 100% !important;
@@ -1779,12 +2321,18 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-repeat: no-repeat;
 }
 
-.interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label.predefined-file-icon::before {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment
+	.monaco-icon-label.predefined-file-icon::before {
 	padding: 0 0 0 2px;
 	align-content: center;
 }
 
-.interactive-session .interactive-item-container.interactive-request .chat-attached-context .chat-attached-context-attachment {
+.interactive-session
+	.interactive-item-container.interactive-request
+	.chat-attached-context
+	.chat-attached-context-attachment {
 	padding-right: 6px;
 }
 
@@ -1813,7 +2361,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-bottom: 4px;
 } */
 
-.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups .monaco-button {
+.interactive-session
+	.interactive-input-part
+	.interactive-input-followups
+	.interactive-session-followups
+	.monaco-button {
 	display: block;
 	color: var(--vscode-textLink-foreground);
 	font-size: 12px;
@@ -1826,12 +2378,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	overflow: hidden;
 }
 
-.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups code {
+.interactive-session
+	.interactive-input-part
+	.interactive-input-followups
+	.interactive-session-followups
+	code {
 	font-family: var(--monaco-monospace-font);
 	font-size: 11px;
 }
 
-.interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups .monaco-button .codicon-sparkle {
+.interactive-session
+	.interactive-input-part
+	.interactive-input-followups
+	.interactive-session-followups
+	.monaco-button
+	.codicon-sparkle {
 	float: left;
 }
 
@@ -1856,12 +2417,23 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin: 0 3px;
 }
 
-.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars .monaco-toolbar,
-.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars .actions-container {
+.quick-input-widget
+	.interactive-session
+	.interactive-input-part
+	.chat-input-toolbars
+	.monaco-toolbar,
+.quick-input-widget
+	.interactive-session
+	.interactive-input-part
+	.chat-input-toolbars
+	.actions-container {
 	height: initial;
 }
 
-.quick-input-widget .interactive-session .interactive-input-part .chat-input-toolbars {
+.quick-input-widget
+	.interactive-session
+	.interactive-input-part
+	.chat-input-toolbars {
 	margin-bottom: 1px;
 	align-items: flex-end;
 }
@@ -1897,7 +2469,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* #endregion */
 
-.interactive-response-progress-tree .monaco-list-row:not(.selected) .monaco-tl-row:hover {
+.interactive-response-progress-tree
+	.monaco-list-row:not(.selected)
+	.monaco-tl-row:hover {
 	background-color: var(--vscode-list-hoverBackground);
 }
 
@@ -1909,7 +2483,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border-color: var(--vscode-focusBorder, transparent);
 }
 
-.interactive-item-container .value .interactive-response-placeholder-codicon .codicon {
+.interactive-item-container
+	.value
+	.interactive-response-placeholder-codicon
+	.codicon {
 	color: var(--vscode-editorGhostText-foreground);
 }
 
@@ -1939,7 +2516,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-chat-slashCommandBackground);
 	color: var(--vscode-chat-slashCommandForeground);
 }
-
 
 .interactive-item-container .chat-resource-widget,
 .interactive-item-container .chat-agent-widget .monaco-button {
@@ -2022,11 +2598,16 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		float: left;
 	}
 
-	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button {
+	.checkpoint-file-changes-summary-header
+		.chat-file-changes-label
+		.monaco-button {
 		width: 100%;
 	}
 
-	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button .codicon {
+	.checkpoint-file-changes-summary-header
+		.chat-file-changes-label
+		.monaco-button
+		.codicon {
 		font-size: 16px;
 	}
 
@@ -2063,8 +2644,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session .checkpoint-file-changes-summary.chat-file-changes-collapsed .chat-summary-list,
-.interactive-session .chat-used-context.chat-used-context-collapsed .chat-used-context-list {
+.interactive-session
+	.checkpoint-file-changes-summary.chat-file-changes-collapsed
+	.chat-summary-list,
+.interactive-session
+	.chat-used-context.chat-used-context-collapsed
+	.chat-used-context-list {
 	display: none;
 }
 
@@ -2096,13 +2681,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session-list {
-
 	.monaco-icon-label {
 		padding: 0px 3px;
 	}
 
 	.monaco-icon-label.excluded {
-		color: var(--vscode-notificationsWarningIcon-foreground)
+		color: var(--vscode-notificationsWarningIcon-foreground);
 	}
 }
 
@@ -2135,7 +2719,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-list-divider .chat-list-divider-line {
 	flex: 1;
 	height: 1px;
-	background-color: var(--vscode-editorWidget-border, var(--vscode-contrastBorder));
+	background-color: var(
+		--vscode-editorWidget-border,
+		var(--vscode-contrastBorder)
+	);
 	opacity: 0.5;
 }
 
@@ -2208,7 +2795,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-used-context-label .monaco-button:hover {
 	background-color: var(--vscode-list-hoverBackground);
 	color: var(--vscode-foreground);
-
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus,
@@ -2217,7 +2803,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus-visible,
-.interactive-session .chat-used-context-label .monaco-text-button:focus-visible {
+.interactive-session
+	.chat-used-context-label
+	.monaco-text-button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 }
 
@@ -2237,7 +2825,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	The working progress also can be replaced by a tool progress part. So align this padding so the text doesn't appear to shift. */
 	padding-top: 2px;
 
-	> .codicon[class*='codicon-'] {
+	> .codicon[class*="codicon-"] {
 		font-size: var(--vscode-chat-font-size-body-s);
 
 		&::before {
@@ -2286,7 +2874,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 6px;
 }
 
-.interactive-item-container .chat-confirmation-widget .interactive-result-code-block,
+.interactive-item-container
+	.chat-confirmation-widget
+	.interactive-result-code-block,
 .interactive-item-container .chat-confirmation-widget .chat-attached-context {
 	margin-bottom: 8px;
 }
@@ -2323,7 +2913,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: block;
 }
 
-.chat-attached-context-hover .chat-attached-context-image-container .chat-attached-context-image {
+.chat-attached-context-hover
+	.chat-attached-context-image-container
+	.chat-attached-context-image {
 	width: 100%;
 	height: 100%;
 	object-fit: contain;
@@ -2332,7 +2924,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	max-width: 100%;
 	min-width: 200px;
 	min-height: 200px;
-
 }
 
 .chat-attached-context-hover .chat-attached-context-url {
@@ -2356,7 +2947,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	margin-top: 2px;
 }
 
-
 .chat-attached-context-attachment .chat-attached-context-pill {
 	font-size: 12px;
 	display: inline-flex;
@@ -2371,7 +2961,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .chat-attached-context-attachment .attachment-additional-info {
 	opacity: 0.7;
-	font-size: .9em;
+	font-size: 0.9em;
 }
 
 .chat-attached-context-attachment .chat-attached-context-pill-image {
@@ -2393,12 +2983,14 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: inline-block;
 }
 
-.chat-attached-context-attachment.show-file-icons.warning .chat-attached-context-custom-text {
+.chat-attached-context-attachment.show-file-icons.warning
+	.chat-attached-context-custom-text {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 	text-decoration: line-through;
 }
 
-.chat-attached-context-attachment.show-file-icons.partial-warning .chat-attached-context-custom-text {
+.chat-attached-context-attachment.show-file-icons.partial-warning
+	.chat-attached-context-custom-text {
 	color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
@@ -2460,22 +3052,25 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.hideSuggestTextIcons .suggest-widget .monaco-list .monaco-list-row .suggest-icon.codicon-symbol-text::before {
+.hideSuggestTextIcons
+	.suggest-widget
+	.monaco-list
+	.monaco-list-row
+	.suggest-icon.codicon-symbol-text::before {
 	display: none;
 }
 
 .interactive-session:not(.chat-widget > .interactive-session) {
-
 	.interactive-item-container {
 		padding: 5px 16px;
 	}
 
 	.interactive-item-container.interactive-request {
 		align-items: flex-end;
-
 	}
 
-	.interactive-item-container.interactive-request:not(.editing):hover .request-hover {
+	.interactive-item-container.interactive-request:not(.editing):hover
+		.request-hover {
 		opacity: 1 !important;
 	}
 
@@ -2502,21 +3097,35 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		margin-left: auto;
 	}
 
-	.interactive-item-container.interactive-request .value .rendered-markdown.clickable:hover {
+	.interactive-item-container.interactive-request
+		.value
+		.rendered-markdown.clickable:hover {
 		cursor: pointer;
 		background-color: var(--vscode-chat-requestBubbleHoverBackground);
 	}
 
-	.hc-black .interactive-item-container.interactive-request .value .rendered-markdown,
-	.hc-light .interactive-item-container.interactive-request .value .rendered-markdown {
+	.hc-black
+		.interactive-item-container.interactive-request
+		.value
+		.rendered-markdown,
+	.hc-light
+		.interactive-item-container.interactive-request
+		.value
+		.rendered-markdown {
 		border: 1px dotted var(--vscode-focusBorder);
 	}
 
-	.interactive-item-container.interactive-request .value .rendered-markdown > :last-child {
+	.interactive-item-container.interactive-request
+		.value
+		.rendered-markdown
+		> :last-child {
 		margin-bottom: 0px;
 	}
 
-	.interactive-item-container.interactive-request .value > .rendered-markdown p {
+	.interactive-item-container.interactive-request
+		.value
+		> .rendered-markdown
+		p {
 		width: fit-content;
 	}
 
@@ -2556,7 +3165,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		position: absolute;
 		overflow: hidden;
 		z-index: 100;
-		background-color: var(--vscode-interactive-result-editor-background-color, var(--vscode-editor-background));
+		background-color: var(
+			--vscode-interactive-result-editor-background-color,
+			var(--vscode-editor-background)
+		);
 		border: 1px solid var(--vscode-chat-requestBorder);
 		top: -13px;
 		right: 20px;
@@ -2587,7 +3199,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 
 	.request-hover:not(.expanded) .actions-container {
-
 		.action-label.codicon-discard,
 		.action-label.codicon-x,
 		.action-label.codicon-edit {
@@ -2599,7 +3210,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.request-hover:focus-within {
 		opacity: 1 !important;
 	}
-
 
 	.checkpoint-container,
 	.checkpoint-restore-container {
@@ -2639,7 +3249,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 
 		.monaco-toolbar .action-label {
-			border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background));
+			border: 1px solid
+				var(--vscode-chat-requestBorder, var(--vscode-input-background));
 			padding: 1px 5px;
 			background-color: var(--vscode-sideBar-background);
 		}
@@ -2664,19 +3275,30 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.checkpoint-container .monaco-toolbar:focus-within,
 	.checkpoint-restore-container .monaco-toolbar,
-	.interactive-item-container.interactive-request:not(.editing):hover .checkpoint-container .monaco-toolbar {
+	.interactive-item-container.interactive-request:not(.editing):hover
+		.checkpoint-container
+		.monaco-toolbar {
 		opacity: 1;
 	}
 
-	.interactive-item-container.interactive-request.editing .checkpoint-container {
+	.interactive-item-container.interactive-request.editing
+		.checkpoint-container {
 		display: none;
 	}
 
-	.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row {
+	.interactive-list
+		> .monaco-list
+		> .monaco-scrollable-element
+		> .monaco-list-rows
+		> .monaco-list-row {
 		overflow: visible !important;
 	}
 
-	.interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.monaco-list-row.focused.request {
+	.interactive-list
+		> .monaco-list
+		> .monaco-scrollable-element
+		> .monaco-list-rows
+		> .monaco-list-row.monaco-list-row.focused.request {
 		outline: none !important;
 	}
 
@@ -2694,7 +3316,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 	}
 
-	.interactive-list > .monaco-list:focus > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row.focused.request {
+	.interactive-list
+		> .monaco-list:focus
+		> .monaco-scrollable-element
+		> .monaco-list-rows
+		> .monaco-list-row.focused.request {
 		outline: none !important;
 
 		.interactive-item-container .value .rendered-markdown {
@@ -2718,14 +3344,20 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.interactive-request.editing {
 		padding: 0px;
 
-		.interactive-input-part .chat-input-container .interactive-input-editor .monaco-editor .native-edit-context {
+		.interactive-input-part
+			.chat-input-container
+			.interactive-input-editor
+			.monaco-editor
+			.native-edit-context {
 			opacity: 0;
 		}
 	}
 }
 
-.editor-instance .interactive-session .interactive-item-container.interactive-response .checkpoint-restore-container {
-
+.editor-instance
+	.interactive-session
+	.interactive-item-container.interactive-response
+	.checkpoint-restore-container {
 	.checkpoint-label-text,
 	.monaco-toolbar {
 		background-color: var(--vscode-editor-background);
@@ -2781,8 +3413,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	height: 1px;
 }
 
-
-.interactive-session .chat-attached-context .chat-attached-context-attachment.implicit.disabled:hover {
+.interactive-session
+	.chat-attached-context
+	.chat-attached-context-attachment.implicit.disabled:hover {
 	cursor: pointer;
 	border-style: solid;
 	background-color: var(--vscode-toolbar-hoverBackground);
@@ -2843,8 +3476,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-shrink: 0;
 }
 
-.chat-welcome-view-suggested-prompt > .chat-suggest-next-dropdown:hover .dropdown-chevron,
-.chat-welcome-view-suggested-prompt > .chat-suggest-next-dropdown:focus .dropdown-chevron {
+.chat-welcome-view-suggested-prompt
+	> .chat-suggest-next-dropdown:hover
+	.dropdown-chevron,
+.chat-welcome-view-suggested-prompt
+	> .chat-suggest-next-dropdown:focus
+	.dropdown-chevron {
 	opacity: 1;
 }
 


### PR DESCRIPTION
I noticed that the model name was overflowing when the chat window was very narrow, to fix it I added some css styles so that it adds some ellipsis dots to the name.

Haven't got a issue for this, but can create one.

Old look:
<img width="310" height="219" alt="Screenshot 2026-01-01 at 14 45 46" src="https://github.com/user-attachments/assets/cc789c51-5ac4-4f82-ad30-ced925ca6bd6" />


New look:
<img width="329" height="209" alt="Screenshot 2026-01-01 at 14 44 53" src="https://github.com/user-attachments/assets/0d66507c-f4c6-4b03-b10a-96cc03bae073" />
