### PR TITLE
Integrated browser focus fixes

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -123,6 +123,66 @@ export const {
 
 //#endregion
 
+//#region External Focus Tracking
+
+/**
+ * A registry for functions that check if a component outside the normal DOM tree has focus.
+ * This is used to extend the concept of "window has focus" to include things like
+ * Electron WebContentsViews (browser views) that exist outside the document.
+ */
+const externalFocusCheckers = new Set<() => boolean>();
+
+/**
+ * Register a function that checks if a component outside the DOM has focus.
+ * This allows `hasExternalFocus` to detect when focus is in components like browser views.
+ *
+ * @param checker A function that returns true if the component has focus
+ * @returns A disposable to unregister the checker
+ */
+export function registerExternalFocusChecker(checker: () => boolean): IDisposable {
+	externalFocusCheckers.add(checker);
+
+	return toDisposable(() => {
+		externalFocusCheckers.delete(checker);
+	});
+}
+
+/**
+ * Check if any registered external component has focus.
+ * This is used to extend focus detection beyond the normal DOM to include
+ * components like Electron WebContentsViews.
+ *
+ * @returns true if any registered external component has focus
+ */
+export function hasExternalFocus(): boolean {
+	for (const checker of externalFocusCheckers) {
+		if (checker()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Check if VS Code has focus in any window, either via the normal DOM or via an
+ * external component like a browser view (which exists outside the document tree).
+ *
+ * @returns true if VS Code owns the current focus
+ */
+export function hasVSCodeFocus(): boolean {
+	for (const { window } of getWindows()) {
+		if (window.document.hasFocus()) {
+			return true;
+		}
+	}
+	if (hasExternalFocus()) {
+		return true;
+	}
+	return false;
+}
+
+//#endregion
+
 export function clearNode(node: HTMLElement): void {
 	while (node.firstChild) {
 		node.firstChild.remove();

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -128,7 +128,7 @@ export const {
 /**
  * A registry for functions that check if a component outside the normal DOM tree has focus.
  * This is used to extend the concept of "window has focus" to include things like
- * Electron WebContentsViews (browser views) that exist outside the document.
+ * Electron WebContentsViews (browser views) that exist outside the workbench DOM.
  */
 const externalFocusCheckers = new Set<() => boolean>();
 
@@ -164,12 +164,12 @@ export function hasExternalFocus(): boolean {
 }
 
 /**
- * Check if VS Code has focus in any window, either via the normal DOM or via an
+ * Check if the application has focus in any window, either via the normal DOM or via an
  * external component like a browser view (which exists outside the document tree).
  *
- * @returns true if VS Code owns the current focus
+ * @returns true if the application owns the current focus
  */
-export function hasVSCodeFocus(): boolean {
+export function hasAppFocus(): boolean {
 	for (const { window } of getWindows()) {
 		if (window.document.hasFocus()) {
 			return true;

--- a/src/vs/platform/browserView/common/browserView.ts
+++ b/src/vs/platform/browserView/common/browserView.ts
@@ -26,6 +26,7 @@ export interface IBrowserViewState {
 	canGoBack: boolean;
 	canGoForward: boolean;
 	loading: boolean;
+	focused: boolean;
 	isDevToolsOpen: boolean;
 	lastScreenshot: VSBuffer | undefined;
 	lastFavicon: string | undefined;

--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -264,6 +264,7 @@ export class BrowserView extends Disposable {
 			canGoBack: webContents.navigationHistory.canGoBack(),
 			canGoForward: webContents.navigationHistory.canGoForward(),
 			loading: webContents.isLoading(),
+			focused: webContents.isFocused(),
 			isDevToolsOpen: webContents.isDevToolsOpened(),
 			lastScreenshot: this._lastScreenshot,
 			lastFavicon: this._lastFavicon,

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -392,6 +392,10 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 		}
 
 		win.focus();
+
+		// Also focus the webContents to ensure focus is taken from any
+		// child views that may currently have focus
+		win.webContents.focus();
 	}
 
 	//#region Window Control Overlays

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -393,8 +393,10 @@ export abstract class BaseWindow extends Disposable implements IBaseWindow {
 
 		win.focus();
 
-		// Also focus the webContents to ensure focus is taken from any
-		// child views that may currently have focus
+		// When focusing the window, the workbench should always be the view that receives focus.
+		// However, in scenarios where the window has multiple child views (e.g. browser WebContentsViews),
+		// the last focused view in the window may not be the workbench.
+		// So we explicitly focus the workbench web contents here to ensure it gets focus.
 		win.webContents.focus();
 	}
 

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isSafari, setFullscreen } from '../../base/browser/browser.js';
-import { addDisposableListener, EventHelper, EventType, getWindow, getWindowById, getWindows, getWindowsCount, hasVSCodeFocus, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from '../../base/browser/dom.js';
+import { addDisposableListener, EventHelper, EventType, getWindow, getWindowById, getWindows, getWindowsCount, hasAppFocus, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from '../../base/browser/dom.js';
 import { DomEmitter } from '../../base/browser/event.js';
 import { HidDeviceData, requestHidDevice, requestSerialPort, requestUsbDevice, SerialPortData, UsbDeviceData } from '../../base/browser/deviceAccess.js';
 import { timeout } from '../../base/common/async.js';
@@ -75,8 +75,8 @@ export abstract class BaseWindow extends Disposable {
 
 	private onElementFocus(targetWindow: CodeWindow): void {
 
-		// Check if focus should transfer: VS Code currently has focus somewhere, but not in the target window.
-		if (!targetWindow.document.hasFocus() && hasVSCodeFocus()) {
+		// Check if focus should transfer: the application currently has focus somewhere, but not in the target window.
+		if (!targetWindow.document.hasFocus() && hasAppFocus()) {
 
 			// Call original focus()
 			targetWindow.focus();

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isSafari, setFullscreen } from '../../base/browser/browser.js';
-import { addDisposableListener, EventHelper, EventType, getActiveWindow, getWindow, getWindowById, getWindows, getWindowsCount, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from '../../base/browser/dom.js';
+import { addDisposableListener, EventHelper, EventType, getWindow, getWindowById, getWindows, getWindowsCount, hasVSCodeFocus, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from '../../base/browser/dom.js';
 import { DomEmitter } from '../../base/browser/event.js';
 import { HidDeviceData, requestHidDevice, requestSerialPort, requestUsbDevice, SerialPortData, UsbDeviceData } from '../../base/browser/deviceAccess.js';
 import { timeout } from '../../base/common/async.js';
@@ -74,8 +74,9 @@ export abstract class BaseWindow extends Disposable {
 	}
 
 	private onElementFocus(targetWindow: CodeWindow): void {
-		const activeWindow = getActiveWindow();
-		if (activeWindow !== targetWindow && activeWindow.document.hasFocus()) {
+
+		// Check if focus should transfer: VS Code currently has focus somewhere, but not in the target window.
+		if (!targetWindow.document.hasFocus() && hasVSCodeFocus()) {
 
 			// Call original focus()
 			targetWindow.focus();

--- a/src/vs/workbench/contrib/browserView/common/browserView.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserView.ts
@@ -79,11 +79,11 @@ export interface IBrowserViewModel extends IDisposable {
 	readonly favicon: string | undefined;
 	readonly screenshot: VSBuffer | undefined;
 	readonly loading: boolean;
+	readonly focused: boolean;
 	readonly canGoBack: boolean;
 	readonly isDevToolsOpen: boolean;
 	readonly canGoForward: boolean;
 	readonly error: IBrowserViewLoadError | undefined;
-	readonly focused: boolean;
 
 	readonly storageScope: BrowserViewStorageScope;
 

--- a/src/vs/workbench/contrib/browserView/common/browserView.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserView.ts
@@ -83,6 +83,7 @@ export interface IBrowserViewModel extends IDisposable {
 	readonly isDevToolsOpen: boolean;
 	readonly canGoForward: boolean;
 	readonly error: IBrowserViewLoadError | undefined;
+	readonly focused: boolean;
 
 	readonly storageScope: BrowserViewStorageScope;
 
@@ -117,6 +118,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 	private _favicon: string | undefined = undefined;
 	private _screenshot: VSBuffer | undefined = undefined;
 	private _loading: boolean = false;
+	private _focused: boolean = false;
 	private _isDevToolsOpen: boolean = false;
 	private _canGoBack: boolean = false;
 	private _canGoForward: boolean = false;
@@ -141,6 +143,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 	get title(): string { return this._title; }
 	get favicon(): string | undefined { return this._favicon; }
 	get loading(): boolean { return this._loading; }
+	get focused(): boolean { return this._focused; }
 	get isDevToolsOpen(): boolean { return this._isDevToolsOpen; }
 	get canGoBack(): boolean { return this._canGoBack; }
 	get canGoForward(): boolean { return this._canGoForward; }
@@ -207,6 +210,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 		this._url = state.url;
 		this._title = state.title;
 		this._loading = state.loading;
+		this._focused = state.focused;
 		this._isDevToolsOpen = state.isDevToolsOpen;
 		this._canGoBack = state.canGoBack;
 		this._canGoForward = state.canGoForward;
@@ -243,6 +247,10 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 
 		this._register(this.onDidChangeFavicon(e => {
 			this._favicon = e.favicon;
+		}));
+
+		this._register(this.onDidChangeFocus(({ focused }) => {
+			this._focused = focused;
 		}));
 	}
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -5,7 +5,7 @@
 
 import './media/browser.css';
 import { localize } from '../../../../nls.js';
-import { $, addDisposableListener, disposableWindowInterval, EventType, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, disposableWindowInterval, EventType, isHTMLElement, registerExternalFocusChecker, scheduleAtNextAnimationFrame } from '../../../../base/browser/dom.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { RawContextKey, IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -242,13 +242,9 @@ export class BrowserEditor extends EditorPane {
 			}
 		}));
 
-		this._register(addDisposableListener(this._browserContainer, EventType.BLUR, () => {
-			// When focus goes to another part of the workbench, make sure the workbench view becomes focused.
-			const focused = this.window.document.activeElement;
-			if (focused && focused !== this._browserContainer) {
-				this.window.focus();
-			}
-		}));
+		// Register external focus checker so that cross-window focus logic knows when
+		// this browser view has focus (since it's outside the normal DOM tree).
+		this._register(registerExternalFocusChecker(() => this._model?.focused ?? false));
 	}
 
 	override async setInput(input: BrowserEditorInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
@@ -303,9 +299,13 @@ export class BrowserEditor extends EditorPane {
 		}));
 
 		this._inputDisposables.add(this._model.onDidChangeFocus(({ focused }) => {
-			// When the view gets focused, make sure the container also has focus.
+			// When the view gets focused, make sure the editor reports that it has focus,
+			// but focus is removed from the workbench.
 			if (focused) {
-				this._browserContainer.focus();
+				this._onDidFocus?.fire();
+				if (isHTMLElement(this.window.document.activeElement)) {
+					this.window.document.activeElement.blur();
+				}
 			}
 		}));
 


### PR DESCRIPTION
The integrated browser uses Electron's `WebContentsView` which exists outside the DOM. This breaks VS Code's cross-window focus handling because `document.hasFocus()` returns `false` when the browser view has focus, and calling `window.focus()` doesn't take focus away from the browser view.

The result is that programmatically focusing an element in the workbench does not actually give that element focus when focus is in the browser. This significantly impacts usability and accessibility.

Solutions are further limited because when the browser view is focused, the workbench doesn't receive any `focus` or `blur` events, so we must hook into programmatic `focus()` calls to tell when focus should move.

**This PR:**
- Adds a concept of "external focus" within the DOM helpers, which browser views provide. This lets us determine if focus is owned by VS Code even outside of the main workbench views.
- Updates native window focusing to specifically focus the main webContents, ensuring the workbench receives focus instead of a browser view.
