### PR TITLE
Fix #250201: Add Restart action to Running Extensions view

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -46,6 +46,7 @@ import { RuntimeExtensionsInput } from '../common/runtimeExtensionsInput.js';
 import { errorIcon, warningIcon } from './extensionsIcons.js';
 import { ExtensionIconWidget } from './extensionsWidgets.js';
 import './media/runtimeExtensionsEditor.css';
+import { ExtensionRuntimeStateAction } from './extensionsActions.js';
 
 interface IExtensionProfileInformation {
 	/**
@@ -293,6 +294,11 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 				}
 
 				data.actionbar.clear();
+				const extensionRuntimeStateAction = this._instantiationService.createInstance(ExtensionRuntimeStateAction);
+				extensionRuntimeStateAction.extension = element.marketplaceInfo ?? null;
+				data.actionbar.push(extensionRuntimeStateAction, { icon: false, label: true });
+				data.elementDisposables.push(extensionRuntimeStateAction);
+
 				const slowExtensionAction = this._createSlowExtensionAction(element);
 				if (slowExtensionAction) {
 					data.actionbar.push(slowExtensionAction, { icon: false, label: true });


### PR DESCRIPTION
Fixes #250201.

This PR adds the missing 'Restart Extensions' action to the 'Running Extensions' view.
When an extension is disabled from the Running Extensions view, the 'Restart Extensions' button now appears in the action bar, consistent with the behavior in the main Extensions view.

Changes:
- Modified 'src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts' to instantiate and render 'ExtensionRuntimeStateAction'.
