### PR TITLE
fix: memory leak in notebook editor widget

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -29,7 +29,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Color, RGBA } from '../../../../base/common/color.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { combinedDisposable, Disposable, DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
+import { combinedDisposable, Disposable, DisposableStore, dispose, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { setTimeout0 } from '../../../../base/common/platform.js';
 import { extname, isEqual } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -1516,16 +1516,17 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}));
 
 		let hasPendingChangeContentHeight = false;
+		const renderScrollHeightDisposable = this._localStore.add(new MutableDisposable());
 		this._localStore.add(this._list.onDidChangeContentHeight(() => {
 			if (hasPendingChangeContentHeight) {
 				return;
 			}
 			hasPendingChangeContentHeight = true;
 
-			this._localStore.add(DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
+			renderScrollHeightDisposable.value = DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
 				hasPendingChangeContentHeight = false;
 				this._updateScrollHeight();
-			}, 100));
+			}, 100);
 		}));
 
 		this._localStore.add(this._list.onDidRemoveOutputs(outputs => {


### PR DESCRIPTION
Fixes a memory leak in notebookEditorWidget.

### Details


In notebookEditorWidget, when the list height changes, the scrollheight is updated. And each time the list changes height, a new disposable is added to `this._localStore`, making the number of disposables grow by one each time the list content height changes:

```ts
this._localStore.add(this._list.onDidChangeContentHeight(() => {
		this._localStore.add(DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
			hasPendingChangeContentHeight = false;
			this._updateScrollHeight();
		}, 100));
}));
```
### Change

The change uses a `MutableDisposable` so that there can be at most one disposable for the animation frame registered


```ts
const renderScrollHeightDisposable = this._localStore.add(new MutableDisposable());

this._localStore.add(this._list.onDidChangeContentHeight(() => {
		renderScrollHeightDisposable.value = DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this.getDomNode()), () => {
			hasPendingChangeContentHeight = false;
			this._updateScrollHeight();
		}, 100);
}));
```

### Before

When executing a notebook cell 37, the number of functions in `AnimationFrameQueueItem` and `NotebookEditorWidget` seems to grow by one each time:

<img width="1400" height="240" alt="Untitled" src="https://github.com/user-attachments/assets/1113b26d-0f88-411a-b0fa-431f58bdba60" />




### After

When executing a notebook cell 37, the number of `AnimationFrameQueueItem` stays constant (only some things link `UndoGroup` and `StackOperations` grow, which seems fine):

![notebook-execute-cell](https://github.com/user-attachments/assets/633021c1-0465-48b5-91e5-d404d3cd6d12)