### PR TITLE
Cleanup: Remove unused _hideReplaceToggle in SearchWidget

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -58,6 +58,7 @@ export interface ISearchWidgetOptions {
 	searchHistory?: string[];
 	replaceHistory?: string[];
 	preserveCase?: boolean;
+	_hideReplaceToggle?: boolean;
 	showContextToggle?: boolean;
 	inputBoxStyles: IInputBoxStyles;
 	toggleStyles: IToggleStyles;
@@ -361,7 +362,9 @@ export class SearchWidget extends Widget {
 		this.domNode = dom.append(container, dom.$('.search-widget'));
 		this.domNode.style.position = 'relative';
 
-		this.renderToggleReplaceButton(this.domNode);
+		if (!options._hideReplaceToggle) {
+			this.renderToggleReplaceButton(this.domNode);
+		}
 
 		this.renderSearchInput(this.domNode, options);
 		this.renderReplaceInput(this.domNode, options);

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -58,7 +58,6 @@ export interface ISearchWidgetOptions {
 	searchHistory?: string[];
 	replaceHistory?: string[];
 	preserveCase?: boolean;
-	_hideReplaceToggle?: boolean; // TODO: Search Editor's replace experience
 	showContextToggle?: boolean;
 	inputBoxStyles: IInputBoxStyles;
 	toggleStyles: IToggleStyles;
@@ -362,9 +361,7 @@ export class SearchWidget extends Widget {
 		this.domNode = dom.append(container, dom.$('.search-widget'));
 		this.domNode.style.position = 'relative';
 
-		if (!options._hideReplaceToggle) {
-			this.renderToggleReplaceButton(this.domNode);
-		}
+		this.renderToggleReplaceButton(this.domNode);
 
 		this.renderSearchInput(this.domNode, options);
 		this.renderReplaceInput(this.domNode, options);


### PR DESCRIPTION
Removes the unused '_hideReplaceToggle' option and its associated TODO from 'searchWidget.ts'. This cleans up technical debt and dead code in the search widget configuration.