### PR TITLE
Support XDG_CONFIG_HOME for argv.json file on Linux

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -442,6 +442,15 @@ function getArgvConfigPath(): string {
 		dataFolderName = `${dataFolderName}-dev`;
 	}
 
+	// On Linux, respect XDG_CONFIG_HOME as per XDG Base Directory Specification
+	if (process.platform === 'linux') {
+		const xdgConfigHome = process.env['XDG_CONFIG_HOME'];
+		if (xdgConfigHome) {
+			return path.join(xdgConfigHome, dataFolderName!, 'argv.json');
+		}
+		return path.join(os.homedir(), '.config', dataFolderName!, 'argv.json');
+	}
+
 	return path.join(os.homedir(), dataFolderName!, 'argv.json');
 }
 

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -8,6 +8,7 @@ import { memoize } from '../../../base/common/decorators.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
 import { dirname, join, normalize, resolve } from '../../../base/common/path.js';
 import { env } from '../../../base/common/process.js';
+import { isLinux } from '../../../base/common/platform.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { NativeParsedArgs } from './argv.js';
@@ -96,6 +97,15 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 		const vscodePortable = env['VSCODE_PORTABLE'];
 		if (vscodePortable) {
 			return URI.file(join(vscodePortable, 'argv.json'));
+		}
+
+		// On Linux, respect XDG_CONFIG_HOME as per XDG Base Directory Specification
+		if (isLinux) {
+			const xdgConfigHome = env['XDG_CONFIG_HOME'];
+			if (xdgConfigHome) {
+				return URI.file(join(xdgConfigHome, this.productService.dataFolderName, 'argv.json'));
+			}
+			return joinPath(this.userHome, '.config', this.productService.dataFolderName, 'argv.json');
 		}
 
 		return joinPath(this.userHome, this.productService.dataFolderName, 'argv.json');


### PR DESCRIPTION
## Summary

This PR adds XDG Base Directory Specification support for the `argv.json` configuration file on Linux.

- Respects `XDG_CONFIG_HOME` environment variable when determining the path for `argv.json`
- Falls back to `~/.config` if `XDG_CONFIG_HOME` is not set
- Changes apply to both early startup (`src/main.ts`) and the environment service (`src/vs/platform/environment/common/environmentService.ts`)

Previously, VS Code stored `argv.json` in `~/.vscode/argv.json` on Linux. With this change:
- If `XDG_CONFIG_HOME` is set: `$XDG_CONFIG_HOME/Code/argv.json`
- If `XDG_CONFIG_HOME` is not set: `~/.config/Code/argv.json`

This aligns with how VS Code already handles `userDataPath` (which respects `XDG_CONFIG_HOME`) and follows the XDG Base Directory Specification.

Fixes #162712

## Test plan

- [ ] On Linux with `XDG_CONFIG_HOME` set, verify `argv.json` is created/read from `$XDG_CONFIG_HOME/Code/argv.json`
- [ ] On Linux without `XDG_CONFIG_HOME` set, verify `argv.json` is created/read from `~/.config/Code/argv.json`
- [ ] On Windows and macOS, verify behavior is unchanged
- [ ] Verify portable mode (`VSCODE_PORTABLE`) still takes precedence