### PR TITLE
Avoid hashing variables for dataId

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3126,8 +3126,8 @@ export namespace ChatResponsePart {
 export namespace ChatAgentRequest {
 	export function to(request: IChatAgentRequest, location2: vscode.ChatRequestEditorData | vscode.ChatRequestNotebookData | undefined, model: vscode.LanguageModelChat, diagnostics: readonly [vscode.Uri, readonly vscode.Diagnostic[]][], tools: Map<string, boolean>, extension: IRelaxedExtensionDescription, logService: ILogService): vscode.ChatRequest {
 
-		const toolReferences: typeof request.variables.variables = [];
-		const variableReferences: typeof request.variables.variables = [];
+		const toolReferences: IChatRequestVariableEntry[] = [];
+		const variableReferences: IChatRequestVariableEntry[] = [];
 		for (const v of request.variables.variables) {
 			if (v.kind === 'tool') {
 				toolReferences.push(v);

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -52,7 +52,7 @@ export function getAttachableImageExtension(mimeType: string): string | undefine
 }
 
 export interface IChatRequestVariableData {
-	variables: IChatRequestVariableEntry[];
+	variables: readonly IChatRequestVariableEntry[];
 }
 
 export namespace IChatRequestVariableData {
@@ -64,6 +64,7 @@ export namespace IChatRequestVariableData {
 export interface IChatRequestModel {
 	readonly id: string;
 	readonly timestamp: number;
+	readonly version: number;
 	readonly modeInfo?: IChatRequestModeInfo;
 	readonly session: IChatModel;
 	readonly message: IParsedChatRequest;
@@ -346,6 +347,11 @@ export class ChatRequestModel implements IChatRequestModel {
 
 	public get editedFileEvents(): IChatAgentEditedFileEvent[] | undefined {
 		return this._editedFileEvents;
+	}
+
+	private _version = 0;
+	public get version(): number {
+		return this._version;
 	}
 
 	constructor(params: IChatRequestModelParameters) {

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -330,6 +330,7 @@ export class ChatRequestModel implements IChatRequestModel {
 	}
 
 	public set variableData(v: IChatRequestVariableData) {
+		this._version++;
 		this._variableData = v;
 	}
 

--- a/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatViewModel.ts
@@ -5,7 +5,6 @@
 
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { hash } from '../../../../../base/common/hash.js';
 import { IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Disposable, dispose } from '../../../../../base/common/lifecycle.js';
 import { IObservable } from '../../../../../base/common/observable.js';
@@ -342,21 +341,16 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 	}
 }
 
-const variablesHash = new WeakMap<readonly IChatRequestVariableEntry[], number>();
-
 export class ChatRequestViewModel implements IChatRequestViewModel {
 	get id() {
 		return this._model.id;
 	}
 
+	/**
+	 * An ID that changes when the request should be re-rendered.
+	 */
 	get dataId() {
-		let varsHash = variablesHash.get(this.variables);
-		if (typeof varsHash !== 'number') {
-			varsHash = hash(this.variables);
-			variablesHash.set(this.variables, varsHash);
-		}
-
-		return `${this.id}_${this.isComplete ? '1' : '0'}_${varsHash}`;
+		return `${this.id}_${this._model.version + (this._model.response?.isComplete ? 1 : 0)}`;
 	}
 
 	/** @deprecated */

--- a/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts
@@ -92,7 +92,7 @@ export function value<T, R>(comparator?: (a: R, b: R) => boolean): TransformValu
 }
 
 /** An array that will use the schema to compare items positionally. */
-export function array<T, R>(schema: TransformObject<T, R> | TransformValue<T, R>): TransformArray<T[], R[]> {
+export function array<T, R>(schema: TransformObject<T, R> | TransformValue<T, R>): TransformArray<readonly T[], R[]> {
 	return {
 		kind: TransformKind.Array,
 		itemSchema: schema,


### PR DESCRIPTION
This can be extremely slow when loading large models. Instead we increment a version number each time they change (which isn't really necessary anyway today, the vars used to be updated async but now they are just set when the request is created, but set this up correctly for changes later)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
