### PR TITLE
Integrated Browser: Select all URL text when URL bar receives focus

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -124,6 +124,11 @@ class BrowserNavigationBar extends Disposable {
 				}
 			}
 		}));
+
+		// Select all URL bar text when the URL bar receives focus (like in regular browsers)
+		this._register(addDisposableListener(this._urlInput, EventType.FOCUS, () => {
+			this._urlInput.select();
+		}));
 	}
 
 	/**


### PR DESCRIPTION
Select all URL text when URL bar receives focus. This matches regular browser behavior.

Related: https://github.com/microsoft/vscode/issues/286579