### PR TITLE
fix: memory leak in createStyleSheet2

### DIFF
--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DisposableStore, toDisposable, IDisposable } from '../common/lifecycle.js';
+import { DisposableStore, toDisposable, IDisposable, Disposable } from '../common/lifecycle.js';
 import { autorun, IObservable } from '../common/observable.js';
 import { isFirefox } from './browser.js';
 import { getWindows, sharedMutationObserver } from './dom.js';
@@ -15,40 +15,27 @@ export function isGlobalStylesheet(node: Node): boolean {
 	return globalStylesheets.has(node as HTMLStyleElement);
 }
 
-/**
- * A version of createStyleSheet which has a unified API to initialize/set the style content.
- */
-export function createStyleSheet2(store: DisposableStore): WrappedStyleElement {
-	return new WrappedStyleElement(store);
-}
-
-class WrappedStyleElement {
+class WrappedStyleElement extends Disposable {
 	private _currentCssStyle = '';
 	private _styleSheet: HTMLStyleElement | undefined = undefined;
-	private _store: DisposableStore | undefined;
 
-	constructor(store: DisposableStore | undefined) {
-		this._store = store;
-	}
-
-	public setStyle(cssStyle: string): void {
+	setStyle(cssStyle: string): void {
 		if (cssStyle === this._currentCssStyle) {
 			return;
 		}
 		this._currentCssStyle = cssStyle;
 
 		if (!this._styleSheet) {
-			this._styleSheet = createStyleSheet(mainWindow.document.head, (s) => s.textContent = cssStyle, this._store);
+			this._styleSheet = createStyleSheet(mainWindow.document.head, s => s.textContent = cssStyle, this._store);
 		} else {
 			this._styleSheet.textContent = cssStyle;
 		}
 	}
 
-	public dispose(): void {
-		if (this._styleSheet) {
-			this._styleSheet.remove();
-			this._styleSheet = undefined;
-		}
+	override dispose(): void {
+		super.dispose();
+
+		this._styleSheet = undefined;
 	}
 }
 
@@ -126,12 +113,10 @@ function getSharedStyleSheet(): HTMLStyleElement {
 
 function getDynamicStyleSheetRules(style: HTMLStyleElement) {
 	if (style?.sheet?.rules) {
-		// Chrome, IE
-		return style.sheet.rules;
+		return style.sheet.rules; // Chrome, IE
 	}
 	if (style?.sheet?.cssRules) {
-		// FF
-		return style.sheet.cssRules;
+		return style.sheet.cssRules; // FF
 	}
 	return [];
 }
@@ -179,7 +164,7 @@ function isCSSStyleRule(rule: CSSRule): rule is CSSStyleRule {
 
 export function createStyleSheetFromObservable(css: IObservable<string>): IDisposable {
 	const store = new DisposableStore();
-	const w = store.add(createStyleSheet2(store));
+	const w = store.add(new WrappedStyleElement());
 	store.add(autorun(reader => {
 		w.setStyle(css.read(reader));
 	}));

--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -18,13 +18,18 @@ export function isGlobalStylesheet(node: Node): boolean {
 /**
  * A version of createStyleSheet which has a unified API to initialize/set the style content.
  */
-export function createStyleSheet2(): WrappedStyleElement {
-	return new WrappedStyleElement();
+export function createStyleSheet2(store: DisposableStore): WrappedStyleElement {
+	return new WrappedStyleElement(store);
 }
 
 class WrappedStyleElement {
 	private _currentCssStyle = '';
 	private _styleSheet: HTMLStyleElement | undefined = undefined;
+	private _store: DisposableStore | undefined;
+
+	constructor(store: DisposableStore | undefined) {
+		this._store = store;
+	}
 
 	public setStyle(cssStyle: string): void {
 		if (cssStyle === this._currentCssStyle) {
@@ -33,7 +38,7 @@ class WrappedStyleElement {
 		this._currentCssStyle = cssStyle;
 
 		if (!this._styleSheet) {
-			this._styleSheet = createStyleSheet(mainWindow.document.head, (s) => s.textContent = cssStyle);
+			this._styleSheet = createStyleSheet(mainWindow.document.head, (s) => s.textContent = cssStyle, this._store);
 		} else {
 			this._styleSheet.textContent = cssStyle;
 		}
@@ -174,7 +179,7 @@ function isCSSStyleRule(rule: CSSRule): rule is CSSStyleRule {
 
 export function createStyleSheetFromObservable(css: IObservable<string>): IDisposable {
 	const store = new DisposableStore();
-	const w = store.add(createStyleSheet2());
+	const w = store.add(createStyleSheet2(store));
 	store.add(autorun(reader => {
 		w.setStyle(css.read(reader));
 	}));


### PR DESCRIPTION
Helps with #287753. Fixes memory leak in createStyleSheet2 by passing in a disposable store to `WrappedStyleElement` and `createStyleSheet`. 




### Before

When opening and closing peek definition 37 times, the number of detached style elements seems to grow by 1 each time: 

```json
{
  "className": "HTMLStyleElement",
  "description": "style",
  "stackTrace": [
    "createStyleSheet (vscode-file://vscode-app/vscode/out/vs/base/browser/domStylesheets.js:37:26)",
    "WrappedStyleElement.setStyle (vscode-file://vscode-app/vscode/out/vs/base/browser/domStylesheets.js:24:26)",
    "AutorunObserver._runFn (vscode-file://vscode-app/vscode/out/vs/base/browser/domStylesheets.js:134:7)",
    "AutorunObserver._run (vscode-file://vscode-app/vscode/out/vs/base/common/observableInternal/reactions/autorunImpl.js:84:16)",
    "new AutorunObserver (vscode-file://vscode-app/vscode/out/vs/base/common/observableInternal/reactions/autorunImpl.js:37:10)",
    "autorun (vscode-file://vscode-app/vscode/out/vs/base/common/observableInternal/reactions/autorun.js:6:10)",
    "createStyleSheetFromObservable (vscode-file://vscode-app/vscode/out/vs/base/browser/domStylesheets.js:133:13)",
    "new InlineCompletionsController (vscode-file://vscode-app/vscode/out/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.js:126:56)"
  ],
  "originalStack": [
    "/vscode/src/vs/base/browser/domStylesheets.ts:51:24",
    "/vscode/src/vs/base/browser/domStylesheets.ts:36:22",
    "/vscode/src/vs/base/browser/domStylesheets.ts:179:4",
    "/vscode/src/vs/base/common/observableInternal/reactions/autorunImpl.ts:110:10",
    "/vscode/src/vs/base/common/observableInternal/reactions/autorunImpl.ts:58:7",
    "/vscode/src/vs/base/common/observableInternal/reactions/autorun.ts:18:8",
    "/vscode/src/vs/base/browser/domStylesheets.ts:178:11",
    "/vscode/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts:161:53"
  ],
  "sourcesHash": "012b90aaf26bb759f59cacccb88c2c9e810f0d55",
  "count": 37
}
```

### After

When opening and closing peek definition 37 times, the number of stylesheet element stays constant.