### PR TITLE
Update swipeToNavigate Commands (microsoft#285591)

### DIFF
--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -1103,9 +1103,9 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 			}
 
 			if (cmd === 'left') {
-				this.send('vscode:runAction', { id: 'workbench.action.openPreviousRecentlyUsedEditor', from: 'mouse' });
+				this.send('vscode:runAction', { id: 'workbench.action.navigateBack', from: 'mouse' });
 			} else if (cmd === 'right') {
-				this.send('vscode:runAction', { id: 'workbench.action.openNextRecentlyUsedEditor', from: 'mouse' });
+				this.send('vscode:runAction', { id: 'workbench.action.navigateForward', from: 'mouse' });
 			}
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR updates the commands that are called when using swipeToNavigate.

Steps to Reproduce:

1. click the back arrow, and the forward arrow suggests I can go forward
2. swipe forward, and nothing happens
3. swipe backwards, and it brings you forward in history, but to a previous editor
4. swipe forwards again, and the arrow doesn't reappear even though I am at the same place as before
5. now I don't know where I am in the history
