### PR TITLE
mcp: read _meta from content item instead of response level

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpToolCallUI.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpToolCallUI.ts
@@ -217,7 +217,7 @@ export class McpToolCallUI extends Disposable {
 			throw new Error('UI resource has no content');
 		}
 
-		const meta = resourceResult._meta?.ui as McpApps.McpUiResourceMeta | undefined;
+		const meta = content._meta?.ui as McpApps.McpUiResourceMeta | undefined;
 
 		return {
 			...meta,


### PR DESCRIPTION
## Summary
Fixes #287106

The `_meta.ui` field containing CSP configuration was being read from the response level instead of from inside the `contents` array item.

Related discussion: https://github.com/modelcontextprotocol/ext-apps/issues/242

## Changes
- Changed `resourceResult._meta?.ui` to `content._meta?.ui` in [mcpToolCallUI.ts:220](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/mcp/browser/mcpToolCallUI.ts#L220)

## Test Plan
- [ ] Create an MCP server returning `_meta` inside `contents[0]` (as per spec)
- [ ] Verify CSP domains are now correctly applied