### PR TITLE
Add `inlineChat.persistModelChoice` setting

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -20,6 +20,7 @@ export const enum InlineChatConfigKeys {
 	/** @deprecated do not read on client */
 	EnableV2 = 'inlineChat.enableV2',
 	notebookAgent = 'inlineChat.notebookAgent',
+	PersistModelChoice = 'inlineChat.persistModelChoice',
 }
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
@@ -51,6 +52,14 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			tags: ['experimental'],
 			experiment: {
 				mode: 'startup'
+			}
+		},
+		[InlineChatConfigKeys.PersistModelChoice]: {
+			description: localize('persistModelChoice', "Whether inline chat remembers the last selected model."),
+			default: false,
+			type: 'boolean',
+			experiment: {
+				mode: 'auto'
 			}
 		}
 	}


### PR DESCRIPTION
This setting allows to control if the inline chat model choice is persisted. The default is `false` (do not persist model choice) because we see many users sticking around with old, less good models.

re https://github.com/microsoft/vscode-internalbacklog/issues/6544