### PR TITLE
improve chat response accessible view content

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView.ts
@@ -5,9 +5,10 @@
 
 import { renderAsPlaintext } from '../../../../../base/browser/markdownRenderer.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { isMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { IMarkdownString, isMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { stripIcons } from '../../../../../base/common/iconLabels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { AccessibleViewProviderId, AccessibleViewType, IAccessibleViewContentProvider } from '../../../../../platform/accessibility/browser/accessibleView.js';
 import { IAccessibleViewImplementation } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
@@ -15,10 +16,11 @@ import { ServicesAccessor } from '../../../../../platform/instantiation/common/i
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 import { migrateLegacyTerminalToolSpecificData } from '../../common/chat.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { IChatToolInvocation } from '../../common/chatService/chatService.js';
+import { IChatExtensionsContent, IChatPullRequestContent, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, ILegacyChatTerminalToolInvocationData, IToolResultOutputDetailsSerialized, isLegacyChatTerminalToolInvocationData } from '../../common/chatService/chatService.js';
 import { isResponseVM } from '../../common/model/chatViewModel.js';
-import { isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
+import { IToolResultInputOutputDetails, IToolResultOutputDetails, isToolResultInputOutputDetails, isToolResultOutputDetails, toolContentToA11yString } from '../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatWidget, IChatWidgetService } from '../chat.js';
+import { Location } from '../../../../../editor/common/languages.js';
 
 export class ChatResponseAccessibleView implements IAccessibleViewImplementation {
 	readonly priority = 100;
@@ -44,6 +46,137 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplementation
 
 		return new ChatResponseAccessibleProvider(verifiedWidget, focusedItem, chatInputFocused);
 	}
+}
+
+type ToolSpecificData = IChatTerminalToolInvocationData | ILegacyChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatPullRequestContent | IChatTodoListContent | IChatSubagentToolInvocationData;
+type ResultDetails = Array<URI | Location> | IToolResultInputOutputDetails | IToolResultOutputDetails | IToolResultOutputDetailsSerialized;
+
+function isOutputDetailsSerialized(obj: unknown): obj is IToolResultOutputDetailsSerialized {
+	return typeof obj === 'object' && obj !== null && 'output' in obj &&
+		typeof (obj as IToolResultOutputDetailsSerialized).output === 'object' &&
+		(obj as IToolResultOutputDetailsSerialized).output?.type === 'data' &&
+		typeof (obj as IToolResultOutputDetailsSerialized).output?.base64Data === 'string';
+}
+
+export function getToolSpecificDataDescription(toolSpecificData: ToolSpecificData | undefined): string {
+	if (!toolSpecificData) {
+		return '';
+	}
+
+	if (isLegacyChatTerminalToolInvocationData(toolSpecificData) || toolSpecificData.kind === 'terminal') {
+		const terminalData = migrateLegacyTerminalToolSpecificData(toolSpecificData);
+		return terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
+	}
+
+	switch (toolSpecificData.kind) {
+		case 'subagent': {
+			const parts: string[] = [];
+			if (toolSpecificData.agentName) {
+				parts.push(localize('subagentName', "Agent: {0}", toolSpecificData.agentName));
+			}
+			if (toolSpecificData.description) {
+				parts.push(toolSpecificData.description);
+			}
+			if (toolSpecificData.prompt) {
+				parts.push(localize('subagentPrompt', "Task: {0}", toolSpecificData.prompt));
+			}
+			return parts.join('. ') || '';
+		}
+		case 'extensions':
+			return toolSpecificData.extensions.length > 0
+				? localize('extensionsList', "Extensions: {0}", toolSpecificData.extensions.join(', '))
+				: '';
+		case 'todoList': {
+			const todos = toolSpecificData.todoList;
+			if (todos.length === 0) {
+				return '';
+			}
+			const todoDescriptions = todos.map(t =>
+				localize('todoItem', "{0} ({1}): {2}", t.title, t.status, t.description)
+			);
+			return localize('todoListCount', "{0} items: {1}", todos.length, todoDescriptions.join('; '));
+		}
+		case 'pullRequest':
+			return localize('pullRequestInfo', "PR: {0} by {1}", toolSpecificData.title, toolSpecificData.author);
+		case 'input':
+			return typeof toolSpecificData.rawInput === 'string'
+				? toolSpecificData.rawInput
+				: JSON.stringify(toolSpecificData.rawInput);
+		default:
+			return '';
+	}
+}
+
+export function getResultDetailsDescription(resultDetails: ResultDetails | undefined): { input?: string; files?: string[]; isError?: boolean } {
+	if (!resultDetails) {
+		return {};
+	}
+
+	if (Array.isArray(resultDetails)) {
+		const files = resultDetails.map(ref => {
+			if (URI.isUri(ref)) {
+				return ref.fsPath || ref.path;
+			}
+			return ref.uri.fsPath || ref.uri.path;
+		});
+		return { files };
+	}
+
+	if (isToolResultInputOutputDetails(resultDetails)) {
+		return {
+			input: resultDetails.input,
+			isError: resultDetails.isError
+		};
+	}
+
+	if (isOutputDetailsSerialized(resultDetails)) {
+		return {
+			input: localize('binaryOutput', "{0} data", resultDetails.output.mimeType)
+		};
+	}
+
+	if (isToolResultOutputDetails(resultDetails)) {
+		return {
+			input: localize('binaryOutput', "{0} data", resultDetails.output.mimeType)
+		};
+	}
+
+	return {};
+}
+
+export function getToolInvocationA11yDescription(
+	invocationMessage: string | undefined,
+	pastTenseMessage: string | undefined,
+	toolSpecificData: ToolSpecificData | undefined,
+	resultDetails: ResultDetails | undefined,
+	isComplete: boolean
+): string {
+	const parts: string[] = [];
+
+	const message = isComplete && pastTenseMessage ? pastTenseMessage : invocationMessage;
+	if (message) {
+		parts.push(message);
+	}
+
+	const toolDataDesc = getToolSpecificDataDescription(toolSpecificData);
+	if (toolDataDesc) {
+		parts.push(toolDataDesc);
+	}
+
+	if (isComplete && resultDetails) {
+		const details = getResultDetailsDescription(resultDetails);
+		if (details.isError) {
+			parts.unshift(localize('errored', "Errored"));
+		}
+		if (details.input && !toolDataDesc) {
+			parts.push(localize('input', "Input: {0}", details.input));
+		}
+		if (details.files && details.files.length > 0) {
+			parts.push(localize('files', "Files: {0}", details.files.join(', ')));
+		}
+	}
+
+	return parts.join('. ');
 }
 
 class ChatResponseAccessibleProvider extends Disposable implements IAccessibleViewContentProvider {
@@ -76,6 +209,10 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 		}
 	}
 
+	private _renderMessageAsPlaintext(message: string | IMarkdownString): string {
+		return typeof message === 'string' ? message : stripIcons(renderAsPlaintext(message, { useLinkFormatter: true }));
+	}
+
 	private _getContent(item: ChatTreeItem): string {
 		let responseContent = isResponseVM(item) ? item.response.toString() : '';
 		if (!responseContent && 'errorDetails' in item && item.errorDetails) {
@@ -100,30 +237,17 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 			for (const toolInvocation of toolInvocations) {
 				const state = toolInvocation.state.get();
 				if (state.type === IChatToolInvocation.StateKind.WaitingForConfirmation && state.confirmationMessages?.title) {
-					const title = typeof state.confirmationMessages.title === 'string' ? state.confirmationMessages.title : state.confirmationMessages.title.value;
-					const message = typeof state.confirmationMessages.message === 'string' ? state.confirmationMessages.message : stripIcons(renderAsPlaintext(state.confirmationMessages.message!));
-					let input = '';
-					if (toolInvocation.toolSpecificData) {
-						if (toolInvocation.toolSpecificData?.kind === 'terminal') {
-							const terminalData = migrateLegacyTerminalToolSpecificData(toolInvocation.toolSpecificData);
-							input = terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original;
-						} else if (toolInvocation.toolSpecificData?.kind === 'subagent') {
-							input = toolInvocation.toolSpecificData.description ?? '';
-						} else {
-							input = toolInvocation.toolSpecificData?.kind === 'extensions'
-								? JSON.stringify(toolInvocation.toolSpecificData.extensions)
-								: toolInvocation.toolSpecificData?.kind === 'todoList'
-									? JSON.stringify(toolInvocation.toolSpecificData.todoList)
-									: toolInvocation.toolSpecificData?.kind === 'pullRequest'
-										? JSON.stringify(toolInvocation.toolSpecificData)
-										: JSON.stringify(toolInvocation.toolSpecificData.rawInput);
-						}
-					}
+					const title = this._renderMessageAsPlaintext(state.confirmationMessages.title);
+					const message = state.confirmationMessages.message ? this._renderMessageAsPlaintext(state.confirmationMessages.message) : '';
+					const toolDataDesc = getToolSpecificDataDescription(toolInvocation.toolSpecificData);
 					responseContent += `${title}`;
-					if (input) {
-						responseContent += `: ${input}`;
+					if (toolDataDesc) {
+						responseContent += `: ${toolDataDesc}`;
 					}
-					responseContent += `\n${message}\n`;
+					if (message) {
+						responseContent += `\n${message}`;
+					}
+					responseContent += '\n';
 				} else if (state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
 					const postApprovalDetails = isToolResultInputOutputDetails(state.resultDetails)
 						? state.resultDetails.input
@@ -133,23 +257,35 @@ class ChatResponseAccessibleProvider extends Disposable implements IAccessibleVi
 					responseContent += localize('toolPostApprovalA11yView', "Approve results of {0}? Result: ", toolInvocation.toolId) + (postApprovalDetails ?? '') + '\n';
 				} else {
 					const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
-					if (resultDetails && 'input' in resultDetails) {
-						responseContent += '\n' + (resultDetails.isError ? 'Errored ' : 'Completed ');
-						responseContent += `${`${typeof toolInvocation.invocationMessage === 'string' ? toolInvocation.invocationMessage : stripIcons(renderAsPlaintext(toolInvocation.invocationMessage))} with input: ${resultDetails.input}`}\n`;
+					const isComplete = IChatToolInvocation.isComplete(toolInvocation);
+					const description = getToolInvocationA11yDescription(
+						this._renderMessageAsPlaintext(toolInvocation.invocationMessage),
+						toolInvocation.pastTenseMessage ? this._renderMessageAsPlaintext(toolInvocation.pastTenseMessage) : undefined,
+						toolInvocation.toolSpecificData,
+						resultDetails,
+						isComplete
+					);
+					if (description) {
+						responseContent += '\n' + description + '\n';
 					}
 				}
 			}
 
 			const pastConfirmations = item.response.value.filter(item => item.kind === 'toolInvocationSerialized');
 			for (const pastConfirmation of pastConfirmations) {
-				if (pastConfirmation.isComplete && pastConfirmation.resultDetails && 'input' in pastConfirmation.resultDetails) {
-					if (pastConfirmation.pastTenseMessage) {
-						responseContent += `\n${`${typeof pastConfirmation.pastTenseMessage === 'string' ? pastConfirmation.pastTenseMessage : stripIcons(renderAsPlaintext(pastConfirmation.pastTenseMessage))} with input: ${pastConfirmation.resultDetails.input}`}\n`;
-					}
+				const description = getToolInvocationA11yDescription(
+					this._renderMessageAsPlaintext(pastConfirmation.invocationMessage),
+					pastConfirmation.pastTenseMessage ? this._renderMessageAsPlaintext(pastConfirmation.pastTenseMessage) : undefined,
+					pastConfirmation.toolSpecificData,
+					pastConfirmation.resultDetails,
+					pastConfirmation.isComplete
+				);
+				if (description) {
+					responseContent += '\n' + description + '\n';
 				}
 			}
 		}
-		const plainText = renderAsPlaintext(new MarkdownString(responseContent), { includeCodeBlocksFences: true });
+		const plainText = renderAsPlaintext(new MarkdownString(responseContent), { includeCodeBlocksFences: true, useLinkFormatter: true });
 		return this._normalizeWhitespace(plainText);
 	}
 

--- a/src/vs/workbench/contrib/chat/test/browser/accessibility/chatResponseAccessibleView.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/accessibility/chatResponseAccessibleView.test.ts
@@ -1,0 +1,342 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { Range } from '../../../../../../editor/common/core/range.js';
+import { Location } from '../../../../../../editor/common/languages.js';
+import { getToolSpecificDataDescription, getResultDetailsDescription, getToolInvocationA11yDescription } from '../../../browser/accessibility/chatResponseAccessibleView.js';
+import { IChatExtensionsContent, IChatPullRequestContent, IChatSubagentToolInvocationData, IChatTerminalToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData } from '../../../common/chatService/chatService.js';
+
+suite('ChatResponseAccessibleView', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('getToolSpecificDataDescription', () => {
+		test('returns empty string for undefined', () => {
+			assert.strictEqual(getToolSpecificDataDescription(undefined), '');
+		});
+
+		test('returns command line for terminal data', () => {
+			const terminalData: IChatTerminalToolInvocationData = {
+				kind: 'terminal',
+				commandLine: {
+					original: 'npm install',
+					toolEdited: 'npm ci',
+					userEdited: 'npm install --save-dev'
+				},
+				language: 'bash'
+			};
+			// Should prefer userEdited over toolEdited over original
+			assert.strictEqual(getToolSpecificDataDescription(terminalData), 'npm install --save-dev');
+		});
+
+		test('returns tool edited command for terminal data without user edit', () => {
+			const terminalData: IChatTerminalToolInvocationData = {
+				kind: 'terminal',
+				commandLine: {
+					original: 'npm install',
+					toolEdited: 'npm ci'
+				},
+				language: 'bash'
+			};
+			assert.strictEqual(getToolSpecificDataDescription(terminalData), 'npm ci');
+		});
+
+		test('returns original command for terminal data without edits', () => {
+			const terminalData: IChatTerminalToolInvocationData = {
+				kind: 'terminal',
+				commandLine: {
+					original: 'npm install'
+				},
+				language: 'bash'
+			};
+			assert.strictEqual(getToolSpecificDataDescription(terminalData), 'npm install');
+		});
+
+		test('returns description for subagent data', () => {
+			const subagentData: IChatSubagentToolInvocationData = {
+				kind: 'subagent',
+				agentName: 'TestAgent',
+				description: 'Running analysis',
+				prompt: 'Analyze the code'
+			};
+			const result = getToolSpecificDataDescription(subagentData);
+			assert.ok(result.includes('TestAgent'));
+			assert.ok(result.includes('Running analysis'));
+			assert.ok(result.includes('Analyze the code'));
+		});
+
+		test('handles subagent with only description', () => {
+			const subagentData: IChatSubagentToolInvocationData = {
+				kind: 'subagent',
+				description: 'Running analysis'
+			};
+			const result = getToolSpecificDataDescription(subagentData);
+			assert.strictEqual(result, 'Running analysis');
+		});
+
+		test('returns extensions list for extensions data', () => {
+			const extensionsData: IChatExtensionsContent = {
+				kind: 'extensions',
+				extensions: ['eslint', 'prettier', 'typescript']
+			};
+			const result = getToolSpecificDataDescription(extensionsData);
+			assert.ok(result.includes('eslint'));
+			assert.ok(result.includes('prettier'));
+			assert.ok(result.includes('typescript'));
+		});
+
+		test('returns empty for empty extensions array', () => {
+			const extensionsData: IChatExtensionsContent = {
+				kind: 'extensions',
+				extensions: []
+			};
+			assert.strictEqual(getToolSpecificDataDescription(extensionsData), '');
+		});
+
+		test('returns todo list description for todoList data', () => {
+			const todoData: IChatTodoListContent = {
+				kind: 'todoList',
+				sessionId: 'session-1',
+				todoList: [
+					{ id: '1', title: 'Task 1', description: 'Do something', status: 'in-progress' },
+					{ id: '2', title: 'Task 2', description: 'Do something else', status: 'completed' }
+				]
+			};
+			const result = getToolSpecificDataDescription(todoData);
+			assert.ok(result.includes('2 items'));
+			assert.ok(result.includes('Task 1'));
+			assert.ok(result.includes('in-progress'));
+			assert.ok(result.includes('Task 2'));
+			assert.ok(result.includes('completed'));
+		});
+
+		test('returns empty for empty todo list', () => {
+			const todoData: IChatTodoListContent = {
+				kind: 'todoList',
+				sessionId: 'session-1',
+				todoList: []
+			};
+			assert.strictEqual(getToolSpecificDataDescription(todoData), '');
+		});
+
+		test('returns PR info for pullRequest data', () => {
+			const prData: IChatPullRequestContent = {
+				kind: 'pullRequest',
+				uri: URI.file('/test'),
+				title: 'Add new feature',
+				description: 'This PR adds a great feature',
+				author: 'testuser',
+				linkTag: '#123'
+			};
+			const result = getToolSpecificDataDescription(prData);
+			assert.ok(result.includes('Add new feature'));
+			assert.ok(result.includes('testuser'));
+		});
+
+		test('returns raw input for input data (string)', () => {
+			const inputData: IChatToolInputInvocationData = {
+				kind: 'input',
+				rawInput: 'some input string'
+			};
+			assert.strictEqual(getToolSpecificDataDescription(inputData), 'some input string');
+		});
+
+		test('returns JSON stringified for input data (object)', () => {
+			const inputData: IChatToolInputInvocationData = {
+				kind: 'input',
+				rawInput: { key: 'value', nested: { data: 123 } }
+			};
+			const result = getToolSpecificDataDescription(inputData);
+			assert.ok(result.includes('key'));
+			assert.ok(result.includes('value'));
+		});
+	});
+
+	suite('getResultDetailsDescription', () => {
+		test('returns empty object for undefined', () => {
+			assert.deepStrictEqual(getResultDetailsDescription(undefined), {});
+		});
+
+		test('returns files for URI array', () => {
+			const uris = [
+				URI.file('/path/to/file1.ts'),
+				URI.file('/path/to/file2.ts')
+			];
+			const result = getResultDetailsDescription(uris);
+			assert.ok(result.files);
+			assert.strictEqual(result.files!.length, 2);
+			assert.ok(result.files![0].includes('file1.ts'));
+			assert.ok(result.files![1].includes('file2.ts'));
+		});
+
+		test('returns files for Location array', () => {
+			const locations: Location[] = [
+				{ uri: URI.file('/path/to/file1.ts'), range: new Range(1, 1, 10, 1) },
+				{ uri: URI.file('/path/to/file2.ts'), range: new Range(5, 1, 15, 1) }
+			];
+			const result = getResultDetailsDescription(locations);
+			assert.ok(result.files);
+			assert.strictEqual(result.files!.length, 2);
+		});
+
+		test('returns input and isError for IToolResultInputOutputDetails', () => {
+			const details = {
+				input: 'create_file path=/test/file.ts',
+				output: [],
+				isError: false
+			};
+			const result = getResultDetailsDescription(details);
+			assert.strictEqual(result.input, 'create_file path=/test/file.ts');
+			assert.strictEqual(result.isError, false);
+		});
+
+		test('returns isError true for errored IToolResultInputOutputDetails', () => {
+			const details = {
+				input: 'create_file path=/test/file.ts',
+				output: [],
+				isError: true
+			};
+			const result = getResultDetailsDescription(details);
+			assert.strictEqual(result.isError, true);
+		});
+	});
+
+	suite('getToolInvocationA11yDescription', () => {
+		test('returns invocation message when not complete', () => {
+			const result = getToolInvocationA11yDescription(
+				'Creating file',
+				'Created file',
+				undefined,
+				undefined,
+				false
+			);
+			assert.strictEqual(result, 'Creating file');
+		});
+
+		test('returns past tense message when complete', () => {
+			const result = getToolInvocationA11yDescription(
+				'Creating file',
+				'Created file',
+				undefined,
+				undefined,
+				true
+			);
+			assert.strictEqual(result, 'Created file');
+		});
+
+		test('includes tool-specific data description', () => {
+			const terminalData: IChatTerminalToolInvocationData = {
+				kind: 'terminal',
+				commandLine: { original: 'npm test' },
+				language: 'bash'
+			};
+			const result = getToolInvocationA11yDescription(
+				'Running command',
+				'Ran command',
+				terminalData,
+				undefined,
+				true
+			);
+			assert.ok(result.includes('Ran command'));
+			assert.ok(result.includes('npm test'));
+		});
+
+		test('includes files from result details when complete', () => {
+			const uris = [
+				URI.file('/path/to/file1.ts'),
+				URI.file('/path/to/file2.ts')
+			];
+			const result = getToolInvocationA11yDescription(
+				'Creating files',
+				'Created files',
+				undefined,
+				uris,
+				true
+			);
+			assert.ok(result.includes('Created files'));
+			assert.ok(result.includes('file1.ts'));
+			assert.ok(result.includes('file2.ts'));
+		});
+
+		test('includes error status when result has error', () => {
+			const details = {
+				input: 'create_file path=/test/file.ts',
+				output: [],
+				isError: true
+			};
+			const result = getToolInvocationA11yDescription(
+				'Creating file',
+				'Created file',
+				undefined,
+				details,
+				true
+			);
+			assert.ok(result.includes('Errored'));
+		});
+
+		test('does not show input when tool-specific data is provided', () => {
+			const terminalData: IChatTerminalToolInvocationData = {
+				kind: 'terminal',
+				commandLine: { original: 'npm test' },
+				language: 'bash'
+			};
+			const details = {
+				input: 'some redundant input',
+				output: [],
+				isError: false
+			};
+			const result = getToolInvocationA11yDescription(
+				'Running command',
+				'Ran command',
+				terminalData,
+				details,
+				true
+			);
+			// Should have tool-specific data but not the "Input:" label
+			assert.ok(result.includes('npm test'));
+			assert.ok(!result.includes('Input:'));
+		});
+
+		test('shows input when no tool-specific data', () => {
+			const details = {
+				input: 'apply_patch file=/test/file.ts',
+				output: [],
+				isError: false
+			};
+			const result = getToolInvocationA11yDescription(
+				'Applying patch',
+				'Applied patch',
+				undefined,
+				details,
+				true
+			);
+			assert.ok(result.includes('Applied patch'));
+			assert.ok(result.includes('Input:'));
+			assert.ok(result.includes('apply_patch'));
+		});
+
+		test('handles all parts together', () => {
+			const subagentData: IChatSubagentToolInvocationData = {
+				kind: 'subagent',
+				agentName: 'CodeReviewer',
+				description: 'Reviewing code changes'
+			};
+			const uris = [URI.file('/src/test.ts')];
+			const result = getToolInvocationA11yDescription(
+				'Starting code review',
+				'Completed code review',
+				subagentData,
+				uris,
+				true
+			);
+			assert.ok(result.includes('Completed code review'));
+			assert.ok(result.includes('CodeReviewer'));
+			assert.ok(result.includes('Reviewing code changes'));
+			assert.ok(result.includes('test.ts'));
+		});
+	});
+});


### PR DESCRIPTION
fix #284313

Before
When Copilot used tools like reading files, the accessible view showed incomplete information:

Screen reader users would hear "Read" with no indication of what file was being read.

After
Now the accessible view shows complete information:

Screen reader users hear the full context
<img width="584" height="419" alt="Screenshot 2026-01-16 at 3 51 38 PM" src="https://github.com/user-attachments/assets/639222d0-9d02-4cfb-ac83-66ddada01117" />

The fix:

Added `useLinkFormatter: true` when converting markdown to plain text. This extracts filenames from markdown links so users hear "Read file.ts" instead of just "Read".

Added helper functions to describe all tool types:

- Terminal commands: Shows the actual command line (including any user edits)
- Subagents: Shows agent name, description, and task prompt
- Extensions: Lists extension names
- Todo lists: Shows todo items with their status
- Pull requests: Shows PR title and author
- File operations: Lists the files that were read/modified
- Errors: Announces when a tool errored
- Added unit tests for all these scenarios.

