### PR TITLE
fix remote terminal suggest

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -368,7 +368,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			case 'tilde': {
 				const home = this._getHomeDir(useWindowsStylePath, capabilities);
 				if (home) {
-					lastWordFolderResource = URI.joinPath(cwd.with({ path: home }), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
+					lastWordFolderResource = URI.joinPath(createUriFromLocalPath(cwd, home), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
 				}
 				if (!lastWordFolderResource) {
 					// Use less strong wording here as it's not as strong of a concept on Windows
@@ -381,9 +381,9 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			case 'absolute': {
 				if (shellType === WindowsShellType.GitBash) {
-					lastWordFolderResource = cwd.with({ path: gitBashToWindowsPath(lastWordFolder, this._processEnv.SystemDrive) });
+					lastWordFolderResource = createUriFromLocalPath(cwd, gitBashToWindowsPath(lastWordFolder, this._processEnv.SystemDrive));
 				} else {
-					lastWordFolderResource = cwd.with({ path: lastWordFolder.replaceAll('\\ ', ' ') });
+					lastWordFolderResource = createUriFromLocalPath(cwd, lastWordFolder.replaceAll('\\ ', ' '));
 				}
 				break;
 			}
@@ -549,7 +549,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 						const cdPathEntries = cdPath.split(useWindowsStylePath ? ';' : ':');
 						for (const cdPathEntry of cdPathEntries) {
 							try {
-								const fileStat = await this._fileService.resolve(cwd.with({ path: cdPathEntry }), { resolveSingleChildDescendants: true });
+								const fileStat = await this._fileService.resolve(createUriFromLocalPath(cwd, cdPathEntry), { resolveSingleChildDescendants: true });
 								if (fileStat?.children) {
 									for (const child of fileStat.children) {
 										if (!child.isDirectory) {
@@ -610,7 +610,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			let homeResource: URI | string | undefined;
 			const home = this._getHomeDir(useWindowsStylePath, capabilities);
 			if (home) {
-				homeResource = URI.joinPath(cwd.with({ path: home }), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
+				homeResource = URI.joinPath(createUriFromLocalPath(cwd, home), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
 			}
 			if (!homeResource) {
 				// Use less strong wording here as it's not as strong of a concept on Windows
@@ -684,4 +684,16 @@ function getIsAbsolutePath(shellType: TerminalShellType | undefined, pathSeparat
 		return lastWord.startsWith(pathSeparator) || /^[a-zA-Z]:\//.test(lastWord);
 	}
 	return useWindowsStylePath ? /^[a-zA-Z]:[\\\/]/.test(lastWord) : lastWord.startsWith(pathSeparator);
+}
+
+/**
+ * Creates a URI from an absolute path, preserving the scheme and authority from the cwd.
+ * For local file:// URIs, uses URI.file() which handles Windows path normalization.
+ * For remote URIs (e.g., vscode-remote://wsl+Ubuntu), preserves the remote context.
+ */
+function createUriFromLocalPath(cwd: URI, absolutePath: string): URI {
+	if (cwd.scheme === 'file') {
+		return URI.file(absolutePath);
+	}
+	return cwd.with({ path: absolutePath });
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -610,7 +610,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			let homeResource: URI | string | undefined;
 			const home = this._getHomeDir(useWindowsStylePath, capabilities);
 			if (home) {
-				homeResource = URI.joinPath(createUriFromLocalPath(cwd, home), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
+				homeResource = createUriFromLocalPath(cwd, home);
 			}
 			if (!homeResource) {
 				// Use less strong wording here as it's not as strong of a concept on Windows

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -368,7 +368,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			case 'tilde': {
 				const home = this._getHomeDir(useWindowsStylePath, capabilities);
 				if (home) {
-					lastWordFolderResource = URI.joinPath(URI.file(home), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
+					lastWordFolderResource = URI.joinPath(cwd.with({ path: home }), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
 				}
 				if (!lastWordFolderResource) {
 					// Use less strong wording here as it's not as strong of a concept on Windows
@@ -381,9 +381,9 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			}
 			case 'absolute': {
 				if (shellType === WindowsShellType.GitBash) {
-					lastWordFolderResource = URI.file(gitBashToWindowsPath(lastWordFolder, this._processEnv.SystemDrive));
+					lastWordFolderResource = cwd.with({ path: gitBashToWindowsPath(lastWordFolder, this._processEnv.SystemDrive) });
 				} else {
-					lastWordFolderResource = URI.file(lastWordFolder.replaceAll('\\ ', ' '));
+					lastWordFolderResource = cwd.with({ path: lastWordFolder.replaceAll('\\ ', ' ') });
 				}
 				break;
 			}
@@ -549,7 +549,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 						const cdPathEntries = cdPath.split(useWindowsStylePath ? ';' : ':');
 						for (const cdPathEntry of cdPathEntries) {
 							try {
-								const fileStat = await this._fileService.resolve(URI.file(cdPathEntry), { resolveSingleChildDescendants: true });
+								const fileStat = await this._fileService.resolve(cwd.with({ path: cdPathEntry }), { resolveSingleChildDescendants: true });
 								if (fileStat?.children) {
 									for (const child of fileStat.children) {
 										if (!child.isDirectory) {
@@ -610,7 +610,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			let homeResource: URI | string | undefined;
 			const home = this._getHomeDir(useWindowsStylePath, capabilities);
 			if (home) {
-				homeResource = URI.joinPath(URI.file(home), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
+				homeResource = URI.joinPath(cwd.with({ path: home }), lastWordFolder.slice(1).replaceAll('\\ ', ' '));
 			}
 			if (!homeResource) {
 				// Use less strong wording here as it's not as strong of a concept on Windows

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -339,6 +339,15 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 							return undefined;
 						}
 					}
+				} else {
+					// `./` by itself means the current directory, use cwd directly to avoid
+					// trailing slash issues with URI.joinPath on some remote file systems.
+					try {
+						await this._fileService.stat(cwd);
+						lastWordFolderResource = cwd;
+					} catch {
+						return undefined;
+					}
 				}
 			}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -827,7 +827,10 @@ suite('TerminalCompletionService', () => {
 
 				// Check that results exist and have the correct scheme/authority
 				assert.ok(result && result.length > 0, 'Should return completions for remote absolute path');
-				// The completions should have been resolved using the remote file service
+				// Verify completions contain paths resolved via the remote file service (not local file://)
+				const absoluteCompletion = result?.find(c => c.label === '/home/');
+				assert.ok(absoluteCompletion, 'Should have absolute path completion');
+				assert.ok(absoluteCompletion.detail?.includes('/home/'), 'Detail should show remote path');
 			});
 
 			test('~/ should preserve remote authority for tilde expansion', async () => {
@@ -849,6 +852,9 @@ suite('TerminalCompletionService', () => {
 
 				// Check that results exist for remote tilde path
 				assert.ok(result && result.length > 0, 'Should return completions for remote tilde path');
+				// Verify the tilde path was resolved using the remote home directory
+				const documentsCompletion = result?.find(c => c.detail?.includes('Documents'));
+				assert.ok(documentsCompletion, 'Should find Documents folder from remote home');
 			});
 
 			test('./relative should preserve remote authority for relative paths', async () => {
@@ -869,8 +875,9 @@ suite('TerminalCompletionService', () => {
 
 				// Check that results exist for remote relative path
 				assert.ok(result && result.length > 0, 'Should return completions for remote relative path');
-				const srcCompletion = result?.find(c => c.detail?.includes('src'));
-				assert.ok(srcCompletion, 'Should find src folder completion');
+				// Verify completions are from the remote filesystem
+				const srcCompletion = result?.find(c => c.detail?.includes('/home/remoteuser/project/src'));
+				assert.ok(srcCompletion, 'Should find src folder completion with remote path in detail');
 			});
 		});
 	}


### PR DESCRIPTION
fix part of https://github.com/microsoft/vscode/issues/286155
fix #249896

File completions weren't working in WSL (and other remote environments) because when creating URIs for absolute paths, tilde paths (~), and $CDPATH entries, the code was using URI.file() which always creates a file:// URI pointing to the local host filesystem.

For example, when typing /home/user in a WSL terminal:

Before: `URI.file('/home/user')` → `file:///home/user` → queries local Windows host
After: `createUriFromLocalPath(cwd, '/home/user')` → `vscode-remote://wsl+Ubuntu/home/user` → queries remote WSL filesystem
Added a helper function `createUriFromLocalPath` that:

For local file:// URIs: Uses `URI.file(path)` to handle Windows path normalization
For remote URIs: Uses `cwd.with({ path })` to preserve the scheme and authority

