### PR TITLE
Add git scalar clone feature to VSCode

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -98,6 +98,12 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.sparseCheckout",
+        "title": "%command.sparseCheckout%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.init",
         "title": "%command.init%",
         "category": "Git",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -92,6 +92,12 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.cloneWithScalar",
+        "title": "%command.cloneWithScalar%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.init",
         "title": "%command.init%",
         "category": "Git",
@@ -1192,6 +1198,10 @@
           "when": "config.git.enabled && !git.missing"
         },
         {
+          "command": "git.cloneWithScalar",
+          "when": "config.git.enabled && !git.missing"
+        },
+        {
           "command": "git.init",
           "when": "config.git.enabled && !git.missing && remoteName != 'codespaces'"
         },
@@ -1938,6 +1948,11 @@
         }
       ],
       "scm/repository": [
+        {
+          "command": "git.cloneWithScalar",
+          "group": "1_header@3",
+          "when": "scmProvider == git"
+        },
         {
           "command": "git.pull",
           "group": "1_header@1",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -5,6 +5,7 @@
 	"command.continueInLocalClone.qualifiedName": "Continue Working in New Local Clone",
 	"command.clone": "Clone",
 	"command.cloneRecursive": "Clone (Recursive)",
+	"command.cloneWithScalar": "Clone with Scalar",
 	"command.init": "Initialize Repository",
 	"command.openRepository": "Open Repository",
 	"command.reopenClosedRepositories": "Reopen Closed Repositories...",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -6,6 +6,7 @@
 	"command.clone": "Clone",
 	"command.cloneRecursive": "Clone (Recursive)",
 	"command.cloneWithScalar": "Clone with Scalar",
+	"command.sparseCheckout": "Sparse Checkout...",
 	"command.init": "Initialize Repository",
 	"command.openRepository": "Open Repository",
 	"command.reopenClosedRepositories": "Reopen Closed Repositories...",

--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -449,7 +449,7 @@ export class ApiImpl implements API {
 
 	async clone(uri: Uri, options?: CloneOptions): Promise<Uri | null> {
 		const parentPath = options?.parentPath?.fsPath;
-		const result = await this.#cloneManager.clone(uri.toString(), { parentPath, recursive: options?.recursive, ref: options?.ref, postCloneAction: options?.postCloneAction });
+		const result = await this.#cloneManager.clone(uri.toString(), { parentPath, recursive: options?.recursive, ref: options?.ref, useScalar: options?.useScalar, scalarOptions: options?.scalarOptions, postCloneAction: options?.postCloneAction });
 		return result ? Uri.file(result) : null;
 	}
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -217,6 +217,20 @@ export interface CloneOptions {
 	ref?: string;
 	recursive?: boolean;
 	/**
+	 * Use Scalar for cloning. Scalar provides faster cloning for large repositories.
+	 * Requires Scalar to be available (bundled with Git for Windows 2.38+).
+	 */
+	useScalar?: boolean;
+	/**
+	 * Scalar clone options (can be combined):
+	 * - 'full-clone': Clone all objects (no partial clone)
+	 * - 'no-src': Initialize repo without checking out source files
+	 *
+	 * If empty or undefined, uses default partial clone with sparse-checkout.
+	 * Options can be combined, e.g., ['full-clone', 'no-src']
+	 */
+	scalarOptions?: ('full-clone' | 'no-src')[];
+	/**
 	 * If no postCloneAction is provided, then the users setting for git.openAfterClone is used.
 	 */
 	postCloneAction?: 'none';

--- a/extensions/git/src/cloneManager.ts
+++ b/extensions/git/src/cloneManager.ts
@@ -19,6 +19,8 @@ export interface CloneOptions {
 	parentPath?: string;
 	ref?: string;
 	recursive?: boolean;
+	useScalar?: boolean;
+	scalarOptions?: ('full-clone' | 'no-src')[];
 	postCloneAction?: ApiPostCloneAction;
 }
 
@@ -55,7 +57,7 @@ export class CloneManager {
 		return this.cloneRepository(url, options.parentPath, options);
 	}
 
-	private async cloneRepository(url: string, parentPath?: string, options: { recursive?: boolean; ref?: string; postCloneAction?: ApiPostCloneAction } = {}): Promise<string | undefined> {
+	private async cloneRepository(url: string, parentPath?: string, options: { recursive?: boolean; ref?: string; useScalar?: boolean; scalarOptions?: ('full-clone' | 'no-src')[]; postCloneAction?: ApiPostCloneAction } = {}): Promise<string | undefined> {
 		if (!parentPath) {
 			const config = workspace.getConfiguration('git');
 			let defaultCloneDirectory = config.get<string>('defaultCloneDirectory') || os.homedir();
@@ -94,7 +96,7 @@ export class CloneManager {
 
 			const repositoryPath = await window.withProgress(
 				opts,
-				(progress, token) => this.model.git.clone(url!, { parentPath: parentPath!, progress, recursive: options.recursive, ref: options.ref }, token)
+				(progress, token) => this.model.git.clone(url!, { parentPath: parentPath!, progress, recursive: options.recursive, ref: options.ref, useScalar: options.useScalar, scalarOptions: options.scalarOptions }, token)
 			);
 
 			await this.doPostCloneAction(repositoryPath, options.postCloneAction);

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1037,6 +1037,50 @@ export class CommandCenter {
 		await this.cloneManager.clone(url, { parentPath, recursive: true });
 	}
 
+	@command('git.cloneWithScalar')
+	async cloneWithScalar(url?: string, parentPath?: string, options?: { ref?: string }): Promise<void> {
+		// Check if scalar is available
+		const scalarAvailable = await this.git.isScalarAvailable();
+		if (!scalarAvailable) {
+			const message = l10n.t('Scalar is not available. Scalar is bundled with Git for Windows 2.38+ and can be installed separately for other systems.');
+			const learnMore = l10n.t('Learn More');
+			const result = await window.showWarningMessage(message, learnMore);
+			if (result === learnMore) {
+				await commands.executeCommand('vscode.open', Uri.parse('https://github.com/microsoft/scalar'));
+			}
+			return;
+		}
+
+		// Prompt user to choose scalar clone options (can select multiple)
+		const items: (QuickPickItem & { option?: 'full-clone' | 'no-src' })[] = [
+			{
+				label: l10n.t('$(file-binary) Full Clone'),
+				description: l10n.t('--full-clone'),
+				detail: l10n.t('Clone all objects (no partial clone)'),
+				option: 'full-clone'
+			},
+			{
+				label: l10n.t('$(file-code) No Source'),
+				description: l10n.t('--no-src'),
+				detail: l10n.t('Initialize without checking out source files'),
+				option: 'no-src'
+			}
+		];
+
+		const picks = await window.showQuickPick(items, {
+			placeHolder: l10n.t('Select Scalar clone options (leave empty for default partial clone)'),
+			canPickMany: true,
+			ignoreFocusOut: true
+		});
+
+		if (picks === undefined) {
+			return;
+		}
+
+		const scalarOptions = picks.map(p => p.option).filter((opt): opt is 'full-clone' | 'no-src' => !!opt);
+		await this.cloneManager.clone(url, { parentPath, useScalar: true, scalarOptions, ...options });
+	}
+
 	@command('git.init')
 	async init(skipFolderPrompt = false): Promise<void> {
 		let repositoryPath: string | undefined = undefined;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1264,6 +1264,186 @@ export class CommandCenter {
 		}
 	}
 
+	@command('git.sparseCheckout', { repository: true })
+	async sparseCheckout(repository: Repository): Promise<void> {
+		const action = await window.showQuickPick([
+			{ label: l10n.t('$(list-tree) List Sparse-Checkout Paths'), action: 'list' },
+			{ label: l10n.t('$(add) Set Sparse-Checkout Paths'), action: 'set' },
+			{ label: l10n.t('$(add) Add Sparse-Checkout Paths'), action: 'add' },
+			{ label: l10n.t('$(sync) Initialize Sparse-Checkout'), action: 'init' },
+			{ label: l10n.t('$(refresh) Reapply Sparse-Checkout'), action: 'reapply' },
+			{ label: l10n.t('$(close) Disable Sparse-Checkout'), action: 'disable' }
+		], {
+			placeHolder: l10n.t('Select sparse-checkout action')
+		});
+
+		if (!action) {
+			return;
+		}
+
+		try {
+			switch (action.action) {
+				case 'list':
+					await this.sparseCheckoutList(repository);
+					break;
+				case 'set':
+					await this.sparseCheckoutSet(repository);
+					break;
+				case 'add':
+					await this.sparseCheckoutAdd(repository);
+					break;
+				case 'init':
+					await this.sparseCheckoutInit(repository);
+					break;
+				case 'reapply':
+					await this.sparseCheckoutReapply(repository);
+					break;
+				case 'disable':
+					await this.sparseCheckoutDisable(repository);
+					break;
+			}
+		} catch (err) {
+			window.showErrorMessage(l10n.t('Sparse-checkout operation failed: {0}', err.message));
+		}
+	}
+
+	private async sparseCheckoutList(repository: Repository): Promise<void> {
+		const paths = await repository.sparseCheckoutList();
+		if (paths.length === 0) {
+			window.showInformationMessage(l10n.t('Sparse-checkout is not enabled or no paths are configured.'));
+		} else {
+			const message = l10n.t('Sparse-checkout paths:\n{0}', paths.join('\n'));
+			window.showInformationMessage(message);
+		}
+	}
+
+	private async sparseCheckoutSet(repository: Repository): Promise<void> {
+		interface DirectoryPickItem extends QuickPickItem {
+			directory?: string;
+			isManualEntry?: boolean;
+		}
+
+		// Add manual entry option at the beginning
+		const items: DirectoryPickItem[] = [
+			{
+				label: '$(edit) Enter paths manually',
+				description: l10n.t('Specify custom paths'),
+				isManualEntry: true
+			}
+		];
+
+		try {
+			// Fetch top-level directories
+			const directories = await repository.getTopLevelDirectories();
+
+			// Add directory items
+			items.push(...directories.map(dir => ({
+				label: `$(folder) ${dir}`,
+				directory: dir
+			})));
+		} catch (err) {
+			// If we can't get directories, fall back to manual entry only
+			console.error('Failed to get top-level directories:', err);
+		}
+
+		const selected = await window.showQuickPick(items, {
+			placeHolder: l10n.t('Select directories for sparse-checkout or choose manual entry'),
+			canPickMany: true,
+			ignoreFocusOut: false
+		});
+
+		if (!selected || selected.length === 0) {
+			return;
+		}
+
+		let paths: string[];
+
+		// Check if manual entry was selected
+		const manualEntrySelected = selected.some(item => item.isManualEntry);
+
+		if (manualEntrySelected) {
+			// Show input box for manual entry
+			const input = await window.showInputBox({
+				prompt: l10n.t('Enter paths to set (space-separated)'),
+				placeHolder: l10n.t('e.g., src docs tests')
+			});
+
+			if (!input) {
+				return;
+			}
+
+			paths = input.trim().split(/\s+/);
+		} else {
+			// Use selected directories
+			paths = selected
+				.filter(item => item.directory)
+				.map(item => item.directory!);
+		}
+
+		if (paths.length === 0) {
+			return;
+		}
+
+		await repository.sparseCheckoutSet(paths);
+		await repository.status();
+		window.showInformationMessage(l10n.t('Sparse-checkout paths set successfully'));
+	}
+
+	private async sparseCheckoutAdd(repository: Repository): Promise<void> {
+		const input = await window.showInputBox({
+			prompt: l10n.t('Enter paths to add (space-separated)'),
+			placeHolder: l10n.t('e.g., src docs tests')
+		});
+
+		if (!input) {
+			return;
+		}
+
+		const paths = input.trim().split(/\s+/);
+		await repository.sparseCheckoutAdd(paths);
+		await repository.status();
+		window.showInformationMessage(l10n.t('Paths added to sparse-checkout successfully'));
+	}
+
+	private async sparseCheckoutInit(repository: Repository): Promise<void> {
+		const useConeMode = await window.showQuickPick([
+			{ label: l10n.t('Cone mode (recommended)'), value: true },
+			{ label: l10n.t('Non-cone mode'), value: false }
+		], {
+			placeHolder: l10n.t('Select sparse-checkout mode')
+		});
+
+		if (useConeMode === undefined) {
+			return;
+		}
+
+		await repository.sparseCheckoutInit(useConeMode.value);
+		await repository.status();
+		window.showInformationMessage(l10n.t('Sparse-checkout initialized'));
+	}
+
+	private async sparseCheckoutReapply(repository: Repository): Promise<void> {
+		await repository.sparseCheckoutReapply();
+		await repository.status();
+		window.showInformationMessage(l10n.t('Sparse-checkout reapplied'));
+	}
+
+	private async sparseCheckoutDisable(repository: Repository): Promise<void> {
+		const confirmation = await window.showWarningMessage(
+			l10n.t('Are you sure you want to disable sparse-checkout? This will check out all files.'),
+			{ modal: true },
+			l10n.t('Disable')
+		);
+
+		if (confirmation !== l10n.t('Disable')) {
+			return;
+		}
+
+		await repository.sparseCheckoutDisable();
+		await repository.status();
+		window.showInformationMessage(l10n.t('Sparse-checkout disabled'));
+	}
+
 	@command('git.openFile')
 	async openFile(arg?: Resource | Uri, ...resourceStates: SourceControlResourceState[]): Promise<void> {
 		const preserveFocus = arg instanceof Resource;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1062,7 +1062,7 @@ export class CommandCenter {
 			{
 				label: l10n.t('$(file-code) No Source'),
 				description: l10n.t('--no-src'),
-				detail: l10n.t('Initialize without checking out source files'),
+				detail: l10n.t('Initialize without creating src folder'),
 				option: 'no-src'
 			}
 		];

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -485,7 +485,7 @@ export class Git {
 
 	private async execScalar(args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
 		if (!this.scalarPath) {
-			throw new Error('Scalar executable not found. Scalar is an optional Git performance optimization tool. Install Scalar and ensure its executable is available on your PATH, or disable Scalar integration in the Git extension settings.');
+			throw new Error('Scalar executable not found. Scalar is an optional Git performance optimization tool. Install Scalar and ensure its executable is available on your PATH.');
 		}
 
 		options.env = assign({}, process.env, this.env, options.env || {});

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -485,7 +485,7 @@ export class Git {
 
 	private async execScalar(args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
 		if (!this.scalarPath) {
-			throw new Error('Scalar executable not found');
+			throw new Error('Scalar executable not found. Scalar is an optional Git performance optimization tool. Install Scalar and ensure its executable is available on your PATH, or disable Scalar integration in the Git extension settings.');
 		}
 
 		options.env = assign({}, process.env, this.env, options.env || {});

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3514,4 +3514,44 @@ export class Repository {
 		this.logger.trace(`[Git][sanitizeRelativePath] relativePath (fallback): ${filePath}`);
 		return filePath;
 	}
+
+	async sparseCheckoutList(): Promise<string[]> {
+		const result = await this.exec(['sparse-checkout', 'list']);
+		return result.stdout.trim().split('\n').filter(line => line.length > 0);
+	}
+
+	async sparseCheckoutInit(cone: boolean = true): Promise<void> {
+		const args = ['sparse-checkout', 'init'];
+		if (cone) {
+			args.push('--cone');
+		}
+		await this.exec(args);
+	}
+
+	async sparseCheckoutSet(paths: string[]): Promise<void> {
+		if (paths.length === 0) {
+			throw new Error('At least one path must be specified');
+		}
+		await this.exec(['sparse-checkout', 'set', ...paths]);
+	}
+
+	async sparseCheckoutAdd(paths: string[]): Promise<void> {
+		if (paths.length === 0) {
+			throw new Error('At least one path must be specified');
+		}
+		await this.exec(['sparse-checkout', 'add', ...paths]);
+	}
+
+	async sparseCheckoutReapply(): Promise<void> {
+		await this.exec(['sparse-checkout', 'reapply']);
+	}
+
+	async sparseCheckoutDisable(): Promise<void> {
+		await this.exec(['sparse-checkout', 'disable']);
+	}
+
+	async getTopLevelDirectories(): Promise<string[]> {
+		const result = await this.exec(['ls-tree', '-d', '--name-only', 'HEAD']);
+		return result.stdout.trim().split('\n').filter(line => line.length > 0);
+	}
 }

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3217,6 +3217,34 @@ export class Repository implements Disposable {
 		return this.unpublishedCommits;
 	}
 
+	async sparseCheckoutList(): Promise<string[]> {
+		return await this.run(Operation.Config(true), () => this.repository.sparseCheckoutList());
+	}
+
+	async sparseCheckoutInit(cone: boolean = true): Promise<void> {
+		await this.run(Operation.Config(false), () => this.repository.sparseCheckoutInit(cone));
+	}
+
+	async sparseCheckoutSet(paths: string[]): Promise<void> {
+		await this.run(Operation.Config(false), () => this.repository.sparseCheckoutSet(paths));
+	}
+
+	async sparseCheckoutAdd(paths: string[]): Promise<void> {
+		await this.run(Operation.Config(false), () => this.repository.sparseCheckoutAdd(paths));
+	}
+
+	async sparseCheckoutReapply(): Promise<void> {
+		await this.run(Operation.Config(false), () => this.repository.sparseCheckoutReapply());
+	}
+
+	async sparseCheckoutDisable(): Promise<void> {
+		await this.run(Operation.Config(false), () => this.repository.sparseCheckoutDisable());
+	}
+
+	async getTopLevelDirectories(): Promise<string[]> {
+		return await this.run(Operation.Config(false), () => this.repository.getTopLevelDirectories());
+	}
+
 	dispose(): void {
 		this.disposables = dispose(this.disposables);
 	}

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -663,4 +663,56 @@ suite('git', () => {
 			);
 		});
 	});
+
+	suite('Scalar Integration', () => {
+		suite('ICloneOptions', () => {
+			test('accepts useScalar option', () => {
+				const options: any = {
+					parentPath: '/test',
+					progress: { report: () => { } },
+					useScalar: true
+				};
+				assert.strictEqual(options.useScalar, true);
+			});
+
+			test('accepts scalarOptions array', () => {
+				const options: any = {
+					parentPath: '/test',
+					progress: { report: () => { } },
+					useScalar: true,
+					scalarOptions: ['full-clone']
+				};
+				assert.deepStrictEqual(options.scalarOptions, ['full-clone']);
+			});
+
+			test('accepts multiple scalarOptions', () => {
+				const options: any = {
+					parentPath: '/test',
+					progress: { report: () => { } },
+					useScalar: true,
+					scalarOptions: ['full-clone', 'no-src']
+				};
+				assert.deepStrictEqual(options.scalarOptions, ['full-clone', 'no-src']);
+			});
+
+			test('accepts scalarOptions without useScalar', () => {
+				const options: any = {
+					parentPath: '/test',
+					progress: { report: () => { } },
+					scalarOptions: ['full-clone']
+				};
+				assert.deepStrictEqual(options.scalarOptions, ['full-clone']);
+			});
+
+			test('valid full-clone option', () => {
+				const scalarOption: 'full-clone' | 'no-src' = 'full-clone';
+				assert.strictEqual(scalarOption, 'full-clone');
+			});
+
+			test('valid no-src option', () => {
+				const scalarOption: 'full-clone' | 'no-src' = 'no-src';
+				assert.strictEqual(scalarOption, 'no-src');
+			});
+		});
+	});
 });

--- a/extensions/git/src/test/scalar.test.ts
+++ b/extensions/git/src/test/scalar.test.ts
@@ -1,0 +1,372 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as path from 'path';
+import { Git, ICloneOptions } from '../git';
+
+suite('Scalar Support', () => {
+	let git: Git;
+	let sandbox: sinon.SinonSandbox;
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+		git = new Git({
+			gitPath: '/usr/bin/git',
+			version: '2.40.0',
+			userAgent: 'git/2.40.0'
+		});
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	suite('isScalarAvailable', () => {
+		test('returns false when git path is not set', async () => {
+			const gitWithoutPath = new Git({
+				gitPath: '',
+				version: '2.40.0',
+				userAgent: 'git/2.40.0'
+			});
+
+			const result = await gitWithoutPath.isScalarAvailable();
+			assert.strictEqual(result, false);
+		});
+
+		test('returns false when scalar executable does not exist', async () => {
+			// This test will naturally fail if scalar is not installed
+			const result = await git.isScalarAvailable();
+			// The result depends on whether scalar is actually installed
+			assert.strictEqual(typeof result, 'boolean');
+		});
+
+		test('caches scalar path after successful verification', async () => {
+			await git.isScalarAvailable();
+			// Call again to ensure caching works
+			const result = await git.isScalarAvailable();
+			assert.strictEqual(typeof result, 'boolean');
+		});
+
+		test('handles errors gracefully', async () => {
+			const gitWithInvalidPath = new Git({
+				gitPath: '/nonexistent/path/git',
+				version: '2.40.0',
+				userAgent: 'git/2.40.0'
+			});
+
+			const result = await gitWithInvalidPath.isScalarAvailable();
+			assert.strictEqual(result, false);
+		});
+	});
+
+	suite('ICloneOptions with Scalar', () => {
+		test('useScalar option is recognized', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true
+			};
+			assert.strictEqual(options.useScalar, true);
+		});
+
+		test('scalarOptions accepts full-clone', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true,
+				scalarOptions: ['full-clone']
+			};
+			assert.deepStrictEqual(options.scalarOptions, ['full-clone']);
+		});
+
+		test('scalarOptions accepts no-src', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true,
+				scalarOptions: ['no-src']
+			};
+			assert.deepStrictEqual(options.scalarOptions, ['no-src']);
+		});
+
+		test('scalarOptions accepts multiple options', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true,
+				scalarOptions: ['full-clone', 'no-src']
+			};
+			assert.deepStrictEqual(options.scalarOptions, ['full-clone', 'no-src']);
+		});
+
+		test('scalarOptions can be empty array', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true,
+				scalarOptions: []
+			};
+			assert.deepStrictEqual(options.scalarOptions, []);
+		});
+
+		test('scalarOptions can be undefined', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				useScalar: true,
+				scalarOptions: undefined
+			};
+			assert.strictEqual(options.scalarOptions, undefined);
+		});
+
+		test('useScalar works with recursive option', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				recursive: true,
+				useScalar: true
+			};
+			assert.strictEqual(options.recursive, true);
+			assert.strictEqual(options.useScalar, true);
+		});
+
+		test('useScalar works with ref option', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				ref: 'main',
+				useScalar: true
+			};
+			assert.strictEqual(options.ref, 'main');
+			assert.strictEqual(options.useScalar, true);
+		});
+
+		test('all clone options work together', () => {
+			const options: ICloneOptions = {
+				parentPath: '/test',
+				progress: { report: () => { } },
+				recursive: true,
+				ref: 'develop',
+				useScalar: true,
+				scalarOptions: ['full-clone']
+			};
+			assert.strictEqual(options.recursive, true);
+			assert.strictEqual(options.ref, 'develop');
+			assert.strictEqual(options.useScalar, true);
+			assert.deepStrictEqual(options.scalarOptions, ['full-clone']);
+		});
+	});
+
+	suite('Scalar Option Validation', () => {
+		test('full-clone is valid option', () => {
+			const option: 'full-clone' | 'no-src' = 'full-clone';
+			assert.strictEqual(option, 'full-clone');
+		});
+
+		test('no-src is valid option', () => {
+			const option: 'full-clone' | 'no-src' = 'no-src';
+			assert.strictEqual(option, 'no-src');
+		});
+
+		test('array of scalar options maintains order', () => {
+			const options: ('full-clone' | 'no-src')[] = ['full-clone', 'no-src'];
+			assert.strictEqual(options[0], 'full-clone');
+			assert.strictEqual(options[1], 'no-src');
+		});
+
+		test('array of scalar options can contain duplicates', () => {
+			const options: ('full-clone' | 'no-src')[] = ['full-clone', 'full-clone'];
+			assert.strictEqual(options.length, 2);
+			assert.strictEqual(options[0], 'full-clone');
+			assert.strictEqual(options[1], 'full-clone');
+		});
+	});
+
+	suite('Scalar Path Detection', () => {
+		test('scalar path is constructed correctly on Windows', () => {
+			const isWindows = process.platform === 'win32';
+			const gitPath = isWindows ? 'C:\\Program Files\\Git\\cmd\\git.exe' : '/usr/bin/git';
+			const expectedScalarName = isWindows ? 'scalar.exe' : 'scalar';
+
+			const gitDir = path.dirname(gitPath);
+			const scalarPath = path.join(gitDir, expectedScalarName);
+
+			if (isWindows) {
+				assert.strictEqual(scalarPath.includes('scalar.exe'), true);
+			} else {
+				assert.strictEqual(scalarPath.includes('scalar'), true);
+			}
+		});
+
+		test('scalar path uses correct executable name for platform', () => {
+			const isWindows = process.platform === 'win32';
+			const scalarExecutable = isWindows ? 'scalar.exe' : 'scalar';
+
+			if (isWindows) {
+				assert.strictEqual(scalarExecutable, 'scalar.exe');
+			} else {
+				assert.strictEqual(scalarExecutable, 'scalar');
+			}
+		});
+	});
+
+	suite('Scalar Command Arguments', () => {
+		test('clone command is constructed correctly', () => {
+			const args = ['clone'];
+			assert.deepStrictEqual(args, ['clone']);
+		});
+
+		test('full-clone option is formatted correctly', () => {
+			const option = 'full-clone';
+			const arg = `--${option}`;
+			assert.strictEqual(arg, '--full-clone');
+		});
+
+		test('no-src option is formatted correctly', () => {
+			const option = 'no-src';
+			const arg = `--${option}`;
+			assert.strictEqual(arg, '--no-src');
+		});
+
+		test('multiple options are formatted correctly', () => {
+			const options: ('full-clone' | 'no-src')[] = ['full-clone', 'no-src'];
+			const args = options.map(opt => `--${opt}`);
+			assert.deepStrictEqual(args, ['--full-clone', '--no-src']);
+		});
+
+		test('branch option is formatted correctly', () => {
+			const ref = 'main';
+			const args = ['--branch', ref];
+			assert.deepStrictEqual(args, ['--branch', 'main']);
+		});
+
+		test('complete scalar clone command structure', () => {
+			const command = ['clone', '--full-clone', '--branch', 'main', 'https://github.com/repo.git', '/path/to/dest'];
+			assert.strictEqual(command[0], 'clone');
+			assert.strictEqual(command[1], '--full-clone');
+			assert.strictEqual(command[2], '--branch');
+			assert.strictEqual(command[3], 'main');
+			assert.strictEqual(command[4], 'https://github.com/repo.git');
+			assert.strictEqual(command[5], '/path/to/dest');
+		});
+	});
+
+	suite('Scalar Error Handling', () => {
+		test('error message for missing scalar is descriptive', () => {
+			const errorMessage = 'Scalar executable not found. Scalar is an optional Git performance optimization tool. Install Scalar and ensure its executable is available on your PATH.';
+			assert.ok(errorMessage.includes('Scalar executable not found'));
+			assert.ok(errorMessage.includes('optional'));
+			assert.ok(errorMessage.includes('PATH'));
+		});
+
+		test('error is thrown when scalar path is not set', async () => {
+			// Attempting to use execScalar without scalarPath should fail
+			// We can't directly test private method, but we can verify the error message is correct
+			const expectedErrorMessage = 'Scalar executable not found. Scalar is an optional Git performance optimization tool. Install Scalar and ensure its executable is available on your PATH.';
+			assert.ok(expectedErrorMessage.includes('Scalar executable not found'));
+		});
+	});
+
+	suite('Scalar Integration with Git', () => {
+		test('scalar version check timeout is reasonable', () => {
+			const timeout = 5000;
+			assert.strictEqual(timeout, 5000);
+			assert.ok(timeout > 0);
+			assert.ok(timeout <= 10000);
+		});
+
+		test('scalar version command uses correct arguments', () => {
+			const args = ['version'];
+			assert.deepStrictEqual(args, ['version']);
+		});
+
+		test('scalar verification checks for output', () => {
+			let hasOutput = false;
+			hasOutput = true;
+			assert.strictEqual(hasOutput, true);
+		});
+
+		test('scalar verification requires both exit code 0 and output', () => {
+			const exitCode = 0;
+			const hasOutput = true;
+			const isValid = exitCode === 0 && hasOutput;
+			assert.strictEqual(isValid, true);
+		});
+
+		test('scalar verification fails with non-zero exit code', () => {
+			const exitCode: number = 1;
+			const hasOutput = true;
+			const isValid = exitCode === 0 && hasOutput;
+			assert.strictEqual(isValid, false);
+		});
+
+		test('scalar verification fails without output', () => {
+			const exitCode = 0;
+			const hasOutput = false;
+			const isValid = exitCode === 0 && hasOutput;
+			assert.strictEqual(isValid, false);
+		});
+	});
+
+	suite('Scalar URL Handling', () => {
+		test('URL with spaces is encoded correctly', () => {
+			const url = 'https://example.com/path with spaces';
+			const encodedUrl = encodeURI(url);
+			assert.strictEqual(encodedUrl, 'https://example.com/path%20with%20spaces');
+		});
+
+		test('URL without spaces is not modified', () => {
+			const url = 'https://github.com/microsoft/vscode.git';
+			const encodedUrl = url.includes(' ') ? encodeURI(url) : url;
+			assert.strictEqual(encodedUrl, url);
+		});
+
+		test('URL encoding preserves protocol', () => {
+			const url = 'https://example.com/path with spaces';
+			const encodedUrl = encodeURI(url);
+			assert.ok(encodedUrl.startsWith('https://'));
+		});
+	});
+
+	suite('Scalar Progress Reporting', () => {
+		test('progress report structure is valid', () => {
+			let reportedIncrement = 0;
+			const progress = {
+				report: (value: { increment: number }) => {
+					reportedIncrement = value.increment;
+				}
+			};
+
+			progress.report({ increment: 25 });
+			assert.strictEqual(reportedIncrement, 25);
+		});
+
+		test('progress increments accumulate correctly', () => {
+			let totalProgress = 0;
+			const progress = {
+				report: (value: { increment: number }) => {
+					totalProgress += value.increment;
+				}
+			};
+
+			progress.report({ increment: 10 });
+			progress.report({ increment: 20 });
+			progress.report({ increment: 30 });
+
+			assert.strictEqual(totalProgress, 60);
+		});
+
+		test('progress calculation from percentage is correct', () => {
+			const match = /(\d+)%/i.exec('Receiving objects:  50%');
+			if (match) {
+				const percentage = parseInt(match[1]);
+				assert.strictEqual(percentage, 50);
+			}
+		});
+	});
+});

--- a/extensions/git/src/test/sparse-checkout.test.ts
+++ b/extensions/git/src/test/sparse-checkout.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+
+suite('Sparse Checkout', () => {
+
+	suite('getTopLevelDirectories output parsing', () => {
+		test('parses list of directories from ls-tree output', () => {
+			const stdout = 'src\ndocs\ntests\nscripts\n';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, ['src', 'docs', 'tests', 'scripts']);
+		});
+
+		test('filters out empty lines', () => {
+			const stdout = 'src\n\ndocs\n\n\ntests\n';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, ['src', 'docs', 'tests']);
+		});
+
+		test('handles empty output', () => {
+			const stdout = '';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, []);
+		});
+
+		test('handles single directory', () => {
+			const stdout = 'src\n';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, ['src']);
+		});
+	});
+
+	suite('sparseCheckoutList output parsing', () => {
+		test('parses list of sparse-checkout paths', () => {
+			const stdout = 'src\ndocs\n';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, ['src', 'docs']);
+		});
+
+		test('filters out empty lines', () => {
+			const stdout = 'src\n\ndocs\n\n';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, ['src', 'docs']);
+		});
+
+		test('handles empty output', () => {
+			const stdout = '';
+			const result = stdout.trim().split('\n').filter(line => line.length > 0);
+
+			assert.deepStrictEqual(result, []);
+		});
+	});
+});


### PR DESCRIPTION
Hello Team:

I am proposing this pr for this feature request I sent out: https://github.com/microsoft/vscode/issues/209285 

To quickly get started on Scalar, please refer to this documentation: https://github.com/microsoft/git/blob/6107aca650556448b9719a3267f228f8e4e80aeb/contrib/scalar/docs/getting-started.md

The changes mainly added one item in command to specifically support clone with scalar with options to specify --full-clone and/or --no-src options.

To test:

Start test instance of VSCode, press Shift + Ctrl + P, type "clone", there will be a new option called "Clone with Scalar" as following screenshot shows:
<img width="587" height="368" alt="scalar clone" src="https://github.com/user-attachments/assets/eac1cc13-9689-4472-ba7d-2bd93a567f16" />
Select it and it will be followed by selectable options (no source, full clone) as following screenshot:
<img width="574" height="154" alt="scalar option" src="https://github.com/user-attachments/assets/d1444dc4-c0c0-4134-a265-9b8f9208331b" />
Click ok, the scalar clone process will start in background just like regular git clone

Also, after use Scalar to clone repo, unless use full-clone, one will need to use git sparse-checkout to manage directories and paths they want to checkout, so added command to support sparse-checkout capablity.

<img width="1196" height="203" alt="Screenshot 2026-01-15 124637" src="https://github.com/user-attachments/assets/9e3d47ec-1ec3-4c4c-b9c8-deb704eb7265" />

For sparse-checkout set command, to help user, instead of ask user to manually input directories name everytime, it will run git ls-tree -d to get top level directories where user can simply select. Also there's option user can select to choose to manually input the directories in case they want to manage directories beyond top level.
