### PR TITLE
fix: prevent star ratings from being clipped in narrow windows

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -118,6 +118,8 @@
 
 .extension-list-item > .details > .header-container > .header > .ratings {
 	text-align: right;
+	flex-shrink: 0;
+	white-space: nowrap;
 }
 
 .extension-list-item > .details > .header-container > .header .extension-icon-badge .codicon {


### PR DESCRIPTION
## Summary

When the extensions view is narrow, the star ratings would get clipped and only show partial stars (e.g., 2 stars instead of 3+), which could mislead users about extension quality.

## Problem

As described in the issue, users with narrow extension panels would see clipped star ratings:
- A 3+ star extension might appear to have only 2 stars
- Users have no way to know if stars are being clipped
- This leads to incorrect extension evaluation

## Solution

Added CSS properties to ensure ratings stay together as a unit:
- `flex-shrink: 0` - Prevents the ratings container from shrinking
- `white-space: nowrap` - Keeps all stars on one line as a unit

### Modified File
- `src/vs/workbench/contrib/extensions/browser/media/extension.css`

Fixes #120826