### PR TITLE
fix: capture diagnostics and add workaround for graphite recording order failures

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="39.2.7"
-ms_build_id="12953945"
+ms_build_id="13098910"
 runtime="electron"
 build_from_source="true"
 legacy-peer-deps="true"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.109.0",
-  "distro": "b570759d1928b4b2f34a86c40da42b1a2b6d3796",
+  "distro": "f44449f84806363760ce8bb8dbe85cd8207498ff",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,7 +227,10 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 		// bypass any specified proxy for the given semi-colon-separated list of hosts
 		'proxy-bypass-list',
 
-		'remote-debugging-port'
+		'remote-debugging-port',
+
+		// Enable recovery from invalid Graphite recordings
+		'enable-graphite-invalid-recording-recovery'
 	];
 
 	if (process.platform === 'linux') {
@@ -374,6 +377,7 @@ interface IArgvConfig {
 	readonly 'use-inmemory-secretstorage'?: boolean;
 	readonly 'enable-rdp-display-tracking'?: boolean;
 	readonly 'remote-debugging-port'?: string;
+	readonly 'enable-graphite-invalid-recording-recovery'?: boolean;
 }
 
 function readArgvConfigSync(): IArgvConfig {

--- a/src/vs/platform/diagnostics/common/diagnostics.ts
+++ b/src/vs/platform/diagnostics/common/diagnostics.ts
@@ -142,6 +142,11 @@ export interface IProcessDiagnostics {
 	readonly name: string;
 }
 
+export interface IGPULogMessage {
+	readonly header: string;
+	readonly message: string;
+}
+
 export interface IMainProcessDiagnostics {
 	readonly mainPID: number;
 	readonly mainArguments: string[]; // All arguments after argv[0], the exec path
@@ -149,4 +154,5 @@ export interface IMainProcessDiagnostics {
 	readonly pidToNames: IProcessDiagnostics[];
 	readonly screenReader: boolean;
 	readonly gpuFeatureStatus: any;
+	readonly gpuLogMessages: IGPULogMessage[];
 }

--- a/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
+++ b/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
@@ -7,7 +7,7 @@ import { app, BrowserWindow, Event as IpcEvent } from 'electron';
 import { validatedIpcMain } from '../../../base/parts/ipc/electron-main/ipcMain.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { URI } from '../../../base/common/uri.js';
-import { IDiagnosticInfo, IDiagnosticInfoOptions, IMainProcessDiagnostics, IProcessDiagnostics, IRemoteDiagnosticError, IRemoteDiagnosticInfo, IWindowDiagnostics } from '../common/diagnostics.js';
+import { IDiagnosticInfo, IDiagnosticInfoOptions, IGPULogMessage, IMainProcessDiagnostics, IProcessDiagnostics, IRemoteDiagnosticError, IRemoteDiagnosticInfo, IWindowDiagnostics } from '../common/diagnostics.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import { ICodeWindow } from '../../window/electron-main/window.js';
 import { getAllWindowsExcludingOffscreen, IWindowsMainService } from '../../windows/electron-main/windows.js';
@@ -94,13 +94,24 @@ export class DiagnosticsMainService implements IDiagnosticsMainService {
 			pidToNames.push({ pid, name });
 		}
 
+		type AppWithGPULogMethod = typeof app & {
+			getGPULogMessages(): IGPULogMessage[];
+		};
+
+		let gpuLogMessages: IGPULogMessage[] = [];
+		const customApp = app as AppWithGPULogMethod;
+		if (typeof customApp.getGPULogMessages === 'function') {
+			gpuLogMessages = customApp.getGPULogMessages();
+		}
+
 		return {
 			mainPID: process.pid,
 			mainArguments: process.argv.slice(1),
 			windows,
 			pidToNames,
 			screenReader: !!app.accessibilitySupportEnabled,
-			gpuFeatureStatus: app.getGPUFeatureStatus()
+			gpuFeatureStatus: app.getGPUFeatureStatus(),
+			gpuLogMessages
 		};
 	}
 

--- a/src/vs/platform/diagnostics/node/diagnosticsService.ts
+++ b/src/vs/platform/diagnostics/node/diagnosticsService.ts
@@ -257,10 +257,8 @@ export class DiagnosticsService implements IDiagnosticsService {
 		output.push(`GPU Status:       ${this.expandGPUFeatures(info.gpuFeatureStatus)}`);
 		if (info.gpuLogMessages && info.gpuLogMessages.length > 0) {
 			output.push(`GPU Log Messages:`);
-			output.join('\n');
 			info.gpuLogMessages.forEach(msg => {
 				output.push(`${msg.header}: ${msg.message}`);
-				output.join('\n');
 			});
 		}
 

--- a/src/vs/platform/diagnostics/node/diagnosticsService.ts
+++ b/src/vs/platform/diagnostics/node/diagnosticsService.ts
@@ -255,6 +255,14 @@ export class DiagnosticsService implements IDiagnosticsService {
 		output.push(`Screen Reader:    ${info.screenReader ? 'yes' : 'no'}`);
 		output.push(`Process Argv:     ${info.mainArguments.join(' ')}`);
 		output.push(`GPU Status:       ${this.expandGPUFeatures(info.gpuFeatureStatus)}`);
+		if (info.gpuLogMessages && info.gpuLogMessages.length > 0) {
+			output.push(`GPU Log Messages:`);
+			output.join('\n');
+			info.gpuLogMessages.forEach(msg => {
+				output.push(`${msg.header}: ${msg.message}`);
+				output.join('\n');
+			});
+		}
 
 		return output.join('\n');
 	}

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -454,6 +454,10 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../../platform/window/electron-b
 			'remote-debugging-port': {
 				type: 'string',
 				description: localize('argv.remoteDebuggingPort', "Specifies the port to use for remote debugging.")
+			},
+			'enable-graphite-invalid-recording-recovery': {
+				type: 'boolean',
+				description: localize('argv.enableGraphiteInvalidRecordingRecovery', "Enables recovery from invalid Graphite recordings.")
 			}
 		}
 	};


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/284162#issuecomment-3745785115

To aid with debugging the broken rendering issue on macOS with the skia graphite backend. This PR does the following,

1) Runtime update incorporates the following patches
[feat_support_gpu_switch_to_recover_from_recording_order_failure.patch](https://github.com/user-attachments/files/24616081/feat_support_gpu_switch_to_recover_from_recording_order_failure.patch)
[feat_improve_diagnostics_and_support_recover_from_record_insertion.patch](https://github.com/user-attachments/files/24616079/feat_improve_diagnostics_and_support_recover_from_record_insertion.patch)
2) https://github.com/microsoft/vscode/commit/59e3bae058dc3b5627f705e31bc2a7c8fd092170 adds support for exposing gpu log messages from `chrome://gpu-internals` as part of `--status` flag. Reasoning

```
This is useful in scenarios where the application rendering
completely breaks and we want to know the health of gpu process
on demand without having to restart the application.

The log messages are usually available on demand via
Developer: Show GPU Info page but during complete rendering failure
the developer page will also fail to render.
```
3) Add support argv.json entry `enable-graphite-invalid-recording-recovery` that will trigger the workaround path in the runtime to recover from the failures.
