### PR TITLE
Add vertical spacing to chat title bars

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
@@ -138,7 +138,7 @@
 
 	/* Base padding: left-aligned content */
 	.agent-sessions-title-container {
-		padding: 0 8px 0 20px;
+		padding: 4px 8px 4px 20px;
 	}
 
 	.agent-session-section {
@@ -149,7 +149,7 @@
 	&.sessions-control-orientation-sidebyside.chat-view-position-right {
 
 		.agent-sessions-title-container {
-			padding: 0 8px;
+			padding: 4px 8px;
 		}
 
 		.agent-session-section {
@@ -162,6 +162,7 @@
 
 		.agent-sessions-title-container {
 			padding-right: 4px;
+			padding-top: 0;
 		}
 
 		/* Right position needs adjusted left padding too */

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewTitleControl.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewTitleControl.css
@@ -62,28 +62,22 @@
 	&.chat-view-location-panel,
 	&.chat-view-location-auxiliarybar {
 		.chat-view-title-container {
-			padding: 0 12px 0 16px;
+			padding: 4px 12px 4px 16px;
 		}
 	}
 
 	/* Auxiliarybar with non-default activity bar position */
 	&.activity-bar-location-other.chat-view-location-auxiliarybar {
 		.chat-view-title-container {
-			padding: 0 8px 0 16px;
+			padding: 0 8px 4px 16px;
 		}
 	}
 
-	/* Side-by-side sessions: left position (any activity bar) */
-	&.has-sessions-control.sessions-control-orientation-sidebyside.chat-view-position-left {
-		.chat-view-title-container {
-			padding: 0 8px;
-		}
-	}
-
-	/* Side-by-side sessions: right position (default activity bar only) */
+	/* Side-by-side sessions: left and right position (default activity bar only) */
+	&.activity-bar-location-default.has-sessions-control.sessions-control-orientation-sidebyside.chat-view-position-left,
 	&.activity-bar-location-default.has-sessions-control.sessions-control-orientation-sidebyside.chat-view-position-right {
 		.chat-view-title-container {
-			padding: 0 8px 0 16px;
+			padding: 4px 8px 4px 16px;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds a small amount of vertical spacing (4px) to chat title bars. Also updated the session title bar when appropriate to make sure the titles in both bars remain aligned.

- Default positions: 4px top and bottom padding
- Auxilary positions: 4px bottom padding only (so we don't add too much space between title bar and CHAT activity bar)

Context: Noticed there's no vertical spacing on chat title bars, resulting in a broken looking hover state where there's no space between the hover background of interactive UI (i.e. back button, title, etc) and the bottom edge of the title bar when you've scrolled down a bit.

Before:

<img width="568" height="120" alt="Screenshot 2026-01-05 at 4 16 41 PM" src="https://github.com/user-attachments/assets/8a175418-c000-4d02-b974-462bd5b37d5b" />

<img width="570" height="189" alt="Screenshot 2026-01-05 at 4 18 30 PM" src="https://github.com/user-attachments/assets/c4e1fc02-b2d3-4041-adfb-de6fd86a4757" />

After:

<img width="568" height="128" alt="Screenshot 2026-01-05 at 4 16 17 PM" src="https://github.com/user-attachments/assets/2568dcf6-e2ab-434d-a176-7445203752f0" />

<img width="571" height="188" alt="Screenshot 2026-01-05 at 4 17 11 PM" src="https://github.com/user-attachments/assets/9aa8e9fa-b9bc-4e4b-bd56-dcc130ca6451" />

<img width="865" height="148" alt="Screenshot 2026-01-05 at 4 19 04 PM" src="https://github.com/user-attachments/assets/3f51a6df-31f0-40cb-84ed-9d7de879405a" />