### PR TITLE
on cursor move, clear and recreate terminal initial hint

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -59,6 +59,11 @@
 
 .chat-terminal-content-part .chat-terminal-content-title .chat-terminal-command-block > .rendered-markdown .monaco-tokenized-source {
 	background: transparent !important;
+	border: none !important;
+}
+
+.chat-terminal-content-part .chat-terminal-content-title .rendered-markdown .monaco-tokenized-source {
+	padding: 1px 0px !important;
 }
 
 .chat-terminal-content-part .chat-terminal-content-title .chat-terminal-command-block > .rendered-markdown code {


### PR DESCRIPTION
fixes #286080

Before:
<img width="744" height="330" alt="Screenshot 2026-01-07 at 10 52 07 AM" src="https://github.com/user-attachments/assets/09e3c3f6-dbc7-4247-ae48-cb6d6ef8691b" />

After:
<img width="1077" height="221" alt="Screenshot 2026-01-07 at 10 51 09 AM" src="https://github.com/user-attachments/assets/1d70640e-f3e9-4701-8d3e-e911921b22ad" />

