### PR TITLE
Fix error in dev console from SCM view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -1644,6 +1644,8 @@ export class SCMHistoryViewPane extends ViewPane {
 	private readonly _refreshThrottler = new Throttler();
 	private readonly _updateChildrenThrottler = new Throttler();
 
+	private _isDisposed = false;
+
 	private readonly _scmProviderCtx: IContextKey<string | undefined>;
 	private readonly _scmCurrentHistoryItemRefHasRemote: IContextKey<boolean>;
 	private readonly _scmCurrentHistoryItemRefHasBase: IContextKey<boolean>;
@@ -1896,6 +1898,10 @@ export class SCMHistoryViewPane extends ViewPane {
 	}
 
 	async refresh(): Promise<void> {
+		if (this._isDisposed) {
+			return;
+		}
+
 		return this._refreshThrottler.queue(token => this._refresh(token));
 	}
 
@@ -2221,6 +2227,10 @@ export class SCMHistoryViewPane extends ViewPane {
 	}
 
 	private _updateChildren(): Promise<void> {
+		if (this._isDisposed) {
+			return Promise.resolve();
+		}
+
 		return this._updateChildrenThrottler.queue(
 			() => this._treeOperationSequencer.queue(
 				async () => {
@@ -2241,6 +2251,7 @@ export class SCMHistoryViewPane extends ViewPane {
 	}
 
 	override dispose(): void {
+		this._isDisposed = true;
 		this._contextMenuDisposables.dispose();
 		this._visibilityDisposables.dispose();
 		super.dispose();


### PR DESCRIPTION
## Description
When the SCM History View is disposed, autoruns triggered by observable changes from `mainThreadSCM.ts` can still call 
`refresh()` or `_updateChildren()` after the `Throttler` instances have been disposed. This results in "Throttler is disposed" errors appearing in the developer console.
The issue occurs because:

1. `SCMHistoryViewPane` registers autoruns in `_visibilityDisposables` that call `refresh()`;
2. Observable changes (e.g., `$onDidChangeHistoryItemRefs`) can trigger these autoruns;
3. When the view is disposed, `_refreshThrottler` and `_updateChildrenThrottler` are disposed via `this._register()`;
4. However, autoruns may still fire in the brief window after disposal, calling methods on the disposed throttlers.

## Fixes
https://github.com/microsoft/vscode/issues/275112

## Changes

Added a `_isDisposed` flag to `SCMHistoryViewPane` and guarded the `refresh()` and `_updateChildren()` methods to prevent calling disposed throttlers:
- Added private `_isDisposed = false` property;
- Added early return guard in `refresh()` when disposed;
- Added early return guard in `_updateChildren()` when disposed;
- Set `this._isDisposed = true` at the start of `dispose()` method.