### PR TITLE
Don't include loader.js in monaco-editor-core build, as the loader is no longer used.

### DIFF
--- a/build/lib/standalone.ts
+++ b/build/lib/standalone.ts
@@ -120,7 +120,6 @@ export function extractEditor(options: tss.ITreeShakingOptions & { destRoot: str
 		copyFile(file);
 	});
 
-	copyFile('vs/loader.js');
 	copyFile('typings/css.d.ts');
 	copyFile('../node_modules/@vscode/tree-sitter-wasm/wasm/web-tree-sitter.d.ts', '@vscode/tree-sitter-wasm.d.ts');
 }


### PR DESCRIPTION
Prepares for https://github.com/microsoft/vscode/issues/285255.