### PR TITLE
Clear prompt input value when onDidEndShellExecution

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -245,8 +245,10 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 
 	private _handleCommandExecuted() {
 		if (this._state === PromptInputState.Execute) {
+			this._logService.trace('PromptInputModel#_handleCommandExecuted: already in Execute state');
 			return;
 		}
+		this._logService.trace('PromptInputModel#_handleCommandExecuted: Inside _handleCommandExecuted but not PromptInputState.Execute yet');
 
 		this._cursorIndex = -1;
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -42,6 +42,12 @@ export interface IPromptInputModel extends IPromptInputModelState {
 	getCombinedString(emptyStringWhenEmpty?: boolean): string;
 
 	setShellType(shellType?: TerminalShellType): void;
+
+	/**
+	 * Clears the prompt input value. This should be called when the command has finished
+	 * and the value is no longer relevant as editable prompt input.
+	 */
+	clearValue(): void;
 }
 
 export interface IPromptInputModelState {
@@ -259,6 +265,14 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		this._state = PromptInputState.Execute;
 		this._onDidFinishInput.fire(event);
 		this._onDidChangeInput.fire(event);
+	}
+
+	/**
+	 * Clears the prompt input value. This should be called when the command has finished
+	 * and the value is no longer relevant as editable prompt input.
+	 */
+	clearValue(): void {
+		this._value = '';
 	}
 
 	@throttle(0)

--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -7,12 +7,12 @@ import { Event } from '../../../base/common/event.js';
 import { Disposable, toDisposable, type IDisposable } from '../../../base/common/lifecycle.js';
 import { TerminalCapability, type ITerminalCommand } from '../../../platform/terminal/common/capabilities/capabilities.js';
 import { ExtHostContext, MainContext, type ExtHostTerminalShellIntegrationShape, type MainThreadTerminalShellIntegrationShape } from '../common/extHost.protocol.js';
-import { ILogService } from '../../../platform/log/common/log.js';
 import { ITerminalService, type ITerminalInstance } from '../../contrib/terminal/browser/terminal.js';
 import { IWorkbenchEnvironmentService } from '../../services/environment/common/environmentService.js';
 import { extHostNamedCustomer, type IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { TerminalShellExecutionCommandLineConfidence } from '../common/extHostTypes.js';
 import { IExtensionService } from '../../services/extensions/common/extensions.js';
+import { ITerminalLogService } from '../../../platform/terminal/common/terminal.js';
 
 @extHostNamedCustomer(MainContext.MainThreadTerminalShellIntegration)
 export class MainThreadTerminalShellIntegration extends Disposable implements MainThreadTerminalShellIntegrationShape {
@@ -23,7 +23,7 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IWorkbenchEnvironmentService workbenchEnvironmentService: IWorkbenchEnvironmentService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
-		@ILogService private readonly _logService: ILogService
+		@ITerminalLogService private readonly _logService: ITerminalLogService
 	) {
 		super();
 

--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -98,6 +98,9 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 			currentCommand = undefined;
 			const instanceId = e.instance.instanceId;
 			instanceDataListeners.get(instanceId)?.dispose();
+			// Clear the prompt input value before sending the event to the extension host
+			// so that subsequent executeCommand calls don't see stale input
+			e.instance.capabilities.get(TerminalCapability.CommandDetection)?.promptInputModel.clearValue();
 			// Shell integration C (executed) and D (command finished) sequences should always be in
 			// their own events, so send this immediately. This means that the D sequence will not
 			// be included as it's currently being parsed when the command finished event fires.

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1008,6 +1008,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// Determine whether to send ETX (ctrl+c) before running the command. Only do this when the
 		// command will be executed immediately or when command detection shows the prompt contains text.
 		if (shouldExecute && (!commandDetection || commandDetection.promptInputModel.value.length > 0)) {
+			this._logService.trace(`PromptInputModel#runCommand: Sending ETX (ctrl+c) before running command`);
+			this._logService.trace(`PromptInputModel#runCommand: state of promptinputmodel before sending ETX: ${commandDetection ? commandDetection.promptInputModel.state : 'no command detection'}`);
+			this._logService.trace(`PromptInputModel#runCommand: value of promptinputmodel before sending ETX: ${commandDetection ? commandDetection.promptInputModel.value : 'no command detection'}`);
+
 			await this.sendText('\x03', false);
 			// Wait a little before running the command to avoid the sequences being echoed while the ^C
 			// is being evaluated


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python-environments/issues/640 

Assumption: activate command always run first before python file command. 
This is now fact thanks to https://github.com/microsoft/vscode-python-environments/pull/1088

When `python-envs.terminal.autoActivationType` us `command` with `"python.useEnvironmentsExtension": true,`:
  ---> Ctrl+c is displayed when pressing the run button to run Python file.
Specific location of this ctrl+c is after activate command, but before python file execution command.

What is happening:
1. Environment extension wait for `onDidTerminalShellExecutionEnd` where we wait for activation command (this should be the first thing that runs in the terminal)
2. Then we `executeCommand()` again (to run Python file.) This is when user presses the run button to run python file.
3. (Bug) Ctrl+c is shown.
4. But why is ctrl+ c shown? After debugging, it turns out the prompt input model value is still showing activate command. Not the empty nor the python file command. 
 
Maybe conpty related bugs, hence why we've been getting more reports from windows users.
Decoration location is off too.

---------------------------------------------------------------------------
How to resolve (below are options we can take):
1. Wait for conpty v.1.25 to stabilize shell integration decoration
2. clear prompt input value when `onDidEndShellExecution` (this PR). 
3. Await (short like 500ms) hard-coded timeout in extension after activation prompt. 
4. Do option 2 first then consider removing once we have option 1? 



Image of the problem: <img width="1099" height="1126" alt="Screenshot 2026-01-09 092911" src="https://github.com/user-attachments/assets/659a2e7c-8cf6-4432-941a-c16f48a45768" />