### PR TITLE
Allow `vscode.LanguageModelChatInformation#isDefault` to be per chat location

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupProviders.ts
@@ -400,7 +400,7 @@ export class SetupAgent extends Disposable implements IChatAgentImplementation {
 
 			for (const id of languageModelsService.getLanguageModelIds()) {
 				const model = languageModelsService.lookupLanguageModel(id);
-				if (model?.isDefault) {
+				if (model?.isDefaultForLocation[ChatAgentLocation.Chat]) {
 					return true;
 				}
 			}

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -32,6 +32,7 @@ import { ChatEntitlement, IChatEntitlementService } from '../../../services/chat
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { ExtensionsRegistry } from '../../../services/extensions/common/extensionsRegistry.js';
 import { ChatContextKeys } from './actions/chatContextKeys.js';
+import { ChatAgentLocation } from './constants.js';
 import { ILanguageModelsProviderGroup, ILanguageModelsConfigurationService } from './languageModelsConfiguration.js';
 
 export const enum ChatMessageRole {
@@ -179,7 +180,7 @@ export interface ILanguageModelChatMetadata {
 	readonly maxInputTokens: number;
 	readonly maxOutputTokens: number;
 
-	readonly isDefault?: boolean;
+	readonly isDefaultForLocation: { [K in ChatAgentLocation]?: boolean };
 	readonly isUserSelectable?: boolean;
 	readonly statusIcon?: ThemeIcon;
 	readonly modelPickerCategory: { label: string; order: number } | undefined;

--- a/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatManagement/chatModelsViewModel.test.ts
@@ -15,6 +15,7 @@ import { ExtensionIdentifier } from '../../../../../../platform/extensions/commo
 import { IStringDictionary } from '../../../../../../base/common/collections.js';
 import { ILanguageModelsConfigurationService } from '../../../common/languageModelsConfiguration.js';
 import { mock } from '../../../../../../base/test/common/mock.js';
+import { ChatAgentLocation } from '../../../common/constants.js';
 
 class MockLanguageModelsService implements ILanguageModelsService {
 	_serviceBrand: undefined;
@@ -214,6 +215,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: true,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -232,6 +236,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: true,
 				agentMode: true
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -250,6 +257,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: false,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -268,6 +278,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: false,
 				vision: true,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -604,6 +617,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: true,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -623,6 +639,9 @@ suite('ChatModelsViewModel', () => {
 					toolCalling: true,
 					vision: true,
 					agentMode: true
+				},
+				isDefaultForLocation: {
+					[ChatAgentLocation.Chat]: true
 				}
 			});
 		}
@@ -708,6 +727,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: false,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -734,6 +756,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: false,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 
@@ -843,6 +868,9 @@ suite('ChatModelsViewModel', () => {
 				toolCalling: true,
 				vision: false,
 				agentMode: false
+			},
+			isDefaultForLocation: {
+				[ChatAgentLocation.Chat]: true
 			}
 		});
 

--- a/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptHovers.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptHovers.test.ts
@@ -14,7 +14,7 @@ import { TestInstantiationService } from '../../../../../../../platform/instanti
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { LanguageModelToolsService } from '../../../../browser/tools/languageModelToolsService.js';
 import { ChatMode, CustomChatMode, IChatModeService } from '../../../../common/chatModes.js';
-import { ChatConfiguration } from '../../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration } from '../../../../common/constants.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../common/tools/languageModelToolsService.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../../common/languageModels.js';
 import { PromptHoverProvider } from '../../../../common/promptSyntax/languageProviders/promptHovers.js';
@@ -53,8 +53,8 @@ suite('PromptHoverProvider', () => {
 		instaService.set(ILanguageModelToolsService, toolService);
 
 		const testModels: ILanguageModelChatMetadata[] = [
-			{ id: 'mae-4', name: 'MAE 4', vendor: 'olama', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true } } satisfies ILanguageModelChatMetadata,
-			{ id: 'mae-4.1', name: 'MAE 4.1', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true } } satisfies ILanguageModelChatMetadata,
+			{ id: 'mae-4', name: 'MAE 4', vendor: 'olama', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true }, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } } satisfies ILanguageModelChatMetadata,
+			{ id: 'mae-4.1', name: 'MAE 4.1', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true }, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } } satisfies ILanguageModelChatMetadata,
 		];
 
 		instaService.stub(ILanguageModelsService, {

--- a/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/promptSyntax/languageProviders/promptValidator.test.ts
@@ -18,7 +18,7 @@ import { IMarkerData, MarkerSeverity } from '../../../../../../../platform/marke
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { LanguageModelToolsService } from '../../../../browser/tools/languageModelToolsService.js';
 import { ChatMode, CustomChatMode, IChatModeService } from '../../../../common/chatModes.js';
-import { ChatConfiguration } from '../../../../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration } from '../../../../common/constants.js';
 import { ILanguageModelToolsService, IToolData, ToolDataSource } from '../../../../common/tools/languageModelToolsService.js';
 import { ILanguageModelChatMetadata, ILanguageModelsService } from '../../../../common/languageModels.js';
 import { getPromptFileExtension } from '../../../../common/promptSyntax/config/promptFileLocations.js';
@@ -112,9 +112,9 @@ suite('PromptValidator', () => {
 		instaService.set(ILanguageModelToolsService, toolService);
 
 		const testModels: ILanguageModelChatMetadata[] = [
-			{ id: 'mae-4', name: 'MAE 4', vendor: 'olama', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true } } satisfies ILanguageModelChatMetadata,
-			{ id: 'mae-4.1', name: 'MAE 4.1', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true } } satisfies ILanguageModelChatMetadata,
-			{ id: 'mae-3.5-turbo', name: 'MAE 3.5 Turbo', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024 } satisfies ILanguageModelChatMetadata
+			{ id: 'mae-4', name: 'MAE 4', vendor: 'olama', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true }, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } } satisfies ILanguageModelChatMetadata,
+			{ id: 'mae-4.1', name: 'MAE 4.1', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, capabilities: { agentMode: true, toolCalling: true }, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } } satisfies ILanguageModelChatMetadata,
+			{ id: 'mae-3.5-turbo', name: 'MAE 3.5 Turbo', vendor: 'copilot', version: '1.0', family: 'mae', modelPickerCategory: undefined, extension: new ExtensionIdentifier('a.b'), isUserSelectable: true, maxInputTokens: 8192, maxOutputTokens: 1024, isDefaultForLocation: { [ChatAgentLocation.Chat]: true } } satisfies ILanguageModelChatMetadata
 		];
 
 		instaService.stub(ILanguageModelsService, {

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -10,7 +10,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { mock } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
-import { ChatMessageRole, languageModelChatProviderExtensionPoint, LanguageModelsService, IChatMessage, IChatResponsePart } from '../../common/languageModels.js';
+import { ChatMessageRole, languageModelChatProviderExtensionPoint, LanguageModelsService, IChatMessage, IChatResponsePart, ILanguageModelChatMetadata } from '../../common/languageModels.js';
 import { IExtensionService, nullExtensionDescription } from '../../../../services/extensions/common/extensions.js';
 import { ExtensionsRegistry } from '../../../../services/extensions/common/extensionsRegistry.js';
 import { DEFAULT_MODEL_PICKER_CATEGORY } from '../../common/widget/input/modelPickerWidget.js';
@@ -80,7 +80,8 @@ suite('LanguageModels', function () {
 						id: 'test-id-1',
 						maxInputTokens: 100,
 						maxOutputTokens: 100,
-					},
+						isDefaultForLocation: {}
+					} satisfies ILanguageModelChatMetadata,
 					{
 						extension: nullExtensionDescription.identifier,
 						name: 'Pretty Name',
@@ -91,7 +92,8 @@ suite('LanguageModels', function () {
 						id: 'test-id-12',
 						maxInputTokens: 100,
 						maxOutputTokens: 100,
-					}
+						isDefaultForLocation: {}
+					} satisfies ILanguageModelChatMetadata
 				];
 				const modelMetadataAndIdentifier = modelMetadata.map(m => ({
 					metadata: m,
@@ -154,7 +156,8 @@ suite('LanguageModels', function () {
 						maxInputTokens: 100,
 						maxOutputTokens: 100,
 						modelPickerCategory: DEFAULT_MODEL_PICKER_CATEGORY,
-					}
+						isDefaultForLocation: {}
+					} satisfies ILanguageModelChatMetadata
 				];
 				const modelMetadataAndIdentifier = modelMetadata.map(m => ({
 					metadata: m,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -205,7 +205,7 @@ export class InlineChatController implements IEditorContribution {
 			this._store.add(result);
 
 			this._store.add(result.widget.chatWidget.input.onDidChangeCurrentLanguageModel(newModel => {
-				InlineChatController._selectVendorDefaultLanguageModel = Boolean(newModel.metadata.isDefault);
+				InlineChatController._selectVendorDefaultLanguageModel = Boolean(newModel.metadata.isDefaultForLocation[location.location]);
 			}));
 
 			result.domNode.classList.add('inline-chat-2');
@@ -440,11 +440,11 @@ export class InlineChatController implements IEditorContribution {
 		// or unless the user has chosen to persist their model choice
 		const persistModelChoice = this._configurationService.getValue<boolean>(InlineChatConfigKeys.PersistModelChoice);
 		const model = this._zone.value.widget.chatWidget.input.selectedLanguageModel;
-		if (!persistModelChoice && InlineChatController._selectVendorDefaultLanguageModel && model && !model.metadata.isDefault) {
+		if (!persistModelChoice && InlineChatController._selectVendorDefaultLanguageModel && model && !model.metadata.isDefaultForLocation[session.chatModel.initialLocation]) {
 			const ids = await this._languageModelService.selectLanguageModels({ vendor: model.metadata.vendor }, false);
 			for (const identifier of ids) {
 				const candidate = this._languageModelService.lookupLanguageModel(identifier);
-				if (candidate?.isDefault) {
+				if (candidate?.isDefaultForLocation[session.chatModel.initialLocation]) {
 					this._zone.value.widget.chatWidget.input.setCurrentLanguageModel({ metadata: candidate, identifier });
 					break;
 				}

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -52,7 +52,7 @@ import { CHAT_CONFIG_MENU_ID } from '../../chat/browser/actions/chatActions.js';
 import { ChatViewId, IChatWidgetService } from '../../chat/browser/chat.js';
 import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { IChatElicitationRequest, IChatToolInvocation } from '../../chat/common/chatService/chatService.js';
-import { ChatModeKind } from '../../chat/common/constants.js';
+import { ChatAgentLocation, ChatModeKind } from '../../chat/common/constants.js';
 import { ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { ILanguageModelToolsService } from '../../chat/common/tools/languageModelToolsService.js';
 import { VIEW_CONTAINER } from '../../extensions/browser/extensions.contribution.js';
@@ -1067,7 +1067,7 @@ export class McpConfigureSamplingModels extends Action2 {
 				label: model.name,
 				description: model.tooltip,
 				id,
-				picked: existingIds.size ? existingIds.has(id) : model.isDefault,
+				picked: existingIds.size ? existingIds.has(id) : model.isDefaultForLocation[ChatAgentLocation.Chat],
 			};
 		}).filter(isDefined);
 

--- a/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
@@ -18,6 +18,7 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { ChatAgentLocation } from '../../chat/common/constants.js';
 import { ChatImageMimeType, ChatMessageRole, IChatMessage, IChatMessagePart, ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { McpCommandIds } from './mcpCommandIds.js';
 import { IMcpServerSamplingConfiguration, mcpServerSamplingSection } from './mcpConfiguration.js';
@@ -232,7 +233,7 @@ export class McpSamplingService extends Disposable implements IMcpSamplingServic
 		}
 
 		// 2. Get the configured models, or the default model(s)
-		const foundModelIdsDeep = config.allowedModels?.filter(m => !!this._languageModelsService.lookupLanguageModel(m)) || this._languageModelsService.getLanguageModelIds().filter(m => this._languageModelsService.lookupLanguageModel(m)?.isDefault);
+		const foundModelIdsDeep = config.allowedModels?.filter(m => !!this._languageModelsService.lookupLanguageModel(m)) || this._languageModelsService.getLanguageModelIds().filter(m => this._languageModelsService.lookupLanguageModel(m)?.isDefaultForLocation[ChatAgentLocation.Chat]);
 
 		const foundModelIds = foundModelIdsDeep.flat().sort((a, b) => b.length - a.length); // Sort by length to prefer most specific
 

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -36,7 +36,7 @@ declare module 'vscode' {
 		 * Whether or not this will be selected by default in the model picker
 		 * NOT BEING FINALIZED
 		 */
-		readonly isDefault?: boolean;
+		readonly isDefault?: boolean | { [K in ChatLocation]?: boolean };
 
 		/**
 		 * Whether or not the model will show up in the model picker immediately upon being made known via {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}.


### PR DESCRIPTION
We have `isDefault` which allows a model to indicate that it is the best/most-recommended model. This PR extends this concept to define default by location, e.g for inline chat a different default model might apply than for panel chat or terminal chat