### PR TITLE
Improve width calculation in ActionList for better layout handling

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -329,6 +329,9 @@ export class ActionList<T> extends Disposable {
 		if (this._allMenuItems.length >= 50) {
 			maxWidth = 380;
 		} else {
+			// Cache computed style values since they're consistent across all list items
+			let cachedHorizontalSpacing: number | undefined;
+
 			// For finding width dynamically (not using resize observer)
 			const itemWidths: number[] = this._allMenuItems.map((_, index): number => {
 				// eslint-disable-next-line no-restricted-syntax
@@ -348,14 +351,17 @@ export class ActionList<T> extends Disposable {
 					element.style.maxWidth = originalMaxWidth;
 					element.style.display = originalDisplay;
 
-					const computedStyle = dom.getWindow(element).getComputedStyle(element);
-					const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
-					const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
-					const marginLeft = parseFloat(computedStyle.marginLeft) || 0;
-					const marginRight = parseFloat(computedStyle.marginRight) || 0;
-					const horizontalSpacing = paddingLeft + paddingRight + marginLeft + marginRight;
+					// Only compute style values once for the first element, then reuse for all others
+					if (cachedHorizontalSpacing === undefined) {
+						const computedStyle = dom.getWindow(element).getComputedStyle(element);
+						const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+						const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+						const marginLeft = parseFloat(computedStyle.marginLeft) || 0;
+						const marginRight = parseFloat(computedStyle.marginRight) || 0;
+						cachedHorizontalSpacing = paddingLeft + paddingRight + marginLeft + marginRight;
+					}
 
-					return width + horizontalSpacing;
+					return width + cachedHorizontalSpacing;
 				}
 				return 0;
 			});

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -334,10 +334,28 @@ export class ActionList<T> extends Disposable {
 				// eslint-disable-next-line no-restricted-syntax
 				const element = this.domNode.ownerDocument.getElementById(this._list.getElementID(index));
 				if (element) {
-					element.style.width = 'auto';
+					const originalWidth = element.style.width;
+					const originalMaxWidth = element.style.maxWidth;
+					const originalDisplay = element.style.display;
+
+					element.style.width = 'max-content';
+					element.style.maxWidth = 'none';
+					element.style.display = 'flex';
+
 					const width = element.getBoundingClientRect().width;
-					element.style.width = '';
-					return width;
+
+					element.style.width = originalWidth;
+					element.style.maxWidth = originalMaxWidth;
+					element.style.display = originalDisplay;
+
+					const computedStyle = dom.getWindow(element).getComputedStyle(element);
+					const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+					const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+					const marginLeft = parseFloat(computedStyle.marginLeft) || 0;
+					const marginRight = parseFloat(computedStyle.marginRight) || 0;
+					const horizontalSpacing = paddingLeft + paddingRight + marginLeft + marginRight;
+
+					return width + horizontalSpacing;
 				}
 				return 0;
 			});


### PR DESCRIPTION
Enhance the width calculation in the ActionList component to improve layout handling by accurately accounting for padding, margins, and other styles. This change ensures a more consistent and visually appealing display of elements. Testing can be done by observing the layout of the ActionList in various scenarios to confirm the improved width calculations.

Addresses: https://github.com/microsoft/vscode/issues/286304

