### PR TITLE
Fix: Replace terminal view lifecycle hack with Event.once

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -337,10 +337,8 @@ export class TerminalViewPane extends ViewPane {
 		// be focused. So wait for connection to finish, then focus.
 		const previousActiveElement = this.element.ownerDocument.activeElement;
 		if (previousActiveElement) {
-			// TODO: Improve lifecycle management this event should be disposed after first fire
-			this._register(this._terminalService.onDidChangeConnectionState(() => {
+			this._register(Event.once(this._terminalService.onDidChangeConnectionState)(() => {
 				// Only focus the terminal if the activeElement has not changed since focus() was called
-				// TODO: Hack
 				if (previousActiveElement && dom.isActiveElement(previousActiveElement)) {
 					this._terminalGroupService.showPanel(true);
 				}

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -337,11 +337,12 @@ export class TerminalViewPane extends ViewPane {
 		// be focused. So wait for connection to finish, then focus.
 		const previousActiveElement = this.element.ownerDocument.activeElement;
 		if (previousActiveElement) {
-			this._register(Event.once(this._terminalService.onDidChangeConnectionState)(() => {
+			const listener = this._register(Event.once(this._terminalService.onDidChangeConnectionState)(() => {
 				// Only focus the terminal if the activeElement has not changed since focus() was called
 				if (previousActiveElement && dom.isActiveElement(previousActiveElement)) {
 					this._terminalGroupService.showPanel(true);
 				}
+				this._store.delete(listener);
 			}));
 		}
 	}


### PR DESCRIPTION
Identical to the fix in terminalTabbedView.ts: replaces a manual 'TODO' event listener in terminalView.ts with a robust Event.once pattern. Ensures proper disposal and prevents memory leaks during terminal connection state changes.