### PR TITLE
fallback to label for aria label when tooltip isn't provided 

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -584,7 +584,7 @@ class SubmenuEntrySelectActionViewItem extends SelectActionViewItem {
 		@IContextViewService contextViewService: IContextViewService,
 		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(null, action, action.actions.map(a => (a.id === Separator.ID ? SeparatorSelectOption : { text: a.label, isDisabled: !a.enabled, })), 0, contextViewService, defaultSelectBoxStyles, { ariaLabel: action.tooltip, optionsAsChildren: true, useCustomDrawn: !hasNativeContextMenu(configurationService) });
+		super(null, action, action.actions.map(a => (a.id === Separator.ID ? SeparatorSelectOption : { text: a.label, isDisabled: !a.enabled, })), 0, contextViewService, defaultSelectBoxStyles, { ariaLabel: action.tooltip || action.label, optionsAsChildren: true, useCustomDrawn: !hasNativeContextMenu(configurationService) });
 		this.select(Math.max(0, action.actions.findIndex(a => a.checked)));
 	}
 


### PR DESCRIPTION
fixes #285527

Before:

<img width="1493" height="764" alt="Screenshot 2026-01-09 at 4 31 23 PM" src="https://github.com/user-attachments/assets/2153bef9-33ea-46ca-9d6e-c60ff930fbdc" />

After:

<img width="1211" height="756" alt="Screenshot 2026-01-09 at 4 29 15 PM" src="https://github.com/user-attachments/assets/175fba91-66eb-4014-bcf3-af66a6906930" />
