### PR TITLE
Fix rulers not visible with negative zoom factor (#284129)

### DIFF
--- a/src/vs/editor/browser/viewParts/rulers/rulers.css
+++ b/src/vs/editor/browser/viewParts/rulers/rulers.css
@@ -7,4 +7,5 @@
 	position: absolute;
 	top: 0;
 	box-shadow: 1px 0 0 0 var(--vscode-editorRuler-foreground) inset;
+	pointer-events: none;
 }

--- a/src/vs/editor/browser/viewParts/rulers/rulers.ts
+++ b/src/vs/editor/browser/viewParts/rulers/rulers.ts
@@ -70,7 +70,7 @@ export class Rulers extends ViewPart {
 			while (addCount > 0) {
 				const node = createFastDomNode(document.createElement('div'));
 				node.setClassName('view-ruler');
-				node.setWidth('1px');
+				node.setWidth('1ch');
 				this.domNode.appendChild(node);
 				this._renderedRulers.push(node);
 				addCount--;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #284129

Using `1px` width for `.view-rulers` makes rulers invisible on low PPI screens, with negative `window.zoomLevel`.
Increase width to `1ch` to fix.