### PR TITLE
fix: memory leak editor group view

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -2209,9 +2209,6 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		this._onWillDispose.fire();
 
 		this.whenRestored = undefined!;
-		this.whenRestoredPromise.cancel().catch(() => {
-			// ignore
-		});
 		this.whenRestoredPromise = undefined!;
 
 		super.dispose();

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -136,8 +136,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	private readonly containerToolBarMenuDisposable = this._register(new MutableDisposable());
 
-	private readonly whenRestoredPromise = new DeferredPromise<void>();
-	readonly whenRestored = this.whenRestoredPromise.p;
+	private whenRestoredPromise = new DeferredPromise<void>();
+	whenRestored = this.whenRestoredPromise.p;
 
 	constructor(
 		from: IEditorGroupView | ISerializedEditorGroupModel | null,
@@ -2207,6 +2207,12 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		this._disposed = true;
 
 		this._onWillDispose.fire();
+
+		this.whenRestored = undefined!;
+		this.whenRestoredPromise.cancel().catch(() => {
+			// ignore
+		});
+		this.whenRestoredPromise = undefined!;
 
 		super.dispose();
 	}


### PR DESCRIPTION
Fixes a promise memory leak in editor group view.


### Before 

When opening two diff editors side by side and then closing all editors 37 times, the number of promises in editorGroup seems to grow by 1 each time:

<img width="1476" height="726" alt="diff-editor" src="https://github.com/user-attachments/assets/05de9cda-47a0-4bf4-9654-616b10f57c1a" />


### After

No more promise leak is detected.
