### PR TITLE
Fix Inline CSP style error

### DIFF
--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -50,7 +50,7 @@ class WrappedStyleElement {
 export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
 	const style = document.createElement('style');
 	style.type = 'text/css';
-	style.nonce = mainWindow?.cspNonce;
+	style.nonce = mainWindow.cspNonce;
 	style.media = 'screen';
 	beforeAppend?.(style);
 	container.appendChild(style);

--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -50,6 +50,7 @@ class WrappedStyleElement {
 export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
 	const style = document.createElement('style');
 	style.type = 'text/css';
+	style.nonce = mainWindow?.cspNonce;
 	style.media = 'screen';
 	beforeAppend?.(style);
 	container.appendChild(style);

--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -50,8 +50,10 @@ class WrappedStyleElement {
 export function createStyleSheet(container: HTMLElement = mainWindow.document.head, beforeAppend?: (style: HTMLStyleElement) => void, disposableStore?: DisposableStore): HTMLStyleElement {
 	const style = document.createElement('style');
 	style.type = 'text/css';
-	style.nonce = mainWindow.cspNonce;
 	style.media = 'screen';
+	if (mainWindow.cspNonce) {
+		style.nonce = mainWindow.cspNonce;
+	}
 	beforeAppend?.(style);
 	container.appendChild(style);
 

--- a/src/vs/base/browser/window.ts
+++ b/src/vs/base/browser/window.ts
@@ -5,6 +5,7 @@
 
 export type CodeWindow = Window & typeof globalThis & {
 	readonly vscodeWindowId: number;
+	readonly cspNonce?: string;
 };
 
 export function ensureCodeWindow(targetWindow: Window, fallbackWindowId: number): asserts targetWindow is CodeWindow {

--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -384,24 +384,25 @@ class ViewLayerRenderer<T extends IVisibleLine> {
 
 	private static _ttPolicy = createTrustedTypesPolicy('editorViewLayer', {
 		createHTML: (value: string) => {
-			if (mainWindow?.cspNonce) {
-				const stylePattern: RegExp = new RegExp('style\\s*=\\s*([\"\'])(.*?)\\1', 'g');
+			if (mainWindow.cspNonce) {
+				const stylePattern = new RegExp('style\\s*=\\s*([\"\'])(.*?)\\1', 'g');
 				const styleMatches = Array.from(value.matchAll(stylePattern)).reverse();
-				const classNames = Array.from({ length: styleMatches.length }, () => 'csp-' + Math.random().toString(36).substring(7));
+				const classNames = Array.from({ length: styleMatches.length }, () => 'editorViewLayer-' + Math.random().toString(36).substring(7));
 				styleMatches.forEach((match, i) => {
-					const tagStart = value.slice(0, match.index).lastIndexOf('<');
-					const tagEnd = match.index + value.slice(match.index).indexOf('>');
-					const classMatch = value.slice(tagStart, tagEnd).match('class\\s*=\\s*([\"\'])(.*?)\\1');
-					value = value.slice(0, tagEnd + 1) + `<style nonce="${mainWindow.cspNonce}">.${classNames[i]}{${match[2]}}</style>` + value.slice(tagEnd + 1);
+					const htmlTagStart = value.slice(0, match.index).lastIndexOf('<');
+					const htmlTagEnd = match.index + value.slice(match.index).indexOf('>');
+					const classMatch = value.slice(htmlTagStart, htmlTagEnd).match('class\\s*=\\s*([\"\'])(.*?)\\1');
+					value = value.slice(0, htmlTagEnd + 1) + `<style nonce="${mainWindow.cspNonce}">.${classNames[i]}{${match[2]}}</style>` + value.slice(htmlTagEnd + 1);
 					if (classMatch?.index !== undefined) {
-						const classEnd = tagStart + classMatch.index + classMatch[0].length;
+						const classEnd = htmlTagStart + classMatch.index + classMatch[0].length;
 						value = value.slice(0, classEnd - 1) + ` ${classNames[i]}` + value.slice(classEnd - 1);
 					} else {
-						value = value.slice(0, tagEnd) + ` class="${classNames[i]}"` + value.slice(tagEnd);
+						value = value.slice(0, htmlTagEnd) + ` class="${classNames[i]}"` + value.slice(htmlTagEnd);
 					}
+					return value.replace(stylePattern, '');
 				});
 			}
-			return value
+			return value;
 		}
 	});
 

--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -399,8 +399,8 @@ class ViewLayerRenderer<T extends IVisibleLine> {
 					} else {
 						value = value.slice(0, htmlTagEnd) + ` class="${classNames[i]}"` + value.slice(htmlTagEnd);
 					}
-					return value.replace(stylePattern, '');
 				});
+				return value.replace(stylePattern, '');
 			}
 			return value;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
While enforcing nonce for CSP style directive in our web application, which uses Monaco Editor, multiple violations were found, originating from two areas:
1. While creating style tags at https://github.com/microsoft/vscode/blob/bf56edffb59c43fa0de636c3aa1d548770b168b8/src/vs/base/browser/domStylesheets.ts#L51 since it is missing the nonce attribute
2. Due to inline style usages such as https://github.com/microsoft/vscode/blob/bf56edffb59c43fa0de636c3aa1d548770b168b8/src/vs/editor/browser/view/viewOverlays.ts#L177

Hence, the proposed changes include:
1. Adding the nonce attribute to the generated style tag.
2. Converting inline styles to style tags, if nonce exists, in the `createHTML` method which is called in `_finishRenderingNewLines` and _finishRenderingInvalidLines before setting innerHTML
