### PR TITLE
Chat - working set/todo list rendering polish

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -776,7 +776,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-container {
-	padding: 6px 3px 6px 3px;
+	padding: 4px 3px 4px 3px;
 	box-sizing: border-box;
 	background-color: var(--vscode-editor-background);
 	border: 1px solid var(--vscode-input-border, transparent);
@@ -817,13 +817,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-direction: row;
 	justify-content: space-between;
 	gap: 6px;
-	padding-right: 4px;
+	padding-right: 3px;
+	height: 22px;
+	line-height: 22px;
 	cursor: pointer;
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-container .chat-editing-session-overview > .working-set-title {
 	color: var(--vscode-descriptionForeground);
-	font-size: 11px;
+	font-size: 12px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -839,6 +841,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: inline-flex;
 	gap: 4px;
 	margin-left: 6px;
+	font-size: 11px;
 	font-weight: 500;
 }
 
@@ -851,7 +854,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-list .working-set-line-counts {
-	margin-left: 6px;
+	margin: 0 6px;
 	display: inline-flex;
 	gap: 4px;
 	font-size: 11px;
@@ -900,10 +903,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session .monaco-button {
-	height: 18px;
+	height: 22px;
 	width: fit-content;
 	padding: 2px 6px;
-	font-size: 11px;
+	font-size: 12px;
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button:hover {
@@ -1032,7 +1035,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border-color: transparent;
 	color: var(--vscode-icon-foreground);
 	cursor: pointer;
-	padding: 0 1px;
+	padding: 0 3px;
 	border-radius: 2px;
 	display: inline-flex;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1108,7 +1108,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget {
-	padding: 6px 3px 6px 3px;
+	padding: 4px 3px 4px 3px;
 	box-sizing: border-box;
 	border: 1px solid var(--vscode-input-border, transparent);
 	background-color: var(--vscode-editor-background);
@@ -1147,16 +1147,16 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: flex;
 	align-items: center;
 	flex: 1;
-	font-size: 11px;
+	font-size: 12px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	line-height: 16px;
+	line-height: 22px;
 }
 
 .interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-expand .todo-list-title-section .codicon {
 	font-size: 16px;
-	line-height: 16px;
+	line-height: 22px;
 	flex-shrink: 0;
 }
 
@@ -1174,14 +1174,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-foreground);
 	cursor: pointer;
 	height: 16px;
-	padding: 2px;
+	padding: 3px;
 	border-radius: 2px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	min-width: unset;
-	width: 14px;
-	margin-right: 1px;
 }
 
 .interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-clear-button-container .monaco-button:hover {
@@ -1206,7 +1204,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part > .chat-todo-list-widget-container .chat-todo-list-widget .todo-list-title {
 	font-weight: normal;
-	font-size: 11px;
+	font-size: 12px;
 	display: flex;
 	align-items: center;
 	overflow: hidden;


### PR DESCRIPTION
Standardize both the working set and todo list to use a line height of 22px in the overview rendering. Working set used 18px while the todo list used 16px. Also adjust the spacing of the various UI elements to the new line height.

Working set
<img width="542" height="141" alt="image" src="https://github.com/user-attachments/assets/8bdc2457-d179-491d-8d9d-5c3deee6dd48" />
<img width="540" height="166" alt="image" src="https://github.com/user-attachments/assets/c30cc7ba-426d-4a8a-bb6b-7fe0eb10d407" />

Todo list
<img width="541" height="140" alt="image" src="https://github.com/user-attachments/assets/c11743e6-019b-4332-9dd9-a3b3cdb1fa0b" />
<img width="543" height="273" alt="image" src="https://github.com/user-attachments/assets/a1519ded-eceb-42d0-b445-5d6bdc3e6074" />

Related https://github.com/microsoft/vscode/issues/283995