### PR TITLE
chat: fix uri compare failing in chat session storage

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -6,10 +6,11 @@
 import { assertNever } from '../../../../../base/common/assert.js';
 import { isMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { equals as objectsEqual } from '../../../../../base/common/objects.js';
-import { isEqual as urisEqual } from '../../../../../base/common/resources.js';
+import { isEqual as _urisEqual } from '../../../../../base/common/resources.js';
 import { hasKey } from '../../../../../base/common/types.js';
-import { ModifiedFileEntryState } from '../editing/chatEditingService.js';
+import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IChatMarkdownContent, ResponseModelState } from '../chatService/chatService.js';
+import { ModifiedFileEntryState } from '../editing/chatEditingService.js';
 import { IParsedChatRequest } from '../requestParser/chatParserTypes.js';
 import { IChatAgentEditedFileEvent, IChatDataSerializerLog, IChatModel, IChatProgressResponseContent, IChatRequestModel, IChatRequestVariableData, ISerializableChatData, ISerializableChatModelInputState, ISerializableChatRequestData, SerializedChatResponsePart } from './chatModel.js';
 import * as Adapt from './objectMutationLog.js';
@@ -93,6 +94,10 @@ const responsePartSchema = Adapt.v<IChatProgressResponseContent, SerializedChatR
 		return false;
 	}
 );
+
+const urisEqual = (a: UriComponents, b: UriComponents): boolean => {
+	return _urisEqual(URI.from(a), URI.from(b));
+};
 
 const messageSchema = Adapt.object<IParsedChatRequest, IParsedChatRequest>({
 	text: Adapt.v(m => m.text),


### PR DESCRIPTION
Fixes a data loss issue where we'd fail to store the session

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
