### PR TITLE
Fix error reading log chat session file when clicking back

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatNewActions.ts
@@ -149,10 +149,10 @@ export function registerNewChatActions() {
 			await editingSession?.stop();
 
 			// Create a new session with the same type as the current session
-			if (isIChatViewViewContext(widget.viewContext)) {
+			const currentResource = widget.viewModel?.model.sessionResource;
+			const sessionType = currentResource ? getChatSessionType(currentResource) : localChatSessionType;
+			if (isIChatViewViewContext(widget.viewContext) && sessionType !== localChatSessionType) {
 				// For the sidebar, we need to explicitly load a session with the same type
-				const currentResource = widget.viewModel?.model.sessionResource;
-				const sessionType = currentResource ? getChatSessionType(currentResource) : localChatSessionType;
 				const newResource = getResourceForNewChatSession(sessionType);
 				const view = await viewsService.openView(ChatViewId) as ChatViewPane;
 				await view.loadSession(newResource);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1158,7 +1158,11 @@ async function openChatSession(accessor: ServicesAccessor, openOptions: NewChatS
 		switch (openOptions.position) {
 			case ChatSessionPosition.Sidebar: {
 				const view = await viewsService.openView(ChatViewId) as ChatViewPane;
-				await view.loadSession(resource);
+				if (openOptions.type === AgentSessionProviders.Local) {
+					await view.widget.clear();
+				} else {
+					await view.loadSession(resource);
+				}
 				view.focus();
 				break;
 			}


### PR DESCRIPTION
```Copilot Generated Description:``` Modify the chat session handling to ensure a new session is created when an empty chat session is disposed, preventing errors when attempting to restore a deleted session. Adjust the loading behavior for local chat sessions in the sidebar to clear the view appropriately.

Fixes microsoft/vscode#287914

