### PR TITLE
Add Node.js version requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "main": "./out/main.js",
   "type": "module",
   "private": true,
-  "scripts": {
+  "engines": {
+    "node": "22.21.1"
+  },
     "test": "echo Please run any of the test scripts from the scripts folder.",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",
     "test-browser-no-install": "node test/unit/browser/index.js",


### PR DESCRIPTION
Added engines field to specify Node.js version.

<!-- Thank you for submitting a Pull Request. Please:
Adds "engines": { "node": "22.21.1" } to the repo root package.json so tooling can warn when contributors use an unsupported Node version.
Aligns with the version pinned in .nvmrc.
Check: node -v shows v22.21.1 and npm install runs successfully.
Fixes #252372
-->
