### PR TITLE
enable focusing the size link on the extension page via keyboard

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1178,6 +1178,8 @@ class AdditionalDetailsWidget extends Disposable {
 			);
 			if (isNative && extension.source === 'resource' && extension.location.scheme === Schemas.file) {
 				element.classList.add('link');
+				element.tabIndex = 0;
+				element.setAttribute('role', 'link');
 				element.title = extension.location.fsPath;
 				this.disposables.add(onClick(element, () => this.openerService.open(extension.location, { openExternal: true })));
 			}
@@ -1192,6 +1194,8 @@ class AdditionalDetailsWidget extends Disposable {
 			);
 			if (isNative && extension.location.scheme === Schemas.file) {
 				element.classList.add('link');
+				element.tabIndex = 0;
+				element.setAttribute('role', 'link');
 				element.title = extension.location.fsPath;
 				this.disposables.add(onClick(element, () => this.openerService.open(extension.location, { openExternal: true })));
 			}
@@ -1212,6 +1216,8 @@ class AdditionalDetailsWidget extends Disposable {
 				);
 				if (isNative && extension.location.scheme === Schemas.file) {
 					element.classList.add('link');
+					element.tabIndex = 0;
+					element.setAttribute('role', 'link');
 					element.title = cacheLocation.fsPath;
 					this.disposables.add(onClick(element, () => this.openerService.open(cacheLocation.with({ scheme: Schemas.file }), { openExternal: true })));
 				}


### PR DESCRIPTION
fixes #285486

<img width="259" height="267" alt="Screenshot 2026-01-09 at 4 41 44 PM" src="https://github.com/user-attachments/assets/45e15a9b-a771-4437-8d5b-8796ff1ed351" />
