### PR TITLE
on model content change, restore last cursor position  (#286779)

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -581,6 +581,8 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 	}
 
 	private _render(provider: AccesibleViewContentProvider, container: HTMLElement, showAccessibleViewHelp?: boolean, updatedContent?: string): IDisposable {
+		const isSameProvider = this._currentProvider?.id === provider.id;
+		const previousPosition = isSameProvider ? this._editorWidget.getPosition() : undefined;
 		this._currentProvider = provider;
 		this._accessibleViewCurrentProviderId.set(provider.id);
 		const verbose = this._verbosityEnabled();
@@ -593,6 +595,9 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 				return;
 			}
 			this._editorWidget.setModel(model);
+			if (previousPosition) {
+				this._editorWidget.setPosition(previousPosition);
+			}
 			const domNode = this._editorWidget.getDomNode();
 			if (!domNode) {
 				return;

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -595,9 +595,6 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 				return;
 			}
 			this._editorWidget.setModel(model);
-			if (previousPosition) {
-				this._editorWidget.setPosition(previousPosition);
-			}
 			const domNode = this._editorWidget.getDomNode();
 			if (!domNode) {
 				return;
@@ -634,6 +631,8 @@ export class AccessibleView extends Disposable implements ITextModelContentProvi
 						this._editorWidget.revealLine(position.lineNumber);
 					}
 				}
+			} else if (previousPosition) {
+				this._editorWidget.setPosition(previousPosition);
 			}
 		});
 		this._updateToolbar(this._currentProvider.actions, provider.options.type);


### PR DESCRIPTION
fixes #286632

With content dynamically streaming in, the cursor position was getting reset to the top. We now keep track of cursor position and on updates, ensure it persists.