### PR TITLE
The Move options in the tab editor context menu move the wrong tab (fix #284925)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2123,7 +2123,7 @@ export class MoveEditorToAboveGroupAction extends ExecuteCommandAction {
 			title: localize2('moveEditorToAboveGroup', 'Move Editor into Group Above'),
 			f1: true,
 			category: Categories.View
-		}, MOVE_ACTIVE_EDITOR_COMMAND_ID, { to: 'up', by: 'group' } satisfies SelectedEditorsMoveCopyArguments);
+		}, MOVE_EDITOR_INTO_ABOVE_GROUP);
 	}
 }
 
@@ -2135,7 +2135,7 @@ export class MoveEditorToBelowGroupAction extends ExecuteCommandAction {
 			title: localize2('moveEditorToBelowGroup', 'Move Editor into Group Below'),
 			f1: true,
 			category: Categories.View
-		}, MOVE_ACTIVE_EDITOR_COMMAND_ID, { to: 'down', by: 'group' } satisfies SelectedEditorsMoveCopyArguments);
+		}, MOVE_EDITOR_INTO_BELOW_GROUP);
 	}
 }
 
@@ -2147,7 +2147,7 @@ export class MoveEditorToLeftGroupAction extends ExecuteCommandAction {
 			title: localize2('moveEditorToLeftGroup', 'Move Editor into Left Group'),
 			f1: true,
 			category: Categories.View
-		}, MOVE_ACTIVE_EDITOR_COMMAND_ID, { to: 'left', by: 'group' } satisfies SelectedEditorsMoveCopyArguments);
+		}, MOVE_EDITOR_INTO_LEFT_GROUP);
 	}
 }
 
@@ -2159,7 +2159,7 @@ export class MoveEditorToRightGroupAction extends ExecuteCommandAction {
 			title: localize2('moveEditorToRightGroup', 'Move Editor into Right Group'),
 			f1: true,
 			category: Categories.View
-		}, MOVE_ACTIVE_EDITOR_COMMAND_ID, { to: 'right', by: 'group' } satisfies SelectedEditorsMoveCopyArguments);
+		}, MOVE_EDITOR_INTO_RIGHT_GROUP);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -141,7 +141,7 @@ const isSelectedEditorsMoveCopyArg = function (arg: SelectedEditorsMoveCopyArgum
 	return true;
 };
 
-function registerActiveEditorMoveCopyCommand(): void {
+function registerEditorMoveCopyCommand(): void {
 
 	const moveCopyJSONSchema: IJSONSchema = {
 		'type': 'object',
@@ -199,6 +199,20 @@ function registerActiveEditorMoveCopyCommand(): void {
 		}
 	});
 
+	[
+		{ id: MOVE_EDITOR_INTO_ABOVE_GROUP, to: 'up' as const },
+		{ id: MOVE_EDITOR_INTO_BELOW_GROUP, to: 'down' as const },
+		{ id: MOVE_EDITOR_INTO_LEFT_GROUP, to: 'left' as const },
+		{ id: MOVE_EDITOR_INTO_RIGHT_GROUP, to: 'right' as const }
+	].forEach(({ id, to }) => {
+		CommandsRegistry.registerCommand(id, function (accessor, ...args) {
+			const resolvedContext = resolveCommandsContext(args, accessor.get(IEditorService), accessor.get(IEditorGroupsService), accessor.get(IListService));
+			if (resolvedContext.groupedEditors.length) {
+				moveCopyEditorsToGroup(true, { to, by: 'group' }, resolvedContext.groupedEditors[0].group, resolvedContext.groupedEditors[0].editors, accessor);
+			}
+		});
+	});
+
 	function moveCopySelectedEditors(isMove: boolean, args: SelectedEditorsMoveCopyArguments = Object.create(null), accessor: ServicesAccessor): void {
 		args.to = args.to || 'right';
 		args.by = args.by || 'tab';
@@ -214,7 +228,7 @@ function registerActiveEditorMoveCopyCommand(): void {
 					}
 					break;
 				case 'group':
-					return moveCopyActiveEditorToGroup(isMove, args, activeGroup, selectedEditors, accessor);
+					return moveCopyEditorsToGroup(isMove, args, activeGroup, selectedEditors, accessor);
 			}
 		}
 	}
@@ -259,7 +273,7 @@ function registerActiveEditorMoveCopyCommand(): void {
 		group.moveEditor(editor, group, { index });
 	}
 
-	function moveCopyActiveEditorToGroup(isMove: boolean, args: SelectedEditorsMoveCopyArguments, sourceGroup: IEditorGroup, editors: EditorInput[], accessor: ServicesAccessor): void {
+	function moveCopyEditorsToGroup(isMove: boolean, args: SelectedEditorsMoveCopyArguments, sourceGroup: IEditorGroup, editors: EditorInput[], accessor: ServicesAccessor): void {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		const configurationService = accessor.get(IConfigurationService);
 
@@ -730,6 +744,7 @@ export function splitEditor(editorGroupsService: IEditorGroupsService, direction
 	const newGroup = editorGroupsService.addGroup(group, direction);
 
 	for (const editorToCopy of editors) {
+
 		// Split editor (if it can be split)
 		if (editorToCopy && !editorToCopy.hasCapability(EditorInputCapabilities.Singleton)) {
 			group.copyEditor(editorToCopy, newGroup, { preserveFocus });
@@ -1386,7 +1401,7 @@ function registerOtherEditorCommands(): void {
 }
 
 export function setup(): void {
-	registerActiveEditorMoveCopyCommand();
+	registerEditorMoveCopyCommand();
 	registerEditorGroupsLayoutCommands();
 	registerDiffEditorCommands();
 	registerOpenEditorAPICommands();

--- a/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
@@ -21,7 +21,6 @@ export interface IResolvedEditorCommandsContext {
 }
 
 export function resolveCommandsContext(commandArgs: unknown[], editorService: IEditorService, editorGroupsService: IEditorGroupsService, listService: IListService): IResolvedEditorCommandsContext {
-
 	const commandContext = getCommandsContext(commandArgs, editorService, editorGroupsService, listService);
 	const preserveFocus = commandContext.length ? commandContext[0].preserveFocus || false : false;
 	const resolvedContext: IResolvedEditorCommandsContext = { groupedEditors: [], preserveFocus };
@@ -59,6 +58,7 @@ export function resolveCommandsContext(commandArgs: unknown[], editorService: IE
 }
 
 function getCommandsContext(commandArgs: unknown[], editorService: IEditorService, editorGroupsService: IEditorGroupsService, listService: IListService): IEditorCommandsContext[] {
+
 	// Figure out if command is executed from a list
 	const list = listService.lastFocusedList;
 	let isListAction = list instanceof List && list.getHTMLElement() === getActiveElement();
@@ -103,6 +103,7 @@ function moveCurrentEditorContextToFront(editorContext: IEditorCommandsContext, 
 }
 
 function getEditorContextFromCommandArgs(commandArgs: unknown[], isListAction: boolean, editorService: IEditorService, editorGroupsService: IEditorGroupsService, listService: IListService): IEditorCommandsContext | undefined {
+
 	// We only know how to extraxt the command context from URI and IEditorCommandsContext arguments
 	const filteredArgs = commandArgs.filter(arg => isEditorCommandsContext(arg) || URI.isUri(arg));
 
@@ -177,7 +178,6 @@ function groupOrEditorToEditorContext(element: IEditorIdentifier | IEditorGroup,
 	}
 
 	const group = editorGroupsService.getGroup(element.groupId);
-
 	return { groupId: element.groupId, editorIndex: group ? group.getIndexOfEditor(element.editor) : -1, preserveFocus };
 }
 

--- a/src/vs/workbench/test/browser/parts/editor/editorCommandsContext.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorCommandsContext.test.ts
@@ -184,5 +184,33 @@ suite('Resolving Editor Commands Context', () => {
 		assert.strictEqual(resolvedContext2.preserveFocus, true);
 	});
 
+	test('resolves context from right-clicked editor (not active)', async () => {
+		const accessor = await createServices();
+		const group = accessor.editorGroupService.activeGroup;
+
+		const input1 = input();
+		const input2 = input();
+		await group.openEditor(input1, { pinned: true });
+		await group.openEditor(input2, { pinned: true });
+
+		// input2 is now active (last opened), but we simulate right-click on input1
+		assert.strictEqual(group.activeEditor, input2);
+
+		const editorCommandContext: IEditorCommandsContext = {
+			groupId: group.id,
+			editorIndex: group.getIndexOfEditor(input1),
+			preserveFocus: false
+		};
+		const resolvedContext = resolveCommandsContext([editorCommandContext], accessor.editorService, accessor.editorGroupService, testListService);
+
+		// Should resolve to input1 (right-clicked editor), not input2 (active editor)
+		assert.strictEqual(resolvedContext.groupedEditors.length, 1);
+		assert.strictEqual(resolvedContext.groupedEditors[0].group.id, group.id);
+		assert.strictEqual(resolvedContext.groupedEditors[0].editors.length, 1);
+		assert.strictEqual(resolvedContext.groupedEditors[0].editors[0], input1);
+		assert.notStrictEqual(resolvedContext.groupedEditors[0].editors[0], input2);
+		assert.strictEqual(resolvedContext.preserveFocus, false);
+	});
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
