### PR TITLE
fix: avoid jumpy scrolling when navigating next/prev problem

### DIFF
--- a/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts
@@ -358,7 +358,7 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 		}
 		this._icon.className = `codicon ${SeverityIcon.className(MarkerSeverity.toSeverity(this._severity))}`;
 
-		this.editor.revealPositionNearTop(position, ScrollType.Smooth);
+		this.editor.revealPositionInCenterIfOutsideViewport(position, ScrollType.Smooth);
 		this.editor.focus();
 	}
 


### PR DESCRIPTION
## Summary

When navigating to the next/prev problem using `editor.action.marker.next` (F8), the editor would always scroll the marker to the top of the viewport using `revealPositionNearTop`. This caused abrupt jumps even when the next error was just slightly below the fold or already visible, leading to loss of context.

## Change

Replaced `revealPositionNearTop` with `revealPositionInCenterIfOutsideViewport`. This ensures that:
- If the marker is already visible, no scrolling occurs.
- If the marker is outside the viewport, it is scrolled to the center (standard VS Code navigation behavior).
- The transition is smooth (`ScrollType.Smooth`).

### Modified File
- `src/vs/editor/contrib/gotoError/browser/gotoErrorWidget.ts`

Fixes #156782