### PR TITLE
Defer remote extension host activation for immediate activations

### DIFF
--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -736,7 +736,8 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 	//#region Stopping / Starting / Restarting
 
-	public stopExtensionHosts(reason: string, auto?: boolean): Promise<boolean> {
+	public async stopExtensionHosts(reason: string, auto?: boolean): Promise<boolean> {
+		await this._initializeIfNeeded();
 		return this._doStopExtensionHostsWithVeto(reason, auto);
 	}
 

--- a/src/vs/workbench/services/extensions/common/extensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManager.ts
@@ -71,7 +71,6 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 	private readonly _customers: IDisposable[];
 	private readonly _extensionHost: IExtensionHost;
 	private _proxy: Promise<IExtensionHostProxy | null> | null;
-	private _hasStarted = false;
 
 	public get pid(): number | null {
 		return this._extensionHost.pid;
@@ -116,7 +115,6 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 
 		this._proxy = this._extensionHost.start().then(
 			(protocol) => {
-				this._hasStarted = true;
 
 				// Track healthy extension host startup
 				const successTelemetryEvent: ExtensionHostStartupEvent = {
@@ -321,10 +319,6 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 	}
 
 	public activateByEvent(activationEvent: string, activationKind: ActivationKind): Promise<void> {
-		if (activationKind === ActivationKind.Immediate && !this._hasStarted) {
-			return Promise.resolve();
-		}
-
 		if (!this._cachedActivationEvents.has(activationEvent)) {
 			this._cachedActivationEvents.set(activationEvent, this._activateByEvent(activationEvent, activationKind));
 		}

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -368,6 +368,7 @@ export class ExtensionPointContribution<T> {
 export interface IWillActivateEvent {
 	readonly event: string;
 	readonly activation: Promise<void>;
+	readonly activationKind: ActivationKind;
 }
 
 export interface IResponsiveStateChangeEvent {

--- a/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
@@ -185,6 +185,8 @@ suite('ExtensionService', () => {
 				remoteAuthorityResolverService,
 				new TestDialogService()
 			);
+
+			this._initializeIfNeeded();
 		}
 
 		private _extHostId = 0;
@@ -280,19 +282,16 @@ suite('ExtensionService', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('issue #152204: Remote extension host not disposed after closing vscode client', async () => {
-		await extService.startExtensionHosts();
 		await extService.stopExtensionHosts('foo');
 		assert.deepStrictEqual(extService.order, (['create 1', 'create 2', 'create 3', 'dispose 3', 'dispose 2', 'dispose 1']));
 	});
 
 	test('Extension host disposed when awaited', async () => {
-		await extService.startExtensionHosts();
 		await extService.stopExtensionHosts('foo');
 		assert.deepStrictEqual(extService.order, (['create 1', 'create 2', 'create 3', 'dispose 3', 'dispose 2', 'dispose 1']));
 	});
 
 	test('Extension host not disposed when vetoed (sync)', async () => {
-		await extService.startExtensionHosts();
 
 		disposables.add(extService.onWillStop(e => e.veto(true, 'test 1')));
 		disposables.add(extService.onWillStop(e => e.veto(false, 'test 2')));
@@ -302,7 +301,6 @@ suite('ExtensionService', () => {
 	});
 
 	test('Extension host not disposed when vetoed (async)', async () => {
-		await extService.startExtensionHosts();
 
 		disposables.add(extService.onWillStop(e => e.veto(false, 'test 1')));
 		disposables.add(extService.onWillStop(e => e.veto(Promise.resolve(true), 'test 2')));
@@ -313,7 +311,6 @@ suite('ExtensionService', () => {
 	});
 
 	test('onWillActivateByEvent includes activationKind for Normal activation', async () => {
-		await extService.startExtensionHosts();
 
 		const events: IWillActivateEvent[] = [];
 		disposables.add(extService.onWillActivateByEvent(e => events.push(e)));
@@ -326,7 +323,6 @@ suite('ExtensionService', () => {
 	});
 
 	test('onWillActivateByEvent includes activationKind for Immediate activation', async () => {
-		await extService.startExtensionHosts();
 
 		const events: IWillActivateEvent[] = [];
 		disposables.add(extService.onWillActivateByEvent(e => events.push(e)));
@@ -339,7 +335,6 @@ suite('ExtensionService', () => {
 	});
 
 	test('Immediate activation only activates local extension hosts', async () => {
-		await extService.startExtensionHosts();
 		extService.activationEvents.length = 0; // Clear any initial activations
 
 		await extService.activateByEvent('onTest', ActivationKind.Immediate);
@@ -352,7 +347,6 @@ suite('ExtensionService', () => {
 	});
 
 	test('Normal activation activates all extension hosts', async () => {
-		await extService.startExtensionHosts();
 		extService.activationEvents.length = 0; // Clear any initial activations
 
 		await extService.activateByEvent('onTest', ActivationKind.Normal);

--- a/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
@@ -40,7 +40,7 @@ import { IExtensionHostManager } from '../../common/extensionHostManagers.js';
 import { ExtensionManifestPropertiesService, IExtensionManifestPropertiesService } from '../../common/extensionManifestPropertiesService.js';
 import { ExtensionRunningLocation } from '../../common/extensionRunningLocation.js';
 import { ExtensionRunningLocationTracker } from '../../common/extensionRunningLocationTracker.js';
-import { IExtensionHost, IExtensionService } from '../../common/extensions.js';
+import { ActivationKind, IExtensionHost, IExtensionService, IWillActivateEvent } from '../../common/extensions.js';
 import { ExtensionsProposedApi } from '../../common/extensionsProposedApi.js';
 import { ILifecycleService } from '../../../lifecycle/common/lifecycle.js';
 import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
@@ -189,16 +189,20 @@ suite('ExtensionService', () => {
 
 		private _extHostId = 0;
 		public readonly order: string[] = [];
+		public readonly activationEvents: { event: string; activationKind: ActivationKind; kind: ExtensionHostKind }[] = [];
 		protected _pickExtensionHostKind(extensionId: ExtensionIdentifier, extensionKinds: ExtensionKind[], isInstalledLocally: boolean, isInstalledRemotely: boolean, preference: ExtensionRunningPreference): ExtensionHostKind | null {
 			throw new Error('Method not implemented.');
 		}
 		protected override _doCreateExtensionHostManager(extensionHost: IExtensionHost, initialActivationEvents: string[]): IExtensionHostManager {
 			const order = this.order;
+			const activationEvents = this.activationEvents;
 			const extensionHostId = ++this._extHostId;
+			const extHostKind = extensionHost.runningLocation.kind;
 			order.push(`create ${extensionHostId}`);
 			return new class extends mock<IExtensionHostManager>() {
 				override onDidExit = Event.None;
 				override onDidChangeResponsiveState = Event.None;
+				override kind = extHostKind;
 				override disconnect() {
 					return Promise.resolve();
 				}
@@ -211,10 +215,17 @@ suite('ExtensionService', () => {
 				override representsRunningLocation(runningLocation: ExtensionRunningLocation): boolean {
 					return extensionHost.runningLocation.equals(runningLocation);
 				}
+				override activateByEvent(event: string, activationKind: ActivationKind): Promise<void> {
+					activationEvents.push({ event, activationKind, kind: extHostKind });
+					return Promise.resolve();
+				}
+				override ready(): Promise<void> {
+					return Promise.resolve();
+				}
 			};
 		}
-		protected _resolveExtensions(): AsyncIterable<ResolvedExtensions> {
-			throw new Error('Method not implemented.');
+		protected async *_resolveExtensions(): AsyncIterable<ResolvedExtensions> {
+			// Return empty iterable - no extensions to resolve in tests
 		}
 		protected _scanSingleExtension(extension: IExtension): Promise<IExtensionDescription | null> {
 			throw new Error('Method not implemented.');
@@ -299,5 +310,57 @@ suite('ExtensionService', () => {
 
 		await extService.stopExtensionHosts('foo');
 		assert.deepStrictEqual(extService.order, (['create 1', 'create 2', 'create 3']));
+	});
+
+	test('onWillActivateByEvent includes activationKind for Normal activation', async () => {
+		await extService.startExtensionHosts();
+
+		const events: IWillActivateEvent[] = [];
+		disposables.add(extService.onWillActivateByEvent(e => events.push(e)));
+
+		await extService.activateByEvent('onTest', ActivationKind.Normal);
+
+		assert.strictEqual(events.length, 1);
+		assert.strictEqual(events[0].event, 'onTest');
+		assert.strictEqual(events[0].activationKind, ActivationKind.Normal);
+	});
+
+	test('onWillActivateByEvent includes activationKind for Immediate activation', async () => {
+		await extService.startExtensionHosts();
+
+		const events: IWillActivateEvent[] = [];
+		disposables.add(extService.onWillActivateByEvent(e => events.push(e)));
+
+		await extService.activateByEvent('onTest', ActivationKind.Immediate);
+
+		assert.strictEqual(events.length, 1);
+		assert.strictEqual(events[0].event, 'onTest');
+		assert.strictEqual(events[0].activationKind, ActivationKind.Immediate);
+	});
+
+	test('Immediate activation only activates local extension hosts', async () => {
+		await extService.startExtensionHosts();
+		extService.activationEvents.length = 0; // Clear any initial activations
+
+		await extService.activateByEvent('onTest', ActivationKind.Immediate);
+
+		// Should only activate on local hosts (LocalProcess and LocalWebWorker), not Remote
+		const activatedKinds = extService.activationEvents.map(e => e.kind);
+		assert.ok(activatedKinds.includes(ExtensionHostKind.LocalProcess), 'Should activate on LocalProcess');
+		assert.ok(activatedKinds.includes(ExtensionHostKind.LocalWebWorker), 'Should activate on LocalWebWorker');
+		assert.ok(!activatedKinds.includes(ExtensionHostKind.Remote), 'Should NOT activate on Remote');
+	});
+
+	test('Normal activation activates all extension hosts', async () => {
+		await extService.startExtensionHosts();
+		extService.activationEvents.length = 0; // Clear any initial activations
+
+		await extService.activateByEvent('onTest', ActivationKind.Normal);
+
+		// Should activate on all hosts
+		const activatedKinds = extService.activationEvents.map(e => e.kind);
+		assert.ok(activatedKinds.includes(ExtensionHostKind.LocalProcess), 'Should activate on LocalProcess');
+		assert.ok(activatedKinds.includes(ExtensionHostKind.LocalWebWorker), 'Should activate on LocalWebWorker');
+		assert.ok(activatedKinds.includes(ExtensionHostKind.Remote), 'Should activate on Remote');
 	});
 });

--- a/test/mcp/package-lock.json
+++ b/test/mcp/package-lock.json
@@ -839,6 +839,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",

--- a/test/mcp/package-lock.json
+++ b/test/mcp/package-lock.json
@@ -839,16 +839,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",


### PR DESCRIPTION
Defer remote extension host activation for Immediate activations

When `activateByEvent` is called with `ActivationKind.Immediate`, only
activate on local extension hosts (LocalProcess, LocalWebWorker) and
defer remote host activation until the remote host is ready. This
prevents blocking startup when extensions need immediate activation
but the remote host isn't available yet.

Changes:
- Add `activationKind` to `IWillActivateEvent` interface
- Track deferred activation events in `_pendingRemoteActivationEvents`
- Filter to local hosts only for Immediate activation
- Replay deferred events on remote hosts after initialization
- Fire `onWillActivateByEvent` again with Normal kind when replaying

Fixes #260061