### PR TITLE
Increase webgl context max to 32

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -352,6 +352,10 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	// Runtime sets the default version to 3, refs https://github.com/electron/electron/pull/44426
 	app.commandLine.appendSwitch('xdg-portal-required-version', '4');
 
+	// Increase the maximum number of active WebGL contexts as each terminal may
+	// use up to 2
+	app.commandLine.appendSwitch('max-active-webgl-contexts', '32');
+
 	return argvConfig;
 }
 


### PR DESCRIPTION
Defaults to 16, this doubles it since sticky scroll takes up another one since that was added.

Fixes #285574

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
