### PR TITLE
mcp: fix start all servers command

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -822,9 +822,9 @@ export class StartServer extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, serverId: string | null | undefined, opts?: IMcpServerStartOpts & { waitForLiveTools?: boolean }) {
+	async run(accessor: ServicesAccessor, serverId: string, opts?: IMcpServerStartOpts & { waitForLiveTools?: boolean }) {
 		let servers = accessor.get(IMcpService).servers.get();
-		if (serverId) {
+		if (serverId !== '*') {
 			servers = servers.filter(s => s.definition.id === serverId);
 		}
 


### PR DESCRIPTION
Resolves #283959.

Previous implementation looked strictly for `undefined`, but the IPC layer
converts `undefined` to `null`. This meant that calling the command via IPC
like:

```
await vscode.commands.executeCommand('workbench.mcp.startServer', undefined);
```

was not working (while `vscode.commands.executeCommand('workbench.mcp.startServer')` was).

Instead of handling `null` as a value as well, use a specicial value of `*`
to indicate all servers should be started so the intent is clearer:

```
BEFORE: await vscode.commands.executeCommand('workbench.mcp.startServer');
AFTER : await vscode.commands.executeCommand('workbench.mcp.startServer', '*');
```

Additionally, add a `waitForLiveTools` parameter that blocks the command
from resolving until the server is downloaded, started, and tools are availble.

Without this, a static sleep or poll would be needed.