### PR TITLE
fix terminal suggest regression 

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -413,6 +413,13 @@ export async function resolveCwdFromCurrentCommandString(currentCommandString: s
 		}
 		const relativeFolder = lastSlashIndex === -1 ? '' : prefix.slice(0, lastSlashIndex);
 
+		// Don't pre-resolve paths with .. segments - let the completion service handle those
+		// to avoid double-navigation (e.g., typing ../ would resolve cwd to parent here,
+		// then completion service would navigate up again from the already-parent cwd)
+		if (relativeFolder.includes('..')) {
+			return undefined;
+		}
+
 		// Use vscode.Uri.joinPath for path resolution
 		const resolvedUri = vscode.Uri.joinPath(currentCwd, relativeFolder);
 

--- a/extensions/terminal-suggest/src/test/completions/cd.test.ts
+++ b/extensions/terminal-suggest/src/test/completions/cd.test.ts
@@ -37,7 +37,8 @@ export const cdTestSuiteSpec: ISuiteSpec = {
 
 		// Relative directories (changes cwd due to /)
 		{ input: 'cd child/|', expectedCompletions, expectedResourceRequests: { type: 'folders', cwd: testPaths.cwdChild } },
-		{ input: 'cd ../|', expectedCompletions, expectedResourceRequests: { type: 'folders', cwd: testPaths.cwdParent } },
-		{ input: 'cd ../sibling|', expectedCompletions, expectedResourceRequests: { type: 'folders', cwd: testPaths.cwdParent } },
+		// Paths with .. are handled by the completion service to avoid double-navigation (no cwd resolution)
+		{ input: 'cd ../|', expectedCompletions, expectedResourceRequests: { type: 'folders' } },
+		{ input: 'cd ../sibling|', expectedCompletions, expectedResourceRequests: { type: 'folders' } },
 	]
 };

--- a/extensions/terminal-suggest/src/test/completions/upstream/ls.test.ts
+++ b/extensions/terminal-suggest/src/test/completions/upstream/ls.test.ts
@@ -84,8 +84,9 @@ export const lsTestSuiteSpec: ISuiteSpec = {
 
 		// Relative directories (changes cwd due to /)
 		{ input: 'ls child/|', expectedCompletions: allOptions, expectedResourceRequests: { type: 'both', cwd: testPaths.cwdChild } },
-		{ input: 'ls ../|', expectedCompletions: allOptions, expectedResourceRequests: { type: 'both', cwd: testPaths.cwdParent } },
-		{ input: 'ls ../sibling|', expectedCompletions: allOptions, expectedResourceRequests: { type: 'both', cwd: testPaths.cwdParent } },
+		// Paths with .. are handled by the completion service to avoid double-navigation (no cwd resolution)
+		{ input: 'ls ../|', expectedCompletions: allOptions, expectedResourceRequests: { type: 'both' } },
+		{ input: 'ls ../sibling|', expectedCompletions: allOptions, expectedResourceRequests: { type: 'both' } },
 	]
 };
 

--- a/extensions/terminal-suggest/src/test/helpers.ts
+++ b/extensions/terminal-suggest/src/test/helpers.ts
@@ -21,7 +21,7 @@ export interface ITestSpec {
 	input: string;
 	expectedResourceRequests?: {
 		type: 'files' | 'folders' | 'both';
-		cwd: Uri;
+		cwd?: Uri;
 	};
 	expectedCompletions?: (string | ICompletionResource)[];
 }

--- a/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
+++ b/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
@@ -85,7 +85,7 @@ suite('Terminal Suggest', () => {
 				let expectedString = testSpec.expectedCompletions ? `[${testSpec.expectedCompletions.map(e => `'${e}'`).join(', ')}]` : '[]';
 				if (testSpec.expectedResourceRequests) {
 					expectedString += ` + ${testSpec.expectedResourceRequests.type}`;
-					if (testSpec.expectedResourceRequests.cwd.fsPath !== testPaths.cwd.fsPath) {
+					if (testSpec.expectedResourceRequests.cwd && testSpec.expectedResourceRequests.cwd.fsPath !== testPaths.cwd.fsPath) {
 						expectedString += ` @ ${basename(testSpec.expectedResourceRequests.cwd.fsPath)}/`;
 					}
 				}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -591,7 +591,7 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 			if (lastWordFolder.length > 0) {
 				label = addPathRelativePrefix(lastWordFolder + label, resourceOptions, lastWordFolderHasDotPrefix);
 			}
-			const parentDir = URI.joinPath(cwd, '..' + resourceOptions.pathSeparator);
+			const parentDir = URI.joinPath(lastWordFolderResource, '..' + resourceOptions.pathSeparator);
 			resourceCompletions.push({
 				label,
 				provider,


### PR DESCRIPTION
fixes #287161

The bug was caused by double-navigation when typing `../`:

- Extension side: `resolveCwdFromCurrentCommandString()` was pre-resolving `../` paths, setting `cwd` to the parent directory
- Completion service side: When processing `../`, it did `URI.joinPath(cwd, '../')` which navigated up AGAIN from the already-resolved parent

So typing `../` from `vscode` resulted in:

- Extension resolved cwd to `Repos` (parent)
- Completion service then did `joinPath(parent, '../')` = `meganrogge`(grandparent)
- Children shown were from grandparent, showing `Repos` instead of `xterm.js`

Added a check in `resolveCwdFromCurrentCommandString` to skip pre-resolution for paths containing `..` to fix this.
