### PR TITLE
fix: show restart extensions notification when disabling from Running Extensions view

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -487,8 +487,28 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 			actions.push(new Separator());
 
 			if (e.element.marketplaceInfo) {
-				actions.push(new Action('runtimeExtensionsEditor.action.disableWorkspace', nls.localize('disable workspace', "Disable (Workspace)"), undefined, true, () => this._extensionsWorkbenchService.setEnablement(e.element!.marketplaceInfo!, EnablementState.DisabledWorkspace)));
-				actions.push(new Action('runtimeExtensionsEditor.action.disable', nls.localize('disable', "Disable"), undefined, true, () => this._extensionsWorkbenchService.setEnablement(e.element!.marketplaceInfo!, EnablementState.DisabledGlobally)));
+				actions.push(new Action('runtimeExtensionsEditor.action.disableWorkspace', nls.localize('disable workspace', "Disable (Workspace)"), undefined, true, async () => {
+					await this._extensionsWorkbenchService.setEnablement(e.element!.marketplaceInfo!, EnablementState.DisabledWorkspace);
+					this._notificationService.prompt(
+						Severity.Info,
+						nls.localize('restartExtensionsRequired', "The extension has been disabled. Please restart extensions to apply the change."),
+						[{
+							label: nls.localize('restartExtensions', "Restart Extensions"),
+							run: () => this._extensionsWorkbenchService.updateRunningExtensions()
+						}]
+					);
+				}));
+				actions.push(new Action('runtimeExtensionsEditor.action.disable', nls.localize('disable', "Disable"), undefined, true, async () => {
+					await this._extensionsWorkbenchService.setEnablement(e.element!.marketplaceInfo!, EnablementState.DisabledGlobally);
+					this._notificationService.prompt(
+						Severity.Info,
+						nls.localize('restartExtensionsRequired', "The extension has been disabled. Please restart extensions to apply the change."),
+						[{
+							label: nls.localize('restartExtensions', "Restart Extensions"),
+							run: () => this._extensionsWorkbenchService.updateRunningExtensions()
+						}]
+					);
+				}));
 			}
 			actions.push(new Separator());
 


### PR DESCRIPTION
## Summary

When an extension is disabled from the Running Extensions view context menu, the user was not notified that extensions need to be restarted for the change to take effect. This was inconsistent with the Extensions view behavior.

## Changes

Added a notification with a 'Restart Extensions' button that appears after disabling an extension from the Running Extensions view. This matches the behavior of the main Extensions view.

### Modified File
- `src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts`

## Before
1. Go to Running Extensions (Developer: Show Running Extensions)
2. Right-click on an extension → Disable
3. No notification appears, user doesn't know a restart is needed

## After
1. Go to Running Extensions
2. Right-click on an extension → Disable
3. A notification appears: "The extension has been disabled. Please restart extensions to apply the change."
4. User can click "Restart Extensions" button to apply immediately

Fixes #250201