### PR TITLE
Sanity tests updates

### DIFF
--- a/test/sanity/src/context.ts
+++ b/test/sanity/src/context.ts
@@ -39,6 +39,7 @@ export class TestContext {
 		public readonly quality: 'stable' | 'insider' | 'exploration',
 		public readonly commit: string,
 		public readonly verbose: boolean,
+		public readonly skipSigningCheck: boolean,
 	) {
 		const osTempDir = fs.realpathSync(os.tmpdir());
 		const logDir = fs.mkdtempSync(path.join(osTempDir, 'vscode-sanity-log'));
@@ -99,6 +100,7 @@ export class TestContext {
 	 * Cleans up all temporary directories created during the test run.
 	 */
 	public cleanup() {
+		process.chdir(os.homedir());
 		for (const dir of this.tempDirs) {
 			this.log(`Deleting temp directory: ${dir}`);
 			try {
@@ -220,6 +222,11 @@ export class TestContext {
 	 * @param filePath The path to the file to validate.
 	 */
 	public validateAuthenticodeSignature(filePath: string) {
+		if (this.skipSigningCheck) {
+			this.log(`Skipping Authenticode signature validation for ${filePath} (signing checks disabled)`);
+			return;
+		}
+
 		this.log(`Validating Authenticode signature for ${filePath}`);
 
 		const result = this.run('powershell', '-Command', `Get-AuthenticodeSignature "${filePath}" | Select-Object -ExpandProperty Status`);
@@ -238,6 +245,11 @@ export class TestContext {
 	 * @param dir The directory to scan for executable files.
 	 */
 	public validateAllAuthenticodeSignatures(dir: string) {
+		if (this.skipSigningCheck) {
+			this.log(`Skipping Authenticode signature validation for ${dir} (signing checks disabled)`);
+			return;
+		}
+
 		const files = fs.readdirSync(dir, { withFileTypes: true });
 		for (const file of files) {
 			const filePath = path.join(dir, file.name);
@@ -254,6 +266,11 @@ export class TestContext {
 	 * @param filePath The path to the file or app bundle to validate.
 	 */
 	public validateCodesignSignature(filePath: string) {
+		if (this.skipSigningCheck) {
+			this.log(`Skipping codesign signature validation for ${filePath} (signing checks disabled)`);
+			return;
+		}
+
 		this.log(`Validating codesign signature for ${filePath}`);
 
 		const result = this.run('codesign', '--verify', '--deep', '--strict', filePath);
@@ -271,6 +288,11 @@ export class TestContext {
 	 * @param dir The directory to scan for Mach-O binaries.
 	 */
 	public validateAllCodesignSignatures(dir: string) {
+		if (this.skipSigningCheck) {
+			this.log(`Skipping codesign signature validation for ${dir} (signing checks disabled)`);
+			return;
+		}
+
 		const files = fs.readdirSync(dir, { withFileTypes: true });
 		for (const file of files) {
 			const filePath = path.join(dir, file.name);
@@ -561,6 +583,21 @@ export class TestContext {
 		}
 
 		return filePath;
+	}
+
+	/**
+	 * Creates a portable data directory in the specified unpacked VS Code directory.
+	 * @param dir The directory where VS Code was unpacked.
+	 * @returns The path to the created portable data directory.
+	 */
+	public createPortableDataDir(dir: string): string {
+		const dataDir = path.join(dir, os.platform() === 'darwin' ? 'code-portable-data' : 'data');
+
+		this.log(`Creating portable data directory: ${dataDir}`);
+		fs.mkdirSync(dataDir, { recursive: true });
+		this.log(`Created portable data directory: ${dataDir}`);
+
+		return dataDir;
 	}
 
 	/**

--- a/test/sanity/src/index.ts
+++ b/test/sanity/src/index.ts
@@ -18,6 +18,7 @@ if (options.help) {
 	console.info('  --commit, -c <commit>           The commit to test (required)');
 	console.info(`  --quality, -q <quality>         The quality to test (required, "stable", "insider" or "exploration")`);
 	console.info('  --no-cleanup                    Do not cleanup downloaded files after each test');
+	console.info('  --no-signing-check              Skip Authenticode and codesign signature checks');
 	console.info('  --grep, -g <pattern>            Only run tests matching the given <pattern>');
 	console.info('  --fgrep, -f <string>            Only run tests containing the given <string>');
 	console.info('  --verbose, -v                   Enable verbose logging');

--- a/test/sanity/src/main.ts
+++ b/test/sanity/src/main.ts
@@ -12,9 +12,9 @@ import { setup as setupServerWebTests } from './serverWeb.test';
 
 const options = minimist(process.argv.slice(2), {
 	string: ['commit', 'quality'],
-	boolean: ['cleanup', 'verbose'],
+	boolean: ['cleanup', 'verbose', 'signing-check'],
 	alias: { commit: 'c', quality: 'q', verbose: 'v' },
-	default: { cleanup: true, verbose: false },
+	default: { cleanup: true, verbose: false, 'signing-check': true },
 });
 
 if (!options.commit) {
@@ -25,7 +25,7 @@ if (!options.quality) {
 	throw new Error('--quality is required');
 }
 
-const context = new TestContext(options.quality, options.commit, options.verbose);
+const context = new TestContext(options.quality, options.commit, options.verbose, !options['signing-check']);
 
 describe('VS Code Sanity Tests', () => {
 	beforeEach(() => {

--- a/test/sanity/src/server.test.ts
+++ b/test/sanity/src/server.test.ts
@@ -90,7 +90,9 @@ export function setup(context: TestContext) {
 			const args = [
 				'--accept-server-license-terms',
 				'--connection-token', context.getRandomToken(),
-				'--port', context.getRandomPort()
+				'--port', context.getRandomPort(),
+				'--server-data-dir', context.createTempDir(),
+				'--extensions-dir', context.createTempDir(),
 			];
 
 			context.log(`Starting server ${entryPoint} with args ${args.join(' ')}`);

--- a/test/sanity/src/uiTest.ts
+++ b/test/sanity/src/uiTest.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import fs from 'fs';
+import path from 'path';
 import { Page } from 'playwright';
 import { TestContext } from './context';
 
@@ -16,7 +17,14 @@ export class UITest {
 	private _workspaceDir: string | undefined;
 	private _userDataDir: string | undefined;
 
-	constructor(private readonly context: TestContext) {
+	constructor(
+		private readonly context: TestContext,
+		dataDir?: string
+	) {
+		if (dataDir) {
+			this._extensionsDir = path.join(dataDir, 'extensions');
+			this._userDataDir = path.join(dataDir, 'user-data');
+		}
 	}
 
 	/**
@@ -107,7 +115,7 @@ export class UITest {
 		this.context.log('Verifying file contents');
 		const filePath = `${this.workspaceDir}/helloWorld.txt`;
 		const fileContents = fs.readFileSync(filePath, 'utf-8');
-		assert.strictEqual(fileContents, 'Hello, World!');
+		assert.strictEqual(fileContents, 'Hello, World!', 'File contents do not match expected value');
 	}
 
 	/**
@@ -135,6 +143,6 @@ export class UITest {
 		this.context.log('Verifying extension is installed');
 		const extensions = fs.readdirSync(this.extensionsDir);
 		const hasExtension = extensions.some(ext => ext.startsWith('github.vscode-pull-request-github'));
-		assert.strictEqual(hasExtension, true);
+		assert.strictEqual(hasExtension, true, 'GitHub Pull Requests extension is not installed');
 	}
 }


### PR DESCRIPTION
Added option to skip code signing validation.
Fixed portable tests to create and use user data directory.
Remove unnecessary env variable in case of x64 macOS.
