### PR TITLE
Clear promptInput's value onCommandFinished 

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -113,6 +113,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		onCommandStart: Event<ITerminalCommand>,
 		onCommandStartChanged: Event<void>,
 		onCommandExecuted: Event<ITerminalCommand>,
+		onCommandFinished: Event<ITerminalCommand>,
 		@ILogService private readonly _logService: ILogService
 	) {
 		super();
@@ -127,6 +128,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		this._register(onCommandStart(e => this._handleCommandStart(e as { marker: IMarker })));
 		this._register(onCommandStartChanged(() => this._handleCommandStartChanged()));
 		this._register(onCommandExecuted(() => this._handleCommandExecuted()));
+		this._register(onCommandFinished(() => this._handleCommandFinished()));
 
 		this._register(this.onDidStartInput(() => this._logCombinedStringIfTrace('PromptInputModel#onDidStartInput')));
 		this._register(this.onDidChangeInput(() => this._logCombinedStringIfTrace('PromptInputModel#onDidChangeInput')));
@@ -259,6 +261,12 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		this._state = PromptInputState.Execute;
 		this._onDidFinishInput.fire(event);
 		this._onDidChangeInput.fire(event);
+	}
+
+	private _handleCommandFinished() {
+		// Clear the prompt input value when command finishes to prepare for the next command
+		// This prevents runCommand from detecting leftover text and sending ^C unnecessarily
+		this._value = '';
 	}
 
 	@throttle(0)

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -267,6 +267,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		// Clear the prompt input value when command finishes to prepare for the next command
 		// This prevents runCommand from detecting leftover text and sending ^C unnecessarily
 		this._value = '';
+		this._onDidChangeInput.fire(this._createStateObject());
 	}
 
 	@throttle(0)

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -84,7 +84,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 	) {
 		super();
 		this._currentCommand = new PartialTerminalCommand(this._terminal);
-		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandStartChanged, this.onCommandExecuted, this._logService));
+		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandStartChanged, this.onCommandExecuted, this.onCommandFinished, this._logService));
 
 		// Pull command line from the buffer if it was not set explicitly
 		this._register(this.onCommandExecuted(command => {

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -24,6 +24,7 @@ suite('PromptInputModel', () => {
 	let onCommandStart: Emitter<ITerminalCommand>;
 	let onCommandStartChanged: Emitter<void>;
 	let onCommandExecuted: Emitter<ITerminalCommand>;
+	let onCommandFinished: Emitter<ITerminalCommand>;
 
 	async function writePromise(data: string) {
 		await new Promise<void>(r => xterm.write(data, r));
@@ -35,6 +36,10 @@ suite('PromptInputModel', () => {
 
 	function fireCommandExecuted() {
 		onCommandExecuted.fire(null!);
+	}
+
+	function fireCommandFinished() {
+		onCommandFinished.fire(null!);
 	}
 
 	function setContinuationPrompt(prompt: string) {
@@ -68,7 +73,8 @@ suite('PromptInputModel', () => {
 		onCommandStart = store.add(new Emitter());
 		onCommandStartChanged = store.add(new Emitter());
 		onCommandExecuted = store.add(new Emitter());
-		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandStartChanged.event, onCommandExecuted.event, new NullLogService));
+		onCommandFinished = store.add(new Emitter());
+		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandStartChanged.event, onCommandExecuted.event, onCommandFinished.event, new NullLogService));
 	});
 
 	test('basic input and execute', async () => {
@@ -136,6 +142,21 @@ suite('PromptInputModel', () => {
 			xterm.input('\x03');
 			writePromise('^C').then(() => fireCommandExecuted());
 		});
+	});
+
+	test('should clear value when command finishes', async () => {
+		await writePromise('$ ');
+		fireCommandStart();
+		await assertPromptInput('|');
+
+		await writePromise('echo hello');
+		await assertPromptInput('echo hello|');
+
+		fireCommandExecuted();
+		strictEqual(promptInputModel.value, 'echo hello');
+
+		fireCommandFinished();
+		strictEqual(promptInputModel.value, '');
 	});
 
 	test('cursor navigation', async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/recordings/rich/macos_zsh_omz_echo_3_times.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/recordings/rich/macos_zsh_omz_echo_3_times.ts
@@ -138,10 +138,6 @@ export const events = [
 		"data": ""
 	},
 	{
-		"type": "promptInputChange",
-		"data": "echo a"
-	},
-	{
 		"type": "output",
 		"data": "\u001b]633;P;Cwd=/Users/tyriar/playground/test1\u0007\u001b]633;EnvSingleStart;0;448d50d0-70fe-4ab5-842e-132f3b1c159a;\u0007\u001b]633;EnvSingleEnd;448d50d0-70fe-4ab5-842e-132f3b1c159a;\u0007\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]633;A\u0007tyriar@Mac test1 % \u001b]633;B\u0007\u001b[K\u001b[?2004h"
 	},
@@ -244,10 +240,6 @@ export const events = [
 	{
 		"type": "output",
 		"data": ""
-	},
-	{
-		"type": "promptInputChange",
-		"data": "echo b"
 	},
 	{
 		"type": "output",
@@ -356,10 +348,6 @@ export const events = [
 	{
 		"type": "output",
 		"data": ""
-	},
-	{
-		"type": "promptInputChange",
-		"data": "echo c"
 	},
 	{
 		"type": "output",


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python-environments/issues/640 
Coming from:  https://github.com/microsoft/vscode-python-environments/pull/1093#discussion_r2682282695

From: https://github.com/microsoft/vscode-python-environments/pull/1093#issue-3800690027 

***
I couldnt seem to repro ^C to show up on Python file run on Mac, but only on Windows.

This is happening because we have some extra polling happening before onCommandStarted event gets fired: https://github.com/microsoft/vscode/blob/86db4eb05dbfd82dc9b4ea022883494257ac3d63/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts#L727 Which is what leads to [resetting the value of promptInputModel](https://github.com/microsoft/vscode/blob/86db4eb05dbfd82dc9b4ea022883494257ac3d63/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts#L213):

We need the promptInputModel's value to be empty and state to be not execute in order to not cause ^C upon executeCommand run: https://github.com/microsoft/vscode/blob/86db4eb05dbfd82dc9b4ea022883494257ac3d63/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L1010

So in that meantime before we clear the value of promptInput to empty string, the state will be execute and value of it will point to activation script. Which will lead to ^C.
***

Flow from env extension:
Send activate command -> wait for `onDidEndShellExecution` -> send file execution.

The ctrl^c came from second arrow.