### PR TITLE
Fix codicon spin animation to ensure rotation occurs around the center

### DIFF
--- a/src/vs/base/browser/ui/codicons/codicon/codicon-modifiers.css
+++ b/src/vs/base/browser/ui/codicons/codicon/codicon-modifiers.css
@@ -21,6 +21,8 @@
 .codicon-tree-item-loading::before {
 	/* Use steps to throttle FPS to reduce CPU usage */
 	animation: codicon-spin 1.5s steps(30) infinite;
+	/* Ensure rotation happens around exact center to prevent wobble */
+	transform-origin: center center;
 }
 
 .codicon-modifier-disabled {

--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -70,6 +70,8 @@
 .monaco-tl-twistie.codicon-tree-item-loading::before {
 	/* Use steps to throttle FPS to reduce CPU usage */
 	animation: codicon-spin 1.25s steps(30) infinite;
+	/* Ensure rotation happens around exact center to prevent wobble */
+	transform-origin: center center;
 }
 
 .monaco-tree-type-filter {

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -198,6 +198,8 @@
 .codicon-testing-loading-icon::before {
 	/* Use steps to throttle FPS to reduce CPU usage */
 	animation: codicon-spin 1.25s steps(30) infinite;
+	/* Ensure rotation happens around exact center to prevent wobble */
+	transform-origin: center center;
 }
 
 .testing-no-test-placeholder {

--- a/src/vs/workbench/services/decorations/browser/decorationsService.ts
+++ b/src/vs/workbench/services/decorations/browser/decorationsService.ts
@@ -143,7 +143,7 @@ class DecorationRule {
 			font-size: 16px;
 			margin-right: 14px;
 			font-weight: normal;
-			${modifier === 'spin' ? 'animation: codicon-spin 1.5s steps(30) infinite; font-style: normal !important;' : ''};
+			${modifier === 'spin' ? 'animation: codicon-spin 1.5s steps(30) infinite; font-style: normal !important; transform-origin: center center;' : ''};
 			`,
 			element
 		);


### PR DESCRIPTION
Adjust the spin animation for codicons to ensure that rotation occurs around the exact center, preventing any wobble during the animation. This change enhances the visual consistency of loading indicators.

