### PR TITLE
Make `IAuthMetadata` not MCP specific

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadMcp.ts
+++ b/src/vs/workbench/api/browser/mainThreadMcp.ts
@@ -29,7 +29,7 @@ import { ExtensionHostKind, extensionHostKindToString } from '../../services/ext
 import { IExtensionService } from '../../services/extensions/common/extensions.js';
 import { IExtHostContext, extHostNamedCustomer } from '../../services/extensions/common/extHostCustomers.js';
 import { Proxied } from '../../services/extensions/common/proxyIdentifier.js';
-import { ExtHostContext, ExtHostMcpShape, IMcpAuthenticationDetails, IMcpAuthenticationOptions, IMcpAuthSetupTelemetry, MainContext, MainThreadMcpShape } from '../common/extHost.protocol.js';
+import { ExtHostContext, ExtHostMcpShape, IMcpAuthenticationDetails, IMcpAuthenticationOptions, IAuthMetadataSource, MainContext, MainThreadMcpShape } from '../common/extHost.protocol.js';
 
 @extHostNamedCustomer(MainContext.MainThreadMcp)
 export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
@@ -357,14 +357,14 @@ export class MainThreadMcp extends Disposable implements MainThreadMcpShape {
 		}
 	}
 
-	$logMcpAuthSetup(data: IMcpAuthSetupTelemetry): void {
+	$logMcpAuthSetup(data: IAuthMetadataSource): void {
 		type McpAuthSetupClassification = {
 			owner: 'TylerLeonhardt';
 			comment: 'Tracks how MCP OAuth authentication setup was discovered and configured';
 			resourceMetadataSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How resource metadata was discovered (header, wellKnown, or none)' };
 			serverMetadataSource: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How authorization server metadata was discovered (resourceMetadata, wellKnown, or default)' };
 		};
-		this._telemetryService.publicLog2<IMcpAuthSetupTelemetry, McpAuthSetupClassification>('mcp/authSetup', data);
+		this._telemetryService.publicLog2<IAuthMetadataSource, McpAuthSetupClassification>('mcp/authSetup', data);
 	}
 
 	private async loginPrompt(mcpLabel: string, providerLabel: string, recreatingSession: boolean): Promise<boolean> {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3156,21 +3156,21 @@ export interface IMcpAuthenticationOptions {
 	forceNewRegistration?: boolean;
 }
 
-export const enum McpAuthResourceMetadataSource {
+export const enum IAuthResourceMetadataSource {
 	Header = 'header',
 	WellKnown = 'wellKnown',
 	None = 'none',
 }
 
-export const enum McpAuthServerMetadataSource {
+export const enum IAuthServerMetadataSource {
 	ResourceMetadata = 'resourceMetadata',
 	WellKnown = 'wellKnown',
 	Default = 'default',
 }
 
-export interface IMcpAuthSetupTelemetry {
-	resourceMetadataSource: McpAuthResourceMetadataSource;
-	serverMetadataSource: McpAuthServerMetadataSource;
+export interface IAuthMetadataSource {
+	resourceMetadataSource: IAuthResourceMetadataSource;
+	serverMetadataSource: IAuthServerMetadataSource;
 }
 
 export interface MainThreadMcpShape {
@@ -3181,7 +3181,7 @@ export interface MainThreadMcpShape {
 	$deleteMcpCollection(collectionId: string): void;
 	$getTokenFromServerMetadata(id: number, authDetails: IMcpAuthenticationDetails, options?: IMcpAuthenticationOptions): Promise<string | undefined>;
 	$getTokenForProviderId(id: number, providerId: string, scopes: string[], options?: IMcpAuthenticationOptions): Promise<string | undefined>;
-	$logMcpAuthSetup(data: IMcpAuthSetupTelemetry): void;
+	$logMcpAuthSetup(data: IAuthMetadataSource): void;
 }
 
 export interface MainThreadDataChannelsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostMcp.ts
+++ b/src/vs/workbench/api/common/extHostMcp.ts
@@ -21,7 +21,7 @@ import { StorageScope } from '../../../platform/storage/common/storage.js';
 import { extensionPrefixedIdentifier, McpCollectionDefinition, McpConnectionState, McpServerDefinition, McpServerLaunch, McpServerStaticMetadata, McpServerStaticToolAvailability, McpServerTransportHTTP, McpServerTransportType, UserInteractionRequiredError } from '../../contrib/mcp/common/mcpTypes.js';
 import { MCP } from '../../contrib/mcp/common/modelContextProtocol.js';
 import { checkProposedApiEnabled, isProposedApiEnabled } from '../../services/extensions/common/extensions.js';
-import { ExtHostMcpShape, IMcpAuthenticationDetails, IMcpAuthSetupTelemetry, IStartMcpOptions, MainContext, MainThreadMcpShape, McpAuthResourceMetadataSource, McpAuthServerMetadataSource } from './extHost.protocol.js';
+import { ExtHostMcpShape, IMcpAuthenticationDetails, IAuthMetadataSource, IStartMcpOptions, MainContext, MainThreadMcpShape, IAuthResourceMetadataSource, IAuthServerMetadataSource } from './extHost.protocol.js';
 import { IExtHostInitDataService } from './extHostInitDataService.js';
 import { IExtHostRpcService } from './extHostRpcService.js';
 import * as Convert from './extHostTypeConverters.js';
@@ -703,8 +703,11 @@ export class McpHTTPHandle extends Disposable {
 		let res = await doFetch();
 		if (isAuthStatusCode(res.status)) {
 			if (!this._authMetadata) {
-				this._authMetadata = await createAuthMetadata(mcpUrl, res, {
-					launchHeaders: this._launch.headers,
+				this._authMetadata = await createAuthMetadata(mcpUrl, res.headers, {
+					sameOriginHeaders: {
+						...Object.fromEntries(this._launch.headers),
+						'MCP-Protocol-Version': MCP.LATEST_PROTOCOL_VERSION
+					},
 					fetch: (url, init) => this._fetch(url, init as MinimalRequestInit),
 					log: (level, message) => this._log(level, message)
 				});
@@ -717,7 +720,7 @@ export class McpHTTPHandle extends Disposable {
 				}
 			} else {
 				// We have auth metadata, but got an auth error. Check if the scopes changed.
-				if (this._authMetadata.update(res)) {
+				if (this._authMetadata.update(res.headers)) {
 					await this._addAuthHeader(headers);
 					if (headers['Authorization']) {
 						// Update the headers in the init object
@@ -848,14 +851,14 @@ export interface IAuthMetadata {
 	readonly resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined;
 	readonly scopes: string[] | undefined;
 	/** Telemetry data about how auth metadata was discovered */
-	readonly telemetry: IMcpAuthSetupTelemetry;
+	readonly telemetry: IAuthMetadataSource;
 
 	/**
 	 * Updates the scopes based on the WWW-Authenticate header in the response.
 	 * @param response The HTTP response containing potential scope challenges
 	 * @returns true if scopes were updated, false otherwise
 	 */
-	update(response: CommonResponse): boolean;
+	update(responseHeaders: Headers): boolean;
 }
 
 /**
@@ -870,7 +873,7 @@ class AuthMetadata implements IAuthMetadata {
 		public readonly serverMetadata: IAuthorizationServerMetadata,
 		public readonly resourceMetadata: IAuthorizationProtectedResourceMetadata | undefined,
 		scopes: string[] | undefined,
-		public readonly telemetry: IMcpAuthSetupTelemetry,
+		public readonly telemetry: IAuthMetadataSource,
 		private readonly _log: AuthMetadataLogger,
 	) {
 		this._scopes = scopes;
@@ -880,8 +883,8 @@ class AuthMetadata implements IAuthMetadata {
 		return this._scopes;
 	}
 
-	update(response: CommonResponse): boolean {
-		const scopesChallenge = this._parseScopesFromResponse(response);
+	update(responseHeaders: Headers): boolean {
+		const scopesChallenge = this._parseScopesFromResponse(responseHeaders);
 		if (!scopesMatch(scopesChallenge, this._scopes)) {
 			this._log(LogLevel.Info, `Scopes changed from ${JSON.stringify(this._scopes)} to ${JSON.stringify(scopesChallenge)}, updating`);
 			this._scopes = scopesChallenge;
@@ -890,12 +893,11 @@ class AuthMetadata implements IAuthMetadata {
 		return false;
 	}
 
-	private _parseScopesFromResponse(response: CommonResponse): string[] | undefined {
-		if (!response.headers.has('WWW-Authenticate')) {
+	private _parseScopesFromResponse(responseHeaders: Headers): string[] | undefined {
+		const authHeader = responseHeaders.get('WWW-Authenticate');
+		if (!authHeader) {
 			return undefined;
 		}
-
-		const authHeader = response.headers.get('WWW-Authenticate')!;
 		const challenges = parseWWWAuthenticateHeader(authHeader);
 		for (const challenge of challenges) {
 			if (challenge.scheme === 'Bearer' && challenge.params['scope']) {
@@ -914,8 +916,8 @@ class AuthMetadata implements IAuthMetadata {
  * Options for creating AuthMetadata.
  */
 export interface ICreateAuthMetadataOptions {
-	/** Headers to include when fetching metadata from the same origin as the MCP server */
-	launchHeaders: Iterable<readonly [string, string]>;
+	/** Headers to include when fetching metadata from the same origin as the resource server */
+	sameOriginHeaders?: Record<string, string>;
 	/** Fetch function to use for HTTP requests */
 	fetch: (url: string, init: MinimalRequestInit) => Promise<CommonResponse>;
 	/** Logger function for diagnostic output */
@@ -931,24 +933,24 @@ export interface ICreateAuthMetadataOptions {
  * 3. Fetches authorization server metadata
  * 4. Falls back to default metadata if discovery fails
  *
- * @param mcpUrl The MCP server URL
- * @param originalResponse The original HTTP response that triggered auth (typically 401/403)
+ * @param resourceUrl The resource server URL
+ * @param wwwAuthenticateValue The value of the WWW-Authenticate header from the original HTTP response
  * @param options Configuration options including headers, fetch function, and logger
  * @returns A new AuthMetadata instance
  */
 export async function createAuthMetadata(
-	mcpUrl: string,
-	originalResponse: CommonResponse,
+	resourceUrl: string,
+	initialResponseHeaders: Headers,
 	options: ICreateAuthMetadataOptions
 ): Promise<AuthMetadata> {
-	const { launchHeaders, fetch, log } = options;
+	const { sameOriginHeaders, fetch, log } = options;
 
 	// Track discovery sources for telemetry
-	let resourceMetadataSource = McpAuthResourceMetadataSource.None;
-	let serverMetadataSource: McpAuthServerMetadataSource | undefined;
+	let resourceMetadataSource = IAuthResourceMetadataSource.None;
+	let serverMetadataSource: IAuthServerMetadataSource | undefined;
 
 	// Parse the WWW-Authenticate header for resource_metadata and scope challenges
-	const { resourceMetadataChallenge, scopesChallenge: scopesChallengeFromHeader } = parseWWWAuthenticateHeaderForChallenges(originalResponse, log);
+	const { resourceMetadataChallenge, scopesChallenge: scopesChallengeFromHeader } = parseWWWAuthenticateHeaderForChallenges(initialResponseHeaders.get('WWW-Authenticate') ?? undefined, log);
 
 	// Fetch the resource metadata either from the challenge URL or from well-known URIs
 	let serverMetadataUrl: string | undefined;
@@ -956,11 +958,8 @@ export async function createAuthMetadata(
 	let scopesChallenge = scopesChallengeFromHeader;
 
 	try {
-		const { metadata, discoveryUrl, errors } = await fetchResourceMetadata(mcpUrl, resourceMetadataChallenge, {
-			sameOriginHeaders: {
-				...Object.fromEntries(launchHeaders),
-				'MCP-Protocol-Version': MCP.LATEST_PROTOCOL_VERSION
-			},
+		const { metadata, discoveryUrl, errors } = await fetchResourceMetadata(resourceUrl, resourceMetadataChallenge, {
+			sameOriginHeaders,
 			fetch: (url, init) => fetch(url, init as MinimalRequestInit)
 		});
 		for (const err of errors) {
@@ -969,7 +968,7 @@ export async function createAuthMetadata(
 		log(LogLevel.Info, `Discovered resource metadata at ${discoveryUrl}`);
 
 		// Determine if resource metadata came from header or well-known
-		resourceMetadataSource = resourceMetadataChallenge ? McpAuthResourceMetadataSource.Header : McpAuthResourceMetadataSource.WellKnown;
+		resourceMetadataSource = resourceMetadataChallenge ? IAuthResourceMetadataSource.Header : IAuthResourceMetadataSource.WellKnown;
 
 		// TODO:@TylerLeonhardt support multiple authorization servers
 		// Consider using one that has an auth provider first, over the dynamic flow
@@ -978,7 +977,7 @@ export async function createAuthMetadata(
 			log(LogLevel.Warning, `No authorization_servers found in resource metadata ${discoveryUrl} - Is this resource metadata configured correctly?`);
 		} else {
 			log(LogLevel.Info, `Using auth server metadata url: ${serverMetadataUrl}`);
-			serverMetadataSource = McpAuthServerMetadataSource.ResourceMetadata;
+			serverMetadataSource = IAuthServerMetadataSource.ResourceMetadata;
 		}
 		scopesChallenge ??= metadata.scopes_supported;
 		resource = metadata;
@@ -986,18 +985,17 @@ export async function createAuthMetadata(
 		log(LogLevel.Warning, `Could not fetch resource metadata: ${String(e)}`);
 	}
 
-	const baseUrl = new URL(originalResponse.url).origin;
+	const baseUrl = new URL(resourceUrl).origin;
 
 	// If we are not given a resource_metadata, see if the well-known server metadata is available
 	// on the base url.
 	let additionalHeaders: Record<string, string> = {};
 	if (!serverMetadataUrl) {
 		serverMetadataUrl = baseUrl;
-		// Maintain the launch headers when talking to the MCP origin.
-		additionalHeaders = {
-			...Object.fromEntries(launchHeaders),
-			'MCP-Protocol-Version': MCP.LATEST_PROTOCOL_VERSION
-		};
+		// Maintain the same origin headers when talking to the resource origin.
+		if (sameOriginHeaders) {
+			additionalHeaders = sameOriginHeaders;
+		}
 	}
 
 	try {
@@ -1013,7 +1011,7 @@ export async function createAuthMetadata(
 
 		// If serverMetadataSource is not yet defined, it means we fell back to baseUrl
 		// and successfully fetched from well-known
-		serverMetadataSource ??= McpAuthServerMetadataSource.WellKnown;
+		serverMetadataSource ??= IAuthServerMetadataSource.WellKnown;
 
 		return new AuthMetadata(
 			URI.parse(serverMetadataUrl),
@@ -1035,7 +1033,7 @@ export async function createAuthMetadata(
 		defaultMetadata,
 		resource,
 		scopesChallenge,
-		{ resourceMetadataSource, serverMetadataSource: McpAuthServerMetadataSource.Default },
+		{ resourceMetadataSource, serverMetadataSource: IAuthServerMetadataSource.Default },
 		log
 	);
 }
@@ -1044,31 +1042,31 @@ export async function createAuthMetadata(
  * Parses the WWW-Authenticate header for resource_metadata and scope challenges.
  */
 function parseWWWAuthenticateHeaderForChallenges(
-	response: CommonResponse,
+	wwwAuthenticateValue: string | undefined,
 	log: AuthMetadataLogger
-): { resourceMetadataChallenge: string | undefined; scopesChallenge: string[] | undefined } {
+): { resourceMetadataChallenge?: string; scopesChallenge?: string[] } {
+	if (!wwwAuthenticateValue) {
+		return {};
+	}
 	let resourceMetadataChallenge: string | undefined;
 	let scopesChallenge: string[] | undefined;
 
-	if (response.headers.has('WWW-Authenticate')) {
-		const authHeader = response.headers.get('WWW-Authenticate')!;
-		const challenges = parseWWWAuthenticateHeader(authHeader);
-		for (const challenge of challenges) {
-			if (challenge.scheme === 'Bearer') {
-				if (!resourceMetadataChallenge && challenge.params['resource_metadata']) {
-					resourceMetadataChallenge = challenge.params['resource_metadata'];
-					log(LogLevel.Debug, `Found resource_metadata challenge in WWW-Authenticate header: ${resourceMetadataChallenge}`);
+	const challenges = parseWWWAuthenticateHeader(wwwAuthenticateValue);
+	for (const challenge of challenges) {
+		if (challenge.scheme === 'Bearer') {
+			if (!resourceMetadataChallenge && challenge.params['resource_metadata']) {
+				resourceMetadataChallenge = challenge.params['resource_metadata'];
+				log(LogLevel.Debug, `Found resource_metadata challenge in WWW-Authenticate header: ${resourceMetadataChallenge}`);
+			}
+			if (!scopesChallenge && challenge.params['scope']) {
+				const scopes = challenge.params['scope'].split(AUTH_SCOPE_SEPARATOR).filter(s => s.trim().length);
+				if (scopes.length) {
+					log(LogLevel.Debug, `Found scope challenge in WWW-Authenticate header: ${challenge.params['scope']}`);
+					scopesChallenge = scopes;
 				}
-				if (!scopesChallenge && challenge.params['scope']) {
-					const scopes = challenge.params['scope'].split(AUTH_SCOPE_SEPARATOR).filter(s => s.trim().length);
-					if (scopes.length) {
-						log(LogLevel.Debug, `Found scope challenge in WWW-Authenticate header: ${challenge.params['scope']}`);
-						scopesChallenge = scopes;
-					}
-				}
-				if (resourceMetadataChallenge && scopesChallenge) {
-					break;
-				}
+			}
+			if (resourceMetadataChallenge && scopesChallenge) {
+				break;
 			}
 		}
 	}

--- a/src/vs/workbench/api/test/common/extHostMcp.test.ts
+++ b/src/vs/workbench/api/test/common/extHostMcp.test.ts
@@ -88,9 +88,9 @@ async function createTestAuthMetadata(options: {
 
 	const authMetadata = await createAuthMetadata(
 		TEST_MCP_URL,
-		originalResponse,
+		originalResponse.headers,
 		{
-			launchHeaders: new Map(),
+			sameOriginHeaders: {},
 			fetch: mockFetch,
 			log: mockLogger
 		}
@@ -137,7 +137,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, true);
 				assert.deepStrictEqual(authMetadata.scopes, ['read', 'write', 'admin']);
@@ -155,7 +155,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, false);
 				assert.deepStrictEqual(authMetadata.scopes, ['read', 'write']);
@@ -173,7 +173,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, false);
 			});
@@ -190,7 +190,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, true);
 				assert.deepStrictEqual(authMetadata.scopes, ['read']);
@@ -208,7 +208,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, true);
 				assert.strictEqual(authMetadata.scopes, undefined);
@@ -224,7 +224,7 @@ suite('ExtHostMcp', () => {
 					headers: {}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, false);
 			});
@@ -241,7 +241,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				authMetadata.update(response);
+				authMetadata.update(response.headers);
 
 				assert.deepStrictEqual(authMetadata.scopes, ['first']);
 			});
@@ -258,7 +258,7 @@ suite('ExtHostMcp', () => {
 					}
 				});
 
-				const result = authMetadata.update(response);
+				const result = authMetadata.update(response.headers);
 
 				assert.strictEqual(result, false);
 				assert.strictEqual(authMetadata.scopes, undefined);
@@ -317,9 +317,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map([['X-Custom', 'value']]),
+					sameOriginHeaders: { 'X-Custom': 'value' },
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -347,9 +347,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -403,9 +403,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -450,9 +450,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -497,9 +497,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -545,16 +545,16 @@ suite('ExtHostMcp', () => {
 				headers: {}
 			});
 
-			const launchHeaders = new Map<string, string>([
-				['Authorization', 'Bearer existing-token'],
-				['X-Custom-Header', 'custom-value']
-			]);
+			const launchHeaders = {
+				'Authorization': 'Bearer existing-token',
+				'X-Custom-Header': 'custom-value'
+			};
 
 			await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders,
+					sameOriginHeaders: launchHeaders,
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -605,9 +605,9 @@ suite('ExtHostMcp', () => {
 
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -659,9 +659,9 @@ suite('ExtHostMcp', () => {
 			// Should not throw - should handle gracefully
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -698,9 +698,9 @@ suite('ExtHostMcp', () => {
 			// Should fall back to default metadata, not throw
 			const authMetadata = await createAuthMetadata(
 				TEST_MCP_URL,
-				originalResponse,
+				originalResponse.headers,
 				{
-					launchHeaders: new Map(),
+					sameOriginHeaders: {},
 					fetch: mockFetch,
 					log: mockLogger
 				}
@@ -725,7 +725,7 @@ suite('ExtHostMcp', () => {
 			});
 
 			// update() should still process the WWW-Authenticate header regardless of status
-			const result = authMetadata.update(response);
+			const result = authMetadata.update(response.headers);
 
 			// The behavior depends on implementation - either it updates or ignores non-401
 			// This test documents the actual behavior


### PR DESCRIPTION
In preperation of moving it out of extHostMcp so that it could be reused for registry auth.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
