### PR TITLE
make chat thinking stream screen reader accessible

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -21,6 +21,7 @@ export const enum AccessibleViewProviderId {
 	MergeEditor = 'mergeEditor',
 	PanelChat = 'panelChat',
 	ChatTerminalOutput = 'chatTerminalOutput',
+	ChatThinking = 'chatThinking',
 	InlineChat = 'inlineChat',
 	AgentChat = 'agentChat',
 	QuickChat = 'quickChat',

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
@@ -5,18 +5,18 @@
 
 import { AccessibleContentProvider, AccessibleViewProviderId, AccessibleViewType } from '../../../../../platform/accessibility/browser/accessibleView.js';
 import { IAccessibleViewImplementation } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
-import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatWidgetService } from '../chat.js';
 import { IChatResponseViewModel, isResponseVM } from '../../common/model/chatViewModel.js';
-import { localize } from '../../../../../nls.js';
 
 export class ChatThinkingAccessibleView implements IAccessibleViewImplementation {
 	readonly priority = 105;
 	readonly name = 'chatThinking';
 	readonly type = AccessibleViewType.View;
-	readonly when = ChatContextKeys.inChatSession;
+	// Never match via the registry - this view is only opened via the explicit command (Alt+Shift+F2)
+	readonly when = ContextKeyExpr.false();
 
 	getProvider(accessor: ServicesAccessor) {
 		const widgetService = accessor.get(IChatWidgetService);
@@ -67,8 +67,7 @@ export class ChatThinkingAccessibleView implements IAccessibleViewImplementation
 		if (thinkingParts.length === 0) {
 			return undefined;
 		}
-
-		const header = localize('chat.thinking.accessibleView.header', 'Thinking content from the latest response:');
-		return `${header}\n\n${thinkingParts.join('\n\n')}`;
+		console.log(`${thinkingParts.join('\n\n')}`);
+		return `${thinkingParts.join('\n\n')}`;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
@@ -67,7 +67,6 @@ export class ChatThinkingAccessibleView implements IAccessibleViewImplementation
 		if (thinkingParts.length === 0) {
 			return undefined;
 		}
-		console.log(`${thinkingParts.join('\n\n')}`);
-		return `${thinkingParts.join('\n\n')}`;
+		return thinkingParts.join('\n\n');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatThinkingAccessibleView.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AccessibleContentProvider, AccessibleViewProviderId, AccessibleViewType } from '../../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
+import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { IChatWidgetService } from '../chat.js';
+import { IChatResponseViewModel, isResponseVM } from '../../common/model/chatViewModel.js';
+import { localize } from '../../../../../nls.js';
+
+export class ChatThinkingAccessibleView implements IAccessibleViewImplementation {
+	readonly priority = 105;
+	readonly name = 'chatThinking';
+	readonly type = AccessibleViewType.View;
+	readonly when = ChatContextKeys.inChatSession;
+
+	getProvider(accessor: ServicesAccessor) {
+		const widgetService = accessor.get(IChatWidgetService);
+		const widget = widgetService.lastFocusedWidget;
+		if (!widget) {
+			return;
+		}
+
+		const viewModel = widget.viewModel;
+		if (!viewModel) {
+			return;
+		}
+
+		// Get the latest response from the chat
+		const items = viewModel.getItems();
+		const latestResponse = [...items].reverse().find(item => isResponseVM(item));
+		if (!latestResponse || !isResponseVM(latestResponse)) {
+			return;
+		}
+
+		// Extract thinking content from the response
+		const thinkingContent = this._extractThinkingContent(latestResponse);
+		if (!thinkingContent) {
+			return;
+		}
+
+		return new AccessibleContentProvider(
+			AccessibleViewProviderId.ChatThinking,
+			{ type: AccessibleViewType.View, id: AccessibleViewProviderId.ChatThinking, language: 'markdown' },
+			() => thinkingContent,
+			() => widget.focusInput(),
+			AccessibilityVerbositySettingId.Chat
+		);
+	}
+
+	private _extractThinkingContent(response: IChatResponseViewModel): string | undefined {
+		const thinkingParts: string[] = [];
+		for (const part of response.response.value) {
+			if (part.kind === 'thinking') {
+				const value = Array.isArray(part.value) ? part.value.join('') : (part.value || '');
+				const trimmed = value.trim();
+				if (trimmed) {
+					thinkingParts.push(trimmed);
+				}
+			}
+		}
+
+		if (thinkingParts.length === 0) {
+			return undefined;
+		}
+
+		const header = localize('chat.thinking.accessibleView.header', 'Thinking content from the latest response:');
+		return `${header}\n\n${thinkingParts.join('\n\n')}`;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
@@ -6,15 +6,19 @@
 import { alert } from '../../../../../base/browser/ui/aria/aria.js';
 import { localize } from '../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
 import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from '../../../../../platform/accessibility/common/accessibility.js';
+import { IAccessibleViewService } from '../../../../../platform/accessibility/browser/accessibleView.js';
+import { ChatThinkingAccessibleView } from '../accessibility/chatThinkingAccessibleView.js';
+import { CHAT_CATEGORY } from './chatActions.js';
 
 export const ACTION_ID_FOCUS_CHAT_CONFIRMATION = 'workbench.action.chat.focusConfirmation';
+export const ACTION_ID_OPEN_THINKING_ACCESSIBLE_VIEW = 'workbench.action.chat.openThinkingAccessibleView';
 
 class AnnounceChatConfirmationAction extends Action2 {
 	constructor() {
@@ -67,6 +71,39 @@ class AnnounceChatConfirmationAction extends Action2 {
 	}
 }
 
+class OpenThinkingAccessibleViewAction extends Action2 {
+	constructor() {
+		super({
+			id: ACTION_ID_OPEN_THINKING_ACCESSIBLE_VIEW,
+			title: { value: localize('openThinkingAccessibleView', 'Open Thinking Accessible View'), original: 'Open Thinking Accessible View' },
+			category: CHAT_CATEGORY,
+			precondition: ChatContextKeys.enabled,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F2,
+				when: ChatContextKeys.inChatSession
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const accessibleViewService = accessor.get(IAccessibleViewService);
+		const instantiationService = accessor.get(IInstantiationService);
+
+		const thinkingView = new ChatThinkingAccessibleView();
+		const provider = instantiationService.invokeFunction(thinkingView.getProvider.bind(thinkingView));
+
+		if (!provider) {
+			alert(localize('noThinking', 'No thinking'));
+			return;
+		}
+
+		accessibleViewService.show(provider);
+	}
+}
+
 export function registerChatAccessibilityActions(): void {
 	registerAction2(AnnounceChatConfirmationAction);
+	registerAction2(OpenThinkingAccessibleViewAction);
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
@@ -81,7 +81,7 @@ class OpenThinkingAccessibleViewAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F2,
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F3,
 				when: ChatContextKeys.inChatSession
 			}
 		});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -17,6 +17,7 @@ import { TerminalContribCommandId } from '../../../terminal/terminalContribExpor
 import { ChatContextKeyExprs, ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
 import { FocusAgentSessionsAction } from '../agentSessions/agentSessionsActions.js';
+import { ACTION_ID_OPEN_THINKING_ACCESSIBLE_VIEW } from './chatAccessibilityActions.js';
 import { IChatWidgetService } from '../chat.js';
 import { ChatEditingShowChangesAction, ViewPreviousEditsAction } from '../chatEditing/chatEditingActions.js';
 
@@ -75,6 +76,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
 		content.push(localize('chat.attachments.removal', 'To remove attached contexts, focus an attachment and press Delete or Backspace.'));
 		content.push(localize('chat.inspectResponse', 'In the input box, inspect the last response in the accessible view{0}.', '<keybinding:editor.action.accessibleView>'));
+		content.push(localize('chat.openThinkingAccessibleView', 'To inspect thinking content from the latest response, invoke the Open Thinking Accessible View command{0}.', `<keybinding:${ACTION_ID_OPEN_THINKING_ACCESSIBLE_VIEW}>`));
 		content.push(localize('workbench.action.chat.focus', 'To focus the chat request and response list, invoke the Focus Chat command{0}. This will move focus to the most recent response, which you can then navigate using the up and down arrow keys.', getChatFocusKeybindingLabel(keybindingService, type, 'last')));
 		content.push(localize('workbench.action.chat.focusLastFocusedItem', 'To return to the last chat response you focused, invoke the Focus Last Focused Chat Response command{0}.', getChatFocusKeybindingLabel(keybindingService, type, 'lastFocused')));
 		content.push(localize('workbench.action.chat.focusInput', 'To focus the input box for chat requests, invoke the Focus Chat Input command{0}.', getChatFocusKeybindingLabel(keybindingService, type, 'input')));

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -113,6 +113,7 @@ import { ChatPasteProvidersFeature } from './widget/input/editor/chatPasteProvid
 import { QuickChatService } from './widgetHosts/chatQuick.js';
 import { ChatResponseAccessibleView } from './accessibility/chatResponseAccessibleView.js';
 import { ChatTerminalOutputAccessibleView } from './accessibility/chatTerminalOutputAccessibleView.js';
+import { ChatThinkingAccessibleView } from './accessibility/chatThinkingAccessibleView.js';
 import { ChatSetupContribution, ChatTeardownContribution } from './chatSetup/chatSetupContributions.js';
 import { ChatStatusBarEntry } from './chatStatus/chatStatusEntry.js';
 import { ChatVariablesService } from './attachments/chatVariables.js';
@@ -1082,6 +1083,7 @@ class ToolReferenceNamesContribution extends Disposable implements IWorkbenchCon
 }
 
 AccessibleViewRegistry.register(new ChatTerminalOutputAccessibleView());
+AccessibleViewRegistry.register(new ChatThinkingAccessibleView());
 AccessibleViewRegistry.register(new ChatResponseAccessibleView());
 AccessibleViewRegistry.register(new PanelChatAccessibilityHelp());
 AccessibleViewRegistry.register(new QuickChatAccessibilityHelp());

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { $, clearNode, hide } from '../../../../../../base/browser/dom.js';
+import { alert } from '../../../../../../base/browser/ui/aria/aria.js';
 import { IChatMarkdownContent, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService/chatService.js';
 import { IChatContentPartRenderContext, IChatContentPart } from './chatContentParts.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
@@ -128,6 +129,9 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 			this.lastExtractedTitle = extractedTitle;
 		}
 		this.currentThinkingValue = initialText;
+
+		// Alert screen reader users that thinking has started
+		alert(localize('chat.thinking.started', 'Thinking'));
 
 		if (configuredMode === ThinkingDisplayMode.Collapsed) {
 			this.setExpanded(false);


### PR DESCRIPTION
fixes #286777 

Adds a `ChatThinkingAccessibleView`, which can be accessed via a command. If no thinking is present, we alert to indicate that. Otherwise, we open the accessible view with the current thinking content. 

Uses `shift+alt+f2` to align with and extend the existing `alt+f2` one. 

- to discuss with screen reader users: should we clear the thinking content once thinking has stopped or leave it around until the next thinking stream comes in?