### PR TITLE
Integrated Browser - New Tab welcome screen

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -390,7 +390,7 @@ export class BrowserEditor extends EditorPane {
 	}
 
 	private get shouldShowView(): boolean {
-		return this._editorVisible && !this._overlayVisible && !this._model?.error;
+		return this._editorVisible && !this._overlayVisible && !this._model?.error && !!this._model?.url;
 	}
 
 	private checkOverlays(): void {

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -280,7 +280,6 @@ export class BrowserEditor extends EditorPane {
 			canGoForward: this._model.canGoForward
 		});
 		this.setBackgroundImage(this._model.screenshot);
-		this.updateWelcomeVisibility();
 
 		if (context.newInGroup) {
 			this._navigationBar.focusUrlInput();
@@ -374,9 +373,18 @@ export class BrowserEditor extends EditorPane {
 	}
 
 	private updateVisibility(): void {
+		const hasUrl = !!this._model?.url;
+		const hasError = !!this._model?.error;
+
+		// Welcome container: shown when no URL is loaded
+		this._welcomeContainer.style.display = hasUrl ? 'none' : 'flex';
+
+		// Error container: shown when there's a load error
+		this._errorContainer.style.display = hasError ? 'flex' : 'none';
+
 		if (this._model) {
 			// Blur the background placeholder screenshot if the view is hidden due to an overlay.
-			this._placeholderScreenshot.classList.toggle('blur', this._editorVisible && this._overlayVisible && !this._model?.error);
+			this._placeholderScreenshot.classList.toggle('blur', this._editorVisible && this._overlayVisible && !hasError);
 			void this._model.setVisible(this.shouldShowView);
 		}
 	}
@@ -403,9 +411,7 @@ export class BrowserEditor extends EditorPane {
 
 		const error: IBrowserViewLoadError | undefined = this._model.error;
 		if (error) {
-			// Show error display
-			this._errorContainer.style.display = 'flex';
-
+			// Update error content
 			while (this._errorContainer.firstChild) {
 				this._errorContainer.removeChild(this._errorContainer.firstChild);
 			}
@@ -435,8 +441,6 @@ export class BrowserEditor extends EditorPane {
 
 			this.setBackgroundImage(undefined);
 		} else {
-			// Hide error display
-			this._errorContainer.style.display = 'none';
 			this.setBackgroundImage(this._model.screenshot);
 		}
 
@@ -577,16 +581,8 @@ export class BrowserEditor extends EditorPane {
 		this._canGoBackContext.set(event.canGoBack);
 		this._canGoForwardContext.set(event.canGoForward);
 
-		// Update welcome screen visible or not
-		this.updateWelcomeVisibility();
-	}
-
-	/**
-	 * Show or hide the welcome screen based on whether a URL is loaded
-	 */
-	private updateWelcomeVisibility(): void {
-		const showWelcome = !this._model?.url;
-		this._welcomeContainer.style.display = showWelcome ? 'flex' : 'none';
+		// Update visibility (welcome screen, error, browser view)
+		this.updateVisibility();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -412,6 +412,7 @@ export class BrowserEditor extends EditorPane {
 		const error: IBrowserViewLoadError | undefined = this._model.error;
 		if (error) {
 			// Update error content
+
 			while (this._errorContainer.firstChild) {
 				this._errorContainer.removeChild(this._errorContainer.firstChild);
 			}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -601,7 +601,7 @@ export class BrowserEditor extends EditorPane {
 		content.appendChild(iconContainer);
 
 		const title = $('.browser-welcome-title');
-		title.textContent = localize('browser.welcomeTitle', "Integrated Browser");
+		title.textContent = localize('browser.welcomeTitle', "Browser");
 		content.appendChild(title);
 
 		const subtitle = $('.browser-welcome-subtitle');

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -82,35 +82,35 @@
 		padding: 80px 40px;
 		margin: 0 2px 2px;
 		background-color: var(--vscode-editor-background);
+	}
 
-		.browser-error-content {
-			max-width: 600px;
-			width: 100%;
-		}
+	.browser-error-content {
+		max-width: 600px;
+		width: 100%;
+	}
 
-		.browser-error-title {
-			font-size: 18px;
+	.browser-error-title {
+		font-size: 18px;
+		font-weight: 600;
+		color: var(--vscode-errorForeground);
+		margin-bottom: 20px;
+	}
+
+	.browser-error-detail {
+		margin-bottom: 12px;
+		line-height: 1.6;
+		color: var(--vscode-foreground);
+
+		strong {
 			font-weight: 600;
-			color: var(--vscode-errorForeground);
-			margin-bottom: 20px;
 		}
 
-		.browser-error-detail {
-			margin-bottom: 12px;
-			line-height: 1.6;
-			color: var(--vscode-foreground);
-
-			strong {
-				font-weight: 600;
-			}
-
-			code {
-				background-color: var(--vscode-textCodeBlock-background);
-				padding: 2px 6px;
-				border-radius: 3px;
-				font-family: var(--monaco-monospace-font);
-				font-size: 12px;
-			}
+		code {
+			background-color: var(--vscode-textCodeBlock-background);
+			padding: 2px 6px;
+			border-radius: 3px;
+			font-family: var(--monaco-monospace-font);
+			font-size: 12px;
 		}
 	}
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -47,12 +47,20 @@
 		margin: 0 2px 2px;
 		overflow: hidden;
 		position: relative;
+		outline: none !important;
+	}
+
+	.browser-placeholder-screenshot {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
 		background-image: none;
 		background-size: contain;
 		background-repeat: no-repeat;
 		filter: blur(0px);
 		transition: opacity 300ms ease-out, filter 300ms ease-out;
-		outline: none !important;
 		opacity: 1.0;
 
 		&.blur {
@@ -74,35 +82,93 @@
 		padding: 80px 40px;
 		margin: 0 2px 2px;
 		background-color: var(--vscode-editor-background);
-	}
 
-	.browser-error-content {
-		max-width: 600px;
-		width: 100%;
-	}
-
-	.browser-error-title {
-		font-size: 18px;
-		font-weight: 600;
-		color: var(--vscode-errorForeground);
-		margin-bottom: 20px;
-	}
-
-	.browser-error-detail {
-		margin-bottom: 12px;
-		line-height: 1.6;
-		color: var(--vscode-foreground);
-
-		strong {
-			font-weight: 600;
+		.browser-error-content {
+			max-width: 600px;
+			width: 100%;
 		}
 
-		code {
-			background-color: var(--vscode-textCodeBlock-background);
-			padding: 2px 6px;
-			border-radius: 3px;
-			font-family: var(--monaco-monospace-font);
-			font-size: 12px;
+		.browser-error-title {
+			font-size: 18px;
+			font-weight: 600;
+			color: var(--vscode-errorForeground);
+			margin-bottom: 20px;
+		}
+
+		.browser-error-detail {
+			margin-bottom: 12px;
+			line-height: 1.6;
+			color: var(--vscode-foreground);
+
+			strong {
+				font-weight: 600;
+			}
+
+			code {
+				background-color: var(--vscode-textCodeBlock-background);
+				padding: 2px 6px;
+				border-radius: 3px;
+				font-family: var(--monaco-monospace-font);
+				font-size: 12px;
+			}
+		}
+	}
+
+	.browser-welcome-container {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: var(--vscode-editor-background);
+
+		.browser-welcome-content {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			padding: 12px;
+		}
+
+		.browser-welcome-icon {
+			min-height: 48px;
+
+			.codicon {
+				font-size: 40px;
+			}
+		}
+
+		.browser-welcome-title {
+			font-size: 24px;
+			margin-top: 5px;
+			text-align: center;
+			line-height: normal;
+			padding: 0 8px;
+		}
+
+		.browser-welcome-subtitle {
+			position: relative;
+			text-align: center;
+			max-width: 100%;
+			padding: 0 20px;
+			margin: 8px auto 0;
+			color: var(--vscode-foreground);
+
+			p {
+				margin-top: 8px;
+				margin-bottom: 8px;
+			}
+		}
+
+		.browser-welcome-tip {
+			color: var(--vscode-foreground);
+			text-align: center;
+			margin: 16px auto 0;
+			max-width: 400px;
+			padding: 0 12px;
+			font-style: italic;
 		}
 	}
 }

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -163,7 +163,7 @@
 		}
 
 		.browser-welcome-tip {
-			color: var(--vscode-foreground);
+			color: var(--vscode-descriptionForeground);
 			text-align: center;
 			margin: 16px auto 0;
 			max-width: 400px;


### PR DESCRIPTION
Add a "null state" or New Tab welcome screen that shows up when the Integrated Browser opens and before the user types a URL.

Also ensures that this new welcome screen isn't applied a blur CSS filter when opening the command palette, by separating the blurrable placeholder screenshot into its own separate element.

<img width="1800" height="1095" alt="image" src="https://github.com/user-attachments/assets/af7d6bd9-e76a-4e4f-99d2-d1cf78b71218" />

Related issue: https://github.com/microsoft/vscode/issues/286579
