### PR TITLE
Explore a controller based chat session item API

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -899,6 +899,7 @@ export default tseslint.config(
 					],
 					'verbs': [
 						'accept',
+						'archive',
 						'change',
 						'close',
 						'collapse',

--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -65,7 +65,7 @@ const _allApiProposals = {
 	},
 	chatSessionsProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts',
-		version: 3
+		version: 4
 	},
 	chatStatusItem: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatStatusItem.d.ts',

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -382,7 +382,6 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		));
 	}
 
-
 	$onDidChangeChatSessionItems(handle: number): void {
 		this._itemProvidersRegistrations.get(handle)?.onDidChangeItems.fire();
 	}
@@ -490,7 +489,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 					changes: revive(session.changes),
 					resource: uri,
 					iconPath: session.iconPath,
-					tooltip: session.tooltip ? this._reviveTooltip(session.tooltip) : undefined,
+					tooltip: session.tooltip ? this._reviveTooltip(session.tooltip) : undefined, archived: session.archived,
 				} satisfies IChatSessionItem;
 			}));
 		} catch (error) {

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -489,7 +489,8 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 					changes: revive(session.changes),
 					resource: uri,
 					iconPath: session.iconPath,
-					tooltip: session.tooltip ? this._reviveTooltip(session.tooltip) : undefined, archived: session.archived,
+					tooltip: session.tooltip ? this._reviveTooltip(session.tooltip) : undefined,
+					archived: session.archived,
 				} satisfies IChatSessionItem;
 			}));
 		} catch (error) {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1525,13 +1525,13 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatParticipantPrivate');
 				return _asExtensionEvent(extHostChatAgents2.onDidDisposeChatSession)(listeners, thisArgs, disposables);
 			},
-			registerChatSessionItemProvider: (id: string, provider: vscode.ChatSessionItemProvider) => {
+			registerChatSessionItemProvider: (chatSessionType: string, provider: vscode.ChatSessionItemProvider) => {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
-				return extHostChatSessions.registerChatSessionItemProvider(extension, id, provider);
+				return extHostChatSessions.registerChatSessionItemProvider(extension, chatSessionType, provider);
 			},
-			createChatSessionItemController: (id: string, refreshHandler: () => Thenable<void>) => {
+			createChatSessionItemController: (chatSessionType: string, refreshHandler: () => Thenable<void>) => {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
-				return extHostChatSessions.createChatSessionItemController(extension, id, refreshHandler);
+				return extHostChatSessions.createChatSessionItemController(extension, chatSessionType, refreshHandler);
 			},
 			registerChatSessionContentProvider(scheme: string, provider: vscode.ChatSessionContentProvider, chatParticipant: vscode.ChatParticipant, capabilities?: vscode.ChatSessionCapabilities) {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1525,9 +1525,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatParticipantPrivate');
 				return _asExtensionEvent(extHostChatAgents2.onDidDisposeChatSession)(listeners, thisArgs, disposables);
 			},
-			registerChatSessionItemProvider: (chatSessionType: string, provider: vscode.ChatSessionItemProvider) => {
+			createChatSessionItemController: (id: string, refreshHandler: () => Thenable<void>) => {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
-				return extHostChatSessions.registerChatSessionItemProvider(extension, chatSessionType, provider);
+				return extHostChatSessions.createChatSessionItemController(extension, id, refreshHandler);
 			},
 			registerChatSessionContentProvider(scheme: string, provider: vscode.ChatSessionContentProvider, chatParticipant: vscode.ChatParticipant, capabilities?: vscode.ChatSessionCapabilities) {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
@@ -1865,6 +1865,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InteractiveSessionVoteDirection: extHostTypes.InteractiveSessionVoteDirection,
 			ChatCopyKind: extHostTypes.ChatCopyKind,
 			ChatSessionChangedFile: extHostTypes.ChatSessionChangedFile,
+			ChatSessionItemController: extHostTypes.ChatSessionItemController,
 			ChatEditingSessionActionOutcome: extHostTypes.ChatEditingSessionActionOutcome,
 			InteractiveEditorResponseFeedbackKind: extHostTypes.InteractiveEditorResponseFeedbackKind,
 			DebugStackFrame: extHostTypes.DebugStackFrame,

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1525,6 +1525,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatParticipantPrivate');
 				return _asExtensionEvent(extHostChatAgents2.onDidDisposeChatSession)(listeners, thisArgs, disposables);
 			},
+			registerChatSessionItemProvider: (id: string, provider: vscode.ChatSessionItemProvider) => {
+				checkProposedApiEnabled(extension, 'chatSessionsProvider');
+				return extHostChatSessions.registerChatSessionItemProvider(extension, id, provider);
+			},
 			createChatSessionItemController: (id: string, refreshHandler: () => Thenable<void>) => {
 				checkProposedApiEnabled(extension, 'chatSessionsProvider');
 				return extHostChatSessions.createChatSessionItemController(extension, id, refreshHandler);
@@ -1865,7 +1869,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InteractiveSessionVoteDirection: extHostTypes.InteractiveSessionVoteDirection,
 			ChatCopyKind: extHostTypes.ChatCopyKind,
 			ChatSessionChangedFile: extHostTypes.ChatSessionChangedFile,
-			ChatSessionItemController: extHostTypes.ChatSessionItemController,
 			ChatEditingSessionActionOutcome: extHostTypes.ChatEditingSessionActionOutcome,
 			InteractiveEditorResponseFeedbackKind: extHostTypes.InteractiveEditorResponseFeedbackKind,
 			DebugStackFrame: extHostTypes.DebugStackFrame,

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -34,7 +34,6 @@ import { SymbolKind, SymbolKinds } from '../../../editor/common/languages.js';
 // #region Chat Session Item Controller
 
 class ChatSessionItemImpl implements vscode.ChatSessionItem {
-	readonly resource: vscode.Uri;
 	#label: string;
 	#iconPath?: vscode.IconPath;
 	#description?: string | vscode.MarkdownString;
@@ -45,6 +44,8 @@ class ChatSessionItemImpl implements vscode.ChatSessionItem {
 	#timing?: { startTime: number; endTime?: number };
 	#changes?: readonly vscode.ChatSessionChangedFile[] | { files: number; insertions: number; deletions: number };
 	#onChanged: () => void;
+
+	readonly resource: vscode.Uri;
 
 	constructor(resource: vscode.Uri, label: string, onChanged: () => void) {
 		this.resource = resource;
@@ -192,10 +193,8 @@ class ChatSessionItemCollectionImpl implements vscode.ChatSessionItemCollection 
 		return this.#items.get(resource);
 	}
 
-	*[Symbol.iterator](): Generator<readonly [id: URI, chatSessionItem: vscode.ChatSessionItem]> {
-		for (const [uri, item] of this.#items) {
-			yield [uri, item] as const;
-		}
+	[Symbol.iterator](): Iterator<readonly [id: URI, chatSessionItem: vscode.ChatSessionItem]> {
+		return this.#items.entries();
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3431,17 +3431,6 @@ export class ChatSessionChangedFile {
 	constructor(public readonly modifiedUri: vscode.Uri, public readonly insertions: number, public readonly deletions: number, public readonly originalUri?: vscode.Uri) { }
 }
 
-// Stub class - actual implementation is in extHostChatSessions.ts
-export class ChatSessionItemController {
-	readonly id!: string;
-	readonly items!: vscode.ChatSessionItemCollection;
-	refreshHandler!: () => Thenable<void>;
-	readonly onDidArchiveChatSessionItem!: vscode.Event<vscode.ChatSessionItem>;
-	readonly onDidDisposeChatSessionItem!: vscode.Event<vscode.ChatSessionItem>;
-	createChatSessionItem(_resource: vscode.Uri, _label: string): vscode.ChatSessionItem { throw new Error('Stub'); }
-	dispose(): void { throw new Error('Stub'); }
-}
-
 export enum ChatResponseReferencePartStatusKind {
 	Complete = 1,
 	Partial = 2,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3431,6 +3431,17 @@ export class ChatSessionChangedFile {
 	constructor(public readonly modifiedUri: vscode.Uri, public readonly insertions: number, public readonly deletions: number, public readonly originalUri?: vscode.Uri) { }
 }
 
+// Stub class - actual implementation is in extHostChatSessions.ts
+export class ChatSessionItemController {
+	readonly id!: string;
+	readonly items!: vscode.ChatSessionItemCollection;
+	refreshHandler!: () => Thenable<void>;
+	readonly onDidArchiveChatSessionItem!: vscode.Event<vscode.ChatSessionItem>;
+	readonly onDidDisposeChatSessionItem!: vscode.Event<vscode.ChatSessionItem>;
+	createChatSessionItem(_resource: vscode.Uri, _label: string): vscode.ChatSessionItem { throw new Error('Stub'); }
+	dispose(): void { throw new Error('Stub'); }
+}
+
 export enum ChatResponseReferencePartStatusKind {
 	Complete = 1,
 	Partial = 2,

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -62,6 +62,7 @@ export interface IChatSessionsExtensionPoint {
 	readonly commands?: IChatSessionCommandContribution[];
 	readonly canDelegate?: boolean;
 }
+
 export interface IChatSessionItem {
 	resource: URI;
 	label: string;

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -190,6 +190,11 @@ declare module 'vscode' {
 		tooltip?: string | MarkdownString;
 
 		/**
+		 * Whether the chat session has been archived.
+		 */
+		archived?: boolean;
+
+		/**
 		 * The times at which session started and ended
 		 */
 		timing?: {

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -30,7 +30,7 @@ declare module 'vscode' {
 		/**
 		 * Creates a new {@link ChatSessionItemController chat session item controller} with the given unique identifier.
 		 */
-		export function createChatSessionItemController(id: string): ChatSessionItemController;
+		export function createChatSessionItemController(id: string, refreshHandler: () => Thenable<void>): ChatSessionItemController;
 	}
 
 	/**
@@ -64,7 +64,7 @@ declare module 'vscode' {
 		/**
 		 * Fired when an item is archived by the editor
 		 *
-		 * TODO: expose archive state on the item too? Or should this
+		 * TODO: expose archive state on the item too?
 		 */
 		readonly onDidArchiveChatSessionItem: Event<ChatSessionItem>;
 
@@ -77,7 +77,7 @@ declare module 'vscode' {
 	/**
 	 * A collection of chat session items. It provides operations for managing and iterating over the items.
 	 */
-	export interface ChatSessionItemCollection extends Iterable<readonly [id: string, chatSessionItem: ChatSessionItem]> {
+	export interface ChatSessionItemCollection extends Iterable<readonly [id: Uri, chatSessionItem: ChatSessionItem]> {
 		/**
 		 * Gets the number of items in the collection.
 		 */

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 3
+// version: 4
 
 declare module 'vscode' {
 	/**

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -26,30 +26,96 @@ declare module 'vscode' {
 		InProgress = 2
 	}
 
+	export namespace chat {
+		/**
+		 * Creates a new {@link ChatSessionItemController chat session item controller} with the given unique identifier.
+		 */
+		export function createChatSessionItemController(id: string): ChatSessionItemController;
+	}
+
 	/**
 	 * Provides a list of information about chat sessions.
 	 */
-	export interface ChatSessionItemProvider {
-		/**
-		 * Event that the provider can fire to signal that chat sessions have changed.
-		 */
-		readonly onDidChangeChatSessionItems: Event<void>;
+	export class ChatSessionItemController {
+		readonly id: string;
 
 		/**
-		 * Provides a list of chat sessions.
+		 * Unregisters the controller, disposing of its associated chat session items.
 		 */
-		// TODO: Do we need a flag to try auth if needed?
-		provideChatSessionItems(token: CancellationToken): ProviderResult<ChatSessionItem[]>;
-
-		// #region Unstable parts of API
+		dispose(): void;
 
 		/**
-		 * Event that the provider can fire to signal that the current (original) chat session should be replaced with a new (modified) chat session.
-		 * The UI can use this information to gracefully migrate the user to the new session.
+		 * Managed collection of chat session items
 		 */
-		readonly onDidCommitChatSessionItem: Event<{ original: ChatSessionItem /** untitled */; modified: ChatSessionItem /** newly created */ }>;
+		readonly items: ChatSessionItemCollection;
 
-		// #endregion
+		/**
+		 * Creates a new managed chat session item that be added to the collection.
+		 */
+		createChatSessionItem(resource: Uri, label: string): ChatSessionItem;
+
+		/**
+		 * Handler called to refresh the collection of chat session items.
+		 *
+		 * This is also called on first load to get the initial set of items.
+		 */
+		refreshHandler: () => Thenable<void>;
+
+		/**
+		 * Fired when an item is archived by the editor
+		 *
+		 * TODO: expose archive state on the item too? Or should this
+		 */
+		readonly onDidArchiveChatSessionItem: Event<ChatSessionItem>;
+
+		/**
+		 * Fired when an item is disposed by the editor
+		 */
+		readonly onDidDisposeChatSessionItem: Event<ChatSessionItem>;
+	}
+
+	/**
+	 * A collection of chat session items. It provides operations for managing and iterating over the items.
+	 */
+	export interface ChatSessionItemCollection extends Iterable<readonly [id: string, chatSessionItem: ChatSessionItem]> {
+		/**
+		 * Gets the number of items in the collection.
+		 */
+		readonly size: number;
+
+		/**
+		 * Replaces the items stored by the collection.
+		 * @param items Items to store.
+		 */
+		replace(items: readonly ChatSessionItem[]): void;
+
+		/**
+		 * Iterate over each entry in this collection.
+		 *
+		 * @param callback Function to execute for each entry.
+		 * @param thisArg The `this` context used when invoking the handler function.
+		 */
+		forEach(callback: (item: ChatSessionItem, collection: ChatSessionItemCollection) => unknown, thisArg?: any): void;
+
+		/**
+		 * Adds the chat session item to the collection. If an item with the same resource URI already
+		 * exists, it'll be replaced.
+		 * @param item Item to add.
+		 */
+		add(item: ChatSessionItem): void;
+
+		/**
+		 * Removes a single chat session item from the collection.
+		 * @param resource Item resource to delete.
+		 */
+		delete(resource: Uri): void;
+
+		/**
+		 * Efficiently gets a chat session item by resource, if it exists, in the collection.
+		 * @param resource Item resource to get.
+		 * @returns The found item or undefined if it does not exist.
+		 */
+		get(resource: Uri): ChatSessionItem | undefined;
 	}
 
 	export interface ChatSessionItem {
@@ -268,18 +334,6 @@ declare module 'vscode' {
 	}
 
 	export namespace chat {
-		/**
-		 * Registers a new {@link ChatSessionItemProvider chat session item provider}.
-		 *
-		 * To use this, also make sure to also add `chatSessions` contribution in the `package.json`.
-		 *
-		 * @param chatSessionType The type of chat session the provider is for.
-		 * @param provider The provider to register.
-		 *
-		 * @returns A disposable that unregisters the provider when disposed.
-		 */
-		export function registerChatSessionItemProvider(chatSessionType: string, provider: ChatSessionItemProvider): Disposable;
-
 		/**
 		 * Registers a new {@link ChatSessionContentProvider chat session content provider}.
 		 *


### PR DESCRIPTION
For #276243

Explores moving the chat session item api to use a controller instead of a provider. This uses managed objects and is based on the `TestController` we already have finalized

Main flow :

- Extensions call `createChatSessionItemController('my.sessionId')` to create the controller. The controller is a managed object with a `dispose` method

- VS Code then calls `refreshHandler` on the controller to build up the initial list

- During refresh, the extension updates the `ChatSessionItemCollection` managed object. This object is basically just a managed array. This lets the editor see changes that are made to the session list


A few other points:

- Chat session items would now also be managed objects. Extensions could set properties to update them in the UI

- If an extension needs to update the list of chat session items independently of VS Code — for example if a new session is created through GitHub.com —  it would simply update the `ChatSessionItemCollection `

- We would have event handlers for when the editor archives or disposes of a chat session item


Still some open questions but seems promising. Also although the general API shape looks pretty different , the logic shouldn't be that different for extensions