### PR TITLE
Git: Use stash hash instead of index for editor identity

### DIFF
--- a/extensions/git/src/artifactProvider.ts
+++ b/extensions/git/src/artifactProvider.ts
@@ -154,7 +154,7 @@ export class GitArtifactProvider implements SourceControlArtifactProvider, IDisp
 				const stashes = await this.repository.getStashes();
 
 				return stashes.map(s => ({
-					id: `stash@{${s.index}}`,
+					id: s.hash,
 					name: s.description,
 					description: s.branchName,
 					icon: new ThemeIcon('git-stash'),


### PR DESCRIPTION
## Problem
View stash relies on stash index, but if a new stash is created while the last one is shown in editor, trying to open the now recent one with index 0 will not work, it will redirect to the already opened now stash 1.

I found this bug when I pinned a stash A diff editor, then worked on something else and created a new stash B. When I tried to open the recent stash B, VS Code redirected me to the pinned editor showing the OLD stash A instead. This was very confusing - I thought my recent stash wasn't saved correctly or was lost, and almost started redoing the changes A from scratch, but I saw with git stash list that it was there but now with index {1}...

**This is not only pinned stash** - it can be simple opened and kept stash diff.

## How to Reproduce

1. Make some changes in a repo then `git stash` them to create stash A (now at `stash@{0}`)
2. Open stash A using the Source Control stash menu → it opens a diff editor
3. (Optional) Pin that editor tab (right-click tab → "Pin") - or just leave it open
4. Make new changes and `git stash` again to create stash B (B is now `stash@{0}`, A becomes `stash@{1}`)
5. Try to open the most recent stash B from the stash menu
6. **Bug**: VS Code redirects to the already open editor (showing A, not B)
7. **Worse**: Click "Pop Stash" or "Drop Stash" from that editor → operates on the wrong stash!

## Solution

With unique hash per stash, every opened editor is linked to its exact stash diff, and trying to open any new stash will open a new tab.

## Side effect/Known limitation
When a stash editor is already open and the stash index shifts (due to new stashes being created), the editor title still shows the original index, even if you re-try to open the stash by View stash menu. The only way to get the updated index is by closing this editor and viewing the stash again.
## Testing

I manually tested with the reproduction steps above. After the fix:
- Opening stash B opens a new tab (no redirect)
- Pinned stash editors remain linked to the correct stashes.

## Related Issues
I found this old issue #203188 that may be linked to this fix.