### PR TITLE
Only show label when not local

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -139,7 +139,14 @@ export class SessionTypePickerActionItem extends ActionWidgetDropdownActionViewI
 		const label = getAgentSessionProviderName(currentType ?? AgentSessionProviders.Local);
 		const icon = getAgentSessionProviderIcon(currentType ?? AgentSessionProviders.Local);
 
-		dom.reset(element, ...renderLabelWithIcons(`$(${icon.id})`), dom.$('span.chat-input-picker-label', undefined, label), ...renderLabelWithIcons(`$(chevron-down)`));
+		const labelElements = [];
+		labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
+		if (currentType !== AgentSessionProviders.Local) {
+			labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
+		}
+		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
+
+		dom.reset(element, ...labelElements);
 		return null;
 	}
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the session target picker to display the label only when the current type is not local.

