### PR TITLE
Custom chat render for agent skills

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -41,6 +41,7 @@ import { INotebookDocumentService } from '../../../../../services/notebook/commo
 import { ExplorerFolderContext } from '../../../../files/common/files.js';
 import { IWorkspaceSymbol } from '../../../../search/common/search.js';
 import { IChatContentInlineReference } from '../../../common/chatService/chatService.js';
+import { IPromptsService } from '../../../common/promptSyntax/service/promptsService.js';
 import { IChatWidgetService } from '../../chat.js';
 import { chatAttachmentResourceContextKey, hookUpSymbolAttachmentDragAndContextMenu } from '../../attachments/chatAttachmentWidgets.js';
 import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
@@ -90,6 +91,7 @@ export class InlineAnchorWidget extends Disposable {
 		@ILanguageService languageService: ILanguageService,
 		@IMenuService menuService: IMenuService,
 		@IModelService modelService: IModelService,
+		@IPromptsService promptsService: IPromptsService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@INotebookDocumentService private readonly notebookDocumentService: INotebookDocumentService,
@@ -126,7 +128,9 @@ export class InlineAnchorWidget extends Disposable {
 		} else {
 			location = this.data;
 
-			const filePathLabel = labelService.getUriBasenameLabel(location.uri);
+			// For skills, we should use the skill name as the label
+			const skillInfo = promptsService.getSkillByUri(location.uri);
+			const filePathLabel = skillInfo ? skillInfo.name : labelService.getUriBasenameLabel(location.uri);
 			if (location.range && this.data.kind !== 'symbol') {
 				const suffix = location.range.startLineNumber === location.range.endLineNumber
 					? `:${location.range.startLineNumber}`

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsService.ts
@@ -331,4 +331,11 @@ export interface IPromptsService extends IDisposable {
 	 * Gets list of agent skills files.
 	 */
 	findAgentSkills(token: CancellationToken): Promise<IAgentSkill[] | undefined>;
+
+	/**
+	 * Gets skill info by URI from the cached skills list.
+	 * Returns undefined if the URI is not a known skill or skills haven't been loaded yet.
+	 * This is a synchronous lookup against already-loaded skills.
+	 */
+	getSkillByUri(uri: URI): IAgentSkill | undefined;
 }

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -85,6 +85,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 		[PromptsType.agent]: new ResourceMap<Promise<IExtensionPromptPath>>(),
 	};
 
+	/**
+	 * Cached skills keyed by URI for synchronous lookup.
+	 * Updated whenever findAgentSkills is called.
+	 */
+	private readonly cachedSkillsByUri = new ResourceMap<IAgentSkill>();
+
 	constructor(
 		@ILogService public readonly logger: ILogService,
 		@ILabelService private readonly labelService: ILabelService,
@@ -705,9 +711,19 @@ export class PromptsService extends Disposable implements IPromptsService {
 				skippedParseFailed
 			});
 
+			// Update the cached skills map for synchronous lookup
+			this.cachedSkillsByUri.clear();
+			for (const skill of result) {
+				this.cachedSkillsByUri.set(skill.uri, skill);
+			}
+
 			return result;
 		}
 		return undefined;
+	}
+
+	public getSkillByUri(uri: URI): IAgentSkill | undefined {
+		return this.cachedSkillsByUri.get(uri);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/mockPromptsService.ts
@@ -62,5 +62,6 @@ export class MockPromptsService implements IPromptsService {
 	setDisabledPromptFiles(type: PromptsType, uris: ResourceSet): void { throw new Error('Method not implemented.'); }
 	registerCustomAgentsProvider(extension: IExtensionDescription, provider: { provideCustomAgents: (options: ICustomAgentQueryOptions, token: CancellationToken) => Promise<IExternalCustomAgent[] | undefined> }): IDisposable { throw new Error('Method not implemented.'); }
 	findAgentSkills(token: CancellationToken): Promise<IAgentSkill[] | undefined> { throw new Error('Method not implemented.'); }
+	getSkillByUri(uri: URI): IAgentSkill | undefined { return undefined; }
 	dispose(): void { }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="294" height="54" alt="image" src="https://github.com/user-attachments/assets/a8afbd36-1302-4acd-bc15-92f10bd1547d" />

This affects all file uri renderings for uris that are agent skills. Alternatively, I could pass a flag from the uri itself to signal to render as a skill (and with the skill name), but I think it is cleaner to handle it in the general case here so that we can easily extend to other types in the future.
