### PR TITLE
Update chat editor overlay background color

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/media/chatEditingEditorOverlay.css
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/media/chatEditingEditorOverlay.css
@@ -6,7 +6,7 @@
 .chat-editor-overlay-widget {
 	padding: 2px 4px;
 	color: var(--vscode-foreground);
-	background-color: var(--vscode-editor-background);
+	background-color: var(--vscode-editorWidget-background);
 	border-radius: 6px;
 	border: 1px solid var(--vscode-contrastBorder);
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/media/chatEditorController.css
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/media/chatEditorController.css
@@ -19,7 +19,7 @@
 .chat-diff-change-content-widget .monaco-action-bar {
 	padding: 4px 4px;
 	border-radius: 6px;
-	background-color: var(--vscode-editor-background);
+	background-color: var(--vscode-editorWidget-background);
 	color: var(--vscode-foreground);
 	border: 1px solid var(--vscode-contrastBorder);
 	overflow: hidden;


### PR DESCRIPTION
Adjust the background color of the chat editor overlay and controller to align with the widget styling for a more cohesive appearance. Testing can be done by reviewing the chat editor interface to ensure the new colors are applied correctly.

