### PR TITLE
vscode mcp: support custom workspace path; enable restart tool

### DIFF
--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -54,17 +54,6 @@ export class Application {
 		return this._workspacePathOrFolder;
 	}
 
-	/**
-	 * Returns the workspace path, throwing if not set.
-	 * Use this in tests that require a workspace to be open.
-	 */
-	get workspacePath(): string {
-		if (!this._workspacePathOrFolder) {
-			throw new Error('No workspace path is set. This test requires a workspace to be open.');
-		}
-		return this._workspacePathOrFolder;
-	}
-
 	get extensionsPath(): string | undefined {
 		return this.options.extensionsPath;
 	}

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -109,6 +109,7 @@ export class Application {
 	private async startApplication(extraArgs: string[] = []): Promise<Code> {
 		const code = this._code = await launch({
 			...this.options,
+			workspacePath: this._workspacePathOrFolder,
 			extraArgs: [...(this.options.extraArgs || []), ...extraArgs],
 		});
 

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -49,8 +49,8 @@ export class Application {
 		return !!this.options.web;
 	}
 
-	private _workspacePathOrFolder: string;
-	get workspacePathOrFolder(): string {
+	private _workspacePathOrFolder: string | undefined;
+	get workspacePathOrFolder(): string | undefined {
 		return this._workspacePathOrFolder;
 	}
 

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -54,6 +54,17 @@ export class Application {
 		return this._workspacePathOrFolder;
 	}
 
+	/**
+	 * Returns the workspace path, throwing if not set.
+	 * Use this in tests that require a workspace to be open.
+	 */
+	get workspacePath(): string {
+		if (!this._workspacePathOrFolder) {
+			throw new Error('No workspace path is set. This test requires a workspace to be open.');
+		}
+		return this._workspacePathOrFolder;
+	}
+
 	get extensionsPath(): string | undefined {
 		return this.options.extensionsPath;
 	}

--- a/test/automation/src/code.ts
+++ b/test/automation/src/code.ts
@@ -18,7 +18,7 @@ export interface LaunchOptions {
 	// Allows you to override the Playwright instance
 	playwright?: typeof playwright;
 	codePath?: string;
-	readonly workspacePath: string;
+	readonly workspacePath?: string;
 	userDataDir?: string;
 	readonly extensionsPath?: string;
 	readonly logger: Logger;

--- a/test/automation/src/electron.ts
+++ b/test/automation/src/electron.ts
@@ -22,8 +22,7 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 	const { codePath, workspacePath, extensionsPath, userDataDir, remote, logger, logsPath, crashesPath, extraArgs } = options;
 	const env = { ...process.env };
 
-	const args = [
-		workspacePath,
+	const args: string[] = [
 		'--skip-release-notes',
 		'--skip-welcome',
 		'--disable-telemetry',
@@ -35,6 +34,12 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 		'--disable-workspace-trust',
 		`--logsPath=${logsPath}`
 	];
+
+	// Only add workspace path if provided
+	if (workspacePath) {
+		args.unshift(workspacePath);
+	}
+
 	if (options.useInMemorySecretStorage) {
 		args.push('--use-inmemory-secretstorage');
 	}
@@ -49,6 +54,9 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 	}
 
 	if (remote) {
+		if (!workspacePath) {
+			throw new Error('Workspace path is required when running remote');
+		}
 		// Replace workspace path with URI
 		args[0] = `--${workspacePath.endsWith('.code-workspace') ? 'file' : 'folder'}-uri=vscode-remote://test+test/${URI.file(workspacePath).path}`;
 

--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -157,7 +157,13 @@ async function launchBrowser(options: LaunchOptions, endpoint: string) {
 		`["logLevel","${options.verbose ? 'trace' : 'info'}"]`
 	].join(',')}]`;
 
-	const gotoPromise = measureAndLog(() => page.goto(`${endpoint}&${workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder'}=${URI.file(workspacePath!).path}&payload=${payloadParam}`), 'page.goto()', logger);
+	// Build URL with optional workspace path
+	let url = `${endpoint}&payload=${payloadParam}`;
+	if (workspacePath) {
+		url = `${endpoint}&${workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder'}=${URI.file(workspacePath).path}&payload=${payloadParam}`;
+	}
+
+	const gotoPromise = measureAndLog(() => page.goto(url), 'page.goto()', logger);
 	const pageLoadedPromise = page.waitForLoadState('load');
 
 	await gotoPromise;

--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -158,10 +158,12 @@ async function launchBrowser(options: LaunchOptions, endpoint: string) {
 	].join(',')}]`;
 
 	// Build URL with optional workspace path
-	let url = `${endpoint}&payload=${payloadParam}`;
+	let url = `${endpoint}&`;
 	if (workspacePath) {
-		url = `${endpoint}&${workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder'}=${URI.file(workspacePath).path}&payload=${payloadParam}`;
+		const workspaceParam = workspacePath.endsWith('.code-workspace') ? 'workspace' : 'folder';
+		url += `${workspaceParam}=${URI.file(workspacePath).path}&`;
 	}
+	url += `payload=${payloadParam}`;
 
 	const gotoPromise = measureAndLog(() => page.goto(url), 'page.goto()', logger);
 	const pageLoadedPromise = page.waitForLoadState('load');

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -232,7 +232,7 @@ async function setup(): Promise<void> {
 	logger.log('Smoketest setup done!\n');
 }
 
-export async function getApplication({ recordVideo }: { recordVideo?: boolean } = {}) {
+export async function getApplication({ recordVideo, workspacePath }: { recordVideo?: boolean; workspacePath?: string } = {}) {
 	const testCodePath = getDevElectronPath();
 	const electronPath = testCodePath;
 	if (!fs.existsSync(electronPath || '')) {
@@ -252,7 +252,7 @@ export async function getApplication({ recordVideo }: { recordVideo?: boolean } 
 		quality,
 		version: parseVersion(version ?? '0.0.0'),
 		codePath: opts.build,
-		workspacePath: rootPath,
+		workspacePath, // Use the provided workspace path or undefined to use last opened
 		logger,
 		logsPath: logsRootPath,
 		crashesPath: crashesRootPath,
@@ -292,12 +292,12 @@ export class ApplicationService {
 		return this._application;
 	}
 
-	async getOrCreateApplication({ recordVideo }: { recordVideo?: boolean } = {}): Promise<Application> {
+	async getOrCreateApplication({ recordVideo, workspacePath }: { recordVideo?: boolean; workspacePath?: string } = {}): Promise<Application> {
 		if (this._closing) {
 			await this._closing;
 		}
 		if (!this._application) {
-			this._application = await getApplication({ recordVideo });
+			this._application = await getApplication({ recordVideo, workspacePath });
 			this._application.code.driver.currentPage.on('close', () => {
 				this._closing = (async () => {
 					if (this._application) {

--- a/test/mcp/src/application.ts
+++ b/test/mcp/src/application.ts
@@ -252,7 +252,8 @@ export async function getApplication({ recordVideo, workspacePath }: { recordVid
 		quality,
 		version: parseVersion(version ?? '0.0.0'),
 		codePath: opts.build,
-		workspacePath, // Use the provided workspace path or undefined to use last opened
+		// Use provided workspace path, or fall back to rootPath on CI (GitHub Actions)
+		workspacePath: workspacePath ?? (process.env.GITHUB_ACTIONS ? rootPath : undefined),
 		logger,
 		logsPath: logsRootPath,
 		crashesPath: crashesRootPath,

--- a/test/mcp/src/automation.ts
+++ b/test/mcp/src/automation.ts
@@ -18,17 +18,18 @@ export async function getServer(appService: ApplicationService): Promise<Server>
 
 	server.tool(
 		'vscode_automation_start',
-		'Start VS Code Build',
+		'Start VS Code Build. If workspacePath is not provided, VS Code will open with the last used workspace or an empty window.',
 		{
-			recordVideo: z.boolean().optional()
+			recordVideo: z.boolean().optional().describe('Whether to record a video of the session'),
+			workspacePath: z.string().optional().describe('Optional path to a workspace or folder to open. If not provided, opens the last used workspace.')
 		},
-		async ({ recordVideo }) => {
-			const app = await appService.getOrCreateApplication({ recordVideo });
+		async ({ recordVideo, workspacePath }) => {
+			const app = await appService.getOrCreateApplication({ recordVideo, workspacePath });
 			await app.startTracing();
 			return {
 				content: [{
 					type: 'text' as const,
-					text: app ? `VS Code started successfully` : `Failed to start VS Code`
+					text: app ? `VS Code started successfully${workspacePath ? ` with workspace: ${workspacePath}` : ''}` : `Failed to start VS Code`
 				}]
 			};
 		}

--- a/test/smoke/src/areas/languages/languages.test.ts
+++ b/test/smoke/src/areas/languages/languages.test.ts
@@ -15,7 +15,12 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (js)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'bin', 'www'));
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length >= 6);
@@ -24,7 +29,12 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (css)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length === 2);
@@ -33,7 +43,12 @@ export function setup(logger: Logger) {
 
 		it('verifies problems view (css)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
 			await app.workbench.editor.waitForTypeInEditor('style.css', '.foo{}');
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.WARNING));
@@ -45,8 +60,13 @@ export function setup(logger: Logger) {
 
 		it('verifies settings (css)', async function () {
 			const app = this.app as Application;
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			await app.workbench.settingsEditor.addUserSetting('css.lint.emptyRules', '"error"');
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.ERROR));
 

--- a/test/smoke/src/areas/languages/languages.test.ts
+++ b/test/smoke/src/areas/languages/languages.test.ts
@@ -15,7 +15,7 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (js)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'bin', 'www'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'bin', 'www'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length >= 6);
@@ -24,7 +24,7 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (css)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length === 2);
@@ -33,7 +33,7 @@ export function setup(logger: Logger) {
 
 		it('verifies problems view (css)', async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
 			await app.workbench.editor.waitForTypeInEditor('style.css', '.foo{}');
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.WARNING));
@@ -46,7 +46,7 @@ export function setup(logger: Logger) {
 		it('verifies settings (css)', async function () {
 			const app = this.app as Application;
 			await app.workbench.settingsEditor.addUserSetting('css.lint.emptyRules', '"error"');
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'public', 'stylesheets', 'style.css'));
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.ERROR));
 

--- a/test/smoke/src/areas/languages/languages.test.ts
+++ b/test/smoke/src/areas/languages/languages.test.ts
@@ -15,12 +15,12 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (js)', async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'bin', 'www'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length >= 6);
@@ -29,12 +29,12 @@ export function setup(logger: Logger) {
 
 		it('verifies quick outline (css)', async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
 
 			await app.workbench.quickaccess.openQuickOutline();
 			await app.workbench.quickinput.waitForQuickInputElements(names => names.length === 2);
@@ -43,12 +43,12 @@ export function setup(logger: Logger) {
 
 		it('verifies problems view (css)', async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
 			await app.workbench.editor.waitForTypeInEditor('style.css', '.foo{}');
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.WARNING));
@@ -60,13 +60,13 @@ export function setup(logger: Logger) {
 
 		it('verifies settings (css)', async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
 			await app.workbench.settingsEditor.addUserSetting('css.lint.emptyRules', '"error"');
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'public', 'stylesheets', 'style.css'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'public', 'stylesheets', 'style.css'));
 
 			await app.code.waitForElement(Problems.getSelectorInEditor(ProblemSeverity.ERROR));
 

--- a/test/smoke/src/areas/multiroot/multiroot.test.ts
+++ b/test/smoke/src/areas/multiroot/multiroot.test.ts
@@ -46,6 +46,9 @@ export function setup(logger: Logger) {
 
 		// Shared before/after handling
 		installAllHandlers(logger, opts => {
+			if (!opts.workspacePath) {
+				throw new Error('Multiroot tests require a workspace to be open');
+			}
 			const workspacePath = createWorkspaceFile(opts.workspacePath);
 			return { ...opts, workspacePath };
 		});

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -21,8 +21,8 @@ export function setup(logger: Logger) {
 
 		after(async function () {
 			const app = this.app as Application;
-			cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder });
-			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
+			cp.execSync('git checkout . --quiet', { cwd: app.workspacePath });
+			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePath });
 		});
 
 		// the heap snapshot fails to parse

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -21,8 +21,13 @@ export function setup(logger: Logger) {
 
 		after(async function () {
 			const app = this.app as Application;
-			cp.execSync('git checkout . --quiet', { cwd: app.workspacePath });
-			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePath });
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			cp.execSync('git checkout . --quiet', { cwd: workspacePath });
+			cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePath });
 		});
 
 		// the heap snapshot fails to parse

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -21,13 +21,13 @@ export function setup(logger: Logger) {
 
 		after(async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			cp.execSync('git checkout . --quiet', { cwd: workspacePath });
-			cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePath });
+			cp.execSync('git checkout . --quiet', { cwd: workspacePathOrFolder });
+			cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePathOrFolder });
 		});
 
 		// the heap snapshot fails to parse

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -15,8 +15,8 @@ export function setup(logger: Logger) {
 
 		after(function () {
 			const app = this.app as Application;
-			retry(async () => cp.execSync('git checkout . --quiet', { cwd: app.workspacePathOrFolder }), 0, 5);
-			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder }), 0, 5);
+			retry(async () => cp.execSync('git checkout . --quiet', { cwd: app.workspacePath }), 0, 5);
+			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePath }), 0, 5);
 		});
 
 		it('verifies the sidebar moves to the right', async function () {

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -15,13 +15,13 @@ export function setup(logger: Logger) {
 
 		after(function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			retry(async () => cp.execSync('git checkout . --quiet', { cwd: workspacePath }), 0, 5);
-			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePath }), 0, 5);
+			retry(async () => cp.execSync('git checkout . --quiet', { cwd: workspacePathOrFolder }), 0, 5);
+			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePathOrFolder }), 0, 5);
 		});
 
 		it('verifies the sidebar moves to the right', async function () {

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -15,8 +15,13 @@ export function setup(logger: Logger) {
 
 		after(function () {
 			const app = this.app as Application;
-			retry(async () => cp.execSync('git checkout . --quiet', { cwd: app.workspacePath }), 0, 5);
-			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePath }), 0, 5);
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			retry(async () => cp.execSync('git checkout . --quiet', { cwd: workspacePath }), 0, 5);
+			retry(async () => cp.execSync('git reset --hard HEAD --quiet', { cwd: workspacePath }), 0, 5);
 		});
 
 		it('verifies the sidebar moves to the right', async function () {

--- a/test/smoke/src/areas/statusbar/statusbar.test.ts
+++ b/test/smoke/src/areas/statusbar/statusbar.test.ts
@@ -15,11 +15,16 @@ export function setup(logger: Logger) {
 
 		it('verifies presence of all default status bar elements', async function () {
 			const app = this.app as Application;
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.BRANCH_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.SYNC_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.PROBLEMS_STATUS);
 
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.ENCODING_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.EOL_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.INDENTATION_STATUS);
@@ -29,11 +34,16 @@ export function setup(logger: Logger) {
 
 		it(`verifies that 'quick input' opens when clicking on status bar elements`, async function () {
 			const app = this.app as Application;
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			await app.workbench.statusbar.clickOn(StatusBarElement.BRANCH_STATUS);
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
 
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.INDENTATION_STATUS);
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
@@ -56,7 +66,12 @@ export function setup(logger: Logger) {
 
 		it(`verifies if changing EOL is reflected in the status bar`, async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.EOL_STATUS);
 
 			await app.workbench.quickinput.selectQuickInputElement(1);

--- a/test/smoke/src/areas/statusbar/statusbar.test.ts
+++ b/test/smoke/src/areas/statusbar/statusbar.test.ts
@@ -19,7 +19,7 @@ export function setup(logger: Logger) {
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.SYNC_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.PROBLEMS_STATUS);
 
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.ENCODING_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.EOL_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.INDENTATION_STATUS);
@@ -33,7 +33,7 @@ export function setup(logger: Logger) {
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
 
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.INDENTATION_STATUS);
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
@@ -56,7 +56,7 @@ export function setup(logger: Logger) {
 
 		it(`verifies if changing EOL is reflected in the status bar`, async function () {
 			const app = this.app as Application;
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.EOL_STATUS);
 
 			await app.workbench.quickinput.selectQuickInputElement(1);

--- a/test/smoke/src/areas/statusbar/statusbar.test.ts
+++ b/test/smoke/src/areas/statusbar/statusbar.test.ts
@@ -15,8 +15,8 @@ export function setup(logger: Logger) {
 
 		it('verifies presence of all default status bar elements', async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
@@ -24,7 +24,7 @@ export function setup(logger: Logger) {
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.SYNC_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.PROBLEMS_STATUS);
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'readme.md'));
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.ENCODING_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.EOL_STATUS);
 			await app.workbench.statusbar.waitForStatusbarElement(StatusBarElement.INDENTATION_STATUS);
@@ -34,8 +34,8 @@ export function setup(logger: Logger) {
 
 		it(`verifies that 'quick input' opens when clicking on status bar elements`, async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
@@ -43,7 +43,7 @@ export function setup(logger: Logger) {
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.INDENTATION_STATUS);
 			await app.workbench.quickinput.waitForQuickInputOpened();
 			await app.workbench.quickinput.closeQuickInput();
@@ -66,12 +66,12 @@ export function setup(logger: Logger) {
 
 		it(`verifies if changing EOL is reflected in the status bar`, async function () {
 			const app = this.app as Application;
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'readme.md'));
 			await app.workbench.statusbar.clickOn(StatusBarElement.EOL_STATUS);
 
 			await app.workbench.quickinput.selectQuickInputElement(1);

--- a/test/smoke/src/areas/workbench/data-loss.test.ts
+++ b/test/smoke/src/areas/workbench/data-loss.test.ts
@@ -28,9 +28,9 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await app.start();
 
 			// Open 3 editors
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'bin', 'www'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'bin', 'www'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'app.js'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
 			await app.workbench.editors.newUntitledFile();
 
@@ -56,7 +56,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			const textToType = 'Hello, Code';
 
 			// open editor and type
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'app.js'));
 			await app.workbench.editor.waitForTypeInEditor('app.js', textToType);
 			await app.workbench.editors.waitForTab('app.js', true);
 
@@ -105,7 +105,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await app.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
 			await app.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await app.workbench.editors.waitForTab('readme.md', !autoSave);
 
@@ -176,9 +176,9 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await stableApp.start();
 
 			// Open 3 editors
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePathOrFolder, 'bin', 'www'));
+			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'bin', 'www'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePathOrFolder, 'app.js'));
+			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'app.js'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
 			await stableApp.workbench.editors.newUntitledFile();
 
@@ -238,7 +238,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await stableApp.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePathOrFolder, 'readme.md'));
+			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'readme.md'));
 			await stableApp.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await stableApp.workbench.editors.waitForTab('readme.md', true);
 

--- a/test/smoke/src/areas/workbench/data-loss.test.ts
+++ b/test/smoke/src/areas/workbench/data-loss.test.ts
@@ -27,15 +27,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
 			// Open 3 editors
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'bin', 'www'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'app.js'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
 			await app.workbench.editors.newUntitledFile();
 
@@ -58,15 +58,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
 			const textToType = 'Hello, Code';
 
 			// open editor and type
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'app.js'));
 			await app.workbench.editor.waitForTypeInEditor('app.js', textToType);
 			await app.workbench.editors.waitForTab('app.js', true);
 
@@ -104,8 +104,8 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
-			const workspacePath = app.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = app.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
@@ -120,7 +120,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await app.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'readme.md'));
 			await app.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await app.workbench.editors.waitForTab('readme.md', !autoSave);
 
@@ -190,15 +190,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			stableApp = new Application(stableOptions);
 			await stableApp.start();
 
-			const workspacePath = stableApp.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = stableApp.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
 			// Open 3 editors
-			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'bin', 'www'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
-			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'app.js'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
 			await stableApp.workbench.editors.newUntitledFile();
 
@@ -251,8 +251,8 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			stableApp = new Application(stableOptions);
 			await stableApp.start();
 
-			const workspacePath = stableApp.workspacePathOrFolder;
-			if (!workspacePath) {
+			const workspacePathOrFolder = stableApp.workspacePathOrFolder;
+			if (!workspacePathOrFolder) {
 				throw new Error('This test requires a workspace to be open');
 			}
 
@@ -263,7 +263,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await stableApp.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePathOrFolder, 'readme.md'));
 			await stableApp.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await stableApp.workbench.editors.waitForTab('readme.md', true);
 

--- a/test/smoke/src/areas/workbench/data-loss.test.ts
+++ b/test/smoke/src/areas/workbench/data-loss.test.ts
@@ -27,10 +27,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			// Open 3 editors
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'bin', 'www'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
 			await app.workbench.quickaccess.runCommand('View: Keep Editor');
 			await app.workbench.editors.newUntitledFile();
 
@@ -53,10 +58,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			const textToType = 'Hello, Code';
 
 			// open editor and type
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'app.js'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
 			await app.workbench.editor.waitForTypeInEditor('app.js', textToType);
 			await app.workbench.editors.waitForTab('app.js', true);
 
@@ -94,6 +104,11 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			});
 			await app.start();
 
+			const workspacePath = app.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			if (autoSave) {
 				await app.workbench.settingsEditor.addUserSetting('files.autoSave', '"afterDelay"');
 			}
@@ -105,7 +120,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await app.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await app.workbench.quickaccess.openFile(join(app.workspacePath, 'readme.md'));
+			await app.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
 			await app.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await app.workbench.editors.waitForTab('readme.md', !autoSave);
 
@@ -175,10 +190,15 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			stableApp = new Application(stableOptions);
 			await stableApp.start();
 
+			const workspacePath = stableApp.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			// Open 3 editors
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'bin', 'www'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'bin', 'www'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'app.js'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'app.js'));
 			await stableApp.workbench.quickaccess.runCommand('View: Keep Editor');
 			await stableApp.workbench.editors.newUntitledFile();
 
@@ -231,6 +251,11 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			stableApp = new Application(stableOptions);
 			await stableApp.start();
 
+			const workspacePath = stableApp.workspacePathOrFolder;
+			if (!workspacePath) {
+				throw new Error('This test requires a workspace to be open');
+			}
+
 			const textToTypeInUntitled = 'Hello from Untitled';
 
 			await stableApp.workbench.editors.newUntitledFile();
@@ -238,7 +263,7 @@ export function setup(ensureStableCode: () => { stableCodePath: string | undefin
 			await stableApp.workbench.editors.waitForTab('Untitled-1', true);
 
 			const textToType = 'Hello, Code';
-			await stableApp.workbench.quickaccess.openFile(join(stableApp.workspacePath, 'readme.md'));
+			await stableApp.workbench.quickaccess.openFile(join(workspacePath, 'readme.md'));
 			await stableApp.workbench.editor.waitForTypeInEditor('readme.md', textToType);
 			await stableApp.workbench.editors.waitForTab('readme.md', true);
 

--- a/test/smoke/src/utils.ts
+++ b/test/smoke/src/utils.ts
@@ -89,6 +89,11 @@ function installAppBeforeHandler(optionsTransform?: (opts: ApplicationOptions) =
 			crashesPath: suiteCrashPath(this.defaultOptions, suiteName)
 		}, optionsTransform);
 		await this.app.start();
+
+		// Smoke tests require a workspace to be open
+		if (!this.app.workspacePathOrFolder) {
+			throw new Error('Smoke tests require a workspace to be open');
+		}
 	});
 }
 

--- a/test/smoke/src/utils.ts
+++ b/test/smoke/src/utils.ts
@@ -89,11 +89,6 @@ function installAppBeforeHandler(optionsTransform?: (opts: ApplicationOptions) =
 			crashesPath: suiteCrashPath(this.defaultOptions, suiteName)
 		}, optionsTransform);
 		await this.app.start();
-
-		// Smoke tests require a workspace to be open
-		if (!this.app.workspacePathOrFolder) {
-			throw new Error('Smoke tests require a workspace to be open');
-		}
 	});
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- optional workspace paths through MCP setup/start so the server can open a specific folder or workspace when requested
- enable reload tool to support window reload