### PR TITLE
mcp: allow resource domains in script-src and style-src CSP

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
@@ -251,8 +251,8 @@ export class ChatMcpAppModel extends Disposable {
 
 		const cspContent = `
 			default-src 'none';
-			script-src 'self' 'unsafe-inline';
-			style-src 'self' 'unsafe-inline';
+			script-src 'self' 'unsafe-inline' ${cleanDomains(csp?.resourceDomains)};
+			style-src 'self' 'unsafe-inline' ${cleanDomains(csp?.resourceDomains)};
 			connect-src 'self' ${cleanDomains(csp?.connectDomains)};
 			img-src 'self' data: ${cleanDomains(csp?.resourceDomains)};
 			font-src 'self' ${cleanDomains(csp?.resourceDomains)};


### PR DESCRIPTION
## Summary
Fixes #286689

This PR fixes an issue where MCP apps cannot load external scripts and stylesheets from domains specified in their CSP `resourceDomains` configuration.

## Changes
- Added `resourceDomains` to `script-src` CSP directive in [chatMcpAppModel.ts:254](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts#L254)
- Added `resourceDomains` to `style-src` CSP directive in [chatMcpAppModel.ts:255](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts#L255)

This aligns the CSP configuration for scripts and styles with the existing pattern already used for `img-src` and `font-src`.

## Test Plan
- [ ] Follow reproduction steps in issue #286689
- [ ] Verify that scripts and styles from resource domains now load without CSP violations
- [ ] Check that other CSP directives continue to work as expected