### PR TITLE
fix: highlight active match when opening find/replace widget

### DIFF
--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -220,10 +220,19 @@ export class FindModelBoundToEditorModel {
 			currentMatchesPosition = matchAfterSelection > 0 ? matchAfterSelection - 1 + 1 /** match position is one based */ : currentMatchesPosition;
 		}
 
+		// Highlight the current match if there are matches
+		let currentMatch: Range | undefined;
+		if (findMatches.length > 0 && currentMatchesPosition > 0) {
+			currentMatch = this._decorations.getDecorationRangeAt(currentMatchesPosition - 1) ?? undefined;
+			if (currentMatch) {
+				this._decorations.setCurrentFindMatch(currentMatch);
+			}
+		}
+
 		this._state.changeMatchInfo(
 			currentMatchesPosition,
 			this._decorations.getCount(),
-			undefined
+			currentMatch
 		);
 
 		if (moveCursor && this._editor.getOption(EditorOption.find).cursorMoveOnType) {

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -854,7 +854,7 @@ suite('FindModel', () => {
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
-			null,
+			[1, 1, 1, 1],
 			[
 				[1, 1, 1, 1],
 				[2, 1, 2, 1],
@@ -1069,7 +1069,7 @@ suite('FindModel', () => {
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
-			null,
+			[1, 1, 1, 18],
 			[
 				[1, 1, 1, 18],
 				[2, 1, 2, 18],
@@ -1098,7 +1098,7 @@ suite('FindModel', () => {
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
-			null,
+			[1, 1, 1, 18],
 			[
 				[1, 1, 1, 18],
 				[2, 1, 2, 18],
@@ -1169,7 +1169,7 @@ suite('FindModel', () => {
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
-			null,
+			[1, 1, 1, 18],
 			[
 				[1, 1, 1, 18],
 				[2, 1, 2, 18],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix: https://github.com/microsoft/vscode/issues/15067
Fixes the issue where the current match is not visually highlighted when opening the Find (Ctrl+F) or Find and Replace (Ctrl+H) widget.

- When find matches are computed, immediately highlight the current match (the one at or after the cursor position)
- Pass the actual `currentMatch` range to `changeMatchInfo()` instead of `undefined`
- This ensures the active match is always visually indicated when the find widget is opened

Unit tests updated in `findModel.test.ts`

## Before

https://github.com/user-attachments/assets/5393118b-c1e6-4d6a-ae04-45b4a91326fc


## After

https://github.com/user-attachments/assets/f41fa1c5-d98c-4180-ab68-af6d2658467a


