### PR TITLE
Track telemetry for azure.yaml and azure.yml with workspace Measures marker

### DIFF
--- a/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
+++ b/src/vs/workbench/contrib/tags/electron-browser/workspaceTagsService.ts
@@ -720,6 +720,7 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			"workspace.yeoman.code.ext" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.cordova.high" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.cordova.low" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.azure.yaml" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.xamarin.android" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.xamarin.ios" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.android.cpp" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
@@ -1275,6 +1276,8 @@ export class WorkspaceTagsService implements IWorkspaceTagsService {
 			tags['workspace.unity'] = nameSet.has('assets') && nameSet.has('library') && nameSet.has('projectsettings');
 			tags['workspace.npm'] = nameSet.has('package.json') || nameSet.has('node_modules');
 			tags['workspace.bower'] = nameSet.has('bower.json') || nameSet.has('bower_components');
+
+			tags['workspace.azure.yaml'] = nameSet.has('azure.yaml') || nameSet.has('azure.yml');
 
 			tags['workspace.java.pom'] = nameSet.has('pom.xml');
 			tags['workspace.java.gradle'] = nameSet.has('build.gradle') || nameSet.has('settings.gradle') || nameSet.has('build.gradle.kts') || nameSet.has('settings.gradle.kts') || nameSet.has('gradlew') || nameSet.has('gradlew.bat');


### PR DESCRIPTION
## Summary
This PR adds telemetry tracking when a user opens a workspace containing `azure.yaml` or `azure.yml` files.

## Changes
- Added `workspace.azure.yaml` Measures marker in `workspaceTagsService.ts`
- Added GDPR annotation for the new telemetry property
- Detection logic checks for both `azure.yaml` and `azure.yml` filenames

## Pattern
This follows the existing pattern used for other workspace file type detection (e.g., `workspace.tsconfig`, `workspace.npm`, `workspace.py.requirements`, etc.).

## Telemetry Output
When a workspace contains an azure.yaml or azure.yml file, the Measures payload will include:
```json
"workspace.azure.yaml": 1
```