### PR TITLE
Redirect Monaco devserver / path to /build/vite/

### DIFF
--- a/build/vite/vite.config.ts
+++ b/build/vite/vite.config.ts
@@ -9,6 +9,24 @@ import { urlToEsmPlugin } from './rollup-url-to-module-plugin/index.mjs';
 import { statSync } from 'fs';
 import { pathToFileURL } from 'url';
 
+function devserverRedirect(): Plugin {
+	return {
+		name: 'devserver-redirect',
+		configureServer(server) {
+			server.middlewares.use('/', (req, res, next) => {
+				if (req.url !== '/') {
+					return next();
+				}
+
+				res.writeHead(302, {
+					location: '/build/vite/'
+				});
+				res.end();
+			});
+		}
+	};
+}
+
 function injectBuiltinExtensionsPlugin(): Plugin {
 	let builtinExtensionsCache: unknown[] | null = null;
 
@@ -164,6 +182,7 @@ logger.warn = (msg, options) => {
 
 export default defineConfig({
 	plugins: [
+		devserverRedirect(),
 		urlToEsmPlugin(),
 		injectBuiltinExtensionsPlugin(),
 		createHotClassSupport()


### PR DESCRIPTION
The path `/` doesn’t serve anything. Instead, the Monaco editor is served on `/build/vite/`. The Vite devserver logs a URL for `/`. By adding this redirect, we can just click the URL logged by vite.

CI will fail for this PR, because external contributors are not allowed to modify the `build` folder.

cc @hediet 