### PR TITLE
Only have icons for built-in modes

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatModes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModes.ts
@@ -250,7 +250,7 @@ export interface IChatMode {
 	readonly id: string;
 	readonly name: IObservable<string>;
 	readonly label: IObservable<string>;
-	readonly icon: IObservable<ThemeIcon>;
+	readonly icon: IObservable<ThemeIcon | undefined>;
 	readonly description: IObservable<string | undefined>;
 	readonly isBuiltin: boolean;
 	readonly kind: ChatModeKind;
@@ -320,8 +320,8 @@ export class CustomChatMode implements IChatMode {
 		return this._descriptionObservable;
 	}
 
-	get icon(): IObservable<ThemeIcon> {
-		return constObservable(Codicon.tasklist);
+	get icon(): IObservable<ThemeIcon | undefined> {
+		return constObservable(undefined);
 	}
 
 	public get isBuiltin(): boolean {


### PR DESCRIPTION
```Copilot Generated Description:``` Update the mode picker to ensure that built-in modes have associated icons. Adjust the icon property in the IChatMode interface to allow for undefined values. Modify the logic in the ModePickerActionItem class to use a default icon for built-in modes when no specific icon is provided.

