### PR TITLE
Remove timeout warning, keep running

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -128,6 +128,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 						const shouldContinuePolling = await this._handleTimeoutState(command, invocationContext, extended, token);
 						if (shouldContinuePolling) {
 							extended = true;
+							this._state = OutputMonitorState.PollingForIdle;
 							continue;
 						} else {
 							this._promptPart?.hide();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -260,63 +260,15 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		return { resources, modelOutputEvalResponse, shouldContinuePollling: false, output: custom?.output ?? output };
 	}
 
-	private async _handleTimeoutState(command: string, invocationContext: IToolInvocationContext | undefined, extended: boolean, token: CancellationToken): Promise<boolean> {
-		let continuePollingPart: ChatElicitationRequestPart | undefined;
-		if (extended) {
+	private async _handleTimeoutState(_command: string, _invocationContext: IToolInvocationContext | undefined, _extended: boolean, _token: CancellationToken): Promise<boolean> {
+		// Stop after extended polling (2 minutes) without notifying user
+		if (_extended) {
+			this._logService.info('OutputMonitor: Extended polling timeout reached after 2 minutes');
 			this._state = OutputMonitorState.Cancelled;
 			return false;
 		}
-		extended = true;
-
-		const { promise: p, part } = await this._promptForMorePolling(command, token, invocationContext);
-		let continuePollingDecisionP: Promise<boolean> | undefined = p;
-		continuePollingPart = part;
-
-		// Start another polling pass and race it against the user's decision
-		const nextPollP = this._waitForIdle(this._execution, extended, token)
-			.catch((): IPollingResult => ({
-				state: OutputMonitorState.Cancelled,
-				output: this._execution.getOutput(),
-				modelOutputEvalResponse: 'Cancelled'
-			}));
-
-		const race = await Promise.race([
-			continuePollingDecisionP.then(v => ({ kind: 'decision' as const, v })),
-			nextPollP.then(r => ({ kind: 'poll' as const, r }))
-		]);
-
-		if (race.kind === 'decision') {
-			try { continuePollingPart?.hide(); } catch { /* noop */ }
-			continuePollingPart = undefined;
-
-			// User explicitly declined to keep waiting, so finish with the timed-out result
-			if (race.v === false) {
-				this._state = OutputMonitorState.Cancelled;
-				return false;
-			}
-
-			// User accepted; keep polling (the loop iterates again).
-			// Clear the decision so we don't race on a resolved promise.
-			continuePollingDecisionP = undefined;
-			return true;
-		} else {
-			// A background poll completed while waiting for a decision
-			const r = race.r;
-			// r can be either an OutputMonitorState or an IPollingResult object (from catch)
-			const state = (typeof r === 'object' && r !== null) ? r.state : r;
-
-			if (state === OutputMonitorState.Idle || state === OutputMonitorState.Cancelled || state === OutputMonitorState.Timeout) {
-				try { continuePollingPart?.hide(); } catch { /* noop */ }
-				continuePollingPart = undefined;
-				continuePollingDecisionP = undefined;
-				this._promptPart = undefined;
-
-				return false;
-			}
-
-			// Still timing out; loop and race again with the same prompt.
-			return true;
-		}
+		// Continue polling with exponential backoff
+		return true;
 	}
 
 	/**
@@ -413,27 +365,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		this._userInputListener?.dispose();
 		this._userInputListener = undefined;
 	}
-
-	private async _promptForMorePolling(command: string, token: CancellationToken, context: IToolInvocationContext | undefined): Promise<{ promise: Promise<boolean>; part?: ChatElicitationRequestPart }> {
-		if (token.isCancellationRequested || this._state === OutputMonitorState.Cancelled) {
-			return { promise: Promise.resolve(false) };
-		}
-		const result = this._createElicitationPart<boolean>(
-			token,
-			context?.sessionId,
-			new MarkdownString(localize('poll.terminal.waiting', "Continue waiting for `{0}`?", command)),
-			new MarkdownString(localize('poll.terminal.polling', "This will continue to poll for output to determine when the terminal becomes idle for up to 2 minutes.")),
-			'',
-			localize('poll.terminal.accept', 'Yes'),
-			localize('poll.terminal.reject', 'No'),
-			async () => true,
-			async () => { this._state = OutputMonitorState.Cancelled; return false; }
-		);
-
-		return { promise: result.promise.then(p => p ?? false), part: result.part };
-	}
-
-
 
 	private async _assessOutputForErrors(buffer: string, token: CancellationToken): Promise<string | undefined> {
 		const model = await this._getLanguageModel();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -26,9 +26,9 @@ import { IConfirmationPrompt, IExecution, IPollingResult, OutputMonitorState, Po
 import { getTextResponseFromStream } from './utils.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
-import { ILogService } from '../../../../../../../platform/log/common/log.js';
 import { ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { LocalChatSessionUri } from '../../../../../chat/common/model/chatUri.js';
+import { ITerminalLogService } from '../../../../../../../platform/terminal/common/terminal.js';
 
 export interface IOutputMonitor extends Disposable {
 	readonly pollingResult: IPollingResult & { pollDurationMs: number } | undefined;
@@ -94,7 +94,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		@IChatService private readonly _chatService: IChatService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ILogService private readonly _logService: ILogService,
+		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/types.ts
@@ -53,6 +53,6 @@ export const enum PollingConsts {
 	MinPollingDuration = 500,
 	FirstPollingMaxDuration = 20000, // 20 seconds
 	ExtendedPollingMaxDuration = 120000, // 2 minutes
-	MaxPollingIntervalDuration = 2000, // 2 seconds
+	MaxPollingIntervalDuration = 10000, // 10 seconds - grows via exponential backoff
 	MaxRecursionCount = 5
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -14,7 +14,8 @@ import { ILanguageModelsService } from '../../../../chat/common/languageModels.j
 import { IChatService } from '../../../../chat/common/chatService/chatService.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { ChatModel } from '../../../../chat/common/model/chatModel.js';
-import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
 import { IToolInvocationContext } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
@@ -72,7 +73,7 @@ suite('OutputMonitor', () => {
 				} as any)
 			}
 		);
-		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(ITerminalLogService, new NullLogService());
 		cts = new CancellationTokenSource();
 	});
 


### PR DESCRIPTION
Fixes #285434

This makes is so we no longer show the timeout warning and just continue to poll up to 2 minutes. After that we don't try to nudge the user or anything as it's perfectly valid for commands to run for longer than 2 minutes. We'll also have an explicit action to move to background soon.

Adding some verbose logging to test and it appears to be working correctly:

```
2026-01-14 06:02:31.316 [info] OutputMonitor: Starting polling loop for command " for i in {1..90}; do date; sleep 2; done" []
2026-01-14 06:02:31.316 [info] OutputMonitor: Loop iteration, state=PollingForIdle, extended=false []
2026-01-14 06:02:31.316 [info] OutputMonitor: Entering _waitForIdle, extended=false []
2026-01-14 06:02:31.316 [info] OutputMonitor: _waitForIdle started, extendedPolling=false, maxWaitMs=20000, maxInterval=10000 []
2026-01-14 06:02:31.316 [info] OutputMonitor: Waiting 500ms (total waited=0ms, maxWait=20000ms, nextInterval=500ms) []
2026-01-14 06:02:31.820 [info] OutputMonitor: Poll check: waited=500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:31.820 [info] OutputMonitor: Waiting 1000ms (total waited=500ms, maxWait=20000ms, nextInterval=1000ms) []
2026-01-14 06:02:32.823 [info] OutputMonitor: Poll check: waited=1500ms, consecutiveIdleEvents=1, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:32.823 [info] OutputMonitor: Waiting 2000ms (total waited=1500ms, maxWait=20000ms, nextInterval=2000ms) []
2026-01-14 06:02:34.825 [info] OutputMonitor: Poll check: waited=3500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:34.826 [info] OutputMonitor: Waiting 4000ms (total waited=3500ms, maxWait=20000ms, nextInterval=4000ms) []
2026-01-14 06:02:38.828 [info] OutputMonitor: Poll check: waited=7500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:38.829 [info] OutputMonitor: Waiting 8000ms (total waited=7500ms, maxWait=20000ms, nextInterval=8000ms) []
2026-01-14 06:02:41.555 [warning] Shell integration failed to add capabilities within 10 seconds []
2026-01-14 06:02:46.831 [info] OutputMonitor: Poll check: waited=15500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:46.832 [info] OutputMonitor: Waiting 4500ms (total waited=15500ms, maxWait=20000ms, nextInterval=10000ms) []
2026-01-14 06:02:51.335 [info] OutputMonitor: Poll check: waited=20000ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:51.336 [info] OutputMonitor: _waitForIdle timeout after 20000ms, returning Timeout []
2026-01-14 06:02:51.336 [info] OutputMonitor: _waitForIdle returned state=Timeout []
2026-01-14 06:02:51.336 [info] OutputMonitor: Loop iteration, state=Timeout, extended=false []
2026-01-14 06:02:51.336 [info] OutputMonitor: Entering _handleTimeoutState, extended=false []
2026-01-14 06:02:51.337 [info] OutputMonitor: _handleTimeoutState returned shouldContinue=true []
2026-01-14 06:02:51.337 [info] OutputMonitor: Continuing with extended polling []
2026-01-14 06:02:51.337 [info] OutputMonitor: Loop iteration, state=PollingForIdle, extended=true []
2026-01-14 06:02:51.337 [info] OutputMonitor: Entering _waitForIdle, extended=true []
2026-01-14 06:02:51.338 [info] OutputMonitor: _waitForIdle started, extendedPolling=true, maxWaitMs=120000, maxInterval=10000 []
2026-01-14 06:02:51.338 [info] OutputMonitor: Waiting 500ms (total waited=0ms, maxWait=120000ms, nextInterval=500ms) []
2026-01-14 06:02:51.838 [info] OutputMonitor: Poll check: waited=500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:51.839 [info] OutputMonitor: Waiting 1000ms (total waited=500ms, maxWait=120000ms, nextInterval=1000ms) []
2026-01-14 06:02:52.839 [info] OutputMonitor: Poll check: waited=1500ms, consecutiveIdleEvents=1, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:52.839 [info] OutputMonitor: Waiting 2000ms (total waited=1500ms, maxWait=120000ms, nextInterval=2000ms) []
2026-01-14 06:02:54.840 [info] OutputMonitor: Poll check: waited=3500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:54.841 [info] OutputMonitor: Waiting 4000ms (total waited=3500ms, maxWait=120000ms, nextInterval=4000ms) []
2026-01-14 06:02:58.842 [info] OutputMonitor: Poll check: waited=7500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:02:58.842 [info] OutputMonitor: Waiting 8000ms (total waited=7500ms, maxWait=120000ms, nextInterval=8000ms) []
2026-01-14 06:03:06.844 [info] OutputMonitor: Poll check: waited=15500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:06.845 [info] OutputMonitor: Waiting 10000ms (total waited=15500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:03:16.846 [info] OutputMonitor: Poll check: waited=25500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:16.846 [info] OutputMonitor: Waiting 10000ms (total waited=25500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:03:26.850 [info] OutputMonitor: Poll check: waited=35500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:26.850 [info] OutputMonitor: Waiting 10000ms (total waited=35500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:03:36.851 [info] OutputMonitor: Poll check: waited=45500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:36.852 [info] OutputMonitor: Waiting 10000ms (total waited=45500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:03:46.853 [info] OutputMonitor: Poll check: waited=55500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:46.854 [info] OutputMonitor: Waiting 10000ms (total waited=55500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:03:56.856 [info] OutputMonitor: Poll check: waited=65500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:03:56.858 [info] OutputMonitor: Waiting 10000ms (total waited=65500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:06.859 [info] OutputMonitor: Poll check: waited=75500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:06.859 [info] OutputMonitor: Waiting 10000ms (total waited=75500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:16.861 [info] OutputMonitor: Poll check: waited=85500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:16.861 [info] OutputMonitor: Waiting 10000ms (total waited=85500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:26.863 [info] OutputMonitor: Poll check: waited=95500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:26.864 [info] OutputMonitor: Waiting 10000ms (total waited=95500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:36.865 [info] OutputMonitor: Poll check: waited=105500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:36.866 [info] OutputMonitor: Waiting 10000ms (total waited=105500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:46.868 [info] OutputMonitor: Poll check: waited=115500ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:46.869 [info] OutputMonitor: Waiting 4500ms (total waited=115500ms, maxWait=120000ms, nextInterval=10000ms) []
2026-01-14 06:04:51.371 [info] OutputMonitor: Poll check: waited=120000ms, consecutiveIdleEvents=0, recentlyIdle=false, isActive=undefined, hasReceivedData=false []
2026-01-14 06:04:51.372 [info] OutputMonitor: _waitForIdle timeout after 120000ms, returning Timeout []
2026-01-14 06:04:51.373 [info] OutputMonitor: _waitForIdle returned state=Timeout []
2026-01-14 06:04:51.373 [info] OutputMonitor: Loop iteration, state=Timeout, extended=true []
2026-01-14 06:04:51.373 [info] OutputMonitor: Entering _handleTimeoutState, extended=true []
2026-01-14 06:04:51.374 [info] OutputMonitor: Extended polling timeout reached after 2 minutes []
2026-01-14 06:04:51.374 [info] OutputMonitor: _handleTimeoutState returned shouldContinue=false []
2026-01-14 06:04:51.374 [info] OutputMonitor: Stopping polling after timeout []
2026-01-14 06:04:51.374 [info] OutputMonitor: Breaking out of loop, final state=Cancelled []
```