### PR TITLE
add accessibility tests for more of the workbench

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "yazl": "^2.4.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.56.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
         "@types/cookie": "^0.3.3",
@@ -176,6 +177,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.0.tgz",
+      "integrity": "sha512-70vBT/Ylqpm65RQz2iCG2o0JJCEG/WCNyefTr2xcOcr1CoSee60gNQYUMZZ7YukoKkFLv26I/jjlsvwwp532oQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@azure-rest/ai-translation-text": {
@@ -4213,6 +4227,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/b4a": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "yazl": "^2.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@types/cookie": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "yazl": "^2.4.3"
   },
   "devDependencies": {
-    "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@types/cookie": "^0.3.3",

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
@@ -113,6 +113,16 @@ div.chat-welcome-view {
 		max-width: 250px;
 		margin: 10px 5px 0px;
 
+		a {
+			color: var(--vscode-textLink-foreground);
+		}
+
+		a:hover,
+		a:focus {
+			text-decoration: underline;
+			outline: 1px solid var(--vscode-focusBorder);
+		}
+
 		.rendered-markdown {
 			gap: 6px;
 			display: flex;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
@@ -85,7 +85,7 @@ div.chat-welcome-view {
 		max-width: 100%;
 		padding: 0 20px;
 		margin: 0 auto;
-		color: var(--vscode-input-placeholderForeground);
+		color: var(--vscode-foreground);
 
 		a {
 			color: var(--vscode-textLink-foreground);
@@ -142,7 +142,7 @@ div.chat-welcome-view {
 	}
 
 	& > .chat-welcome-view-disclaimer {
-		color: var(--vscode-input-placeholderForeground);
+		color: var(--vscode-foreground);
 		text-align: center;
 		margin: -16px auto;
 		max-width: 400px;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
@@ -91,7 +91,9 @@ div.chat-welcome-view {
 			color: var(--vscode-textLink-foreground);
 		}
 
+		a:hover,
 		a:focus {
+			text-decoration: underline;
 			outline: 1px solid var(--vscode-focusBorder);
 		}
 
@@ -140,7 +142,9 @@ div.chat-welcome-view {
 			color: var(--vscode-textLink-foreground);
 		}
 
+		a:hover,
 		a:focus {
+			text-decoration: underline;
 			outline: 1px solid var(--vscode-focusBorder);
 		}
 	}

--- a/test/automation/package-lock.json
+++ b/test/automation/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.71.0",
       "license": "MIT",
       "dependencies": {
+        "axe-core": "^4.10.2",
         "ncp": "^2.0.0",
         "tmp": "0.2.4",
         "tree-kill": "1.2.2",
@@ -69,6 +70,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/test/automation/package.json
+++ b/test/automation/package.json
@@ -18,6 +18,7 @@
     "prepublishOnly": "npm run copy-package-version"
   },
   "dependencies": {
+    "axe-core": "^4.10.2",
     "ncp": "^2.0.0",
     "tmp": "0.2.4",
     "tree-kill": "1.2.2",

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -410,7 +410,7 @@ export class PlaywrightDriver {
 			() => this.page.evaluate(
 				([ctx, opts]) => {
 					// @ts-expect-error axe is injected globally
-					return window.axe.run(ctx.include ? ctx.include[0] : document, opts);
+					return window.axe.run(ctx, opts);
 				},
 				[context, runOptions] as const
 			),

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -432,25 +432,25 @@ export class PlaywrightDriver {
 		// Filter out violations for specific elements based on excludeRules
 		let filteredViolations = results.violations;
 		if (options?.excludeRules) {
-			filteredViolations = results.violations.map(violation => {
+			filteredViolations = results.violations.map((violation: AxeResults['violations'][number]) => {
 				const excludePatterns = options.excludeRules![violation.id];
 				if (!excludePatterns) {
 					return violation;
 				}
 				// Filter out nodes that match any of the exclude patterns
-				const filteredNodes = violation.nodes.filter(node => {
+				const filteredNodes = violation.nodes.filter((node: AxeResults['violations'][number]['nodes'][number]) => {
 					const target = node.target.join(' ');
 					const html = node.html || '';
 					// Check if any exclude pattern appears in target or HTML
 					return !excludePatterns.some(pattern => target.includes(pattern) || html.includes(pattern));
 				});
 				return { ...violation, nodes: filteredNodes };
-			}).filter(violation => violation.nodes.length > 0);
+			}).filter((violation: AxeResults['violations'][number]) => violation.nodes.length > 0);
 		}
 
 		if (filteredViolations.length > 0) {
-			const violationMessages = filteredViolations.map(violation => {
-				const nodes = violation.nodes.map(node => {
+			const violationMessages = filteredViolations.map((violation: AxeResults['violations'][number]) => {
+				const nodes = violation.nodes.map((node: AxeResults['violations'][number]['nodes'][number]) => {
 					const target = node.target.join(' > ');
 					const html = node.html || 'N/A';
 					// Extract class from HTML for easier identification
@@ -472,7 +472,7 @@ export class PlaywrightDriver {
 
 			throw new Error(
 				`Accessibility violations found:\n\n${violationMessages}\n\n` +
-				`Total: ${filteredViolations.length} violation(s) affecting ${filteredViolations.reduce((sum, v) => sum + v.nodes.length, 0)} element(s)`
+				`Total: ${filteredViolations.length} violation(s) affecting ${filteredViolations.reduce((sum: number, v: AxeResults['violations'][number]) => sum + v.nodes.length, 0)} element(s)`
 			);
 		}
 	}

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -15,7 +15,14 @@ import { ChildProcess } from 'child_process';
 import type { AxeResults, RunOptions } from 'axe-core';
 
 // Load axe-core source for injection into pages (works with Electron)
-const axeSource = readFileSync(require.resolve('axe-core/axe.min.js'), 'utf-8');
+let axeSource = '';
+try {
+	const axePath = require.resolve('axe-core/axe.min.js');
+	axeSource = readFileSync(axePath, 'utf-8');
+} catch {
+	// axe-core may not be installed; keep axeSource empty to avoid failing module initialization
+	axeSource = '';
+}
 
 type PageFunction<Arg, T> = (arg: Arg) => T | Promise<T>;
 

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -26,7 +26,14 @@ export interface AccessibilityScanOptions {
 	tags?: string[];
 	/** Rule IDs to disable for this scan. */
 	disableRules?: string[];
-	/** Patterns to exclude from specific rules. Keys are rule IDs, values are strings to match against element target or HTML. */
+	/**
+	 * Patterns to exclude from specific rules. Keys are rule IDs, values are strings to match against element target or HTML.
+	 *
+	 * **IMPORTANT**: Adding exclusions here bypasses accessibility checks. Before adding an exclusion:
+	 * 1. File an issue to track the accessibility problem
+	 * 2. Ensure there's a plan to fix the underlying issue (e.g., hover/focus states that axe can't detect)
+	 * 3. Get approval from @anthropics/accessibility team
+	 */
 	excludeRules?: { [ruleId: string]: string[] };
 }
 

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -415,11 +415,25 @@ export class PlaywrightDriver {
 
 		if (results.violations.length > 0) {
 			const violationMessages = results.violations.map(violation => {
-				const nodes = violation.nodes.map(node =>
-					`  - ${node.target.join(' > ')}: ${node.failureSummary}`
-				).join('\n');
-				return `[${violation.id}] ${violation.help} (${violation.impact})\n${nodes}`;
-			}).join('\n\n');
+				const nodes = violation.nodes.map(node => {
+					const target = node.target.join(' > ');
+					const html = node.html || 'N/A';
+					// Extract class from HTML for easier identification
+					const classMatch = html.match(/class="([^"]+)"/);
+					const className = classMatch ? classMatch[1] : 'no class';
+					return [
+						`  Element: ${target}`,
+						`    Class: ${className}`,
+						`    HTML: ${html}`,
+						`    Issue: ${node.failureSummary}`
+					].join('\n');
+				}).join('\n\n');
+				return [
+					`[${violation.id}] ${violation.help} (${violation.impact})`,
+					`  Help URL: ${violation.helpUrl}`,
+					nodes
+				].join('\n');
+			}).join('\n\n---\n\n');
 
 			throw new Error(
 				`Accessibility violations found:\n\n${violationMessages}\n\n` +

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -381,14 +381,14 @@ export class PlaywrightDriver {
 			runOnly: {
 				type: 'tag',
 				values: options?.tags ?? ['wcag2a', 'wcag2aa', 'wcag21aa']
-			},
-			rules: {}
+			}
 		};
 
 		// Disable specific rules if requested
 		if (options?.disableRules && options.disableRules.length > 0) {
+			runOptions.rules = {};
 			for (const ruleId of options.disableRules) {
-				runOptions.rules![ruleId] = { enabled: false };
+				runOptions.rules[ruleId] = { enabled: false };
 			}
 		}
 

--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -6,7 +6,7 @@
 import { Application, Logger } from '../../../../automation';
 import { installAllHandlers } from '../../utils';
 
-export function setup(logger: Logger) {
+export function setup(logger: Logger, opts: { web?: boolean }) {
 	describe('Accessibility', function () {
 
 		// Increase timeout for accessibility scans
@@ -69,27 +69,30 @@ export function setup(logger: Logger) {
 			});
 		});
 
-		describe('Chat', function () {
+		// Chat is not available in web mode
+		if (!opts.web) {
+			describe('Chat', function () {
 
-			it('chat panel has no accessibility violations', async function () {
-				// Open chat panel
-				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+				it('chat panel has no accessibility violations', async function () {
+					// Open chat panel
+					await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
 
-				// Wait for chat view to be visible
-				await app.code.waitForElement('div[id="workbench.panel.chat"]');
+					// Wait for chat view to be visible
+					await app.code.waitForElement('div[id="workbench.panel.chat"]');
 
-				await app.code.driver.assertNoAccessibilityViolations({
-					selector: 'div[id="workbench.panel.chat"]',
-					disableRules: [
-						// Color contrast issues are tracked separately
-						'color-contrast'
-					],
-					excludeRules: {
-						// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
-						'link-in-text-block': ['command:workbench.action.chat.generateInstructions']
-					}
+					await app.code.driver.assertNoAccessibilityViolations({
+						selector: 'div[id="workbench.panel.chat"]',
+						disableRules: [
+							// Color contrast issues are tracked separately
+							'color-contrast'
+						],
+						excludeRules: {
+							// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
+							'link-in-text-block': ['command:workbench.action.chat.generateInstructions']
+						}
+					});
 				});
 			});
-		});
+		}
 	});
 }

--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application, Logger } from '../../../../automation';
+import { installAllHandlers } from '../../utils';
+
+export function setup(logger: Logger) {
+	describe('Accessibility', function () {
+
+		// Increase timeout for accessibility scans
+		this.timeout(2 * 60 * 1000);
+
+		// Retry tests to minimize flakiness
+		this.retries(2);
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		let app: Application;
+
+		before(async function () {
+			app = this.app as Application;
+		});
+
+		describe('Workbench', function () {
+
+			it('workbench has no accessibility violations', async function () {
+				// Wait for workbench to be fully loaded
+				await app.code.waitForElement('.monaco-workbench');
+
+				await app.code.driver.assertNoAccessibilityViolations({
+					selector: '.monaco-workbench',
+					// Disable rules that may have known issues being addressed separately
+					disableRules: [
+						// Color contrast issues are tracked separately
+						'color-contrast'
+					]
+				});
+			});
+
+			it('activity bar has no accessibility violations', async function () {
+				await app.code.waitForElement('.activitybar');
+
+				await app.code.driver.assertNoAccessibilityViolations({
+					selector: '.activitybar'
+				});
+			});
+
+			it('sidebar has no accessibility violations', async function () {
+				await app.code.waitForElement('.sidebar');
+
+				await app.code.driver.assertNoAccessibilityViolations({
+					selector: '.sidebar'
+				});
+			});
+
+			it('status bar has no accessibility violations', async function () {
+				await app.code.waitForElement('.statusbar');
+
+				await app.code.driver.assertNoAccessibilityViolations({
+					selector: '.statusbar'
+				});
+			});
+		});
+
+		describe('Chat', function () {
+
+			it('chat panel has no accessibility violations', async function () {
+				// Open chat panel
+				await app.workbench.quickaccess.runCommand('workbench.action.chat.open');
+
+				// Wait for chat view to be visible
+				await app.code.waitForElement('div[id="workbench.panel.chat"]');
+
+				await app.code.driver.assertNoAccessibilityViolations({
+					selector: 'div[id="workbench.panel.chat"]',
+					disableRules: [
+						// Color contrast issues are tracked separately
+						'color-contrast'
+					]
+				});
+			});
+		});
+	});
+}

--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -36,7 +36,11 @@ export function setup(logger: Logger) {
 					disableRules: [
 						// Color contrast issues are tracked separately
 						'color-contrast'
-					]
+					],
+					excludeRules: {
+						// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
+						'link-in-text-block': ['command:workbench.action.chat.generateInstructions']
+					}
 				});
 			});
 
@@ -79,7 +83,11 @@ export function setup(logger: Logger) {
 					disableRules: [
 						// Color contrast issues are tracked separately
 						'color-contrast'
-					]
+					],
+					excludeRules: {
+						// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
+						'link-in-text-block': ['command:workbench.action.chat.generateInstructions']
+					}
 				});
 			});
 		});

--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -32,11 +32,6 @@ export function setup(logger: Logger, opts: { web?: boolean }) {
 
 				await app.code.driver.assertNoAccessibilityViolations({
 					selector: '.monaco-workbench',
-					// Disable rules that may have known issues being addressed separately
-					disableRules: [
-						// Color contrast issues are tracked separately
-						'color-contrast'
-					],
 					excludeRules: {
 						// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
 						'link-in-text-block': ['command:workbench.action.chat.generateInstructions']
@@ -82,10 +77,6 @@ export function setup(logger: Logger, opts: { web?: boolean }) {
 
 					await app.code.driver.assertNoAccessibilityViolations({
 						selector: 'div[id="workbench.panel.chat"]',
-						disableRules: [
-							// Color contrast issues are tracked separately
-							'color-contrast'
-						],
 						excludeRules: {
 							// Links in chat welcome view show underline on hover/focus which axe-core static analysis cannot detect
 							'link-in-text-block': ['command:workbench.action.chat.generateInstructions']

--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -10,7 +10,7 @@ export function setup(logger: Logger, opts: { web?: boolean }) {
 	describe('Accessibility', function () {
 
 		// Increase timeout for accessibility scans
-		this.timeout(2 * 60 * 1000);
+		this.timeout(30 * 1000);
 
 		// Retry tests to minimize flakiness
 		this.retries(2);

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -27,6 +27,7 @@ import { setup as setupLaunchTests } from './areas/workbench/launch.test';
 import { setup as setupTerminalTests } from './areas/terminal/terminal.test';
 import { setup as setupTaskTests } from './areas/task/task.test';
 import { setup as setupChatTests } from './areas/chat/chat.test';
+import { setup as setupAccessibilityTests } from './areas/accessibility/accessibility.test';
 
 const rootPath = path.join(__dirname, '..', '..', '..');
 
@@ -405,4 +406,5 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web && !opts.remote && quality !== Quality.Dev && quality !== Quality.OSS) { setupLocalizationTests(logger); }
 	if (!opts.web && !opts.remote) { setupLaunchTests(logger); }
 	if (!opts.web) { setupChatTests(logger); }
+	setupAccessibilityTests(logger);
 });

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -406,5 +406,5 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web && !opts.remote && quality !== Quality.Dev && quality !== Quality.OSS) { setupLocalizationTests(logger); }
 	if (!opts.web && !opts.remote) { setupLaunchTests(logger); }
 	if (!opts.web) { setupChatTests(logger); }
-	setupAccessibilityTests(logger);
+	setupAccessibilityTests(logger, opts);
 });


### PR DESCRIPTION
This PR adds automated accessibility testing to VS Code's smoke test suite using `axe-core`. The integration injects axe-core directly into the Electron page to run WCAG 2.1 AA compliance checks on key UI components.

Created new accessibility smoke tests covering the `workbench`, `activity bar`, `sidebar`, `status bar`, and `chat panel`

The accessibility scan is performed by injecting axe-core's minified source into the page and running `axe.run()` against specified selectors. Tests fail with detailed violation reports including the affected elements, rule IDs, and remediation suggestions. The scanner defaults to WCAG 2.1 AA compliance tags and excludes known areas like Monaco editor view lines and terminal canvas that have their own accessibility handling.

The tests can be run with:

```
cd /Users/meganrogge/Repos/vscode/test/smoke && node test/index.js -g "Accessibility"
```

<img width="766" height="574" alt="Screenshot 2026-01-08 at 3 03 55 PM" src="https://github.com/user-attachments/assets/f473d9ab-e80c-4791-a97b-f331b1bc2cb8" />

2 failures discovered, for example:

<img width="1400" height="279" alt="Screenshot 2026-01-07 at 4 38 01 PM" src="https://github.com/user-attachments/assets/6a0394a7-2d0b-4c44-b2a3-218a98d15f5c" />

Fixes #286587
Fixes #286594

Before:

https://github.com/user-attachments/assets/e07b6104-2ed5-46a9-b190-e72d5ce91f03

After:

https://github.com/user-attachments/assets/f80fc8a1-6bab-4e8f-a4a0-afcad530bd0f

One can adds excludes rules once a violation has been addressed (underline on the link on hover or focus), for example:

https://github.com/microsoft/vscode/blob/25908b3b97916ef914b105f152165b2e78f74e1b/test/smoke/src/areas/accessibility/accessibility.test.ts#L89-L92
