### PR TITLE
Minor memory leak fixes, maybe

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -45,14 +45,17 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._overrideIcon.set(value, undefined);
 	}
 
+	protected readonly element: ChatTreeItem;
+
 	constructor(
 		private title: IMarkdownString | string,
-		protected readonly context: IChatContentPartRenderContext,
+		context: IChatContentPartRenderContext,
 		private readonly hoverMessage: IMarkdownString | undefined,
 		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
-		this.hasFollowingContent = this.context.contentIndex + 1 < this.context.content.length;
+		this.element = context.element;
+		this.hasFollowingContent = context.contentIndex + 1 < context.content.length;
 	}
 
 	get domNode(): HTMLElement {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatContentParts.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatContentParts.ts
@@ -46,9 +46,9 @@ export interface IChatContentPartRenderContext {
 	readonly container: HTMLElement;
 	readonly content: ReadonlyArray<IChatRendererContent>;
 	readonly contentIndex: number;
-	readonly preceedingContentParts: ReadonlyArray<IChatContentPart>;
 	readonly editorPool: EditorPool;
 	readonly codeBlockStartIndex: number;
+	readonly treeStartIndex: number;
 	readonly diffEditorPool: DiffEditorPool;
 	readonly codeBlockModelCollection: CodeBlockModelCollection;
 	readonly currentWidth: IObservable<number>;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -176,14 +176,14 @@ export class ChatUsedReferencesListContentPart extends ChatCollapsibleListConten
 	}
 
 	protected override isExpanded(): boolean {
-		const element = this.context.element as IChatResponseViewModel;
+		const element = this.element as IChatResponseViewModel;
 		return element.usedReferencesExpanded ?? !!(
 			this.options.expandedWhenEmptyResponse && element.response.value.length === 0
 		);
 	}
 
 	protected override setExpanded(value: boolean): void {
-		const element = this.context.element as IChatResponseViewModel;
+		const element = this.element as IChatResponseViewModel;
 		element.usedReferencesExpanded = !this.isExpanded();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -146,7 +146,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		if (this.fixedScrollingMode) {
 			node.classList.add('chat-thinking-fixed-mode');
 			this.currentTitle = this.defaultTitle;
-			if (this._collapseButton && !this.context.element.isComplete) {
+			if (this._collapseButton && !this.element.isComplete) {
 				this._collapseButton.icon = ThemeIcon.modify(Codicon.loading, 'spin');
 			}
 		}
@@ -155,7 +155,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		this._register(autorun(r => {
 			this.expanded.read(r);
 			if (this._collapseButton && this.wrapper) {
-				if (this.wrapper.classList.contains('chat-thinking-streaming') && !this.context.element.isComplete) {
+				if (this.wrapper.classList.contains('chat-thinking-streaming') && !this.element.isComplete) {
 					this._collapseButton.icon = ThemeIcon.modify(Codicon.loading, 'spin');
 				} else {
 					this._collapseButton.icon = Codicon.check;
@@ -163,7 +163,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 			}
 		}));
 
-		if (this._collapseButton && !this.streamingCompleted && !this.context.element.isComplete) {
+		if (this._collapseButton && !this.streamingCompleted && !this.element.isComplete) {
 			this._collapseButton.icon = ThemeIcon.modify(Codicon.loading, 'spin');
 		}
 
@@ -577,7 +577,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	}
 
 	protected override setTitle(title: string, omitPrefix?: boolean): void {
-		if (!title || this.context.element.isComplete) {
+		if (!title || this.element.isComplete) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTreeContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTreeContentPart.ts
@@ -19,13 +19,12 @@ import { WorkbenchCompressibleAsyncDataTree } from '../../../../../../platform/l
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { IResourceLabel, ResourceLabels } from '../../../../../browser/labels.js';
-import { ChatTreeItem } from '../../chat.js';
-import { IDisposableReference, ResourcePool } from './chatCollections.js';
-import { IChatContentPart } from './chatContentParts.js';
-import { IChatProgressRenderableResponseContent } from '../../../common/model/chatModel.js';
-import { IChatResponseProgressFileTreeData } from '../../../common/chatService/chatService.js';
 import { createFileIconThemableTreeContainerScope } from '../../../../files/browser/views/explorerView.js';
 import { IFilesConfiguration } from '../../../../files/common/files.js';
+import { IChatResponseProgressFileTreeData } from '../../../common/chatService/chatService.js';
+import { IChatProgressRenderableResponseContent } from '../../../common/model/chatModel.js';
+import { IDisposableReference, ResourcePool } from './chatCollections.js';
+import { IChatContentPart } from './chatContentParts.js';
 
 const $ = dom.$;
 
@@ -41,9 +40,7 @@ export class ChatTreeContentPart extends Disposable implements IChatContentPart 
 
 	constructor(
 		data: IChatResponseProgressFileTreeData,
-		element: ChatTreeItem,
 		treePool: TreePool,
-		treeDataIndex: number,
 		@IOpenerService private readonly openerService: IOpenerService
 	) {
 		super();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -296,7 +296,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	updateViewModel(viewModel: IChatViewModel | undefined): void {
 		this.viewModel = viewModel;
 		this._announcedToolProgressKeys.clear();
-
+		this.codeBlocksByEditorUri.clear();
+		this.codeBlocksByResponseId.clear();
+		this.fileTreesByResponseId.clear();
+		this.focusedFileTreesByResponseId.clear();
 	}
 
 	getCodeBlockInfoForEditor(uri: URI): IChatCodeBlockInfo | undefined {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -860,7 +860,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				elementIndex: index,
 				contentIndex: contentIndex,
 				content: content,
-				preceedingContentParts: parts,
 				container: templateData.rowContainer,
 				editorPool: this._editorPool,
 				diffEditorPool: this._diffEditorPool,
@@ -868,8 +867,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				currentWidth: this._currentLayoutWidth,
 				onDidChangeVisibility: this._onDidChangeVisibility.event,
 				get codeBlockStartIndex() {
-					return context.preceedingContentParts.reduce((acc, part) => acc + (part.codeblocks?.length ?? 0), 0);
+					return parts.reduce((acc, part) => acc + (part.codeblocks?.length ?? 0), 0);
 				},
+				get treeStartIndex() {
+					return parts.filter(part => part instanceof ChatTreeContentPart).length;
+				}
 			};
 			const newPart = this.renderChatContentPart(data, templateData, context);
 			if (newPart) {
@@ -1036,7 +1038,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				element,
 				elementIndex: elementIndex,
 				content: contentForThisTurn,
-				preceedingContentParts,
 				contentIndex: contentIndex,
 				container: templateData.rowContainer,
 				editorPool: this._editorPool,
@@ -1045,8 +1046,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				currentWidth: this._currentLayoutWidth,
 				onDidChangeVisibility: this._onDidChangeVisibility.event,
 				get codeBlockStartIndex() {
-					return context.preceedingContentParts.reduce((acc, part) => acc + (part.codeblocks?.length ?? 0), 0);
+					return preceedingContentParts.reduce((acc, part) => acc + (part.codeblocks?.length ?? 0), 0);
 				},
+				get treeStartIndex() {
+					return preceedingContentParts.filter(part => part instanceof ChatTreeContentPart).length;
+				}
 			};
 
 			// combine tool invocations into thinking part if needed. render the tool, but do not replace the working spinner with the new part's dom node since it is already inside the thinking part.
@@ -1450,8 +1454,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private renderTreeData(content: IChatTreeData, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext): IChatContentPart {
 		const data = content.treeData;
-		const treeDataIndex = context.preceedingContentParts.filter(part => part instanceof ChatTreeContentPart).length;
-		const treePart = this.instantiationService.createInstance(ChatTreeContentPart, data, context.element, this._treePool, treeDataIndex);
+		const treePart = this.instantiationService.createInstance(ChatTreeContentPart, data, this._treePool);
 
 		treePart.addDisposable(treePart.onDidChangeHeight(() => {
 			this.updateItemHeight(templateData);
@@ -1460,7 +1463,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (isResponseVM(context.element)) {
 			const fileTreeFocusInfo = {
 				treeDataId: data.uri.toString(),
-				treeIndex: treeDataIndex,
+				treeIndex: context.treeStartIndex,
 				focus() {
 					treePart.domFocus();
 				}
@@ -1813,6 +1816,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	}
 
 	disposeTemplate(templateData: IChatListItemTemplate): void {
+		this.clearRenderedParts(templateData);
 		templateData.templateDisposables.dispose();
 	}
 


### PR DESCRIPTION
Ensure that the maps in the renderer like codeBlocksByEditorUri get cleared (surely these can go away somehow)

Mainly get rid of preceedingContentParts, I don't think this really fixes the issue since the getters on the context still retain a ref but it wasn't used anywhere else so might as well clean it up