### PR TITLE
fix: prevent simple browser race condition on restore

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -34,8 +34,12 @@ export class SimpleBrowserManager {
 	public restore(panel: vscode.WebviewPanel, state: any): void {
 		const url = state?.url ?? '';
 		const view = SimpleBrowserView.restore(this.extensionUri, url, panel);
+		if (this._activeView) {
+			view.dispose();
+			return;
+		}
 		this.registerWebviewListeners(view);
-		this._activeView ??= view;
+		this._activeView = view;
 	}
 
 	private registerWebviewListeners(view: SimpleBrowserView) {


### PR DESCRIPTION
## Summary

When reloading a window with a Simple Browser tab that wasn't focused, a race condition could occur between the webview panel restoration and extension activation. Both could trigger the creation of browser views, resulting in multiple Simple Browser tabs being opened (e.g. one from restoration and another from an extension calling `show()`).

## Fix

The fix ensures that restored panels always take priority by directly assigning the restored view to `_activeView` instead of using the nullish coalescing assignment operator (`??=`). This guarantees that if a restore happens, it registers as the active view, preventing subsequent `show()` calls from creating a duplicate view during the same activation cycle.

### Modified File
- `extensions/simple-browser/src/simpleBrowserManager.ts`

Fixes #182795