### PR TITLE
feat: add hoverForeground and hoverBackground to activity bars

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -13,7 +13,7 @@ import { IInstantiationService, ServicesAccessor } from '../../../../platform/in
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ToggleSidebarPositionAction, ToggleSidebarVisibilityAction } from '../../actions/layoutActions.js';
 import { IThemeService, IColorTheme, registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
-import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_ACTIVE_BORDER, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_INACTIVE_FOREGROUND, ACTIVITY_BAR_ACTIVE_BACKGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_ACTIVE_FOCUS_BORDER } from '../../../common/theme.js';
+import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_ACTIVE_BORDER, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_INACTIVE_FOREGROUND, ACTIVITY_BAR_ACTIVE_BACKGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_ACTIVE_FOCUS_BORDER, ACTIVITY_BAR_HOVER_FOREGROUND, ACTIVITY_BAR_HOVER_BACKGROUND } from '../../../common/theme.js';
 import { activeContrastBorder, contrastBorder, focusBorder } from '../../../../platform/theme/common/colorRegistry.js';
 import { addDisposableListener, append, EventType, isAncestor, $, clearNode } from '../../../../base/browser/dom.js';
 import { assertReturnsDefined } from '../../../../base/common/types.js';
@@ -93,6 +93,8 @@ export class ActivitybarPart extends Part {
 				badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 				badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
 				dragAndDropBorder: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BORDER),
+				hoverForegroundColor: theme.getColor(ACTIVITY_BAR_HOVER_FOREGROUND),
+				hoverBackgroundColor: theme.getColor(ACTIVITY_BAR_HOVER_BACKGROUND),
 				activeBackgroundColor: undefined, inactiveBackgroundColor: undefined, activeBorderBottomColor: undefined,
 			}),
 			overflowActionSize: ActivitybarPart.ACTION_HEIGHT,
@@ -575,6 +577,24 @@ registerThemingParticipant((theme, collector) => {
 			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator {
 				z-index: 0;
 				background-color: ${activityBarActiveBackgroundColor};
+			}
+		`);
+	}
+
+	// Hover colors
+	const activityBarHoverForegroundColor = theme.getColor(ACTIVITY_BAR_HOVER_FOREGROUND);
+	const activityBarHoverBackgroundColor = theme.getColor(ACTIVITY_BAR_HOVER_BACKGROUND);
+	if (activityBarHoverForegroundColor) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .action-label::before {
+				color: ${activityBarHoverForegroundColor};
+			}
+		`);
+	}
+	if (activityBarHoverBackgroundColor) {
+		collector.addRule(`
+			.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:not(.checked):hover .action-label::before {
+				background-color: ${activityBarHoverBackgroundColor};
 			}
 		`);
 	}

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -134,6 +134,8 @@ export interface ICompositeBarColors {
 	readonly activeBorderBottomColor?: Color;
 	readonly activeForegroundColor?: Color;
 	readonly inactiveForegroundColor?: Color;
+	readonly hoverForegroundColor?: Color;
+	readonly hoverBackgroundColor?: Color;
 	readonly badgeBackground?: Color;
 	readonly badgeForeground?: Color;
 	readonly dragAndDropBorder?: Color;

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -13,7 +13,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { contrastBorder } from '../../../../platform/theme/common/colorRegistry.js';
-import { SIDE_BAR_TITLE_FOREGROUND, SIDE_BAR_TITLE_BORDER, SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND, SIDE_BAR_BORDER, SIDE_BAR_DRAG_AND_DROP_BACKGROUND, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_TOP_FOREGROUND, ACTIVITY_BAR_TOP_ACTIVE_BORDER, ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND, ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER } from '../../../common/theme.js';
+import { SIDE_BAR_TITLE_FOREGROUND, SIDE_BAR_TITLE_BORDER, SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND, SIDE_BAR_BORDER, SIDE_BAR_DRAG_AND_DROP_BACKGROUND, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_TOP_FOREGROUND, ACTIVITY_BAR_TOP_ACTIVE_BORDER, ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND, ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_TOP_HOVER_FOREGROUND, ACTIVITY_BAR_TOP_HOVER_BACKGROUND } from '../../../common/theme.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { AnchorAlignment } from '../../../../base/browser/ui/contextview/contextview.js';
@@ -199,7 +199,9 @@ export class SidebarPart extends AbstractPaneCompositePart {
 				inactiveForegroundColor: theme.getColor(ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND),
 				badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 				badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
-				dragAndDropBorder: theme.getColor(ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER)
+				dragAndDropBorder: theme.getColor(ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER),
+				hoverForegroundColor: theme.getColor(ACTIVITY_BAR_TOP_HOVER_FOREGROUND),
+				hoverBackgroundColor: theme.getColor(ACTIVITY_BAR_TOP_HOVER_BACKGROUND)
 			}),
 			compact: true
 		};

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -474,6 +474,16 @@ export const ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER = registerColor('activityBarT
 
 export const ACTIVITY_BAR_TOP_BACKGROUND = registerColor('activityBarTop.background', null, localize('activityBarTopBackground', "Background color of the activity bar when set to top / bottom."));
 
+// Activity Bar Hover Colors
+export const ACTIVITY_BAR_HOVER_FOREGROUND = registerColor('activityBar.hoverForeground', ACTIVITY_BAR_FOREGROUND, localize('activityBarHoverForeground', "Activity bar item foreground color when hovering. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_HOVER_BACKGROUND = registerColor('activityBar.hoverBackground', null, localize('activityBarHoverBackground', "Activity bar item background color when hovering. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_TOP_HOVER_FOREGROUND = registerColor('activityBarTop.hoverForeground', ACTIVITY_BAR_TOP_FOREGROUND, localize('activityBarTopHoverForeground', "Activity bar item foreground color when hovering and the activity bar is on top / bottom. The activity allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_TOP_HOVER_BACKGROUND = registerColor('activityBarTop.hoverBackground', null, localize('activityBarTopHoverBackground', "Activity bar item background color when hovering and the activity bar is on top / bottom. The activity allows to switch between views of the side bar."));
+
+
 
 // < --- Panels --- >
 


### PR DESCRIPTION
## Summary

This PR adds new color customization tokens for the activity bar hover state, allowing theme creators and users to set distinct colors when hovering over activity bar icons.

## New Color Tokens

| Token | Description |
|-------|-------------|
| `activityBar.hoverForeground` | Foreground color when hovering over activity bar items |
| `activityBar.hoverBackground` | Background color when hovering over activity bar items |
| `activityBarTop.hoverForeground` | Foreground when hovering (activity bar at top/bottom) |
| `activityBarTop.hoverBackground` | Background when hovering (activity bar at top/bottom) |

## Problem

Currently, the foreground color when hovering applies the same as the active foreground color. This causes issues when trying to customize themes where the hover foreground ends up being the same as the background color, making icons invisible during hover.

## Changes

- **`src/vs/workbench/common/theme.ts`**: Added 4 new color token registrations
- **`src/vs/workbench/browser/parts/compositeBarActions.ts`**: Extended `ICompositeBarColors` interface
- **`src/vs/workbench/browser/parts/activitybar/activitybarPart.ts`**: Integrated hover colors with CSS theming
- **`src/vs/workbench/browser/parts/sidebar/sidebarPart.ts`**: Added hover colors for top/bottom position

## Example Usage

```json
{
  "activityBar.hoverForeground": "#00a0df",
  "activityBar.hoverBackground": "#a4dcf3"
}
```

Fixes #210694