### PR TITLE
Disable tooltips for Quick Input to prevent obscuring dropdown result (fix #285927)

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -43,6 +43,7 @@ export interface IFindInputOptions {
 	readonly inputBoxStyles: IInputBoxStyles;
 	readonly history?: IHistory<string>;
 	readonly hoverLifecycleOptions?: IHoverLifecycleOptions;
+	readonly hideHoverOnKeyDown?: boolean;
 }
 
 const NLS_DEFAULT_LABEL = nls.localize('defaultLabel', "input");
@@ -118,7 +119,8 @@ export class FindInput extends Widget {
 			inputBoxStyles: options.inputBoxStyles,
 			history: options.history,
 			actions: options.actions,
-			actionViewItemProvider: options.actionViewItemProvider
+			actionViewItemProvider: options.actionViewItemProvider,
+			hideHoverOnKeyDown: options.hideHoverOnKeyDown
 		}));
 
 		if (this.showCommonFindToggles) {

--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -43,7 +43,7 @@ export interface IFindInputOptions {
 	readonly inputBoxStyles: IInputBoxStyles;
 	readonly history?: IHistory<string>;
 	readonly hoverLifecycleOptions?: IHoverLifecycleOptions;
-	readonly hideHoverOnKeyDown?: boolean;
+	readonly hideHoverOnValueChange?: boolean;
 }
 
 const NLS_DEFAULT_LABEL = nls.localize('defaultLabel', "input");
@@ -120,7 +120,7 @@ export class FindInput extends Widget {
 			history: options.history,
 			actions: options.actions,
 			actionViewItemProvider: options.actionViewItemProvider,
-			hideHoverOnKeyDown: options.hideHoverOnKeyDown
+			hideHoverOnValueChange: options.hideHoverOnValueChange
 		}));
 
 		if (this.showCommonFindToggles) {

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -40,6 +40,7 @@ export interface IInputOptions {
 	readonly actionViewItemProvider?: IActionViewItemProvider;
 	readonly inputBoxStyles: IInputBoxStyles;
 	readonly history?: IHistory<string>;
+	readonly hideHoverOnKeyDown?: boolean;
 }
 
 export interface IInputBoxStyles {
@@ -200,6 +201,12 @@ export class InputBox extends Widget {
 		this.oninput(this.input, () => this.onValueChange());
 		this.onblur(this.input, () => this.onBlur());
 		this.onfocus(this.input, () => this.onFocus());
+
+		if (this.options.hideHoverOnKeyDown) {
+			this._register(dom.addDisposableListener(this.input, dom.EventType.KEY_DOWN, () => {
+				getBaseLayerHoverDelegate().hideHover();
+			}));
+		}
 
 		this._register(this.ignoreGesture(this.input));
 

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -202,12 +202,6 @@ export class InputBox extends Widget {
 		this.onblur(this.input, () => this.onBlur());
 		this.onfocus(this.input, () => this.onFocus());
 
-		if (this.options.hideHoverOnKeyDown) {
-			this._register(dom.addDisposableListener(this.input, dom.EventType.KEY_DOWN, () => {
-				getBaseLayerHoverDelegate().hideHover();
-			}));
-		}
-
 		this._register(this.ignoreGesture(this.input));
 
 		setTimeout(() => this.updateMirror(), 0);
@@ -575,6 +569,10 @@ export class InputBox extends Widget {
 
 		if (this.state === 'open' && this.contextViewProvider) {
 			this.contextViewProvider.layout();
+		}
+
+		if (this.options.hideHoverOnKeyDown) {
+			getBaseLayerHoverDelegate().hideHover();
 		}
 	}
 

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -40,7 +40,7 @@ export interface IInputOptions {
 	readonly actionViewItemProvider?: IActionViewItemProvider;
 	readonly inputBoxStyles: IInputBoxStyles;
 	readonly history?: IHistory<string>;
-	readonly hideHoverOnKeyDown?: boolean;
+	readonly hideHoverOnValueChange?: boolean;
 }
 
 export interface IInputBoxStyles {
@@ -571,7 +571,7 @@ export class InputBox extends Widget {
 			this.contextViewProvider.layout();
 		}
 
-		if (this.options.hideHoverOnKeyDown) {
+		if (this.options.hideHoverOnValueChange) {
 			getBaseLayerHoverDelegate().hideHover();
 		}
 	}

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -261,11 +261,6 @@ export class InputBox extends Widget {
 		}
 	}
 
-	public clearTooltip(): void {
-		getBaseLayerHoverDelegate().hideHover();
-		this.hover.clear();
-	}
-
 	public setAriaLabel(label: string): void {
 		this.ariaLabel = label;
 

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -261,6 +261,11 @@ export class InputBox extends Widget {
 		}
 	}
 
+	public clearTooltip(): void {
+		getBaseLayerHoverDelegate().hideHover();
+		this.hover.clear();
+	}
+
 	public setAriaLabel(label: string): void {
 		this.ariaLabel = label;
 

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -35,7 +35,7 @@ export class QuickInputBox extends Disposable {
 				inputBoxStyles,
 				toggleStyles,
 				actionViewItemProvider: createToggleActionViewItemProvider(toggleStyles),
-				hideHoverOnKeyDown: true
+				hideHoverOnValueChange: true
 			}));
 		const input = this.findInput.inputBox.inputElement;
 		input.role = 'textbox';

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -40,6 +40,9 @@ export class QuickInputBox extends Disposable {
 		input.role = 'textbox';
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
+
+		// Disable tooltips for Quick Input to prevent obscuring dropdown results
+		this.findInput.inputBox.setTooltip = () => { /* no-op */ };
 	}
 
 	get onKeyDown() {

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../base/browser/dom.js';
 import { FindInput } from '../../../base/browser/ui/findinput/findInput.js';
+import { getBaseLayerHoverDelegate } from '../../../base/browser/ui/hover/hoverDelegate2.js';
 import { IInputBoxStyles, IRange, MessageType } from '../../../base/browser/ui/inputbox/inputBox.js';
 import { createToggleActionViewItemProvider, IToggleStyles, Toggle } from '../../../base/browser/ui/toggle/toggle.js';
 import { IAction } from '../../../base/common/actions.js';
@@ -41,13 +42,9 @@ export class QuickInputBox extends Disposable {
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
 
-		// Handle tooltip visibility based on input state
-		this._register(this.findInput.onDidChange(() => {
-			if (this.value) {
-				this.findInput.inputBox.clearTooltip();
-			} else if (this.placeholder) {
-				this.findInput.inputBox.setTooltip(this.placeholder);
-			}
+		// Hide tooltip when user starts typing to prevent obscuring dropdown results
+		this._register(dom.addDisposableListener(input, dom.EventType.KEY_DOWN, () => {
+			getBaseLayerHoverDelegate().hideHover();
 		}));
 	}
 
@@ -85,9 +82,6 @@ export class QuickInputBox extends Disposable {
 
 	setPlaceholder(placeholder: string): void {
 		this.findInput.inputBox.setPlaceHolder(placeholder);
-		if (!this.value) {
-			this.findInput.inputBox.setTooltip(placeholder);
-		}
 	}
 
 	get placeholder() {
@@ -96,9 +90,6 @@ export class QuickInputBox extends Disposable {
 
 	set placeholder(placeholder: string) {
 		this.findInput.inputBox.setPlaceHolder(placeholder);
-		if (!this.value) {
-			this.findInput.inputBox.setTooltip(placeholder);
-		}
 	}
 
 	get password() {

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../base/browser/dom.js';
 import { FindInput } from '../../../base/browser/ui/findinput/findInput.js';
-import { getBaseLayerHoverDelegate } from '../../../base/browser/ui/hover/hoverDelegate2.js';
 import { IInputBoxStyles, IRange, MessageType } from '../../../base/browser/ui/inputbox/inputBox.js';
 import { createToggleActionViewItemProvider, IToggleStyles, Toggle } from '../../../base/browser/ui/toggle/toggle.js';
 import { IAction } from '../../../base/common/actions.js';
@@ -35,17 +34,13 @@ export class QuickInputBox extends Disposable {
 				label: '',
 				inputBoxStyles,
 				toggleStyles,
-				actionViewItemProvider: createToggleActionViewItemProvider(toggleStyles)
+				actionViewItemProvider: createToggleActionViewItemProvider(toggleStyles),
+				hideHoverOnKeyDown: true
 			}));
 		const input = this.findInput.inputBox.inputElement;
 		input.role = 'textbox';
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
-
-		// Hide tooltip when user starts typing to prevent obscuring dropdown results
-		this._register(dom.addDisposableListener(input, dom.EventType.KEY_DOWN, () => {
-			getBaseLayerHoverDelegate().hideHover();
-		}));
 	}
 
 	get onKeyDown() {

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -41,8 +41,14 @@ export class QuickInputBox extends Disposable {
 		input.ariaHasPopup = 'menu';
 		input.ariaAutoComplete = 'list';
 
-		// Disable tooltips for Quick Input to prevent obscuring dropdown results
-		this.findInput.inputBox.setTooltip = () => { /* no-op */ };
+		// Handle tooltip visibility based on input state
+		this._register(this.findInput.onDidChange(() => {
+			if (this.value) {
+				this.findInput.inputBox.clearTooltip();
+			} else if (this.placeholder) {
+				this.findInput.inputBox.setTooltip(this.placeholder);
+			}
+		}));
 	}
 
 	get onKeyDown() {
@@ -79,6 +85,9 @@ export class QuickInputBox extends Disposable {
 
 	setPlaceholder(placeholder: string): void {
 		this.findInput.inputBox.setPlaceHolder(placeholder);
+		if (!this.value) {
+			this.findInput.inputBox.setTooltip(placeholder);
+		}
 	}
 
 	get placeholder() {
@@ -87,6 +96,9 @@ export class QuickInputBox extends Disposable {
 
 	set placeholder(placeholder: string) {
 		this.findInput.inputBox.setPlaceHolder(placeholder);
+		if (!this.value) {
+			this.findInput.inputBox.setTooltip(placeholder);
+		}
 	}
 
 	get password() {


### PR DESCRIPTION
Disable tooltips for Quick Input to prevent obscuring dropdown result (fix #285927)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
