### PR TITLE
chore: bump native node modules

### DIFF
--- a/build/linux/debian/dep-lists.ts
+++ b/build/linux/debian/dep-lists.ts
@@ -64,7 +64,6 @@ export const referenceGeneratedDepsByArch = {
 		'libatk-bridge2.0-0 (>= 2.5.3)',
 		'libatk1.0-0 (>= 2.11.90)',
 		'libatspi2.0-0 (>= 2.9.90)',
-		'libc6 (>= 2.15)',
 		'libc6 (>= 2.16)',
 		'libc6 (>= 2.17)',
 		'libc6 (>= 2.25)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@vscode/proxy-agent": "^0.36.0",
         "@vscode/ripgrep": "^1.15.13",
         "@vscode/spdlog": "^0.15.2",
-        "@vscode/sqlite3": "5.1.10-vscode",
+        "@vscode/sqlite3": "5.1.11-vscode",
         "@vscode/sudo-prompt": "9.3.2",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/@vscode/policy-watcher": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@vscode/policy-watcher/-/policy-watcher-1.3.5.tgz",
-      "integrity": "sha512-k1n9gaDBjyVRy5yJLABbZCnyFwgQ8OA4sR3vXmXnmB+mO9JA0nsl/XOXQfVCoLasBu3UHCOfAnDWGn2sRzCR+A==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@vscode/policy-watcher/-/policy-watcher-1.3.7.tgz",
+      "integrity": "sha512-OvIczTbtGLZs7YU0ResbjM0KEB2ORBnlJ4ICxaB9fKHNVBwNVp4i2qIkDQGp3UBGtu7P8/+eg4/ZKk2oJGFcug==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3320,9 +3320,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.4.tgz",
-      "integrity": "sha512-NmFasVWjn/6BjHMAjqalsbG2srQCt8yfC0EczP5wzNQFawv74rhvuarhWi44x3St9LB8bZBxrpbT7igPaTJwcw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.6.tgz",
+      "integrity": "sha512-s0ei7I0rLrNlsGTa8EVoAXe4qvbsfXrHebQ5dNbu7dc1Zs/DbnJNSADpHUy8vtNvTJukBWjOXFhAYUfXxGk+Bg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3332,9 +3332,9 @@
       }
     },
     "node_modules/@vscode/sqlite3": {
-      "version": "5.1.10-vscode",
-      "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.10-vscode.tgz",
-      "integrity": "sha512-sCJozBr1jItK4eCtbibX3Vi8BXfNyDsPCplojm89OuydoSxwP+Z3gSgzsTXWD5qYyXpTvVaT3LtHLoH2Byv8oA==",
+      "version": "5.1.11-vscode",
+      "resolved": "https://registry.npmjs.org/@vscode/sqlite3/-/sqlite3-5.1.11-vscode.tgz",
+      "integrity": "sha512-x2vBjFRZj/34Ji46lrxotjUtgljistPZU3cbxpckml3bMwF+Z0zbJYiplIeskHLo2g0Kj3kvR8MRRJ+o2nxNug==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3559,9 +3559,9 @@
       }
     },
     "node_modules/@vscode/windows-mutex": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-mutex/-/windows-mutex-0.5.2.tgz",
-      "integrity": "sha512-O9CNYVl2GmFVbiHiz7tyFrKIdXVs3qf8HnyWlfxyuMaKzXd1L35jSTNCC1oAVwr8F0O2P4o3C/jOSIXulUCJ7w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-mutex/-/windows-mutex-0.5.3.tgz",
+      "integrity": "sha512-hWNmD+AzINR57jWuc/iW53kA+BghI4iOuicxhAEeeJLPOeMm9X5IUD0ttDwJFEib+D8H/2T9pT/8FeB/xcqbRw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3580,9 +3580,9 @@
       }
     },
     "node_modules/@vscode/windows-registry": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-registry/-/windows-registry-1.1.2.tgz",
-      "integrity": "sha512-/eDRmGNe6g11wHckOyiVLvK/mEE5UBZFeoRlBosIL343LDrSKUL5JDAcFeAZqOXnlTtZ3UZtj5yezKiAz99NcA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-registry/-/windows-registry-1.1.3.tgz",
+      "integrity": "sha512-si8+b+2Wh0x2X6W2+kgDyLJD9hyGIrjUo1X/7RWlvsxyI5+Pg+bpdHJrVYtIW4cHOPVB0FYFaN1UZndbUbU5lQ==",
       "hasInstallScript": true,
       "license": "MIT"
     },
@@ -12818,9 +12818,9 @@
       "license": "MIT"
     },
     "node_modules/native-keymap": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/native-keymap/-/native-keymap-3.3.7.tgz",
-      "integrity": "sha512-07n5kF0L9ERC9pilqEFucnhs1XG4WttbHAMWhhOSqQYXhB8mMNTSCzP4psTaVgDSp6si2HbIPhTIHuxSia6NPQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/native-keymap/-/native-keymap-3.3.9.tgz",
+      "integrity": "sha512-d/ydQ5x+GM5W0dyAjFPwexhtc9CDH1g/xWZESS5CXk16ThyFzSBLvlBJq1+FyzUIFf/F2g1MaHdOpa6G9150YQ==",
       "hasInstallScript": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@vscode/proxy-agent": "^0.36.0",
     "@vscode/ripgrep": "^1.15.13",
     "@vscode/spdlog": "^0.15.2",
-    "@vscode/sqlite3": "5.1.10-vscode",
+    "@vscode/sqlite3": "5.1.11-vscode",
     "@vscode/sudo-prompt": "9.3.2",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.4.tgz",
-      "integrity": "sha512-NmFasVWjn/6BjHMAjqalsbG2srQCt8yfC0EczP5wzNQFawv74rhvuarhWi44x3St9LB8bZBxrpbT7igPaTJwcw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.6.tgz",
+      "integrity": "sha512-s0ei7I0rLrNlsGTa8EVoAXe4qvbsfXrHebQ5dNbu7dc1Zs/DbnJNSADpHUy8vtNvTJukBWjOXFhAYUfXxGk+Bg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@vscode/windows-process-tree": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.6.2.tgz",
-      "integrity": "sha512-uzyUuQ93m7K1jSPrB/72m4IspOyeGpvvghNwFCay/McZ+y4Hk2BnLdZPb6EJ8HLRa3GwCvYjH/MQZzcnLOVnaQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.6.3.tgz",
+      "integrity": "sha512-mjirLbtgjv7P6fwD8gx7iaY961EfGqUExGvfzsKl3spLfScg57ejlMi+7O1jfJqpM2Zly9DTSxyY4cFsDN6c9Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@vscode/windows-registry": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vscode/windows-registry/-/windows-registry-1.1.2.tgz",
-      "integrity": "sha512-/eDRmGNe6g11wHckOyiVLvK/mEE5UBZFeoRlBosIL343LDrSKUL5JDAcFeAZqOXnlTtZ3UZtj5yezKiAz99NcA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-registry/-/windows-registry-1.1.3.tgz",
+      "integrity": "sha512-si8+b+2Wh0x2X6W2+kgDyLJD9hyGIrjUo1X/7RWlvsxyI5+Pg+bpdHJrVYtIW4cHOPVB0FYFaN1UZndbUbU5lQ==",
       "hasInstallScript": true,
       "license": "MIT"
     },


### PR DESCRIPTION
This PR bumps several native node modules to bring in the latest BinSkim fixes.

The previous attempt brought in packages compiled with a fortify-source flag that were incompatible with the Linux build.

Verification build: https://monacotools.visualstudio.com/Monaco/_build/results?buildId=391398&view=results