### PR TITLE
Avoid unnecessary layouts while typing in chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1207,10 +1207,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 		this.input.renderChatEditingSessionState(this._editingSession.get() ?? null);
-
-		if (this.bodyDimension) {
-			this.layout(this.bodyDimension.height, this.bodyDimension.width);
-		}
 	}
 
 	private async renderFollowups(): Promise<void> {
@@ -2041,10 +2037,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				this.scrollToEnd();
 			}
 		})));
-		this.viewModelDisposables.add(autorun(reader => {
-			this._editingSession.read(reader); // re-render when the session changes
-			this.renderChatEditingSessionState();
-		}));
 		this.viewModelDisposables.add(this.viewModel.onDidDisposeModel(() => {
 			// Ensure that view state is saved here, because we will load it again when a new model is assigned
 			if (this.viewModel?.editing) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -493,13 +493,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				this._editingSession.set(undefined, undefined);
 				this.renderChatEditingSessionState();
 			}));
-			r.store.add(this.onDidChangeParsedInput(() => {
-				this.renderChatEditingSessionState();
-			}));
 			r.store.add(this.inputEditor.onDidChangeModelContent(() => {
 				if (this.getInput() === '') {
 					this.refreshParsedInput();
-					this.renderChatEditingSessionState();
 				}
 			}));
 			this.renderChatEditingSessionState();


### PR DESCRIPTION
Fixes #286531

Rendering the chat edit session state when input changes was added for rendering file variables in the working set, in https://github.com/microsoft/vscode/commit/92df7b670ebd0799b69de298359a57287b386885, which we don't do anymore anyway.

The second commit is a bit more aggressive but I'm pretty sure that it's safe.

just fyi @justschen 