### PR TITLE
Fix `Inefficient results collection in TextSearchResultsCollector`

### DIFF
--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -259,6 +259,7 @@ export class TextSearchResultsCollector {
 
 		if (!this._currentFileMatch) {
 			this._currentFolderIdx = folderIdx;
+			this._currentUri = data.uri;
 			this._currentFileMatch = {
 				resource: data.uri,
 				results: []

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -346,12 +346,12 @@ flakySuite('TextSearch-integration', function () {
 		};
 
 		return doSearchTest(config, 3).then(results => {
-			assert.strictEqual(results.length, 3);
+			assert.strictEqual(results.length, 1);
+			assert.strictEqual(results[0].results!.length, 3);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 24);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
-			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
-			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 26);
-			assert.strictEqual((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
+			assert.strictEqual((<ITextSearchContext>results[0].results![2]).lineNumber, 26);
+			assert.strictEqual((<ITextSearchContext>results[0].results![2]).text, '        compiler.emit();');
 		});
 	});
 


### PR DESCRIPTION
## Description
Fixes inefficient results collection in [TextSearchResultsCollector](cci:2://file:///Users/kevinramos/Desktop/Projects/open-source-projects/vscode/src/vs/workbench/services/search/common/textSearchManager.ts:239:0-286:1) where `_currentUri` was never being set, causing results from the same file to be incorrectly split into separate `ISerializedFileMatch` objects.
## Changes
1. Added missing `this._currentUri = data.uri;` assignment in `TextSearchResultsCollector.add()`
2. Updated the integration test `'Search with context matches'` to expect the correct behavior
Fixes #264127