### PR TITLE
chat: fix MCP tool confirmation quick tree hide timing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService.ts
@@ -765,9 +765,9 @@ export class LanguageModelToolsConfirmationService extends Disposable implements
 			for (const item of quickTree.activeItems) {
 				if (item.type === 'manage') {
 					(item as ILanguageModelToolConfirmationContributionQuickTreeItem).onDidOpen?.();
+					quickTree.hide();
 				}
 			}
-			quickTree.hide();
 		}));
 
 		disposables.add(quickTree.onDidHide(() => {


### PR DESCRIPTION
Moves the quickTree.hide() call inside the conditional block to ensure it
only hides after the onDidOpen callback has been invoked for 'manage' items.
This prevents the tree from closing prematurely before the manage action
has completed.

Fixes https://github.com/microsoft/vscode/issues/275102

(Commit message generated by Copilot)
