### PR TITLE
Support `model` param in handoff

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
@@ -77,7 +77,7 @@ export class ChatSuggestNextWidget extends Disposable {
 		// Filter handoffs: if a model is specified, only show if that model exists and is usable
 		const visibleHandoffs = handoffs.filter(handoff => {
 			if (handoff.model) {
-				// Direct lookup by model identifier (e.g., "cerebras/zai-glm-4.7")
+				// Direct lookup by model identifier
 				let metadata = this.languageModelsService.lookupLanguageModel(handoff.model);
 
 				// Fallback: if not found by ID, search by model name

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget.ts
@@ -78,7 +78,19 @@ export class ChatSuggestNextWidget extends Disposable {
 		const visibleHandoffs = handoffs.filter(handoff => {
 			if (handoff.model) {
 				// Direct lookup by model identifier (e.g., "cerebras/zai-glm-4.7")
-				const metadata = this.languageModelsService.lookupLanguageModel(handoff.model);
+				let metadata = this.languageModelsService.lookupLanguageModel(handoff.model);
+
+				// Fallback: if not found by ID, search by model name
+				if (!metadata) {
+					for (const modelId of this.languageModelsService.getLanguageModelIds()) {
+						const candidateMetadata = this.languageModelsService.lookupLanguageModel(modelId);
+						if (candidateMetadata?.name === handoff.model) {
+							metadata = candidateMetadata;
+							break;
+						}
+					}
+				}
+
 				// Model must exist and be user selectable (configured and in picker)
 				return metadata !== undefined && metadata.isUserSelectable === true;
 			}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1171,7 +1171,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (shouldShow) {
 			// Log telemetry only when widget transitions from hidden to visible
 			const wasHidden = this.chatSuggestNextWidget.domNode.style.display === 'none';
-			this.chatSuggestNextWidget.render(currentMode);
+			this.chatSuggestNextWidget.render(currentMode, (model) => this.input.canSwitchToModel(model));
 
 			if (wasHidden) {
 				this.telemetryService.publicLog2<ChatHandoffWidgetShownEvent, ChatHandoffWidgetShownClassification>('chat.handoffWidgetShown', {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1216,6 +1216,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		} else if (handoff.agent) {
 			// Regular handoff to specified agent
 			this._switchToAgentByName(handoff.agent);
+
+			// Switch to the specified model if provided
+			if (handoff.model) {
+				this.input.switchModelByQualifiedName(handoff.model);
+			}
+
 			// Insert the handoff prompt into the input
 			this.input.setValue(promptToUse, false);
 			this.input.focus();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1219,7 +1219,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 			// Switch to the specified model if provided
 			if (handoff.model) {
-				this.input.switchModelByQualifiedName(handoff.model);
+				this.input.switchModelByIdOrName(handoff.model);
 			}
 
 			// Insert the handoff prompt into the input
@@ -2377,7 +2377,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		if (model !== undefined) {
-			this.input.switchModelByQualifiedName(model);
+			this.input.switchModelByIdOrName(model);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -724,7 +724,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
-	 * Find a model by ID, qualified name, model name, or hashed model ID.
+	 * Find a model by ID, qualified name, or hashed model ID.
 	 * Returns undefined if no matching model is found in the available models.
 	 */
 	private findModelByIdOrName(idOrName: string): ILanguageModelChatMetadataAndIdentifier | undefined {
@@ -738,11 +738,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 		}
 
-		// Fall back to searching by qualified name, model name, or hashed ID in available models
+		// Fall back to searching by qualified name or hashed ID in available models
 		const models = this.getModels();
 		return models.find(m =>
 			ILanguageModelChatMetadata.matchesQualifiedName(idOrName, m.metadata) ||
-			m.metadata.name === idOrName ||
 			ChatInputPart.hashModelId(m.identifier) === idOrName
 		);
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -697,25 +697,53 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 	}
 
-	public switchModelByIdOrName(idOrName: string): boolean {
-		// First try direct lookup by ID (more efficient)
-		const metadata = this.languageModelsService.lookupLanguageModel(idOrName);
-		if (metadata) {
-			this.setCurrentLanguageModel({ identifier: idOrName, metadata });
-			return true;
-		}
+	/**
+	 * Check if a model can be switched to by ID or name without actually switching.
+	 * Uses the same lookup logic as switchModelByIdOrName.
+	 */
+	public canSwitchToModel(idOrName: string): boolean {
+		return this.findModelByIdOrName(idOrName) !== undefined;
+	}
 
-		// Fall back to searching by qualified name or model name
-		const models = this.getModels();
-		const model = models.find(m =>
-			ILanguageModelChatMetadata.matchesQualifiedName(idOrName, m.metadata) ||
-			m.metadata.name === idOrName
-		);
+	public switchModelByIdOrName(idOrName: string): boolean {
+		const model = this.findModelByIdOrName(idOrName);
 		if (model) {
 			this.setCurrentLanguageModel(model);
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Find a model by ID, qualified name, or model name.
+	 * Returns undefined if no matching model is found in the available models.
+	 */
+	private findModelByIdOrName(idOrName: string): ILanguageModelChatMetadataAndIdentifier | undefined {
+		// First try direct lookup by ID, but only if the model is in our filtered list
+		const metadata = this.languageModelsService.lookupLanguageModel(idOrName);
+		if (metadata) {
+			const candidate = { identifier: idOrName, metadata };
+			// Verify the model is available (passes all filters)
+			if (this.isModelAvailable(candidate)) {
+				return candidate;
+			}
+		}
+
+		// Fall back to searching by qualified name or model name in available models
+		const models = this.getModels();
+		return models.find(m =>
+			ILanguageModelChatMetadata.matchesQualifiedName(idOrName, m.metadata) ||
+			m.metadata.name === idOrName
+		);
+	}
+
+	/**
+	 * Check if a model is available (passes all filters: isUserSelectable, modelSupportedForDefaultAgent, modelSupportedForInlineChat).
+	 */
+	private isModelAvailable(model: ILanguageModelChatMetadataAndIdentifier): boolean {
+		return !!model.metadata?.isUserSelectable &&
+			this.modelSupportedForDefaultAgent(model) &&
+			this.modelSupportedForInlineChat(model);
 	}
 
 	public switchToNextModel(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -699,7 +699,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	public switchModelByQualifiedName(qualifiedModelName: string): boolean {
 		const models = this.getModels();
-		const model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
+		// First try to match by model identifier (e.g., "cerebras/zai-glm-4.7")
+		let model = models.find(m => m.identifier === qualifiedModelName);
+		// Fall back to qualified name match (e.g., "ModelName (vendor)")
+		if (!model) {
+			model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
+		}
 		if (model) {
 			this.setCurrentLanguageModel(model);
 			return true;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
@@ -232,7 +232,7 @@ export class PromptHeader {
 		return undefined;
 	}
 
-	public get handOffs(): IHandOff[] | undefined { //skip
+	public get handOffs(): IHandOff[] | undefined {
 		const handoffsAttribute = this._parsedHeader.attributes.find(attr => attr.key === PromptHeaderAttributes.handOffs);
 		if (!handoffsAttribute) {
 			return undefined;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/promptFileParser.ts
@@ -232,13 +232,13 @@ export class PromptHeader {
 		return undefined;
 	}
 
-	public get handOffs(): IHandOff[] | undefined {
+	public get handOffs(): IHandOff[] | undefined { //skip
 		const handoffsAttribute = this._parsedHeader.attributes.find(attr => attr.key === PromptHeaderAttributes.handOffs);
 		if (!handoffsAttribute) {
 			return undefined;
 		}
 		if (handoffsAttribute.value.type === 'array') {
-			// Array format: list of objects: { agent, label, prompt, send?, showContinueOn? }
+			// Array format: list of objects: { agent, label, prompt, send?, showContinueOn?, model? }
 			const handoffs: IHandOff[] = [];
 			for (const item of handoffsAttribute.value.items) {
 				if (item.type === 'object') {
@@ -247,6 +247,7 @@ export class PromptHeader {
 					let prompt: string | undefined;
 					let send: boolean | undefined;
 					let showContinueOn: boolean | undefined;
+					let model: string | undefined;
 					for (const prop of item.properties) {
 						if (prop.key.value === 'agent' && prop.value.type === 'string') {
 							agent = prop.value.value;
@@ -258,6 +259,8 @@ export class PromptHeader {
 							send = prop.value.value;
 						} else if (prop.key.value === 'showContinueOn' && prop.value.type === 'boolean') {
 							showContinueOn = prop.value.value;
+						} else if (prop.key.value === 'model' && prop.value.type === 'string') {
+							model = prop.value.value;
 						}
 					}
 					if (agent && label && prompt !== undefined) {
@@ -266,7 +269,8 @@ export class PromptHeader {
 							label,
 							prompt,
 							...(send !== undefined ? { send } : {}),
-							...(showContinueOn !== undefined ? { showContinueOn } : {})
+							...(showContinueOn !== undefined ? { showContinueOn } : {}),
+							...(model !== undefined ? { model } : {})
 						};
 						handoffs.push(handoff);
 					}
@@ -305,6 +309,7 @@ export interface IHandOff {
 	readonly prompt: string;
 	readonly send?: boolean;
 	readonly showContinueOn?: boolean; // treated exactly like send (optional boolean)
+	readonly model?: string; // optional model to switch to - handoff only visible if this model exists
 }
 
 export interface IHeaderAttribute {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSuggestNextWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSuggestNextWidget.test.ts
@@ -1,0 +1,249 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { Emitter } from '../../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatSuggestNextWidget } from '../../../../browser/widget/chatContentParts/chatSuggestNextWidget.js';
+import { IChatMode } from '../../../../common/chatModes.js';
+import { IChatSessionsService, IChatSessionsExtensionPoint } from '../../../../common/chatSessionsService.js';
+import { ChatModeKind } from '../../../../common/constants.js';
+import { ILanguageModelsService, ILanguageModelChatMetadata } from '../../../../common/languageModels.js';
+import { IHandOff } from '../../../../common/promptSyntax/promptFileParser.js';
+import { PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
+
+suite('ChatSuggestNextWidget', () => {
+
+	let store: DisposableStore;
+	let widget: ChatSuggestNextWidget;
+	let mockLanguageModelsService: MockLanguageModelsService;
+
+	class MockLanguageModelsService {
+		private models = new Map<string, ILanguageModelChatMetadata>();
+
+		registerModel(id: string, metadata: Partial<ILanguageModelChatMetadata>): void {
+			this.models.set(id, {
+				id,
+				vendor: 'test',
+				name: metadata.name ?? id,
+				family: 'test',
+				version: '1.0',
+				isUserSelectable: metadata.isUserSelectable ?? true,
+				isDefaultForLocation: {},
+				...metadata,
+			} as ILanguageModelChatMetadata);
+		}
+
+		clearModels(): void {
+			this.models.clear();
+		}
+
+		lookupLanguageModel(id: string): ILanguageModelChatMetadata | undefined {
+			return this.models.get(id);
+		}
+
+		getLanguageModelIds(): string[] {
+			return Array.from(this.models.keys());
+		}
+	}
+
+	class MockChatSessionsService implements Partial<IChatSessionsService> {
+		private readonly _onDidChangeChatSessions = new Emitter<void>();
+		readonly onDidChangeChatSessions = this._onDidChangeChatSessions.event;
+
+		getAllChatSessionContributions(): IChatSessionsExtensionPoint[] {
+			return [];
+		}
+	}
+
+	function createMockMode(handoffs: IHandOff[]): IChatMode {
+		return {
+			id: 'test-mode',
+			kind: ChatModeKind.Agent,
+			label: constObservable('Test Mode'),
+			name: constObservable('Test Mode'),
+			icon: constObservable(Codicon.commentDiscussion),
+			description: constObservable(''),
+			isBuiltin: false,
+			handOffs: constObservable(handoffs),
+			source: { storage: PromptsStorage.local },
+		};
+	}
+
+	setup(() => {
+		store = new DisposableStore();
+
+		mockLanguageModelsService = new MockLanguageModelsService();
+		const mockChatSessionsService = new MockChatSessionsService();
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(new TestConfigurationService)),
+		}, store);
+
+		instaService.stub(ILanguageModelsService, mockLanguageModelsService);
+		instaService.stub(IChatSessionsService, mockChatSessionsService);
+
+		store.add(instaService);
+		widget = store.add(instaService.createInstance(ChatSuggestNextWidget));
+	});
+
+	teardown(() => {
+		store.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('Model filtering', () => {
+
+		test('shows handoff when model is not specified', () => {
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt' }
+			];
+			const mode = createMockMode(handoffs);
+
+			widget.render(mode);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+			assert.strictEqual(widget.getCurrentMode(), mode, 'Mode should be set');
+		});
+
+		test('shows handoff when model exists and isModelAvailable returns true', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'gpt-4' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// isModelAvailable callback returns true (simulates modelSupportedForDefaultAgent = yes)
+			widget.render(mode, () => true);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+		});
+
+		test('hides handoff when isModelAvailable returns false (modelSupportedForDefaultAgent = no)', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'gpt-4' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// isModelAvailable callback returns false (simulates modelSupportedForDefaultAgent = no)
+			widget.render(mode, () => false);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when model not supported');
+		});
+
+		test('hides handoff when model does not exist (fallback check)', () => {
+			// Don't register any models
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'non-existent-model' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// No isModelAvailable callback - falls back to lookupLanguageModel check
+			widget.render(mode);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when model not found');
+		});
+
+		test('shows some handoffs while filtering others based on model availability', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+			mockLanguageModelsService.registerModel('gpt-3.5', { name: 'GPT-3.5', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Use GPT-4', prompt: 'With GPT-4', model: 'gpt-4' },
+				{ agent: 'Default', label: 'Use GPT-3.5', prompt: 'With GPT-3.5', model: 'gpt-3.5' },
+				{ agent: 'Default', label: 'No Model', prompt: 'No model specified' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// Track which models were checked by the callback
+			const checkedModels: string[] = [];
+			widget.render(mode, (model) => {
+				checkedModels.push(model);
+				// Only allow gpt-4, not gpt-3.5 (simulates modelSupportedForDefaultAgent being selective)
+				return model === 'gpt-4';
+			});
+
+			// Widget should be visible because at least one handoff (gpt-4 and no-model) passed the filter
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+			// Verify the callback was called for both handoffs with models
+			assert.deepStrictEqual(checkedModels.sort(), ['gpt-3.5', 'gpt-4'], 'Callback should be called for handoffs with models');
+		});
+
+		test('hides entire widget when all handoffs are filtered out', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Use GPT-4', prompt: 'With GPT-4', model: 'gpt-4' },
+				{ agent: 'Default', label: 'Use GPT-3.5', prompt: 'With GPT-3.5', model: 'gpt-3.5' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// Reject all models
+			widget.render(mode, () => false);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when all handoffs filtered');
+		});
+
+		test('uses fallback lookup by model name when isModelAvailable not provided', () => {
+			mockLanguageModelsService.registerModel('model-id-123', { name: 'GPT-4' });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test', model: 'model-id-123' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// No callback - uses basic existence check via lookupLanguageModel
+			widget.render(mode);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible when model exists');
+		});
+	});
+
+	suite('isModelAvailable callback scenarios', () => {
+
+		test('callback receives correct model string', () => {
+			mockLanguageModelsService.registerModel('my-model', { name: 'My Model' });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test', model: 'my-model' }
+			];
+			const mode = createMockMode(handoffs);
+
+			let receivedModel: string | undefined;
+			widget.render(mode, (model) => {
+				receivedModel = model;
+				return true;
+			});
+
+			assert.strictEqual(receivedModel, 'my-model', 'Callback should receive the model string from handoff');
+		});
+
+		test('callback not called for handoffs without model', () => {
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test' }
+			];
+			const mode = createMockMode(handoffs);
+
+			let callbackCalled = false;
+			widget.render(mode, () => {
+				callbackCalled = true;
+				return true;
+			});
+
+			assert.strictEqual(callbackCalled, false, 'Callback should not be called for handoffs without model');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
@@ -165,6 +165,69 @@ suite('NewPromptsParser', () => {
 		assert.deepEqual(result.header.handOffs[0].showContinueOn, undefined);
 	});
 
+	test('mode with handoff and model parameter', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Implement with GPT-4"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Implement the plan"',
+			/* 07 */'    model: "gpt-4"',
+			/* 08 */'  - label: "Save"',
+			/* 09 */'    agent: Default',
+			/* 10 */'    prompt: "Save the plan"',
+			/* 11 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs, [
+			{ label: 'Implement with GPT-4', agent: 'Default', prompt: 'Implement the plan', model: 'gpt-4' },
+			{ label: 'Save', agent: 'Default', prompt: 'Save the plan' }
+		]);
+	});
+
+	test('model defaults to undefined when not specified per handoff', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs[0].model, undefined);
+	});
+
+	test('ignores model when value is not a string', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'    model: true',
+			/* 08 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		// model should be undefined because 'true' is a boolean, not a string
+		assert.deepEqual(result.header.handOffs[0].model, undefined);
+	});
+
 	test('instructions', async () => {
 		const uri = URI.parse('file:///test/prompt1.md');
 		const content = [


### PR DESCRIPTION
add the parameter "model" to handoff definitions. If the model is not found (or not visible to the user) then the handoff is not shown