### PR TITLE
chat: cache variable part of dataId in request hash

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAttachmentsContentPart.ts
@@ -16,7 +16,7 @@ import { ChatResponseReferencePartStatusKind, IChatContentReference } from '../.
 import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 
 export interface IChatAttachmentsContentPartOptions {
-	readonly variables: IChatRequestVariableEntry[];
+	readonly variables: readonly IChatRequestVariableEntry[];
 	readonly contentReferences?: ReadonlyArray<IChatContentReference>;
 	readonly domNode?: HTMLElement;
 	readonly limit?: number;
@@ -29,7 +29,7 @@ export class ChatAttachmentsContentPart extends Disposable {
 	private readonly _contextResourceLabels: ResourceLabels;
 	private _showingAll = false;
 
-	private readonly variables: IChatRequestVariableEntry[];
+	private readonly variables: readonly IChatRequestVariableEntry[];
 	private readonly contentReferences: ReadonlyArray<IChatContentReference>;
 	private readonly limit?: number;
 	public readonly domNode: HTMLElement | undefined;
@@ -70,7 +70,7 @@ export class ChatAttachmentsContentPart extends Disposable {
 		}
 	}
 
-	private getVisibleAttachments(): IChatRequestVariableEntry[] {
+	private getVisibleAttachments(): readonly IChatRequestVariableEntry[] {
 		if (!this.limit || this._showingAll) {
 			return this.variables;
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1628,7 +1628,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return part;
 	}
 
-	private renderAttachments(variables: IChatRequestVariableEntry[], contentReferences: ReadonlyArray<IChatContentReference> | undefined, templateData: IChatListItemTemplate) {
+	private renderAttachments(variables: readonly IChatRequestVariableEntry[], contentReferences: ReadonlyArray<IChatContentReference> | undefined, templateData: IChatListItemTemplate) {
 		return this.instantiationService.createInstance(ChatAttachmentsContentPart, {
 			variables,
 			contentReferences,

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -12,15 +12,15 @@ import * as marked from '../../../../../base/common/marked/marked.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { annotateVulnerabilitiesInText } from '../widget/annotations.js';
-import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from '../participants/chatAgents.js';
-import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
-import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatMcpServersStarting, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from '../chatService/chatService.js';
 import { IChatRequestVariableEntry } from '../attachments/chatVariableEntries.js';
-import { countWords } from './chatWordCounter.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatMcpServersStarting, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from '../chatService/chatService.js';
+import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from '../participants/chatAgents.js';
+import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
+import { annotateVulnerabilitiesInText } from '../widget/annotations.js';
 import { CodeBlockModelCollection } from '../widget/codeBlockModelCollection.js';
+import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
 import { ChatStreamStatsTracker, IChatStreamStats } from './chatStreamStats.js';
+import { countWords } from './chatWordCounter.js';
 
 export function isRequestVM(item: unknown): item is IChatRequestViewModel {
 	return !!item && typeof item === 'object' && 'message' in item;
@@ -87,7 +87,7 @@ export interface IChatRequestViewModel {
 	readonly message: IParsedChatRequest | IChatFollowup;
 	readonly messageText: string;
 	readonly attempt: number;
-	readonly variables: IChatRequestVariableEntry[];
+	readonly variables: readonly IChatRequestVariableEntry[];
 	currentRenderedHeight: number | undefined;
 	readonly contentReferences?: ReadonlyArray<IChatContentReference>;
 	readonly confirmation?: string;
@@ -368,13 +368,21 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 	}
 }
 
+const variablesHash = new WeakMap<readonly IChatRequestVariableEntry[], number>();
+
 export class ChatRequestViewModel implements IChatRequestViewModel {
 	get id() {
 		return this._model.id;
 	}
 
 	get dataId() {
-		return this.id + `_${hash(this.variables)}_${hash(this.isComplete)}`;
+		let varsHash = variablesHash.get(this.variables);
+		if (typeof varsHash !== 'number') {
+			varsHash = hash(this.variables);
+			variablesHash.set(this.variables, varsHash);
+		}
+
+		return `${this.id}_${this.isComplete ? '1' : '0'}_${varsHash}`;
 	}
 
 	/** @deprecated */


### PR DESCRIPTION
- Make IChatRequestVariableEntry readonly in the type signatures where variables are passed/stored to reduce aliasing issues
- Cache the hash result for variables in ChatRequestViewModel.dataId to avoid recalculating the same hash repeatedly. This improves performance when the same variables array is queried multiple times.

Fixes https://github.com/microsoft/vscode/issues/286450

(Commit message generated by Copilot)
