### PR TITLE
Editor GPU: Implement horizontal scroll bar sizing

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
@@ -671,6 +671,10 @@ export class ViewLines extends ViewPart implements IViewLines {
 	// --- width
 
 	private _ensureMaxLineWidth(lineWidth: number): void {
+		// When GPU rendering is enabled, ViewLinesGpu handles max line width tracking
+		if (this._viewLineOptions.useGpu) {
+			return;
+		}
 		const iLineWidth = Math.ceil(lineWidth);
 		if (this._maxLineWidth < iLineWidth) {
 			this._maxLineWidth = iLineWidth;


### PR DESCRIPTION
The issue here is that the scroll bar size was driven entirely by the DOM renderer before, so if there was a GPU line longer than a DOM line it would not allow scrolling to it. This change inverts that such that the sizing is done entirely by the GPU renderer but it also sizes the DOM rendered lines.

Fixes #233790

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
