### PR TITLE
ensure important extension info wraps so low vision users can see it at 200% zoom

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -66,7 +66,8 @@
 
 .extension-editor > .header > .details > .title {
 	display: flex;
-	align-items: center;
+	align-items: baseline;
+	flex-wrap: wrap;
 }
 
 .extension-editor > .header > .details > .title > .name {
@@ -74,7 +75,6 @@
 	font-size: 26px;
 	line-height: 30px;
 	font-weight: 600;
-	white-space: nowrap;
 }
 
 .extension-editor > .header > .details > .title > .name.deprecated {
@@ -131,9 +131,8 @@
 
 .extension-editor > .header > .details > .subtitle {
 	padding-top: 6px;
-	white-space: nowrap;
-	height: 20px;
 	line-height: 20px;
+	flex-wrap: wrap;
 }
 
 .extension-editor > .header > .details > .subtitle .hide {
@@ -179,9 +178,6 @@
 
 .extension-editor > .header > .details > .description {
 	margin-top: 10px;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
 }
 
 .extension-editor > .header > .details > .actions-status-container {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -66,8 +66,7 @@
 
 .extension-editor > .header > .details > .title {
 	display: flex;
-	align-items: baseline;
-	flex-wrap: wrap;
+	align-items: center;
 }
 
 .extension-editor > .header > .details > .title > .name {
@@ -75,6 +74,7 @@
 	font-size: 26px;
 	line-height: 30px;
 	font-weight: 600;
+	white-space: nowrap;
 }
 
 .extension-editor > .header > .details > .title > .name.deprecated {


### PR DESCRIPTION
fixes #287226

Before

<img width="658" height="466" alt="Screenshot 2026-01-13 at 11 36 47 AM" src="https://github.com/user-attachments/assets/9e208bc2-885f-4ceb-a093-bcc829996ed7" />

After

<img width="549" height="421" alt="Screenshot 2026-01-13 at 11 36 09 AM" src="https://github.com/user-attachments/assets/0ce0b86d-239d-4241-9594-c3b17027e6bf" />
