### PR TITLE
Implement more sanity tests

### DIFF
--- a/test/sanity/src/desktop.test.ts
+++ b/test/sanity/src/desktop.test.ts
@@ -3,16 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import assert from 'assert';
-import fs from 'fs';
 import path from 'path';
 import { _electron } from 'playwright';
 import { TestContext } from './context';
+import { UITest } from './uiTest';
 
 export function setup(context: TestContext) {
 	describe('Desktop', () => {
 		if (context.platform === 'darwin-x64') {
-			it('darwin', async () => {
+			it('desktop-darwin', async () => {
 				const dir = await context.downloadAndUnpack('darwin');
 				const entryPoint = context.installMacApp(dir);
 				await testDesktopApp(entryPoint);
@@ -20,7 +19,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'darwin-arm64') {
-			it('darwin-arm64', async () => {
+			it('desktop-darwin-arm64', async () => {
 				const dir = await context.downloadAndUnpack('darwin-arm64');
 				const entryPoint = context.installMacApp(dir);
 				await testDesktopApp(entryPoint);
@@ -28,7 +27,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform.startsWith('darwin-')) {
-			it('darwin-universal', async () => {
+			it('desktop-darwin-universal', async () => {
 				const dir = await context.downloadAndUnpack('darwin-universal');
 				const entryPoint = context.installMacApp(dir);
 				await testDesktopApp(entryPoint);
@@ -36,7 +35,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm64') {
-			it('linux-arm64', async () => {
+			it('desktop-linux-arm64', async () => {
 				const dir = await context.downloadAndUnpack('linux-arm64');
 				const entryPoint = context.getEntryPoint('desktop', dir);
 				await testDesktopApp(entryPoint);
@@ -44,7 +43,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm') {
-			it('linux-armhf', async () => {
+			it('desktop-linux-armhf', async () => {
 				const dir = await context.downloadAndUnpack('linux-armhf');
 				const entryPoint = context.getEntryPoint('desktop', dir);
 				await testDesktopApp(entryPoint);
@@ -52,7 +51,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm64') {
-			it('linux-deb-arm64', async () => {
+			it('desktop-linux-deb-arm64', async () => {
 				const packagePath = await context.downloadTarget('linux-deb-arm64');
 				const entryPoint = context.installDeb(packagePath);
 				await testDesktopApp(entryPoint);
@@ -60,7 +59,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm') {
-			it('linux-deb-armhf', async () => {
+			it('desktop-linux-deb-armhf', async () => {
 				const packagePath = await context.downloadTarget('linux-deb-armhf');
 				const entryPoint = context.installDeb(packagePath);
 				await testDesktopApp(entryPoint);
@@ -68,7 +67,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('linux-deb-x64', async () => {
+			it('desktop-linux-deb-x64', async () => {
 				const packagePath = await context.downloadTarget('linux-deb-x64');
 				const entryPoint = context.installDeb(packagePath);
 				await testDesktopApp(entryPoint);
@@ -76,7 +75,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm64') {
-			it('linux-rpm-arm64', async () => {
+			it('desktop-linux-rpm-arm64', async () => {
 				const packagePath = await context.downloadTarget('linux-rpm-arm64');
 				const entryPoint = context.installRpm(packagePath);
 				await testDesktopApp(entryPoint);
@@ -84,7 +83,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-arm') {
-			it('linux-rpm-armhf', async () => {
+			it('desktop-linux-rpm-armhf', async () => {
 				const packagePath = await context.downloadTarget('linux-rpm-armhf');
 				const entryPoint = context.installRpm(packagePath);
 				await testDesktopApp(entryPoint);
@@ -92,7 +91,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('linux-rpm-x64', async () => {
+			it('desktop-linux-rpm-x64', async () => {
 				const packagePath = await context.downloadTarget('linux-rpm-x64');
 				const entryPoint = context.installRpm(packagePath);
 				await testDesktopApp(entryPoint);
@@ -100,7 +99,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('linux-snap-x64', async () => {
+			it('desktop-linux-snap-x64', async () => {
 				const packagePath = await context.downloadTarget('linux-snap-x64');
 				const entryPoint = context.installSnap(packagePath);
 				await testDesktopApp(entryPoint);
@@ -108,7 +107,7 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('linux-x64', async () => {
+			it('desktop-linux-x64', async () => {
 				const dir = await context.downloadAndUnpack('linux-x64');
 				const entryPoint = context.getEntryPoint('desktop', dir);
 				await testDesktopApp(entryPoint);
@@ -116,17 +115,18 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'win32-arm64') {
-			it('win32-arm64', async () => {
+			it('desktop-win32-arm64', async () => {
 				const packagePath = await context.downloadTarget('win32-arm64');
 				context.validateSignature(packagePath);
 				const entryPoint = context.installWindowsApp('system', packagePath);
 				context.validateAllSignatures(path.dirname(entryPoint));
 				await testDesktopApp(entryPoint);
+				await context.uninstallWindowsApp('system');
 			});
 		}
 
 		if (context.platform === 'win32-arm64') {
-			it('win32-arm64-archive', async () => {
+			it('desktop-win32-arm64-archive', async () => {
 				const dir = await context.downloadAndUnpack('win32-arm64-archive');
 				context.validateAllSignatures(dir);
 				const entryPoint = context.getEntryPoint('desktop', dir);
@@ -135,27 +135,29 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'win32-arm64') {
-			it('win32-arm64-user', async () => {
+			it('desktop-win32-arm64-user', async () => {
 				const packagePath = await context.downloadTarget('win32-arm64-user');
 				context.validateSignature(packagePath);
 				const entryPoint = context.installWindowsApp('user', packagePath);
 				context.validateAllSignatures(path.dirname(entryPoint));
 				await testDesktopApp(entryPoint);
+				await context.uninstallWindowsApp('user');
 			});
 		}
 
 		if (context.platform === 'win32-x64') {
-			it('win32-x64', async () => {
+			it('desktop-win32-x64', async () => {
 				const packagePath = await context.downloadTarget('win32-x64');
 				context.validateSignature(packagePath);
 				const entryPoint = context.installWindowsApp('system', packagePath);
 				context.validateAllSignatures(path.dirname(entryPoint));
 				await testDesktopApp(entryPoint);
+				await context.uninstallWindowsApp('system');
 			});
 		}
 
 		if (context.platform === 'win32-x64') {
-			it('win32-x64-archive', async () => {
+			it('desktop-win32-x64-archive', async () => {
 				const dir = await context.downloadAndUnpack('win32-x64-archive');
 				context.validateAllSignatures(dir);
 				const entryPoint = context.getEntryPoint('desktop', dir);
@@ -164,73 +166,34 @@ export function setup(context: TestContext) {
 		}
 
 		if (context.platform === 'win32-x64') {
-			it('win32-x64-user', async () => {
+			it('desktop-win32-x64-user', async () => {
 				const packagePath = await context.downloadTarget('win32-x64-user');
 				context.validateSignature(packagePath);
 				const entryPoint = context.installWindowsApp('user', packagePath);
 				context.validateAllSignatures(path.dirname(entryPoint));
 				await testDesktopApp(entryPoint);
+				await context.uninstallWindowsApp('user');
 			});
 		}
 
-		async function testDesktopApp(executablePath: string) {
-			const extensionsDir = context.createTempDir();
-			const dataDir = context.createTempDir();
-			const workspaceDir = context.createTempDir();
-			const args = ['--extensions-dir', extensionsDir, '--user-data-dir', dataDir, workspaceDir];
+		async function testDesktopApp(entryPoint: string) {
+			const test = new UITest(context);
+			const args = [
+				'--extensions-dir', test.extensionsDir,
+				'--user-data-dir', test.userDataDir,
+				test.workspaceDir
+			];
 
-			context.log(`Start VS Code: ${executablePath} with args: ${args.join(' ')}`);
-			const app = await _electron.launch({ executablePath, args });
+			context.log(`Starting VS Code ${entryPoint} with args ${args.join(' ')}`);
+			const app = await _electron.launch({ executablePath: entryPoint, args });
 			const window = await app.firstWindow();
 
-			context.log('Dismiss workspace trust dialog');
-			await window.getByText('Yes, I trust the authors').click();
+			await test.run(window);
 
-			context.log('Focus Explorer view');
-			await window.keyboard.press('Control+Shift+E');
-
-			context.log('Click New File button');
-			await window.getByLabel('New File...').click();
-
-			context.log('Type file name');
-			await window.locator('input').fill('helloWorld.txt');
-			await window.keyboard.press('Enter');
-
-			context.log('Focus the code editor');
-			await window.getByText(/Start typing/).focus();
-
-			context.log('Type some content into the file');
-			await window.keyboard.type('Hello, World!');
-
-			context.log('Save the file');
-			await window.keyboard.press('Control+S');
-
-			context.log('Open Extensions view');
-			await window.keyboard.press('Control+Shift+X');
-			await window.waitForSelector('.extension-list-item');
-
-			context.log('Type extension name to search for');
-			await window.keyboard.type('GitHub Pull Requests');
-			await new Promise(resolve => setTimeout(resolve, 2000));
-
-			context.log('Click Install on the first extension in the list');
-			await window.locator('.extension-action:not(.disabled)', { hasText: /Install/ }).first().click();
-
-			context.log('Wait for extension to be installed');
-			await window.locator('.extension-action:not(.disabled)', { hasText: /Uninstall/ }).waitFor();
-
-			context.log('Close the application');
+			context.log('Closing the application');
 			await app.close();
 
-			context.log('Verify file contents');
-			const filePath = `${workspaceDir}/helloWorld.txt`;
-			const fileContents = fs.readFileSync(filePath, 'utf-8');
-			assert.strictEqual(fileContents, 'Hello, World!');
-
-			context.log('Verify extension is installed');
-			const extensions = fs.readdirSync(extensionsDir);
-			const hasExtension = extensions.some(ext => ext.startsWith('github.vscode-pull-request-github'));
-			assert.strictEqual(hasExtension, true);
+			test.validate();
 		}
 	});
 }

--- a/test/sanity/src/server.test.ts
+++ b/test/sanity/src/server.test.ts
@@ -3,49 +3,65 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import assert from 'assert';
+import { spawn } from 'child_process';
 import { TestContext } from './context';
 
 export function setup(context: TestContext) {
 	describe('Server', () => {
 		if (context.platform === 'linux-arm64') {
 			it('server-alpine-arm64', async () => {
-				await context.downloadAndUnpack('server-alpine-arm64');
+				const dir = await context.downloadAndUnpack('server-alpine-arm64');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-x64') {
 			it('server-alpine-x64', async () => {
-				await context.downloadAndUnpack('server-linux-alpine');
+				const dir = await context.downloadAndUnpack('server-linux-alpine');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'darwin-arm64') {
 			it('server-darwin-arm64', async () => {
-				await context.downloadAndUnpack('server-darwin-arm64');
+				const dir = await context.downloadAndUnpack('server-darwin-arm64');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'darwin-x64') {
 			it('server-darwin-x64', async () => {
-				await context.downloadAndUnpack('server-darwin');
+				const dir = await context.downloadAndUnpack('server-darwin');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-arm64') {
 			it('server-linux-arm64', async () => {
-				await context.downloadAndUnpack('server-linux-arm64');
+				const dir = await context.downloadAndUnpack('server-linux-arm64');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-arm') {
 			it('server-linux-armhf', async () => {
-				await context.downloadAndUnpack('server-linux-armhf');
+				const dir = await context.downloadAndUnpack('server-linux-armhf');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-x64') {
 			it('server-linux-x64', async () => {
-				await context.downloadAndUnpack('server-linux-x64');
+				const dir = await context.downloadAndUnpack('server-linux-x64');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
@@ -53,6 +69,8 @@ export function setup(context: TestContext) {
 			it('server-win32-arm64', async () => {
 				const dir = await context.downloadAndUnpack('server-win32-arm64');
 				context.validateAllSignatures(dir);
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
@@ -60,6 +78,48 @@ export function setup(context: TestContext) {
 			it('server-win32-x64', async () => {
 				const dir = await context.downloadAndUnpack('server-win32-x64');
 				context.validateAllSignatures(dir);
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
+			});
+		}
+
+		async function testServer(entryPoint: string) {
+			const args = ['--accept-server-license-terms', '--connection-token', '12345'];
+
+			context.log(`Starting server ${entryPoint} with args ${args.join(' ')}`);
+			const server = spawn(entryPoint, args, { shell: true });
+
+			server.stderr.on('data', (data) => {
+				context.error(`[Server Error] ${data.toString().trim()}`);
+			});
+
+			server.stdout.on('data', (data) => {
+				const text = data.toString().trim();
+				text.split('\n').forEach((line: string) => {
+					context.log(`[Server Output] ${line}`);
+				});
+
+				const port = /Extension host agent listening on (\d+)/.exec(text)?.[1];
+				if (port) {
+					(async function () {
+						try {
+							const url = `http://localhost:${port}/version`;
+							context.log(`Fetching ${url}`);
+							const response = await fetch(url);
+							assert.equal(response.status, 200);
+							assert.equal(await response.text(), context.commit);
+						} catch (error) {
+							assert.fail(error instanceof Error ? error.message : String(error));
+						} finally {
+							context.killProcessTree(server.pid!);
+						}
+					})();
+				}
+			});
+
+			await new Promise<void>((resolve, reject) => {
+				server.on('error', reject);
+				server.on('exit', resolve);
 			});
 		}
 	});

--- a/test/sanity/src/serverWeb.test.ts
+++ b/test/sanity/src/serverWeb.test.ts
@@ -3,63 +3,147 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import assert from 'assert';
+import { spawn } from 'child_process';
+import path from 'path';
 import { TestContext } from './context';
+import { UITest } from './uiTest';
 
 export function setup(context: TestContext) {
 	describe('Server Web', () => {
 		if (context.platform === 'linux-arm64') {
-			it('server-alpine-arm64-web', async () => {
-				await context.downloadAndUnpack('server-alpine-arm64-web');
+			it('server-web-alpine-arm64', async () => {
+				const dir = await context.downloadAndUnpack('server-alpine-arm64-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('server-alpine-x64-web', async () => {
-				await context.downloadAndUnpack('server-linux-alpine-web');
+			it('server-web-alpine-x64', async () => {
+				const dir = await context.downloadAndUnpack('server-linux-alpine-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'darwin-arm64') {
-			it('server-darwin-arm64-web', async () => {
-				await context.downloadAndUnpack('server-darwin-arm64-web');
+			it('server-web-darwin-arm64', async () => {
+				const dir = await context.downloadAndUnpack('server-darwin-arm64-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'darwin-x64') {
-			it('server-darwin-x64-web', async () => {
-				await context.downloadAndUnpack('server-darwin-web');
+			it('server-web-darwin-x64', async () => {
+				const dir = await context.downloadAndUnpack('server-darwin-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-arm64') {
-			it('server-linux-arm64-web', async () => {
-				await context.downloadAndUnpack('server-linux-arm64-web');
+			it('server-web-linux-arm64', async () => {
+				const dir = await context.downloadAndUnpack('server-linux-arm64-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-arm') {
-			it('server-linux-armhf-web', async () => {
-				await context.downloadAndUnpack('server-linux-armhf-web');
+			it('server-web-linux-armhf', async () => {
+				const dir = await context.downloadAndUnpack('server-linux-armhf-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'linux-x64') {
-			it('server-linux-x64-web', async () => {
-				await context.downloadAndUnpack('server-linux-x64-web');
+			it('server-web-linux-x64', async () => {
+				const dir = await context.downloadAndUnpack('server-linux-x64-web');
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'win32-arm64') {
-			it('server-win32-arm64-web', async () => {
+			it('server-web-win32-arm64', async () => {
 				const dir = await context.downloadAndUnpack('server-win32-arm64-web');
 				context.validateAllSignatures(dir);
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
 			});
 		}
 
 		if (context.platform === 'win32-x64') {
-			it('server-win32-x64-web', async () => {
+			it('server-web-win32-x64', async () => {
 				const dir = await context.downloadAndUnpack('server-win32-x64-web');
 				context.validateAllSignatures(dir);
+				const entryPoint = context.getServerEntryPoint(dir);
+				await testServer(entryPoint);
+			});
+		}
+
+		async function testServer(entryPoint: string) {
+			const token = '12345';
+			const test = new UITest(context);
+			const args = [
+				'--accept-server-license-terms',
+				'--connection-token', token,
+				'--server-data-dir', context.createTempDir(),
+				'--extensions-dir', test.extensionsDir,
+				'--user-data-dir', test.userDataDir
+			];
+
+			context.log(`Starting server ${entryPoint} with args ${args.join(' ')}`);
+			const server = spawn(entryPoint, args, { shell: true });
+
+			server.stderr.on('data', (data) => {
+				context.error(`[Server Error] ${data.toString().trim()}`);
+			});
+
+			server.stdout.on('data', (data) => {
+				const text = data.toString().trim();
+				text.split('\n').forEach((line: string) => {
+					context.log(`[Server Output] ${line}`);
+				});
+
+				const port = /Extension host agent listening on (\d+)/.exec(text)?.[1];
+				if (port) {
+					(async function () {
+						try {
+							const browser = await context.launchBrowser();
+							const page = await browser.newPage();
+
+							const url = `http://localhost:${port}?tkn=${token}&folder=/${test.workspaceDir.replaceAll(path.sep, '/')}`;
+							context.log(`Navigating to ${url}`);
+							await page.goto(url, { waitUntil: 'networkidle' });
+
+							context.log('Waiting for the workbench to load');
+							await page.waitForSelector('.monaco-workbench');
+
+							context.log('Verifying page title contains "Visual Studio Code"');
+							assert.match(await page.title(), /Visual Studio Code/);
+
+							await test.run(page);
+
+							context.log('Closing browser');
+							await browser.close();
+
+							test.validate();
+						} catch (error) {
+							assert.fail(error instanceof Error ? error.message : String(error));
+						} finally {
+							context.killProcessTree(server.pid!);
+						}
+					})();
+				}
+			});
+
+			await new Promise<void>((resolve, reject) => {
+				server.on('error', reject);
+				server.on('exit', resolve);
 			});
 		}
 	});

--- a/test/sanity/src/uiTest.ts
+++ b/test/sanity/src/uiTest.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import fs from 'fs';
+import { Page } from 'playwright';
+import { TestContext } from './context';
+
+/**
+ * UI Test helper class to perform common UI actions and verifications.
+ */
+export class UITest {
+	private _extensionsDir: string | undefined;
+	private _workspaceDir: string | undefined;
+	private _userDataDir: string | undefined;
+
+	constructor(private readonly context: TestContext) {
+	}
+
+	/**
+	 * The directory where extensions are installed.
+	 */
+	public get extensionsDir(): string {
+		return this._extensionsDir ??= this.context.createTempDir();
+	}
+
+	/**
+	 * The workspace directory used for testing.
+	 */
+	public get workspaceDir(): string {
+		return this._workspaceDir ??= this.context.createTempDir();
+	}
+
+	/**
+	 * The user data directory used for testing.
+	 */
+	public get userDataDir(): string {
+		return this._userDataDir ??= this.context.createTempDir();
+	}
+
+	/**
+	 * Run the UI test actions.
+	 */
+	public async run(page: Page) {
+		await this.dismissWorkspaceTrustDialog(page);
+		await this.createTextFile(page);
+		await this.installExtension(page);
+	}
+
+	/**
+	 * Validate the results of the UI test actions.
+	 */
+	public async validate() {
+		this.verifyTextFileCreated();
+		this.verifyExtensionInstalled();
+	}
+
+	/**
+	 * Dismiss the workspace trust dialog.
+	 */
+	private async dismissWorkspaceTrustDialog(page: Page) {
+		this.context.log('Dismissing workspace trust dialog');
+		await page.getByText('Yes, I trust the authors').click();
+		await page.waitForTimeout(500);
+	}
+
+	/**
+	 * Create a new text file in the editor with some content and save it.
+	 */
+	private async createTextFile(page: Page) {
+		this.context.log('Focusing Explorer view');
+		await page.keyboard.press('Control+Shift+E');
+
+		this.context.log('Clicking New File button');
+		await page.getByLabel('New File...').click();
+
+		this.context.log('Typing file name');
+		await page.locator('input').fill('helloWorld.txt');
+		await page.keyboard.press('Enter');
+
+		this.context.log('Focusing the code editor');
+		await page.getByText(/Start typing/).focus();
+
+		this.context.log('Typing some content into the file');
+		await page.keyboard.type('Hello, World!');
+
+		this.context.log('Saving the file');
+		await page.keyboard.press('Control+S');
+		await page.waitForTimeout(1000);
+	}
+
+	/**
+	 * Verify that the text file was created with the expected content.
+	 */
+	private verifyTextFileCreated() {
+		this.context.log('Verifying file contents');
+		const filePath = `${this.workspaceDir}/helloWorld.txt`;
+		const fileContents = fs.readFileSync(filePath, 'utf-8');
+		assert.strictEqual(fileContents, 'Hello, World!');
+	}
+
+	/**
+	 * Install GitHub Pull Requests extension from the Extensions view.
+	 */
+	private async installExtension(page: Page) {
+		this.context.log('Opening Extensions view');
+		await page.keyboard.press('Control+Shift+X');
+		await page.waitForSelector('.extension-list-item');
+
+		this.context.log('Typing extension name to search for');
+		await page.keyboard.type('GitHub Pull Requests');
+		await page.waitForTimeout(2000);
+
+		this.context.log('Clicking Install on the first extension in the list');
+		await page.locator('.extension-action:not(.disabled)', { hasText: /Install/ }).first().click();
+
+		this.context.log('Waiting for extension to be installed');
+		await page.locator('.extension-action:not(.disabled)', { hasText: /Uninstall/ }).waitFor();
+	}
+
+	/**
+	 * Verify that the GitHub Pull Requests extension is installed.
+	 */
+	private verifyExtensionInstalled() {
+		this.context.log('Verifying extension is installed');
+		const extensions = fs.readdirSync(this.extensionsDir);
+		const hasExtension = extensions.some(ext => ext.startsWith('github.vscode-pull-request-github'));
+		assert.strictEqual(hasExtension, true);
+	}
+}


### PR DESCRIPTION
Refactored UI test into a separate class so it can be reused between desktop and web server tests.
Added uninstall step for Windows.
Added server tests (validate /version endpoint).
Added web server tests (run UI test in the browser).
Updated desktop tests to use the new UITest class.
Updated CLI tests to not depend on user being authenticated.

With these changes all win32-x64 tests pass on a clean Win11 machine.

Contributes towards #279402.
