### PR TITLE
git: add stash submenu to Changes view context menu

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2232,6 +2232,21 @@
           "command": "git.stageAllUntracked",
           "when": "scmProvider == git && scmResourceGroup == untracked",
           "group": "inline@2"
+        },
+        {
+          "submenu": "git.stash",
+          "group": "2_stash",
+          "when": "scmProvider == git && scmResourceGroup == workingTree"
+        },
+        {
+          "submenu": "git.stash",
+          "group": "2_stash",
+          "when": "scmProvider == git && scmResourceGroup == index"
+        },
+        {
+          "submenu": "git.stash",
+          "group": "2_stash",
+          "when": "scmProvider == git && scmResourceGroup == untracked"
         }
       ],
       "scm/resourceFolder/context": [


### PR DESCRIPTION
Hey, noticed that the new Stashes list has all the nice stash actions in the context menu, but the Changes/Staged/Untracked views were missing them entirely. Seemed like an oversight since you'd expect to be able to stash directly from where you're looking at your changes.

This just adds the existing `git.stash` submenu to those resource group context menus so users don't have to go hunting for stash options when they're already looking at their working tree.

Tested locally - the submenu shows up correctly on all three resource groups (Changes, Staged Changes, Untracked Changes) and all the existing stash actions work as expected.

Fixes #281005