### PR TITLE
agents control and agent projection tweaks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -948,9 +948,12 @@ MenuRegistry.appendMenuItem(MenuId.CommandCenter, {
 			ChatContextKeys.Setup.disabled.negate()
 		),
 		ContextKeyExpr.has('config.chat.commandCenter.enabled'),
-		ContextKeyExpr.has(`config.${ChatConfiguration.AgentStatusEnabled}`).negate() // Hide when agent status is shown
+		ContextKeyExpr.or(
+			ContextKeyExpr.has(`config.${ChatConfiguration.AgentStatusEnabled}`).negate(), // Show when agent status is disabled
+			ChatContextKeys.agentStatusHasNotifications.negate() // Or when agent status has no notifications
+		)
 	),
-	order: 10001 // to the right of command center
+	order: 10003 // to the right of agent controls
 });
 
 // Add to the global title bar if command center is disabled

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionProjectionActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionProjectionActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../../nls.js';
-import { Action2, MenuId } from '../../../../../platform/actions/common/actions.js';
+import { Action2 } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
@@ -15,7 +15,6 @@ import { IAgentSessionProjectionService } from './agentSessionProjectionService.
 import { IAgentSession, isMarshalledAgentSessionContext, IMarshalledAgentSessionContext } from './agentSessionsModel.js';
 import { IAgentSessionsService } from './agentSessionsService.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
-import { openSessionInChatWidget } from './agentSessionsOpener.js';
 import { ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
 import { IsCompactTitleBarContext } from '../../../../common/contextkeys.js';
 
@@ -85,45 +84,6 @@ export class ExitAgentSessionProjectionAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const projectionService = accessor.get(IAgentSessionProjectionService);
 		await projectionService.exitProjection();
-	}
-}
-
-//#endregion
-
-//#region Open in Chat Panel
-
-export class OpenInChatPanelAction extends Action2 {
-	static readonly ID = 'agentSession.openInChatPanel';
-
-	constructor() {
-		super({
-			id: OpenInChatPanelAction.ID,
-			title: localize2('openInChatPanel', "Open in Chat Panel"),
-			category: CHAT_CATEGORY,
-			precondition: ChatContextKeys.enabled,
-			menu: [{
-				id: MenuId.AgentSessionsContext,
-				group: '1_open',
-				order: 1,
-			}]
-		});
-	}
-
-	override async run(accessor: ServicesAccessor, context?: IAgentSession | IMarshalledAgentSessionContext): Promise<void> {
-		const agentSessionsService = accessor.get(IAgentSessionsService);
-
-		let session: IAgentSession | undefined;
-		if (context) {
-			if (isMarshalledAgentSessionContext(context)) {
-				session = agentSessionsService.getSession(context.session.resource);
-			} else {
-				session = context;
-			}
-		}
-
-		if (session) {
-			await openSessionInChatWidget(accessor, session);
-		}
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
@@ -28,6 +28,7 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { AuxiliaryBarMaximizedContext } from '../../../../common/contextkeys.js';
+import { LayoutSettings } from '../../../../services/layout/browser/layoutService.js';
 
 //#region Actions and Menus
 
@@ -240,9 +241,15 @@ class AgentStatusRendering extends Disposable implements IWorkbenchContribution 
 		}, undefined));
 
 		// Add/remove CSS class on workbench based on setting
+		// Also force enable command center when agent status is enabled
 		const updateClass = () => {
 			const enabled = configurationService.getValue<boolean>(ChatConfiguration.AgentStatusEnabled) === true;
 			mainWindow.document.body.classList.toggle('agent-status-enabled', enabled);
+
+			// Force enable command center when agent status is enabled
+			if (enabled && configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== true) {
+				configurationService.updateValue(LayoutSettings.COMMAND_CENTER, true);
+			}
 		};
 		updateClass();
 		this._register(configurationService.onDidChangeConfiguration(e => {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution.ts
@@ -62,7 +62,6 @@ registerAction2(SetAgentSessionsOrientationSideBySideAction);
 // Agent Session Projection
 registerAction2(EnterAgentSessionProjectionAction);
 registerAction2(ExitAgentSessionProjectionAction);
-// registerAction2(OpenInChatPanelAction); // TODO@joshspicer https://github.com/microsoft/vscode/issues/288082
 registerAction2(ToggleAgentStatusAction);
 registerAction2(ToggleAgentSessionProjectionAction);
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -197,15 +197,6 @@ export class PickAgentSessionAction extends Action2 {
 					order: 2
 				},
 				{
-					id: MenuId.ViewTitle,
-					when: ContextKeyExpr.and(
-						ContextKeyExpr.equals('view', ChatViewId),
-						ContextKeyExpr.equals(`config.${ChatConfiguration.ChatViewSessionsEnabled}`, true)
-					),
-					group: '2_history',
-					order: 1
-				},
-				{
 					id: MenuId.EditorTitle,
 					when: ActiveEditorContext.isEqualTo(ChatEditorInput.EditorID),
 				}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
@@ -299,19 +299,11 @@ Agent Status Widget - Titlebar control
 	border: 1px solid color-mix(in srgb, var(--vscode-progressBar-background) 50%, transparent);
 	flex-shrink: 0;
 	-webkit-app-region: no-drag;
-	transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
-	opacity: 1;
-	/* Reserve minimum width to prevent layout shift */
-	min-width: 50px;
-	justify-content: center;
 }
 
-/* Empty badge - invisible but reserves space to prevent layout shift */
+/* Empty badge - completely hidden */
 .agent-status-badge.empty {
-	opacity: 0;
-	pointer-events: none;
-	background-color: transparent;
-	border-color: transparent;
+	display: none;
 }
 
 /* Badge section (for split UI) */

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
@@ -271,6 +271,22 @@ Agent Status Widget - Titlebar control
 	outline-offset: -1px;
 }
 
+/* Command center toolbar (debug toolbar, etc.) */
+.agent-status-command-center-toolbar {
+	display: flex;
+	align-items: center;
+	-webkit-app-region: no-drag;
+}
+
+/* Separator dot between command center toolbar and agent status pill */
+.agent-status-separator {
+	padding: 0 8px;
+	height: 100%;
+	opacity: 0.5;
+	display: flex;
+	align-items: center;
+}
+
 /* Status badge (separate rectangle on right of pill) */
 .agent-status-badge {
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentStatusWidget.css
@@ -321,11 +321,18 @@ Agent Status Widget - Titlebar control
 	gap: 4px;
 	padding: 0 8px;
 	height: 100%;
+	position: relative;
 }
 
 /* Separator between sections */
-.agent-status-badge-section + .agent-status-badge-section {
-	border-left: 1px solid color-mix(in srgb, var(--vscode-progressBar-background) 40%, transparent);
+.agent-status-badge-section + .agent-status-badge-section::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 4px;
+	bottom: 4px;
+	width: 1px;
+	background-color: color-mix(in srgb, var(--vscode-progressBar-background) 40%, transparent);
 }
 
 /* Unread section styling */

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -195,7 +195,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.AgentStatusEnabled]: {
 			type: 'boolean',
-			markdownDescription: nls.localize('chat.agentsControl.enabled', "Controls whether the Agent Status is shown in the title bar command center, replacing the search box with quick access to chat sessions."),
+			markdownDescription: nls.localize('chat.agentsControl.enabled', "Controls whether the Agent Status is shown in the title bar command center, replacing the search box with quick access to chat sessions. Enabling this setting will automatically enable {0}.", '`#window.commandCenter#`'),
 			default: false,
 			tags: ['experimental']
 		},

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -109,6 +109,8 @@ export namespace ChatContextKeys {
 	export const isKatexMathElement = new RawContextKey<boolean>('chatIsKatexMathElement', false, { type: 'boolean', description: localize('chatIsKatexMathElement', "True when focusing a KaTeX math element.") });
 
 	export const inAgentSessionProjection = new RawContextKey<boolean>('chatInAgentSessionProjection', false, { type: 'boolean', description: localize('chatInAgentSessionProjection', "True when the workbench is in agent session projection mode for reviewing an agent session.") });
+
+	export const agentStatusHasNotifications = new RawContextKey<boolean>('agentStatusHasNotifications', false, { type: 'boolean', description: localize('agentStatusHasNotifications', "True when the agent status widget has unread or in-progress sessions.") });
 }
 
 export namespace ChatContextKeyExprs {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/288260, https://github.com/microsoft/vscode/issues/288272, https://github.com/microsoft/vscode/issues/288082

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


## Agent Control Improvements

### 1. Debug toolbar integration in agent status control
- When `debug.toolBarLocation` is set to `commandCenter`, the debug toolbar now shows up alongside the agent status control (to the left with a dot separator), matching the behavior of the normal command center

### 2. Status badge click filtering
- Clicking the **unread count** (blue dot) opens the sessions view filtered to unread sessions
- Clicking the **in-progress count** (spinner) opens filtered to in-progress + needs-input sessions
- Clicking the same filter again toggles it off (removes filters)
- Filter auto-clears when the filtered category becomes empty (e.g., all unread sessions are marked read)

### 3. Command center dependency
- Enabling agent status now automatically enables `window.commandCenter` (required for it to display)
- Updated setting description to clarify this behavior

### 4. Badge UI polish
- Badge divider doesn't touch top/bottom edges anymore (uses 4px inset pseudo-element)
- Badge completely hides when empty (`display: none`) - no more reserved space causing awkward gaps

### 5. Agent session projection fixes
- No longer enters "projection mode" for sessions without any artifacts/diffs to display (background chats)
- Local sessions with editing changes now properly enter projection mode (was checking wrong data source)

### 6. Removed redundant actions
- Removed `PickAgentSessionAction` from ViewTitle dropdown (sessions already visible in sidebar)
- Removed `OpenInChatPanelAction` entirely (redundant - clicking sessions already opens them)

### 7. Performance optimization
- Reuse `CommandCenterCenter` menu instance instead of recreating on each render