### PR TITLE
add name to model picker aria label

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -184,6 +184,12 @@ export class ModelPickerActionItem extends ChatInputPickerActionViewItem {
 		return statusIcon && tooltip ? `${label} • ${tooltip}` : label;
 	}
 
+	protected override setAriaLabelAttributes(element: HTMLElement): void {
+		super.setAriaLabelAttributes(element);
+		const modelName = this.currentModel?.metadata.name ?? localize('chat.modelPicker.auto', "Auto");
+		element.ariaLabel = localize('chat.modelPicker.ariaLabel', "Pick Model, {0}", modelName);
+	}
+
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
 		const { name, statusIcon } = this.currentModel?.metadata || {};
 		const domChildren = [];


### PR DESCRIPTION
fixes #288460

Before:

<img width="987" height="418" alt="Screenshot 2026-01-16 at 3 12 05 PM" src="https://github.com/user-attachments/assets/d1a28fe9-6b5a-495a-9530-01f254895c40" />

After:

<img width="918" height="520" alt="Screenshot 2026-01-16 at 3 07 04 PM" src="https://github.com/user-attachments/assets/eacc5ffa-10a4-4c2b-b947-4d8e36d9ab78" />
