### PR TITLE
Combine action and warning tooltip text into a single string in getHoverContents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -9,7 +9,7 @@ import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languag
 import { localize } from '../../../../../../nls.js';
 import * as dom from '../../../../../../base/browser/dom.js';
 import { renderIcon, renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction, IActionWidgetDropdownActionProvider, IActionWidgetDropdownOptions } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
@@ -23,7 +23,7 @@ import { ITelemetryService } from '../../../../../../platform/telemetry/common/t
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
-import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IManagedHoverContent } from '../../../../../../base/browser/ui/hover/hover.js';
 
 export interface IModelPickerDelegate {
 	readonly onDidChangeModel: Event<ILanguageModelChatMetadataAndIdentifier>;
@@ -139,7 +139,6 @@ function getModelPickerActionBarActionProvider(commandService: ICommandService, 
  * Action view item for selecting a language model in the chat interface.
  */
 export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
-	private readonly tooltipDisposable = this._register(new MutableDisposable());
 
 	constructor(
 		action: IAction,
@@ -153,13 +152,11 @@ export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IProductService productService: IProductService,
-		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		// Modify the original action with a different label and make it show the current model
 		const actionWithLabel: IAction = {
 			...action,
 			label: currentModel?.metadata.name ?? localize('chat.modelPicker.auto', "Auto"),
-			tooltip: localize('chat.modelPicker.label', "Pick Model"),
 			run: () => { }
 		};
 
@@ -173,22 +170,26 @@ export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
 		// Listen for model changes from the delegate
 		this._register(delegate.onDidChangeModel(model => {
 			this.currentModel = model;
+			this.updateTooltip();
 			if (this.element) {
 				this.renderLabel(this.element);
 			}
 		}));
 	}
 
+	protected override getHoverContents(): IManagedHoverContent | undefined {
+		const label = `${localize('chat.modelPicker.label', "Pick Model")}${super.getHoverContents()}`;
+		const { statusIcon, tooltip } = this.currentModel?.metadata || {};
+		return statusIcon && tooltip ? `${label} • ${tooltip}` : label;
+	}
+
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
-		const { name, statusIcon, tooltip } = this.currentModel?.metadata || {};
+		const { name, statusIcon } = this.currentModel?.metadata || {};
 		const domChildren = [];
 
 		if (statusIcon) {
 			const iconElement = renderIcon(statusIcon);
 			domChildren.push(iconElement);
-			if (tooltip) {
-				this.tooltipDisposable.value = this.hoverService.setupDelayedHoverAtMouse(iconElement, () => ({ content: tooltip }));
-			}
 		}
 
 		domChildren.push(dom.$('span.chat-model-label', undefined, name ?? localize('chat.modelPicker.auto', "Auto")));


### PR DESCRIPTION
Fixes #269416
