### PR TITLE
Custom hover for session type picker and mode picker in chat

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -353,6 +353,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 			delegate,
 			anchor,
 			editorDom,
+			undefined,
 			this._getActionBarActions(actions, at, options));
 	}
 

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.ts
@@ -143,7 +143,7 @@ class PostEditWidget<T extends DocumentPasteEdit | DocumentDropEdit> extends Dis
 					return this.onSelectNewEdit(i);
 				}
 			},
-		}, anchor, this.editor.getDomNode() ?? undefined, this.additionalActions);
+		}, anchor, this.editor.getDomNode() ?? undefined, undefined, this.additionalActions);
 	}
 }
 

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -21,7 +21,6 @@ import { defaultListStyles } from '../../theme/browser/defaultStyles.js';
 import { asCssVariable } from '../../theme/common/colorRegistry.js';
 import { ILayoutService } from '../../layout/browser/layoutService.js';
 import { IHoverService } from '../../hover/browser/hover.js';
-import { HoverPosition } from '../../../base/browser/ui/hover/hoverWidget.js';
 import { IHoverPositionOptions } from '../../../base/browser/ui/hover/hover.js';
 
 export interface IActionListHoverOptions {

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -207,7 +207,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 		if (this._customHover && tooltipText) {
 			data.elementDisposables.add(this._hoverService.setupDelayedHover(
 				data.container,
-				{ content: tooltipText, position: this._customHover.position ?? { hoverPosition: HoverPosition.LEFT }, appearance: { showPointer: true } },
+				{ content: tooltipText, position: this._customHover.position, appearance: { showPointer: true } },
 				{ groupId: 'actionList' }
 			));
 			data.container.title = '';

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -36,7 +36,7 @@ export const IActionWidgetService = createDecorator<IActionWidgetService>('actio
 export interface IActionWidgetService {
 	readonly _serviceBrand: undefined;
 
-	show<T>(user: string, supportsPreview: boolean, customHover: IActionListHoverOptions | undefined, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void;
+	show<T>(user: string, supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, customHover: IActionListHoverOptions | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void;
 
 	hide(didCancel?: boolean): void;
 
@@ -60,7 +60,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		super();
 	}
 
-	show<T>(user: string, supportsPreview: boolean, customHover: IActionListHoverOptions | undefined, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void {
+	show<T>(user: string, supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, customHover: IActionListHoverOptions | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void {
 		const visibleContext = ActionWidgetContextKeys.Visible.bindTo(this._contextKeyService);
 
 		const list = this._instantiationService.createInstance(ActionList, user, supportsPreview, customHover, items, delegate, accessibilityProvider);

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -10,7 +10,7 @@ import { KeyCode, KeyMod } from '../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
 import './actionWidget.css';
 import { localize, localize2 } from '../../../nls.js';
-import { acceptSelectedActionCommand, ActionList, IActionListDelegate, IActionListItem, previewSelectedActionCommand } from './actionList.js';
+import { acceptSelectedActionCommand, ActionList, IActionListDelegate, IActionListItem, IActionListHoverOptions, previewSelectedActionCommand } from './actionList.js';
 import { Action2, registerAction2 } from '../../actions/common/actions.js';
 import { IContextKeyService, RawContextKey } from '../../contextkey/common/contextkey.js';
 import { IContextViewService } from '../../contextview/browser/contextView.js';
@@ -36,7 +36,7 @@ export const IActionWidgetService = createDecorator<IActionWidgetService>('actio
 export interface IActionWidgetService {
 	readonly _serviceBrand: undefined;
 
-	show<T>(user: string, supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void;
+	show<T>(user: string, supportsPreview: boolean, customHover: IActionListHoverOptions | undefined, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void;
 
 	hide(didCancel?: boolean): void;
 
@@ -60,10 +60,10 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		super();
 	}
 
-	show<T>(user: string, supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void {
+	show<T>(user: string, supportsPreview: boolean, customHover: IActionListHoverOptions | undefined, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: HTMLElement | StandardMouseEvent | IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[], accessibilityProvider?: Partial<IListAccessibilityProvider<IActionListItem<T>>>): void {
 		const visibleContext = ActionWidgetContextKeys.Visible.bindTo(this._contextKeyService);
 
-		const list = this._instantiationService.createInstance(ActionList, user, supportsPreview, items, delegate, accessibilityProvider);
+		const list = this._instantiationService.createInstance(ActionList, user, supportsPreview, customHover, items, delegate, accessibilityProvider);
 		this._contextViewService.showContextView({
 			getAnchor: () => anchor,
 			render: (container: HTMLElement) => {

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -173,11 +173,11 @@ export class ActionWidgetDropdown extends BaseDropdown {
 		this.actionWidgetService.show<IActionWidgetDropdownAction>(
 			this._options.label ?? '',
 			false,
-			this._options.customHover,
 			actionWidgetItems,
 			actionWidgetDelegate,
 			this._options.getAnchor?.() ?? this.element,
 			undefined,
+			this._options.customHover,
 			actionBarActions,
 			accessibilityProvider
 		);

--- a/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidgetDropdown.ts
@@ -6,7 +6,7 @@
 import { IActionWidgetService } from './actionWidget.js';
 import { IAction } from '../../../base/common/actions.js';
 import { BaseDropdown, IActionProvider, IBaseDropdownOptions } from '../../../base/browser/ui/dropdown/dropdown.js';
-import { ActionListItemKind, IActionListDelegate, IActionListItem } from './actionList.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem, IActionListHoverOptions } from './actionList.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { Codicon } from '../../../base/common/codicons.js';
 import { getActiveElement, isHTMLElement } from '../../../base/browser/dom.js';
@@ -36,6 +36,9 @@ export interface IActionWidgetDropdownOptions extends IBaseDropdownOptions {
 
 	// Function that returns the anchor element for the dropdown
 	getAnchor?: () => HTMLElement;
+
+	/** When set, tooltips will be rendered using the custom workbench hover instead of title attribute */
+	customHover?: IActionListHoverOptions;
 }
 
 /**
@@ -170,6 +173,7 @@ export class ActionWidgetDropdown extends BaseDropdown {
 		this.actionWidgetService.show<IActionWidgetDropdownAction>(
 			this._options.label ?? '',
 			false,
+			this._options.customHover,
 			actionWidgetItems,
 			actionWidgetDelegate,
 			this._options.getAnchor?.() ?? this.element,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -57,6 +57,19 @@ export function getAgentSessionProviderIcon(provider: AgentSessionProviders): Th
 	}
 }
 
+export function getAgentSessionProviderDescription(provider: AgentSessionProviders): string {
+	switch (provider) {
+		case AgentSessionProviders.Local:
+			return localize('chat.session.providerDescription.local', "Run in your local workspace.");
+		case AgentSessionProviders.Background:
+			return localize('chat.session.providerDescription.background', "Runs locally on a copy of the workspace. Changes won't appear until you apply them. Uses GitHub Copilot CLI and runs in a git worktree.");
+		case AgentSessionProviders.Cloud:
+			return localize('chat.session.providerDescription.cloud', "Runs on a remote device in the cloud. Changes won't appear in the active workspace until you check them out. Will create a public pull request in your repository.");
+		case AgentSessionProviders.ClaudeCode:
+			return localize('chat.session.providerDescription.claude', "Run in your local workspace using Anthropic's Claude SDK.");
+	}
+}
+
 export enum AgentSessionsViewerOrientation {
 	Stacked = 1,
 	SideBySide,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -30,6 +30,7 @@ import { ExtensionAgentSourceType, PromptsStorage } from '../../../common/prompt
 import { getOpenChatActionIdForMode } from '../../actions/chatActions.js';
 import { IToggleChatModeArgs, ToggleAgentModeActionId } from '../../actions/chatExecuteActions.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
+import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 
 export interface IModePickerDelegate {
 	readonly currentMode: IObservable<IChatMode>;
@@ -131,7 +132,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			actionBarActionProvider: {
 				getActions: () => this.getModePickerActionBarActions()
 			},
-			showItemKeybindings: true
+			showItemKeybindings: true,
+			customHover: { position: { hoverPosition: HoverPosition.LEFT } },
 		};
 
 		super(action, modePickerActionWidgetOptions, pickerOptions, actionWidgetService, keybindingService, contextKeyService);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -17,9 +17,10 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
-import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
+import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { ISessionTypePickerDelegate } from '../../chat.js';
+import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 
 interface ISessionTypeItem {
 	type: AgentSessionProviders;
@@ -97,6 +98,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 			actionBarActions,
 			actionBarActionProvider: undefined,
 			showItemKeybindings: true,
+			customHover: { position: { hoverPosition: HoverPosition.LEFT } },
 		};
 
 		super(action, sessionTargetPickerOptions, pickerOptions, actionWidgetService, keybindingService, contextKeyService);
@@ -111,7 +113,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		const localSessionItem = {
 			type: AgentSessionProviders.Local,
 			label: getAgentSessionProviderName(AgentSessionProviders.Local),
-			description: localize('chat.sessionTarget.local.description', "Local chat session"),
+			description: getAgentSessionProviderDescription(AgentSessionProviders.Local),
 			commandId: `workbench.action.chat.openNewChatSessionInPlace.${AgentSessionProviders.Local}`,
 		};
 
@@ -124,10 +126,11 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 				continue;
 			}
 
+			const description = getAgentSessionProviderDescription(agentSessionType);
 			agentSessionItems.push({
 				type: agentSessionType,
 				label: getAgentSessionProviderName(agentSessionType),
-				description: contribution.description,
+				description: description,
 				commandId: `workbench.action.chat.openNewChatSessionInPlace.${contribution.type}`,
 			});
 		}

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
@@ -148,7 +148,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 				this._terminal?.focus();
 			},
 		};
-		this._actionWidgetService.show('quickFixWidget', false, toActionWidgetItems(actionSet.validActions, true), delegate, this._currentRenderContext.anchor, this._currentRenderContext.parentElement);
+		this._actionWidgetService.show('quickFixWidget', false, toActionWidgetItems(actionSet.validActions, true), delegate, this._currentRenderContext.anchor, this._currentRenderContext.parentElement, undefined);
 	}
 
 	registerCommandSelector(selector: ITerminalCommandSelector): void {


### PR DESCRIPTION
```Copilot Generated Description:``` Implement custom hover functionality for the session type picker and mode picker in the chat interface. This includes adding descriptions for different agent session providers and updating the hover options for better interaction.

https://github.com/microsoft/vscode/issues/284091

