### PR TITLE
extensions: TreeItem `no-twisty` CSS not always following TreeItemCollapsibleState in 1.107.x (and Insiders)

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -160,10 +160,6 @@
 	flex-wrap: nowrap;
 }
 
-.customview-tree .monaco-list .monaco-list-row .custom-view-tree-node-item.no-twisty {
-	padding-left: 3px;
-}
-
 .customview-tree .monaco-list .monaco-list-row.selected .custom-view-tree-node-item .custom-view-tree-node-item-checkbox {
 	background-color: var(--vscode-checkbox-selectBackground);
 	border: 1px solid var(--vscode-checkbox-selectBorder);

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -751,7 +751,16 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 			},
 			multipleSelectionSupport: this.canSelectMany,
 			dnd: this.treeViewDnd,
-			overrideStyles: getLocationBasedViewColors(this.viewLocation).listOverrideStyles
+			overrideStyles: getLocationBasedViewColors(this.viewLocation).listOverrideStyles,
+			twistieAdditionalCssClass: (element) => {
+				if (!(element.parent instanceof Root)) {
+					return undefined;
+				}
+				if (element.parent.children?.every(child => child.collapsibleState === TreeItemCollapsibleState.None)) {
+					return 'no-twisty';
+				}
+				return undefined;
+			}
 		}));
 
 		this.treeDisposables.add(renderer.onDidChangeMenuContext(e => e.forEach(e => this.tree?.rerender(e))));
@@ -1494,13 +1503,6 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 			templateData.actionBar.actionRunner = this._actionRunner;
 		}
 		this.setAlignment(templateData.container, node);
-		if (node.parent instanceof Root) {
-			if (node.collapsibleState === TreeItemCollapsibleState.None) {
-				templateData.container.classList.add('no-twisty');
-			} else {
-				templateData.container.classList.remove('no-twisty');
-			}
-		}
 
 		// remember rendered element, an element can be rendered multiple times
 		const renderedItems = this._renderedElements.get(element.element.handle) ?? [];

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -751,16 +751,7 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 			},
 			multipleSelectionSupport: this.canSelectMany,
 			dnd: this.treeViewDnd,
-			overrideStyles: getLocationBasedViewColors(this.viewLocation).listOverrideStyles,
-			twistieAdditionalCssClass: (element) => {
-				if (!(element.parent instanceof Root)) {
-					return undefined;
-				}
-				if (element.parent.children?.every(child => child.collapsibleState === TreeItemCollapsibleState.None)) {
-					return 'no-twisty';
-				}
-				return undefined;
-			}
+			overrideStyles: getLocationBasedViewColors(this.viewLocation).listOverrideStyles
 		}));
 
 		this.treeDisposables.add(renderer.onDidChangeMenuContext(e => e.forEach(e => this.tree?.rerender(e))));


### PR DESCRIPTION
Fixes #284625