### PR TITLE
Tighten webgl lifecycle, ensure chat doesn't use

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -59,7 +59,7 @@ abstract class DetachedTerminalMirror extends Disposable {
 		container.classList.add('chat-terminal-output-terminal');
 		const needsAttach = this._attachedContainer !== container || container.firstChild === null;
 		if (needsAttach) {
-			terminal.attachToElement(container);
+			terminal.attachToElement(container, { enableGpu: false });
 			this._attachedContainer = container;
 		}
 		return terminal;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -803,6 +803,10 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 		if (!this.raw.element || this._webglAddon && this._webglAddonCustomGlyphs === this._terminalConfigurationService.config.customGlyphs) {
 			return;
 		}
+
+		// Dispose of existing addon before creating a new one to avoid leaking WebGL contexts
+		this._disposeOfWebglRenderer();
+
 		this._webglAddonCustomGlyphs = this._terminalConfigurationService.config.customGlyphs;
 
 		const Addon = await this._xtermAddonLoader.importAddon('webgl');
@@ -892,6 +896,9 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 	}
 
 	private _disposeOfWebglRenderer(): void {
+		if (!this._webglAddon) {
+			return;
+		}
 		try {
 			this._webglAddon?.dispose();
 		} catch {


### PR DESCRIPTION
The webgl renderer has a limited number of contexts, because there are potentially many chat terminals and interaction with them is minimal, we don't want to consume one of the contexts.

Fixes #285452

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
