### PR TITLE
chat: fix performance slowdowns when closing/reloading the window

### DIFF
--- a/src/vs/editor/common/core/ranges/offsetRange.ts
+++ b/src/vs/editor/common/core/ranges/offsetRange.ts
@@ -18,6 +18,10 @@ export class OffsetRange implements IOffsetRange {
 		return new OffsetRange(start, endExclusive);
 	}
 
+	public static equals(r1: IOffsetRange, r2: IOffsetRange): boolean {
+		return r1.start === r2.start && r1.endExclusive === r2.endExclusive;
+	}
+
 	public static addRange(range: OffsetRange, sortedRanges: OffsetRange[]): void {
 		let i = 0;
 		while (i < sortedRanges.length && sortedRanges[i].endExclusive < range.start) {

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -206,7 +206,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 		this._tools.set(toolData.id, { data: toolData });
 		this._ctxToolsCount.set(this._tools.size);
-		this._onDidChangeToolsScheduler.schedule();
+		if (!this._onDidChangeToolsScheduler.isScheduled()) {
+			this._onDidChangeToolsScheduler.schedule();
+		}
 
 		toolData.when?.keys().forEach(key => this._toolContextKeys.add(key));
 
@@ -223,7 +225,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			this._tools.delete(toolData.id);
 			this._ctxToolsCount.set(this._tools.size);
 			this._refreshAllToolContextKeys();
-			this._onDidChangeToolsScheduler.schedule();
+			if (!this._onDidChangeToolsScheduler.isScheduled()) {
+				this._onDidChangeToolsScheduler.schedule();
+			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -755,8 +755,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (!this.viewModel) {
 			return;
 		}
+
+		const previous = this.parsedChatRequest;
 		this.parsedChatRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequest(this.viewModel.sessionResource, this.getInput(), this.location, { selectedAgent: this._lastSelectedAgent, mode: this.input.currentModeKind });
-		this._onDidChangeParsedInput.fire();
+		if (!previous || !IParsedChatRequest.equals(previous, this.parsedChatRequest)) {
+			this._onDidChangeParsedInput.fire();
+		}
 	}
 
 	getSibling(item: ChatTreeItem, type: 'next' | 'previous'): ChatTreeItem | undefined {

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatParserTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatParserTypes.ts
@@ -6,19 +6,31 @@
 import { revive } from '../../../../../base/common/marshalling.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { IOffsetRange, OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
-import { IRange } from '../../../../../editor/common/core/range.js';
+import { IRange, Range } from '../../../../../editor/common/core/range.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentService, reviveSerializedAgent } from '../participants/chatAgents.js';
 import { IChatSlashData } from '../participants/chatSlashCommands.js';
 import { IChatRequestProblemsVariable, IChatRequestVariableValue } from '../attachments/chatVariables.js';
 import { ChatAgentLocation } from '../constants.js';
 import { IToolData } from '../tools/languageModelToolsService.js';
 import { IChatRequestToolEntry, IChatRequestToolSetEntry, IChatRequestVariableEntry, IDiagnosticVariableEntryFilterData } from '../attachments/chatVariableEntries.js';
+import { arrayEquals } from '../../../../../base/common/equals.js';
 
 // These are in a separate file to avoid circular dependencies with the dependencies of the parser
 
 export interface IParsedChatRequest {
 	readonly parts: ReadonlyArray<IParsedChatRequestPart>;
 	readonly text: string;
+}
+
+export namespace IParsedChatRequest {
+	export function equals(a: IParsedChatRequest, b: IParsedChatRequest): boolean {
+		return a.text === b.text && arrayEquals(a.parts, b.parts, (p1, p2) =>
+			p1.kind === p2.kind &&
+			OffsetRange.equals(p1.range, p2.range) &&
+			Range.equalsRange(p1.editorRange, p2.editorRange) &&
+			p1.text === p2.text
+		);
+	}
 }
 
 export interface IParsedChatRequestPart {

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -114,7 +114,7 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 			};
 
 			// Don't bother cleaning up tools internally during shutdown. This just costs time for no benefit.
-			if (!this.lifecycleService.willShutdown) {
+			if (this.lifecycleService.willShutdown) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -29,6 +29,7 @@ import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocatio
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { IMcpServer, IMcpService, IMcpTool, IMcpToolResourceLinkContents, McpResourceURI, McpToolResourceLinkMimeType, McpToolVisibility } from './mcpTypes.js';
 import { mcpServerToSourceData } from './mcpTypesUtils.js';
+import { ILifecycleService } from '../../../services/lifecycle/common/lifecycle.js';
 
 interface ISyncedToolData {
 	toolData: IToolData;
@@ -44,6 +45,7 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 		@IMcpService mcpService: IMcpService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 	) {
 		super();
 
@@ -111,7 +113,18 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 				store.add(collectionData.value.toolSet.addTool(toolData));
 			};
 
+			// Don't bother cleaning up tools internally during shutdown. This just costs time for no benefit.
+			if (!this.lifecycleService.willShutdown) {
+				return;
+			}
+
 			const collection = collectionObservable.read(reader);
+			if (!collection) {
+				tools.forEach(t => t.store.dispose());
+				tools.clear();
+				return;
+			}
+
 			for (const tool of server.tools.read(reader)) {
 				// Skip app-only tools - they should not be registered with the language model tools service
 				if (!(tool.visibility & McpToolVisibility.Model)) {

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -1212,10 +1212,10 @@ class WorkspaceExtensionsManagementService extends Disposable {
 	) {
 		super();
 
-		this._register(Event.debounce<FileChangesEvent, FileChangesEvent[]>(this.fileService.onDidFilesChange, (last, e) => {
+		this._register(Event.throttle<FileChangesEvent, FileChangesEvent[]>(this.fileService.onDidFilesChange, (last, e) => {
 			(last = last ?? []).push(e);
 			return last;
-		}, 1000)(events => {
+		}, 1000, false)(events => {
 			const changedInvalidExtensions = this.extensions.filter(extension => !extension.isValid && events.some(e => e.affects(extension.location)));
 			if (changedInvalidExtensions.length) {
 				this.checkExtensionsValidity(changedInvalidExtensions);


### PR DESCRIPTION
- _onDidChangeToolsScheduler.isScheduled is checked to avoid thrashing setTimeout when disposing many tools
- WorkspaceExtensionsManagementService was listening to file change events using a debounce. Debounces have overhead because a new timer is scheduled on every single call. For large amount of file changes (during EH shutdown when schemas for tools are deregistered) this caused a notable slowdown. `throttle` should be functionally equivalent, cc @sandy081 
- avoid triggering input updates (w/ downstream editor effects) each time the input gets parsed, which happened every time tools got changed
- big hammer -- don't bother deregistering MCP tools if we're already shutting down

Results:

- `216ms` to shut down EH before making these changes
- `87ms` in the first three bullets
- `54ms` after skipping MCP tool deregistering. (Basically all the overhead there was unregistering the JSON schema for tool inputs.)

Closes https://github.com/microsoft/vscode/issues/287174