### PR TITLE
Fixes Inefficient results collection in TextSearchResultsCollector

### DIFF
--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -259,6 +259,7 @@ export class TextSearchResultsCollector {
 
 		if (!this._currentFileMatch) {
 			this._currentFolderIdx = folderIdx;
+			this._currentUri = data.uri;
 			this._currentFileMatch = {
 				resource: data.uri,
 				results: []


### PR DESCRIPTION
Fixes #264127 

## Description of the changes:

**File changed**: textSearchManager.ts

**Update**: Set this._currentUri = data.uri when starting a new file match so results from the same file are batched and pushToCollector() isn’t called excessively.

**Patch location**: Inside add(...), in the if (!this._currentFileMatch) block.

**Rationale**: The previous logic compared data.uri to this._currentUri but never updated _currentUri, causing constant mismatches and premature flushes.