### PR TITLE
Make inline chat fallback to the default model of selected vendor

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -104,6 +104,8 @@ export class InlineChatController implements IEditorContribution {
 		return editor.getContribution<InlineChatController>(InlineChatController.ID) ?? undefined;
 	}
 
+	private static _selectVendorDefaultLanguageModel: boolean = true;
+
 	private readonly _store = new DisposableStore();
 	private readonly _isActiveController = observableValue(this, false);
 	private readonly _zone: Lazy<InlineChatZoneWidget>;
@@ -125,7 +127,7 @@ export class InlineChatController implements IEditorContribution {
 		@IInlineChatSessionService private readonly _inlineChatSessionService: IInlineChatSessionService,
 		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IConfigurationService configurationService: IConfigurationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ISharedWebContentExtractorService private readonly _webContentExtractorService: ISharedWebContentExtractorService,
 		@IFileService private readonly _fileService: IFileService,
 		@IChatAttachmentResolveService private readonly _chatAttachmentResolveService: IChatAttachmentResolveService,
@@ -135,7 +137,7 @@ export class InlineChatController implements IEditorContribution {
 	) {
 
 		const ctxInlineChatVisible = CTX_INLINE_CHAT_VISIBLE.bindTo(contextKeyService);
-		const notebookAgentConfig = observableConfigValue(InlineChatConfigKeys.notebookAgent, false, configurationService);
+		const notebookAgentConfig = observableConfigValue(InlineChatConfigKeys.notebookAgent, false, this._configurationService);
 
 		this._zone = new Lazy<InlineChatZoneWidget>(() => {
 
@@ -201,6 +203,10 @@ export class InlineChatController implements IEditorContribution {
 			);
 
 			this._store.add(result);
+
+			this._store.add(result.widget.chatWidget.input.onDidChangeCurrentLanguageModel(newModel => {
+				InlineChatController._selectVendorDefaultLanguageModel = Boolean(newModel.metadata.isDefault);
+			}));
 
 			result.domNode.classList.add('inline-chat-2');
 
@@ -428,6 +434,22 @@ export class InlineChatController implements IEditorContribution {
 		this._isActiveController.set(true, undefined);
 
 		const session = this._inlineChatSessionService.createSession(this._editor);
+
+
+		// fallback to the default model of the selected vendor unless an explicit selection was made for the session
+		// or unless the user has chosen to persist their model choice
+		const persistModelChoice = this._configurationService.getValue<boolean>(InlineChatConfigKeys.PersistModelChoice);
+		const model = this._zone.value.widget.chatWidget.input.selectedLanguageModel;
+		if (!persistModelChoice && InlineChatController._selectVendorDefaultLanguageModel && model && !model.metadata.isDefault) {
+			const ids = await this._languageModelService.selectLanguageModels({ vendor: model.metadata.vendor }, false);
+			for (const identifier of ids) {
+				const candidate = this._languageModelService.lookupLanguageModel(identifier);
+				if (candidate?.isDefault) {
+					this._zone.value.widget.chatWidget.input.setCurrentLanguageModel({ metadata: candidate, identifier });
+					break;
+				}
+			}
+		}
 
 		// ADD diagnostics
 		const entries: IChatRequestVariableEntry[] = [];

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -20,6 +20,7 @@ export const enum InlineChatConfigKeys {
 	/** @deprecated do not read on client */
 	EnableV2 = 'inlineChat.enableV2',
 	notebookAgent = 'inlineChat.notebookAgent',
+	PersistModelChoice = 'inlineChat.persistModelChoice',
 }
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
@@ -52,6 +53,11 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			experiment: {
 				mode: 'startup'
 			}
+		},
+		[InlineChatConfigKeys.PersistModelChoice]: {
+			description: localize('persistModelChoice', "Whether to persist the selected language model choice across inline chat sessions. The default is not to persist and to use the vendor's default model for inline chat because that yields the best experience."),
+			default: false,
+			type: 'boolean'
 		}
 	}
 });


### PR DESCRIPTION
This makes sure inline chat uses the model the vendor/extension recommends. Also makes sure folks aren't stuck on an old model selection. This can be disabled (via setting) and a custom selection will be honoured for the duration of a vscode session (lifetime of a window)

https://github.com/microsoft/vscode-internalbacklog/issues/6544