### PR TITLE
Suppress unhandled errors in WordHighlighter's runDelayer triggers.

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -272,7 +272,7 @@ class WordHighlighter {
 				return;
 			}
 
-			this.runDelayer.trigger(() => { this._onPositionChanged(e); });
+			this.runDelayer.trigger(() => { this._onPositionChanged(e); }).catch(onUnexpectedError);
 		}));
 		this.toUnhook.add(editor.onDidFocusEditorText((e) => {
 			if (this.occurrencesHighlightEnablement === 'off') {
@@ -281,7 +281,7 @@ class WordHighlighter {
 			}
 
 			if (!this.workerRequest) {
-				this.runDelayer.trigger(() => { this._run(); });
+				this.runDelayer.trigger(() => { this._run(); }).catch(onUnexpectedError);
 			}
 		}));
 		this.toUnhook.add(editor.onDidChangeModelContent((e) => {
@@ -364,7 +364,7 @@ class WordHighlighter {
 		}
 
 		this.runDelayer.cancel();
-		this.runDelayer.trigger(() => { this._run(false, delay); });
+		this.runDelayer.trigger(() => { this._run(false, delay); }).catch(onUnexpectedError);
 	}
 
 	public trigger() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #285890 (related: https://github.com/microsoft/monaco-editor/issues/4702 )

## Description

This PR fixes unhandled `CancellationError` exceptions that occur when the `WordHighlighter` is disposed while a delayed operation is pending.

The `Delayer.trigger()` method returns a Promise that rejects with `CancellationError` when cancelled (e.g., during disposal). Without proper error handling, this causes unhandled promise rejection warnings.

### Changes

Added `.catch(onUnexpectedError)` to all three `runDelayer.trigger()` calls in `wordHighlighter.ts`.

The `onUnexpectedError` function from `vs/base/common/errors` automatically filters out `CancellationError`, so only genuine unexpected errors are reported.

This follows the same pattern used in other editor contributions:
- `parameterHintsModel.ts`
- `findWidget.ts`
- `stickyScrollModelProvider.ts`

## How to test

1. Clone https://github.com/y-scope/yscope-log-viewer.git
2. Run `npm ci` then `npm run dev`
3. Open the browser console - without this fix, you'll see:
   ```
   Uncaught (in promise) Canceled: Canceled
       CancellationError errors.js:91
       cancel async.js:251
       dispose async.js:260
       dispose lifecycle.js:24
       clear lifecycle.js:114
       dispose lifecycle.js:98
       dispose wordHighlighter.js:652
       dispose wordHighlighter.js:709
       dispose lifecycle.js:24
   ```
4. Replace the monaco-editor assets in the project with the built assets from this PR
5. Restart the dev server (`npm run dev`)
6. Verify the `CancellationError` warning no longer appears in the browser console
