### PR TITLE
mirror default icon display behavior for chatSession optionGroups

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
@@ -122,10 +122,16 @@ export class ChatSessionPickerActionItem extends ActionWidgetDropdownActionViewI
 		const domChildren = [];
 		element.classList.add('chat-session-option-picker');
 
+		// If the current option is the default and has an icon, collapse the text and show only the icon
+		const isDefaultWithIcon = this.currentOption?.default && this.currentOption?.icon;
+
 		if (this.currentOption?.icon) {
 			domChildren.push(renderIcon(this.currentOption.icon));
 		}
-		domChildren.push(dom.$('span.chat-session-option-label', undefined, this.currentOption?.name ?? localize('chat.sessionPicker.label', "Pick Option")));
+
+		if (!isDefaultWithIcon) {
+			domChildren.push(dom.$('span.chat-session-option-label', undefined, this.currentOption?.name ?? localize('chat.sessionPicker.label', "Pick Option")));
+		}
 
 		domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
