### PR TITLE
Bhrg/paste empty selection includes newline

### DIFF
--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -60,7 +60,7 @@ function getDataToCopy(viewModel: IViewModel, modelSelections: Range[], emptySel
 	const rawTextToCopy = viewModel.getPlainTextToCopy(modelSelections, emptySelectionClipboard, isWindows);
 	const newLineCharacter = viewModel.model.getEOL();
 
-	const isFromEmptySelection = (emptySelectionClipboard && modelSelections.length === 1 && modelSelections[0].isEmpty());
+	const isFromEmptySelection = modelSelections.map(selection => selection.isEmpty()); // (emptySelectionClipboard && modelSelections.length === 1 && modelSelections[0].isEmpty());
 	const multicursorText = (Array.isArray(rawTextToCopy) ? rawTextToCopy : null);
 	const text = (Array.isArray(rawTextToCopy) ? rawTextToCopy.join(newLineCharacter) : rawTextToCopy);
 
@@ -112,7 +112,7 @@ export class InMemoryClipboardMetadataManager {
 }
 
 export interface ClipboardDataToCopy {
-	isFromEmptySelection: boolean;
+	isFromEmptySelection: boolean[];
 	multicursorText: string[] | null | undefined;
 	text: string;
 	html: string | null | undefined;
@@ -122,7 +122,7 @@ export interface ClipboardDataToCopy {
 export interface ClipboardStoredMetadata {
 	version: 1;
 	id: string | undefined;
-	isFromEmptySelection: boolean | undefined;
+	isFromEmptySelection: boolean[] | undefined;
 	multicursorText: string[] | null | undefined;
 	mode: string | null;
 }

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -151,13 +151,13 @@ export class NativeEditContext extends AbstractEditContext {
 				return;
 			}
 			metadata = metadata || InMemoryClipboardMetadataManager.INSTANCE.get(text);
-			let pasteOnNewLine = false;
+			let pasteOnNewLine: boolean[] | null = null;
 			let multicursorText: string[] | null = null;
 			let mode: string | null = null;
 			if (metadata) {
 				const options = this._context.configuration.options;
 				const emptySelectionClipboard = options.get(EditorOption.emptySelectionClipboard);
-				pasteOnNewLine = emptySelectionClipboard && !!metadata.isFromEmptySelection;
+				pasteOnNewLine = emptySelectionClipboard ? metadata.isFromEmptySelection ?? null : null;
 				multicursorText = typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null;
 				mode = metadata.mode;
 			}

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -286,11 +286,11 @@ export class TextAreaEditContext extends AbstractEditContext {
 		}));
 
 		this._register(this._textAreaInput.onPaste((e: IPasteData) => {
-			let pasteOnNewLine = false;
+			let pasteOnNewLine: boolean[] | null = null;
 			let multicursorText: string[] | null = null;
 			let mode: string | null = null;
 			if (e.metadata) {
-				pasteOnNewLine = (this._emptySelectionClipboard && !!e.metadata.isFromEmptySelection);
+				pasteOnNewLine = this._emptySelectionClipboard ? e.metadata.isFromEmptySelection ?? null : null;
 				multicursorText = (typeof e.metadata.multicursorText !== 'undefined' ? e.metadata.multicursorText : null);
 				mode = e.metadata.mode;
 			}

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -553,7 +553,7 @@ export interface IPasteEvent {
  */
 export interface PastePayload {
 	text: string;
-	pasteOnNewLine: boolean;
+	pasteOnNewLine: boolean[] | null;
 	multicursorText: string[] | null;
 	mode: string | null;
 	clipboardEvent?: ClipboardEvent;

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -37,7 +37,7 @@ export interface IMouseDispatchData {
 }
 
 export interface ICommandDelegate {
-	paste(text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null): void;
+	paste(text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[] | null, mode: string | null): void;
 	type(text: string): void;
 	compositionType(text: string, replacePrevCharCnt: number, replaceNextCharCnt: number, positionDelta: number): void;
 	startComposition(): void;
@@ -64,7 +64,7 @@ export class ViewController {
 		this.commandDelegate = commandDelegate;
 	}
 
-	public paste(text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null): void {
+	public paste(text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[] | null, mode: string | null): void {
 		this.commandDelegate.paste(text, pasteOnNewLine, multicursorText, mode);
 	}
 

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1116,7 +1116,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				}
 				case editorCommon.Handler.Paste: {
 					const args = <Partial<editorBrowser.PastePayload>>payload;
-					this._paste(source, args.text || '', args.pasteOnNewLine || false, args.multicursorText || null, args.mode || null, args.clipboardEvent);
+					this._paste(source, args.text || '', args.pasteOnNewLine ?? null, args.multicursorText || null, args.mode || null, args.clipboardEvent);
 					return;
 				}
 				case editorCommon.Handler.Cut:
@@ -1186,7 +1186,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._modelData.viewModel.compositionType(text, replacePrevCharCnt, replaceNextCharCnt, positionDelta, source);
 	}
 
-	private _paste(source: string | null | undefined, text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null, clipboardEvent?: ClipboardEvent): void {
+	private _paste(source: string | null | undefined, text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[] | null, mode: string | null, clipboardEvent?: ClipboardEvent): void {
 		if (!this._modelData) {
 			return;
 		}
@@ -1885,7 +1885,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		let commandDelegate: ICommandDelegate;
 		if (this.isSimpleWidget) {
 			commandDelegate = {
-				paste: (text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null) => {
+				paste: (text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[] | null, mode: string | null) => {
 					this._paste('keyboard', text, pasteOnNewLine, multicursorText, mode);
 				},
 				type: (text: string) => {
@@ -1906,7 +1906,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 			};
 		} else {
 			commandDelegate = {
-				paste: (text: string, pasteOnNewLine: boolean, multicursorText: string[] | null, mode: string | null) => {
+				paste: (text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[] | null, mode: string | null) => {
 					const payload: editorBrowser.PastePayload = { text, pasteOnNewLine, multicursorText, mode };
 					this._commandService.executeCommand(editorCommon.Handler.Paste, payload);
 				},

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -850,6 +850,11 @@ export interface IEditorOptions {
 	 * Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.
 	 */
 	inlineCompletionsAccessibilityVerbose?: boolean;
+	/**
+	 * Configure the behaviour when copy-pasting empty selection.
+	 * Defaults to 'always'.
+	 */
+	pasteEmptySelectionIncludesNewline?: 'always' | 'never' | 'singleOnly' | 'multipleOnly';
 }
 
 /**
@@ -5896,7 +5901,8 @@ export const enum EditorOption {
 	inlineCompletionsAccessibilityVerbose,
 	effectiveEditContext,
 	scrollOnMiddleClick,
-	effectiveAllowVariableFonts
+	effectiveAllowVariableFonts,
+	pasteEmptySelectionIncludesNewline,
 }
 
 export const EditorOptions = {
@@ -6804,7 +6810,21 @@ export const EditorOptions = {
 	wrappingIndent: register(new WrappingIndentOption()),
 	wrappingStrategy: register(new WrappingStrategy()),
 	effectiveEditContextEnabled: register(new EffectiveEditContextEnabled()),
-	effectiveAllowVariableFonts: register(new EffectiveAllowVariableFonts())
+	effectiveAllowVariableFonts: register(new EffectiveAllowVariableFonts()),
+	pasteEmptySelectionIncludesNewline: register(new EditorStringEnumOption(
+		EditorOption.pasteEmptySelectionIncludesNewline, 'pasteEmptySelectionIncludesNewline',
+		'always' as 'always' | 'never' | 'singleOnly' | 'multipleOnly',
+		['always', 'never', 'singleOnly', 'multipleOnly'] as const,
+		{
+			markdownEnumDescriptions: [
+				nls.localize('pasteEmptySelectionIncludesNewline.always', "Both single & multiple cursors paste with '\n' when copying empty selection"),
+				nls.localize('pasteEmptySelectionIncludesNewline.never', "Both single & multiple cursors trim '\n' from the end when copying empty selection"),
+				nls.localize('pasteEmptySelectionIncludesNewline.singleOnly', "Multiple cursors trim '\n' from the end when copying empty selection"),
+				nls.localize('pasteEmptySelectionIncludesNewline.multipleOnly', "Single cursor trims '\n' from the end when copying empty selection"),
+			],
+			markdownDescription: nls.localize('pasteEmptySelectionIncludesNewline', "Include '\n' character when copying empty selection")
+		}
+	)),
 };
 
 type EditorOptionsType = typeof EditorOptions;

--- a/src/vs/editor/common/cursor/cursor.ts
+++ b/src/vs/editor/common/cursor/cursor.ts
@@ -598,7 +598,7 @@ export class CursorsController extends Disposable {
 		}, eventsCollector, source);
 	}
 
-	public paste(eventsCollector: ViewModelEventsCollector, text: string, pasteOnNewLine: boolean, multicursorText?: string[] | null | undefined, source?: string | null | undefined): void {
+	public paste(eventsCollector: ViewModelEventsCollector, text: string, pasteOnNewLine: boolean[] | null, multicursorText?: string[] | null | undefined, source?: string | null | undefined): void {
 		const reason = EditSources.cursor({ kind: 'paste', detailedSource: source });
 
 		this._executeEdit(() => {

--- a/src/vs/editor/common/cursor/cursorTypeOperations.ts
+++ b/src/vs/editor/common/cursor/cursorTypeOperations.ts
@@ -57,7 +57,7 @@ export class TypeOperations {
 		return unshiftIndent(config, indentation, count);
 	}
 
-	public static paste(config: CursorConfiguration, model: ICursorSimpleModel, selections: Selection[], text: string, pasteOnNewLine: boolean, multicursorText: string[]): EditOperationResult {
+	public static paste(config: CursorConfiguration, model: ICursorSimpleModel, selections: Selection[], text: string, pasteOnNewLine: boolean[] | null, multicursorText: string[]): EditOperationResult {
 		return PasteOperation.getEdits(config, model, selections, text, pasteOnNewLine, multicursorText);
 	}
 

--- a/src/vs/editor/common/cursorCommon.ts
+++ b/src/vs/editor/common/cursorCommon.ts
@@ -80,6 +80,7 @@ export class CursorConfiguration {
 	public readonly shouldAutoCloseBefore: { quote: (ch: string) => boolean; bracket: (ch: string) => boolean; comment: (ch: string) => boolean };
 	public readonly wordSegmenterLocales: string[];
 	public readonly overtypeOnPaste: boolean;
+	public readonly pasteEmptySelectionIncludesNewline: 'always' | 'never' | 'singleOnly' | 'multipleOnly';
 
 	private readonly _languageId: string;
 	private _electricChars: { [key: string]: boolean } | null;
@@ -104,6 +105,7 @@ export class CursorConfiguration {
 			|| e.hasChanged(EditorOption.readOnly)
 			|| e.hasChanged(EditorOption.wordSegmenterLocales)
 			|| e.hasChanged(EditorOption.overtypeOnPaste)
+			|| e.hasChanged(EditorOption.pasteEmptySelectionIncludesNewline)
 		);
 	}
 
@@ -144,6 +146,7 @@ export class CursorConfiguration {
 		this.autoIndent = options.get(EditorOption.autoIndent);
 		this.wordSegmenterLocales = options.get(EditorOption.wordSegmenterLocales);
 		this.overtypeOnPaste = options.get(EditorOption.overtypeOnPaste);
+		this.pasteEmptySelectionIncludesNewline = options.get(EditorOption.pasteEmptySelectionIncludesNewline);
 
 		this.surroundingPairs = {};
 		this._electricChars = null;

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -346,7 +346,8 @@ export enum EditorOption {
 	inlineCompletionsAccessibilityVerbose = 169,
 	effectiveEditContext = 170,
 	scrollOnMiddleClick = 171,
-	effectiveAllowVariableFonts = 172
+	effectiveAllowVariableFonts = 172,
+	pasteEmptySelectionIncludesNewline = 173,
 }
 
 /**

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -1184,7 +1184,7 @@ export class ViewModel extends Disposable implements IViewModel {
 	public compositionType(text: string, replacePrevCharCnt: number, replaceNextCharCnt: number, positionDelta: number, source?: string | null | undefined): void {
 		this._executeCursorEdit(eventsCollector => this._cursor.compositionType(eventsCollector, text, replacePrevCharCnt, replaceNextCharCnt, positionDelta, source));
 	}
-	public paste(text: string, pasteOnNewLine: boolean, multicursorText?: string[] | null | undefined, source?: string | null | undefined): void {
+	public paste(text: string, pasteOnNewLine: boolean[] | null, multicursorText?: string[] | null | undefined, source?: string | null | undefined): void {
 		this._executeCursorEdit(eventsCollector => this._cursor.paste(eventsCollector, text, pasteOnNewLine, multicursorText, source));
 	}
 	public cut(source?: string | null | undefined): void {

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -312,11 +312,11 @@ if (PasteAction) {
 					const clipboardText = await clipboardService.readText();
 					if (clipboardText !== '') {
 						const metadata = InMemoryClipboardMetadataManager.INSTANCE.get(clipboardText);
-						let pasteOnNewLine = false;
+						let pasteOnNewLine: boolean[] | null = null;
 						let multicursorText: string[] | null = null;
 						let mode: string | null = null;
 						if (metadata) {
-							pasteOnNewLine = (focusedEditor.getOption(EditorOption.emptySelectionClipboard) && !!metadata.isFromEmptySelection);
+							pasteOnNewLine = focusedEditor.getOption(EditorOption.emptySelectionClipboard) ? metadata.isFromEmptySelection ?? null : null;
 							multicursorText = (typeof metadata.multicursorText !== 'undefined' ? metadata.multicursorText : null);
 							mode = metadata.mode;
 						}

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -459,7 +459,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 			];
 			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(pasteText, true, undefined, 'keyboard');
+			viewModel.paste(pasteText, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 16));
 			assert.strictEqual(model.getValue(), pasteText);
 		});
@@ -488,7 +488,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 			].join('\n');
 
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(pasteText, true, undefined, 'keyboard');
+			viewModel.paste(pasteText, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 11, 2));
 			assert.strictEqual(model.getValue(), pasteText);
 		});
@@ -507,7 +507,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel, instantiationService) => {
 			editor.setSelection(new Selection(2, 6, 2, 6));
 			const text = ', null';
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			autoIndentOnPasteController.trigger(new Range(2, 6, 2, 11));
 			assert.strictEqual(model.getValue(), [
@@ -534,7 +534,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 		withTestCodeEditor(model, { autoIndent: 'full', serviceCollection }, (editor, viewModel, instantiationService) => {
 			editor.setSelection(new Selection(5, 24, 5, 34));
 			const text = 'IMacLinuxKeyMapping';
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			autoIndentOnPasteController.trigger(new Range(5, 24, 5, 43));
 			assert.strictEqual(model.getValue(), [
@@ -562,7 +562,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				' *  Licensed under ...',
 				' *-----------------*/',
 			].join('\n');
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 22));
 			assert.strictEqual(model.getValue(), text);
@@ -598,7 +598,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 
 			editor.setSelection(new Selection(2, 10, 2, 15));
-			viewModel.paste('which', true, undefined, 'keyboard');
+			viewModel.paste('which', [true], undefined, 'keyboard');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			autoIndentOnPasteController.trigger(new Range(2, 1, 2, 28));
 			assert.strictEqual(model.getValue(), initialText);
@@ -648,7 +648,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 			];
 			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 4));
 			assert.strictEqual(model.getValue(), text);
 		});
@@ -674,7 +674,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				''
 			].join('\n');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(2, 1, 5, 1));
 
 			// notes:
@@ -715,7 +715,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				' '
 			].join('\n');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			// todo@aiday-mar, make sure range is correct, and make test work as in real life
 			autoIndentOnPasteController.trigger(new Range(2, 5, 5, 6));
 			assert.strictEqual(model.getValue(), [
@@ -745,7 +745,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'}',
 			].join('\n');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			// todo@aiday-mar, make sure range is correct, and make test work as in real life
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 2));
 			assert.strictEqual(model.getValue(), [
@@ -807,7 +807,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'const foo = 42',
 			].join('\n');
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(2, 1, 3, 15));
 			assert.strictEqual(model.getValue(), [
 				'function bar() {',
@@ -1547,7 +1547,7 @@ suite('Auto Indent On Paste - Go', () => {
 			editor.setSelection(new Selection(3, 1, 3, 1));
 			const text = '  ';
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
-			viewModel.paste(text, true, undefined, 'keyboard');
+			viewModel.paste(text, [true], undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(3, 1, 3, 3));
 			assert.strictEqual(model.getValue(), [
 				'var s = `',

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -2061,7 +2061,7 @@ suite('Editor Controller', () => {
 			moveTo(editor, viewModel, 2, 1, false);
 			moveTo(editor, viewModel, 2, 6, true);
 
-			viewModel.paste('line1\n', true);
+			viewModel.paste('line1\n', [true]);
 
 			assert.strictEqual(model.getLineContent(1), 'line1');
 			assert.strictEqual(model.getLineContent(2), 'line1');
@@ -2079,7 +2079,7 @@ suite('Editor Controller', () => {
 		}, (editor, model, viewModel) => {
 			viewModel.setSelections('test', [new Selection(2, 6, 2, 9)]);
 
-			viewModel.paste('line1\n', true);
+			viewModel.paste('line1\n', [true]);
 
 			assert.strictEqual(model.getLineContent(1), 'line1');
 			assert.strictEqual(model.getLineContent(2), 'line line1');
@@ -2100,7 +2100,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'a\nb\nc\nd',
-				false,
+				[false, false],
 				[
 					'a\nb',
 					'c\nd'
@@ -2135,7 +2135,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'aaa\nbbb\nccc\n',
-				false,
+				null,
 				null
 			);
 
@@ -2178,7 +2178,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'aaa\r\nbbb\r\nccc\r\nddd\r\n',
-				false,
+				null,
 				null
 			);
 
@@ -2203,7 +2203,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'a\nb\nc',
-				false,
+				null,
 				null
 			);
 
@@ -2227,7 +2227,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'a\nb\nc\n',
-				false,
+				null,
 				null
 			);
 
@@ -2255,7 +2255,7 @@ suite('Editor Controller', () => {
 
 			viewModel.paste(
 				'line1\nline2\n',
-				true,
+				[true, true],
 				['line1\n', 'line2\n']
 			);
 
@@ -2264,6 +2264,37 @@ suite('Editor Controller', () => {
 				'line1',
 				'line1',
 				'line2',
+				'line2',
+				'line3'
+			].join('\n'));
+		});
+	});
+
+	test('issue #286892: paste from multiple cursors with empty selections and multiCursorPaste full in the middle of the line', () => {
+		usingCursor({
+			text: [
+				'line1',
+				'line2',
+				'line3'
+			],
+			editorOpts: {
+				multiCursorPaste: 'full'
+			}
+		}, (editor, model, viewModel) => {
+			// 2 cursors in the middle of lines 1 and 2
+			viewModel.setSelections('test', [new Selection(1, 3, 1, 3), new Selection(2, 3, 2, 3)]);
+
+			viewModel.paste(
+				'added1\nadded2\n',
+				[true, true],
+				['added1\n', 'added2\n']
+			);
+
+			// Each cursor gets its respective line
+			assert.strictEqual(model.getValue(), [
+				'added1',
+				'line1',
+				'added2',
 				'line2',
 				'line3'
 			].join('\n'));
@@ -2962,7 +2993,7 @@ suite('Editor Controller', () => {
 			editor.setSelections([
 				new Selection(2, 1, 2, 1)
 			]);
-			viewModel.paste('something\n', true);
+			viewModel.paste('something\n', [true]);
 			assert.strictEqual(model.getValue(), [
 				'abc123',
 				'something',
@@ -3570,7 +3601,7 @@ suite('Editor Controller', () => {
 			].join('\n'));
 			assertCursor(viewModel, new Position(4, model.getLineMaxColumn(4)));
 
-			viewModel.paste('        // I\'m gonna copy this line\n', true);
+			viewModel.paste('        // I\'m gonna copy this line\n', [true]);
 			assert.strictEqual(model.getValue(), [
 				'    function f() {',
 				'        // I\'m gonna copy this line',
@@ -3597,7 +3628,7 @@ suite('Editor Controller', () => {
 		withTestCodeEditor(model, {}, (editor, viewModel) => {
 
 			editor.setSelections([new Selection(4, 10, 4, 10)]);
-			viewModel.paste('        // I\'m gonna copy this line\n', true);
+			viewModel.paste('        // I\'m gonna copy this line\n', [true]);
 
 			assert.strictEqual(model.getValue(), [
 				'    function f() {',
@@ -6631,14 +6662,14 @@ suite('Overtype Mode', () => {
 
 		withTestCodeEditor(model, {}, (editor, viewModel) => {
 			viewModel.setSelections('test', [new Selection(1, 5, 1, 5)]);
-			viewModel.paste('cc', false);
+			viewModel.paste('cc', [false]);
 			assert.strictEqual(model.getValue(EndOfLinePreference.LF), [
 				'1234cc789',
 				'123456789',
 			].join('\n'), 'assert1');
 
 			viewModel.setSelections('test', [new Selection(1, 5, 1, 5)]);
-			viewModel.paste('dddddddd', false);
+			viewModel.paste('dddddddd', [false]);
 			assert.strictEqual(model.getValue(EndOfLinePreference.LF), [
 				'1234dddddddd',
 				'123456789',
@@ -6662,7 +6693,7 @@ suite('Overtype Mode', () => {
 
 		withTestCodeEditor(model, {}, (editor, viewModel) => {
 			viewModel.setSelections('test', [new Selection(1, 5, 2, 3)]);
-			viewModel.paste('cc', false);
+			viewModel.paste('cc', [false]);
 			assert.strictEqual(model.getValue(EndOfLinePreference.LF), [
 				'1234cc456789',
 			].join('\n'), 'assert1');
@@ -6688,7 +6719,7 @@ suite('Overtype Mode', () => {
 			viewModel.paste([
 				'aaaaaaa',
 				'bbbbbbb'
-			].join('\n'), false);
+			].join('\n'), [false]);
 			assert.strictEqual(model.getValue(EndOfLinePreference.LF), [
 				'1234aaaaaaa',
 				'bbbbbbb',

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3989,6 +3989,11 @@ declare namespace monaco.editor {
 		 * Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.
 		 */
 		inlineCompletionsAccessibilityVerbose?: boolean;
+		/**
+		 * Configure the behaviour when copy-pasting empty selection.
+		 * Defaults to 'always'.
+		 */
+		pasteEmptySelectionIncludesNewline?: 'always' | 'never' | 'singleOnly' | 'multipleOnly';
 	}
 
 	export interface IDiffEditorBaseOptions {
@@ -5236,7 +5241,8 @@ declare namespace monaco.editor {
 		inlineCompletionsAccessibilityVerbose = 169,
 		effectiveEditContext = 170,
 		scrollOnMiddleClick = 171,
-		effectiveAllowVariableFonts = 172
+		effectiveAllowVariableFonts = 172,
+		pasteEmptySelectionIncludesNewline = 173
 	}
 
 	export const EditorOptions: {
@@ -5413,6 +5419,7 @@ declare namespace monaco.editor {
 		wrappingStrategy: IEditorOption<EditorOption.wrappingStrategy, 'simple' | 'advanced'>;
 		effectiveEditContextEnabled: IEditorOption<EditorOption.effectiveEditContext, boolean>;
 		effectiveAllowVariableFonts: IEditorOption<EditorOption.effectiveAllowVariableFonts, boolean>;
+		pasteEmptySelectionIncludesNewline: IEditorOption<EditorOption.pasteEmptySelectionIncludesNewline, 'always' | 'never' | 'singleOnly' | 'multipleOnly'>;
 	};
 
 	type EditorOptionsType = typeof EditorOptions;

--- a/src/vs/workbench/contrib/codeEditor/electron-browser/selectionClipboard.ts
+++ b/src/vs/workbench/contrib/codeEditor/electron-browser/selectionClipboard.ts
@@ -133,7 +133,7 @@ class PasteSelectionClipboardAction extends EditorAction {
 
 		editor.trigger('keyboard', Handler.Paste, {
 			text: text,
-			pasteOnNewLine: false,
+			pasteOnNewLine: null,
 			multicursorText: null
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -387,7 +387,7 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 			}
 			case Handler.Paste: {
 				const args = <Partial<PastePayload>>e.payload;
-				controller.paste(eventsCollector, args.text || '', args.pasteOnNewLine || false, args.multicursorText || null, e.source);
+				controller.paste(eventsCollector, args.text || '', args.pasteOnNewLine ?? null, args.multicursorText || null, e.source);
 				break;
 			}
 			case Handler.Cut:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Inspired by https://github.com/microsoft/vscode/issues/256039#issuecomment-3730542071
Depends on: https://github.com/microsoft/vscode/pull/286895

## Description
Add new setting: `editor.pasteEmptySelectionIncludesNewline`  
Values:
- `always` (default): Both single & multiple cursors paste with '\n' when copying empty selection
- `never`: Both single & multiple cursors trim '\n' from the end when copying empty selection
- `singleOnly`: Multiple cursors trim '\n' from the end when copying empty selection
- `multipleOnly`: Single cursor trims '\n' from the end when copying empty selection

## More detailed description:  
In each case I show before and after copy-pasting with single and multiple cursors. `|` denotes cursor(s).  
### `always`
```
aa=|=
```
-> 
```
aa==
aa=|=
```
---
```
aa=|=
bb=|=
```
->
```
aa==
aa=|=
bb==
bb=|=
```
### `never`
```
aa=|=
```
-> 
```
aa=aa==|=
```
---
```
aa=|=
bb=|=
```
->
```
aa=aa==|=
bb=bb==|=
```
### `singleOnly`
```
aa=|=
```
-> 
```
aa==
aa=|=
```
---
```
aa=|=
bb=|=
```
->
```
aa=aa==|=
bb=bb==|=
```

### `multipleOnly`
```
aa=|=
```
-> 
```
aa=aa==|=
```
---
```
aa=|=
bb=|=
```
->
```
aa==
aa=|=
bb==
bb=|=
```
