### PR TITLE
fix remote terminal completions

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
@@ -124,19 +124,19 @@ export class TerminalCompletionItem extends SimpleCompletionItem {
 	constructor(
 		override readonly completion: ITerminalCompletion,
 		/**
-		 * The path separator used by the terminal. When provided, this is used instead of the
-		 * local platform's path separator for path normalization. This is important for remote
-		 * scenarios (e.g., WSL) where the remote OS may use different path separators than the
-		 * local OS.
+		 * The path separator used by the terminal. When provided, this is used instead of
+		 * detecting the separator from the label. This is important for remote scenarios
+		 * (e.g., WSL) where the remote OS may use different path separators than the local OS.
 		 */
 		pathSeparator?: string
 	) {
 		super(completion);
 
-		// Use provided pathSeparator to determine if we should use Windows-style paths.
-		// Default to Unix-style (/) since it works on all platforms and is safer for remote
-		// scenarios where we may not know the remote OS yet.
-		const useWindowsStylePath = pathSeparator === '\\';
+		// Detect path separator from the label if not provided. This ensures correct behavior
+		// for all scenarios (local Windows, local Unix, WSL, SSH remotes) by using the actual
+		// separator present in the completion rather than assuming based on the local OS.
+		const detectedSeparator = pathSeparator ?? (this.labelLow.includes('\\') ? '\\' : undefined);
+		const useWindowsStylePath = detectedSeparator === '\\';
 
 		// ensure lower-variants (perf)
 		this.labelLowExcludeFileExt = this.labelLow;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionItem.ts
@@ -5,7 +5,6 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { basename } from '../../../../../base/common/path.js';
-import { isWindows } from '../../../../../base/common/platform.js';
 import { CompletionItem, CompletionItemKind, CompletionItemProvider } from '../../../../../editor/common/languages.js';
 import { ISimpleCompletion, SimpleCompletionItem } from '../../../../services/suggest/browser/simpleCompletionItem.js';
 
@@ -123,9 +122,21 @@ export class TerminalCompletionItem extends SimpleCompletionItem {
 	resolveCache?: Promise<void>;
 
 	constructor(
-		override readonly completion: ITerminalCompletion
+		override readonly completion: ITerminalCompletion,
+		/**
+		 * The path separator used by the terminal. When provided, this is used instead of the
+		 * local platform's path separator for path normalization. This is important for remote
+		 * scenarios (e.g., WSL) where the remote OS may use different path separators than the
+		 * local OS.
+		 */
+		pathSeparator?: string
 	) {
 		super(completion);
+
+		// Use provided pathSeparator to determine if we should use Windows-style paths.
+		// Default to Unix-style (/) since it works on all platforms and is safer for remote
+		// scenarios where we may not know the remote OS yet.
+		const useWindowsStylePath = pathSeparator === '\\';
 
 		// ensure lower-variants (perf)
 		this.labelLowExcludeFileExt = this.labelLow;
@@ -135,7 +146,7 @@ export class TerminalCompletionItem extends SimpleCompletionItem {
 		// documentation for now, but this would be better to come in through a `kind`
 		// See https://github.com/microsoft/vscode/issues/255864
 		if (isFile(completion) || completion.kind === TerminalCompletionItemKind.Branch) {
-			if (isWindows) {
+			if (useWindowsStylePath) {
 				this.labelLow = this.labelLow.replaceAll('/', '\\');
 			}
 		}
@@ -150,7 +161,7 @@ export class TerminalCompletionItem extends SimpleCompletionItem {
 		}
 
 		if (isFile(completion) || completion.kind === TerminalCompletionItemKind.Folder) {
-			if (isWindows) {
+			if (useWindowsStylePath) {
 				this.labelLowNormalizedPath = this.labelLow.replaceAll('\\', '/');
 			}
 			if (completion.kind === TerminalCompletionItemKind.Folder) {

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -344,7 +344,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			const firstDir = completions.find(e => e.kind === TerminalCompletionItemKind.Folder);
 			const textLabel = isString(firstDir?.label) ? firstDir.label : firstDir?.label.label;
 			// Get path separator from the completion label, which is coming from the extension host
-			// and falling back to the OS-based default
 			const labelSep = textLabel?.match(/(?<sep>[\\\/])/)?.groups?.sep;
 			if (labelSep) {
 				this._pathSeparator = labelSep;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -685,7 +685,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			// model and the slowdown/flickering that could potentially cause.
 			this._addPropertiesToInlineCompletionItem(completions);
 
-			const x = new TerminalCompletionItem(this._inlineCompletion);
+			const x = new TerminalCompletionItem(this._inlineCompletion, this._pathSeparator);
 			this._inlineCompletionItem.idx = x.idx;
 			this._inlineCompletionItem.score = x.score;
 			this._inlineCompletionItem.labelLow = x.labelLow;


### PR DESCRIPTION
Debugging showed the completions were getting created correctly, but then were filtered out. 

This was happening because we were using the local path sep instead of the one from the extension host. The fix is to pass `pathSep` into `TerminalCompletionItem`. 

fixes https://github.com/microsoft/vscode/issues/286155

