### PR TITLE
Only keep around text models for live code blocks

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -8,7 +8,6 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { hash } from '../../../../../base/common/hash.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, dispose } from '../../../../../base/common/lifecycle.js';
-import * as marked from '../../../../../base/common/marked/marked.js';
 import { IObservable } from '../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -17,7 +16,6 @@ import { IChatRequestVariableEntry } from '../attachments/chatVariableEntries.js
 import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatCodeCitation, IChatContentReference, IChatFollowup, IChatMcpServersStarting, IChatProgressMessage, IChatResponseErrorDetails, IChatTask, IChatUsedContext } from '../chatService/chatService.js';
 import { getFullyQualifiedId, IChatAgentCommand, IChatAgentData, IChatAgentNameService, IChatAgentResult } from '../participants/chatAgents.js';
 import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
-import { annotateVulnerabilitiesInText } from '../widget/annotations.js';
 import { CodeBlockModelCollection } from '../widget/codeBlockModelCollection.js';
 import { IChatModel, IChatProgressRenderableResponseContent, IChatRequestDisablement, IChatRequestModel, IChatResponseModel, IChatTextEditGroup, IResponse } from './chatModel.js';
 import { ChatStreamStatsTracker, IChatStreamStats } from './chatStreamStats.js';
@@ -270,7 +268,6 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 		_model.getRequests().forEach((request, i) => {
 			const requestModel = this.instantiationService.createInstance(ChatRequestViewModel, request);
 			this._items.push(requestModel);
-			this.updateCodeBlockTextModels(requestModel);
 
 			if (request.response) {
 				this.onAddResponse(request.response);
@@ -282,7 +279,6 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 			if (e.kind === 'addRequest') {
 				const requestModel = this.instantiationService.createInstance(ChatRequestViewModel, e.request);
 				this._items.push(requestModel);
-				this.updateCodeBlockTextModels(requestModel);
 
 				if (e.request.response) {
 					this.onAddResponse(e.request.response);
@@ -317,13 +313,9 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 	private onAddResponse(responseModel: IChatResponseModel) {
 		const response = this.instantiationService.createInstance(ChatResponseViewModel, responseModel, this);
 		this._register(response.onDidChange(() => {
-			if (response.isComplete) {
-				this.updateCodeBlockTextModels(response);
-			}
 			return this._onDidChange.fire(null);
 		}));
 		this._items.push(response);
-		this.updateCodeBlockTextModels(response);
 	}
 
 	getItems(): (IChatRequestViewModel | IChatResponseViewModel)[] {
@@ -347,24 +339,6 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 	override dispose() {
 		super.dispose();
 		dispose(this._items.filter((item): item is ChatResponseViewModel => item instanceof ChatResponseViewModel));
-	}
-
-	updateCodeBlockTextModels(model: IChatRequestViewModel | IChatResponseViewModel) {
-		let content: string;
-		if (isRequestVM(model)) {
-			content = model.messageText;
-		} else {
-			content = annotateVulnerabilitiesInText(model.response.value).map(x => x.content.value).join('');
-		}
-
-		let codeBlockIndex = 0;
-		marked.walkTokens(marked.lexer(content), token => {
-			if (token.type === 'code') {
-				const lang = token.lang || '';
-				const text = token.text;
-				this.codeBlockModelCollection.update(this._model.sessionResource, model, codeBlockIndex++, { text, languageId: lang, isComplete: true });
-			}
-		});
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/widget/annotations.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/annotations.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IRange } from '../../../../../editor/common/core/range.js';
 import { isLocation } from '../../../../../editor/common/languages.js';
 import { IChatProgressRenderableResponseContent, IChatProgressResponseContent, appendMarkdownString, canMergeMarkdownStrings } from '../model/chatModel.js';
-import { IChatAgentVulnerabilityDetails, IChatMarkdownContent } from '../chatService/chatService.js';
+import { IChatAgentVulnerabilityDetails } from '../chatService/chatService.js';
 
 export const contentRefUrl = 'http://_vscodecontentref_'; // must be lowercase for URI
 
@@ -79,31 +79,6 @@ export interface IMarkdownVulnerability {
 	readonly description: string;
 	readonly range: IRange;
 }
-
-export function annotateVulnerabilitiesInText(response: ReadonlyArray<IChatProgressResponseContent>): readonly IChatMarkdownContent[] {
-	const result: IChatMarkdownContent[] = [];
-	for (const item of response) {
-		const previousItem = result[result.length - 1];
-		if (item.kind === 'markdownContent') {
-			if (previousItem?.kind === 'markdownContent') {
-				result[result.length - 1] = { content: new MarkdownString(previousItem.content.value + item.content.value, { isTrusted: previousItem.content.isTrusted }), kind: 'markdownContent' };
-			} else {
-				result.push(item);
-			}
-		} else if (item.kind === 'markdownVuln') {
-			const vulnText = encodeURIComponent(JSON.stringify(item.vulnerabilities));
-			const markdownText = `<vscode_annotation details='${vulnText}'>${item.content.value}</vscode_annotation>`;
-			if (previousItem?.kind === 'markdownContent') {
-				result[result.length - 1] = { content: new MarkdownString(previousItem.content.value + markdownText, { isTrusted: previousItem.content.isTrusted }), kind: 'markdownContent' };
-			} else {
-				result.push({ content: new MarkdownString(markdownText), kind: 'markdownContent' });
-			}
-		}
-	}
-
-	return result;
-}
-
 export function extractCodeblockUrisFromText(text: string): { uri: URI; isEdit?: boolean; textWithoutResult: string } | undefined {
 	const match = /<vscode_codeblock_uri( isEdit)?>(.*?)<\/vscode_codeblock_uri>/ms.exec(text);
 	if (match) {


### PR DESCRIPTION
Seeing if we can improve perf by only keeping text models for live code blocks. This was potentially helpful in ask mode but not as useful in agent mode

cc @roblourens 