### PR TITLE
Chat - expand working set when opening a session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2026,6 +2026,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._chatInputTodoListWidget.value?.clear(sessionResource, force);
 	}
 
+	setWorkingSetCollapsed(collapsed: boolean): void {
+		this._workingSetCollapsed.set(collapsed, undefined);
+	}
+
 	renderChatEditingSessionState(chatEditingSession: IChatEditingSession | null) {
 		dom.setVisibility(Boolean(chatEditingSession), this.chatEditingSessionWidgetContainer);
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -750,7 +750,13 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			const newModelRef = await this.chatService.loadSessionForResource(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
 			clearWidget.dispose();
 			await queue;
-			return this.showModel(newModelRef);
+
+			const chatModel = await this.showModel(newModelRef);
+			if (chatModel) {
+				this._widget.input.setWorkingSetCollapsed(false);
+			}
+
+			return chatModel;
 		});
 	}
 


### PR DESCRIPTION
Before the holiday we were talking about the fact that most of the time one opens an agent session to look at the changes in the working set. Since the working set is collapsed by default, I added a method to expand the working set **only** when we open a session. Please let me know if there is a better way to do this. 

//cc @bpasero 