### PR TITLE
chat: add confirmation not needed reason to tool invocations

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -631,6 +631,8 @@ export class ButtonWithIcon extends Button {
 
 	public get labelElement() { return this._mdlabelElement; }
 
+	public get iconElement() { return this._iconElement; }
+
 	constructor(container: HTMLElement, options: IButtonOptions) {
 		super(container, options);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -5,11 +5,13 @@
 
 import { $ } from '../../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
+import { HoverStyle } from '../../../../../../base/browser/ui/hover/hover.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
@@ -18,6 +20,7 @@ import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../../base/browser/markdownRenderer.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 
 
 export abstract class ChatCollapsibleContentPart extends Disposable implements IChatContentPart {
@@ -32,9 +35,21 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 	protected _isExpanded = observableValue<boolean>(this, false);
 	protected _collapseButton: ButtonWithIcon | undefined;
 
+	private readonly _overrideIcon = observableValue<ThemeIcon | undefined>(this, undefined);
+
+	public get icon(): ThemeIcon | undefined {
+		return this._overrideIcon.get();
+	}
+
+	public set icon(value: ThemeIcon | undefined) {
+		this._overrideIcon.set(value, undefined);
+	}
+
 	constructor(
 		private title: IMarkdownString | string,
 		protected readonly context: IChatContentPartRenderContext,
+		private readonly hoverMessage: IMarkdownString | undefined,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 		this.hasFollowingContent = this.context.contentIndex + 1 < this.context.content.length;
@@ -65,6 +80,13 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
 
+		if (this.hoverMessage && this.hoverService) {
+			this._register(this.hoverService.setupDelayedHover(collapseButton.iconElement, {
+				content: this.hoverMessage,
+				style: HoverStyle.Pointer,
+			}));
+		}
+
 		this._register(collapseButton.onDidClick(() => {
 			const value = this._isExpanded.get();
 			this._isExpanded.set(!value, undefined);
@@ -72,7 +94,7 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 
 		this._register(autorun(r => {
 			const expanded = this._isExpanded.read(r);
-			collapseButton.icon = expanded ? Codicon.chevronDown : Codicon.chevronRight;
+			collapseButton.icon = this._overrideIcon.read(r) ?? (expanded ? Codicon.chevronDown : Codicon.chevronRight);
 			this._domNode?.classList.toggle('chat-used-context-collapsed', !expanded);
 			this.updateAriaLabel(collapseButton.element, typeof referencesLabel === 'string' ? referencesLabel : referencesLabel.value, expanded);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -80,7 +80,7 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
 
-		if (this.hoverMessage && this.hoverService) {
+		if (this.hoverMessage) {
 			this._register(this.hoverService.setupDelayedHover(collapseButton.iconElement, {
 				content: this.hoverMessage,
 				style: HoverStyle.Pointer,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -46,6 +46,7 @@ import { ChatTreeItem, IChatWidgetService } from '../../chat.js';
 import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
 import { IDisposableReference, ResourcePool } from './chatCollections.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 
 const $ = dom.$;
 
@@ -73,14 +74,17 @@ export class ChatCollapsibleListContentPart extends ChatCollapsibleContentPart {
 		labelOverride: IMarkdownString | string | undefined,
 		context: IChatContentPartRenderContext,
 		private readonly contentReferencesListPool: CollapsibleListPool,
+		hoverMessage: IMarkdownString | undefined,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+		@IHoverService hoverService: IHoverService,
 	) {
 		super(labelOverride ?? (data.length > 1 ?
 			localize('usedReferencesPlural', "Used {0} references", data.length) :
-			localize('usedReferencesSingular', "Used {0} reference", 1)), context);
+			localize('usedReferencesSingular', "Used {0} reference", 1)), context, hoverMessage,
+			hoverService);
 	}
 
 	protected override initContent(): HTMLElement {
@@ -163,8 +167,9 @@ export class ChatUsedReferencesListContentPart extends ChatCollapsibleListConten
 		@IMenuService menuService: IMenuService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
+		@IHoverService hoverService: IHoverService,
 	) {
-		super(data, labelOverride, context, contentReferencesListPool, openerService, menuService, instantiationService, contextMenuService);
+		super(data, labelOverride, context, contentReferencesListPool, undefined, openerService, menuService, instantiationService, contextMenuService, hoverService);
 		if (data.length === 0) {
 			dom.hide(this.domNode);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTaskContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTaskContentPart.ts
@@ -31,7 +31,7 @@ export class ChatTaskContentPart extends Disposable implements IChatContentPart 
 
 		if (task.progress.length) {
 			this.isSettled = true;
-			const refsPart = this._register(instantiationService.createInstance(ChatCollapsibleListContentPart, task.progress, task.content.value, context, contentReferencesListPool));
+			const refsPart = this._register(instantiationService.createInstance(ChatCollapsibleListContentPart, task.progress, task.content.value, context, contentReferencesListPool, undefined));
 			this.domNode = dom.$('.chat-progress-task');
 			this.domNode.appendChild(refsPart.domNode);
 			this.onDidChangeHeight = refsPart.onDidChangeHeight;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -24,6 +24,7 @@ import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
 import { ChatMessageRole, ILanguageModelsService } from '../../../common/languageModels.js';
 import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
 import './media/chatThinkingContent.css';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 
 
 function extractTextFromPart(content: IChatThinkingPart): string {
@@ -105,12 +106,13 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IChatMarkdownAnchorService private readonly chatMarkdownAnchorService: IChatMarkdownAnchorService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
+		@IHoverService hoverService: IHoverService,
 	) {
 		const initialText = extractTextFromPart(content);
 		const extractedTitle = extractTitleFromThinkingContent(initialText)
 			?? 'Thinking...';
 
-		super(extractedTitle, context);
+		super(extractedTitle, context, undefined, hoverService);
 
 		this.id = content.id;
 		this.content = content;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -5,7 +5,7 @@
 
 import { ProgressBar } from '../../../../../../../base/browser/ui/progressbar/progressbar.js';
 import { decodeBase64 } from '../../../../../../../base/common/buffer.js';
-import { IMarkdownString, createMarkdownCommandLink, MarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Lazy } from '../../../../../../../base/common/lazy.js';
 import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { getExtensionForMimeType } from '../../../../../../../base/common/mime.js';
@@ -13,15 +13,15 @@ import { autorun } from '../../../../../../../base/common/observable.js';
 import { basename } from '../../../../../../../base/common/resources.js';
 import { ILanguageService } from '../../../../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../../../../editor/common/services/model.js';
-import { localize } from '../../../../../../../nls.js';
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
 import { ChatResponseResource } from '../../../../common/model/chatModel.js';
-import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
+import { IChatToolInvocation, IChatToolInvocationSerialized } from '../../../../common/chatService/chatService.js';
 import { IToolResultInputOutputDetails } from '../../../../common/tools/languageModelToolsService.js';
 import { IChatCodeBlockInfo } from '../../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatCollapsibleInputOutputContentPart, ChatCollapsibleIOPart, IChatCollapsibleIOCodePart } from '../chatToolInputOutputContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
+import { getToolApprovalMessage } from './chatToolPartUtilities.js';
 
 export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationSubPart {
 	/** Remembers expanded tool parts on re-render */
@@ -150,32 +150,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 	}
 
 	private getAutoApproveMessageContent() {
-		const reason = IChatToolInvocation.executionConfirmedOrDenied(this.toolInvocation);
-		if (!reason || typeof reason === 'boolean') {
-			return;
-		}
-
-		let md: string;
-		switch (reason.type) {
-			case ToolConfirmKind.Setting:
-				md = localize('chat.autoapprove.setting', 'Auto approved by {0}', createMarkdownCommandLink({ title: '`' + reason.id + '`', id: 'workbench.action.openSettings', arguments: [reason.id] }, false));
-				break;
-			case ToolConfirmKind.LmServicePerTool:
-				md = reason.scope === 'session'
-					? localize('chat.autoapprove.lmServicePerTool.session', 'Auto approved for this session')
-					: reason.scope === 'workspace'
-						? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
-						: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
-				md += ' (' + createMarkdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
-				break;
-			case ToolConfirmKind.UserAction:
-			case ToolConfirmKind.Denied:
-			case ToolConfirmKind.ConfirmationNotNeeded:
-			default:
-				return;
-		}
-
-
-		return new MarkdownString(md, { isTrusted: true });
+		return getToolApprovalMessage(this.toolInvocation);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatResultListSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatResultListSubPart.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { Location } from '../../../../../../../editor/common/languages.js';
@@ -12,6 +13,7 @@ import { IChatCodeBlockInfo } from '../../../chat.js';
 import { IChatContentPartRenderContext } from '../chatContentParts.js';
 import { ChatCollapsibleListContentPart, CollapsibleListPool, IChatCollapsibleListItem } from '../chatReferencesContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
+import { getToolApprovalMessage } from './chatToolPartUtilities.js';
 
 export class ChatResultListSubPart extends BaseChatToolInvocationSubPart {
 	public readonly domNode: HTMLElement;
@@ -36,7 +38,9 @@ export class ChatResultListSubPart extends BaseChatToolInvocationSubPart {
 			message,
 			context,
 			listPool,
+			getToolApprovalMessage(toolInvocation),
 		));
+		collapsibleListPart.icon = Codicon.check;
 		this._register(collapsibleListPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		this.domNode = collapsibleListPart.domNode;
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolPartUtilities.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolPartUtilities.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createMarkdownCommandLink, IMarkdownString, MarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { localize } from '../../../../../../../nls.js';
+import { ConfirmedReason, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
+
+/**
+ * Creates a markdown message explaining why a tool was auto-approved.
+ * @param toolInvocation The tool invocation to get the approval message for
+ * @returns A markdown string with the approval message, or undefined if no message should be shown
+ */
+export function getToolApprovalMessage(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized): IMarkdownString | undefined {
+	const reason = IChatToolInvocation.executionConfirmedOrDenied(toolInvocation);
+	if (!reason || typeof reason === 'boolean') {
+		return undefined;
+	}
+
+	return getApprovalMessageFromReason(reason);
+}
+
+/**
+ * Creates a markdown message from a ConfirmedReason explaining why a tool was auto-approved.
+ * @param reason The confirmation reason
+ * @returns A markdown string with the approval message, or undefined if no message should be shown
+ */
+export function getApprovalMessageFromReason(reason: ConfirmedReason): IMarkdownString | undefined {
+	let md: string;
+	switch (reason.type) {
+		case ToolConfirmKind.Setting:
+			md = localize('chat.autoapprove.setting', 'Auto approved by {0}', createMarkdownCommandLink({ title: '`' + reason.id + '`', id: 'workbench.action.openSettings', arguments: [reason.id] }, false));
+			break;
+		case ToolConfirmKind.LmServicePerTool:
+			md = reason.scope === 'session'
+				? localize('chat.autoapprove.lmServicePerTool.session', 'Auto approved for this session')
+				: reason.scope === 'workspace'
+					? localize('chat.autoapprove.lmServicePerTool.workspace', 'Auto approved for this workspace')
+					: localize('chat.autoapprove.lmServicePerTool.profile', 'Auto approved for this profile');
+			md += ' (' + createMarkdownCommandLink({ title: localize('edit', 'Edit'), id: 'workbench.action.chat.editToolApproval', arguments: [reason.scope] }) + ')';
+			break;
+		case ToolConfirmKind.ConfirmationNotNeeded:
+			if (reason.reason) {
+				return typeof reason.reason === 'string'
+					? new MarkdownString(reason.reason, { isTrusted: true })
+					: reason.reason;
+			}
+			return undefined;
+		case ToolConfirmKind.UserAction:
+		case ToolConfirmKind.Denied:
+		default:
+			return undefined;
+	}
+
+	return new MarkdownString(md, { isTrusted: true });
+}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -429,7 +429,7 @@ export const enum ToolConfirmKind {
 
 export type ConfirmedReason =
 	| { type: ToolConfirmKind.Denied }
-	| { type: ToolConfirmKind.ConfirmationNotNeeded }
+	| { type: ToolConfirmKind.ConfirmationNotNeeded; reason?: string | IMarkdownString }
 	| { type: ToolConfirmKind.Setting; id: string }
 	| { type: ToolConfirmKind.LmServicePerTool; scope: 'session' | 'workspace' | 'profile' }
 	| { type: ToolConfirmKind.UserAction }

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -49,7 +49,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this.parameters = parameters;
 
 		if (!this.confirmationMessages?.title) {
-			this._state = observableValue(this, { type: IChatToolInvocation.StateKind.Executing, confirmed: { type: ToolConfirmKind.ConfirmationNotNeeded }, progress: this._progress });
+			this._state = observableValue(this, { type: IChatToolInvocation.StateKind.Executing, confirmed: { type: ToolConfirmKind.ConfirmationNotNeeded, reason: this.confirmationMessages?.confirmationNotNeededReason }, progress: this._progress });
 		} else {
 			this._state = observableValue(this, {
 				type: IChatToolInvocation.StateKind.WaitingForConfirmation,

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -263,6 +263,8 @@ export interface IToolConfirmationMessages {
 	terminalCustomActions?: ToolConfirmationAction[];
 	/** If true, confirmation will be requested after the tool executes and before results are sent to the model */
 	confirmResults?: boolean;
+	/** If title is not set (no confirmation needed), this reason will be shown to explain why confirmation was not needed */
+	confirmationNotNeededReason?: string | IMarkdownString;
 }
 
 export interface IToolConfirmationAction {


### PR DESCRIPTION
Adds a 'confirmationNotNeededReason' field to tool confirmation messages to display why a tool didn't require user confirmation. This makes fetch results more consistent with other tool calls by providing transparency about auto-approval decisions.

Changes:
- Adds confirmationNotNeededReason property to IToolConfirmationMessages
- Populates reason in FetchWebPageTool when URL is mentioned in prompt
- Updates ChatToolInvocation to include reason in confirmed state
- Extracts tool part utilities into shared module for reuse
- Improves UI consistency with confirmation status display

Fixes #282238