### PR TITLE
AI related quick picker accessible even when AI disabled (fix #286526)

### DIFF
--- a/src/vs/platform/quickinput/browser/helpQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/helpQuickAccess.ts
@@ -6,6 +6,7 @@
 import { localize } from '../../../nls.js';
 import { Registry } from '../../registry/common/platform.js';
 import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
+import { IContextKeyService } from '../../contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
 import { Extensions, IQuickAccessProvider, IQuickAccessProviderDescriptor, IQuickAccessRegistry } from '../common/quickAccess.js';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from '../common/quickInput.js';
@@ -22,7 +23,8 @@ export class HelpQuickAccessProvider implements IQuickAccessProvider {
 
 	constructor(
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) { }
 
 	provide(picker: IQuickPick<IHelpQuickAccessPickItem, { useSeparators: true }>): IDisposable {
@@ -39,8 +41,8 @@ export class HelpQuickAccessProvider implements IQuickAccessProvider {
 		// Also open a picker when we detect the user typed the exact
 		// name of a provider (e.g. `?term` for terminals)
 		disposables.add(picker.onDidChangeValue(value => {
-			const providerDescriptor = this.registry.getQuickAccessProvider(value.substr(HelpQuickAccessProvider.PREFIX.length));
-			if (providerDescriptor && providerDescriptor.prefix && providerDescriptor.prefix !== HelpQuickAccessProvider.PREFIX) {
+			const providerDescriptor = this.registry.getQuickAccessProvider(value.substr(HelpQuickAccessProvider.PREFIX.length), this.contextKeyService);
+			if (providerDescriptor?.prefix && providerDescriptor.prefix !== HelpQuickAccessProvider.PREFIX) {
 				this.quickInputService.quickAccess.show(providerDescriptor.prefix, { preserveValue: true });
 			}
 		}));
@@ -53,7 +55,7 @@ export class HelpQuickAccessProvider implements IQuickAccessProvider {
 
 	getQuickAccessProviders(): IHelpQuickAccessPickItem[] {
 		const providers: IHelpQuickAccessPickItem[] = this.registry
-			.getQuickAccessProviders()
+			.getQuickAccessProviders(this.contextKeyService)
 			.sort((providerA, providerB) => providerA.prefix.localeCompare(providerB.prefix))
 			.flatMap(provider => this.createPicks(provider));
 

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -7,6 +7,7 @@ import { DeferredPromise } from '../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable, isDisposable, toDisposable } from '../../../base/common/lifecycle.js';
+import { IContextKeyService } from '../../contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { DefaultQuickAccessFilterValue, Extensions, IQuickAccessController, IQuickAccessOptions, IQuickAccessProvider, IQuickAccessProviderDescriptor, IQuickAccessRegistry } from '../common/quickAccess.js';
 import { IQuickInputService, IQuickPick, IQuickPickItem, ItemActivation } from '../common/quickInput.js';
@@ -27,7 +28,8 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 
 	constructor(
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) {
 		super();
 		this._register(toDisposable(() => {
@@ -233,7 +235,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 	}
 
 	private getOrInstantiateProvider(value: string, enabledProviderPrefixes?: string[]): [IQuickAccessProvider | undefined, IQuickAccessProviderDescriptor | undefined] {
-		const providerDescriptor = this.registry.getQuickAccessProvider(value);
+		const providerDescriptor = this.registry.getQuickAccessProvider(value, this.contextKeyService);
 		if (!providerDescriptor || enabledProviderPrefixes && !enabledProviderPrefixes?.includes(providerDescriptor.prefix)) {
 			return [undefined, undefined];
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
@@ -154,6 +154,7 @@ Registry.as<IQuickAccessRegistry>(QuickAccessExtensions.Quickaccess).registerQui
 	ctor: AgentSessionsQuickAccessProvider,
 	prefix: AGENT_SESSIONS_QUICK_ACCESS_PREFIX,
 	contextKey: 'inAgentSessionsPicker',
+	when: ChatContextKeys.enabled,
 	placeholder: localize('agentSessionsQuickAccessPlaceholder', "Search agent sessions by name"),
 	helpEntries: [{
 		description: localize('agentSessionsQuickAccessHelp', "Show All Agent Sessions"),

--- a/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcp.contribution.ts
@@ -16,6 +16,7 @@ import { IConfigurationMigrationRegistry, Extensions as ConfigurationMigrationEx
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { EditorExtensions } from '../../../common/editor.js';
 import { mcpSchemaId } from '../../../services/configuration/common/configuration.js';
+import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { ExtensionMcpDiscovery } from '../common/discovery/extensionMcpDiscovery.js';
 import { InstalledMcpServersDiscovery } from '../common/discovery/installedMcpServersDiscovery.js';
 import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
@@ -108,6 +109,7 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 Registry.as<IQuickAccessRegistry>(QuickAccessExtensions.Quickaccess).registerQuickAccessProvider({
 	ctor: McpResourceQuickAccess,
 	prefix: McpResourceQuickAccess.PREFIX,
+	when: ChatContextKeys.enabled,
 	placeholder: localize('mcp.quickaccess.placeholder', "Filter to an MCP resource"),
 	helpEntries: [{
 		description: localize('mcp.quickaccess.add', "MCP Server Resources"),

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -52,6 +52,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { stripIcons } from '../../../../base/common/iconLabels.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { ASK_QUICK_QUESTION_ACTION_ID } from '../../chat/browser/actions/chatQuickInputActions.js';
 import { IQuickChatService } from '../../chat/browser/chat.js';
@@ -136,6 +137,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IQuickChatService private readonly quickChatService: IQuickChatService,
 		@ILogService private readonly logService: ILogService,
 		@ICustomEditorLabelService private readonly customEditorLabelService: ICustomEditorLabelService
@@ -827,7 +829,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		}
 
 		type IHelpAnythingQuickPickItem = IAnythingQuickPickItem & { commandCenterOrder: number };
-		const providers: IHelpAnythingQuickPickItem[] = this.lazyRegistry.value.getQuickAccessProviders()
+		const providers: IHelpAnythingQuickPickItem[] = this.lazyRegistry.value.getQuickAccessProviders(this.contextKeyService)
 			.filter(p => p.helpEntries.some(h => h.commandCenterOrder !== undefined))
 			.flatMap(provider => provider.helpEntries
 				.filter(h => h.commandCenterOrder !== undefined)


### PR DESCRIPTION
fyi @TylerLeonhardt this adds ability to restrict a quick open provider to a `when` condition to hide some when AI is disabled.