### PR TITLE
Use built-in agent dropdown for Custom Agents in background agents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -414,7 +414,9 @@ export class OpenModePickerAction extends Action2 {
 						ChatContextKeys.enabled,
 						ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 						ChatContextKeys.inQuickChat.negate(),
-						ChatContextKeys.lockedToCodingAgent.negate()),
+						ContextKeyExpr.or(
+							ChatContextKeys.lockedToCodingAgent.negate(),
+							ChatContextKeys.chatSessionHasCustomAgentTarget)),
 					group: 'navigation',
 				},
 			]

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -197,6 +197,10 @@ const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsEx
 					description: localize('chatSessionsExtPoint.canDelegate', 'Whether delegation is supported. Default is false. Note that enabling this is experimental and may not be respected at all times.'),
 					type: 'boolean',
 					default: false
+				},
+				customAgentTarget: {
+					description: localize('chatSessionsExtPoint.customAgentTarget', 'When set, the chat session will show a filtered mode picker with only custom agents that have a matching target property. This enables the standard agent/mode dropdown with filtered custom agents.'),
+					type: 'string'
 				}
 			},
 			required: ['type', 'name', 'displayName', 'description'],
@@ -1088,6 +1092,15 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 	public getCapabilitiesForSessionType(chatSessionType: string): IChatAgentAttachmentCapabilities | undefined {
 		const contribution = this._contributions.get(chatSessionType)?.contribution;
 		return contribution?.capabilities;
+	}
+
+	/**
+	 * Get the customAgentTarget for a specific session type.
+	 * When set, the mode picker should show filtered custom agents matching this target.
+	 */
+	public getCustomAgentTargetForSessionType(chatSessionType: string): string | undefined {
+		const contribution = this._contributions.get(chatSessionType)?.contribution;
+		return contribution?.customAgentTarget;
 	}
 
 	public getContentProviderSchemes(): string[] {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -199,7 +199,7 @@ const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsEx
 					default: false
 				},
 				customAgentTarget: {
-					description: localize('chatSessionsExtPoint.customAgentTarget', 'When set, the chat session will show a filtered mode picker with only custom agents that have a matching target property. This enables the standard agent/mode dropdown with filtered custom agents.'),
+					description: localize('chatSessionsExtPoint.customAgentTarget', 'When set, the chat session will show a filtered mode picker that prefers custom agents whose target property matches this value. Custom agents without a target property are still shown in all session types. This enables the use of standard agent/mode with contributed sessions.'),
 					type: 'string'
 				}
 			},

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -84,7 +84,7 @@ import { IChatEditingSession, IModifiedFileEntry, ModifiedFileEntryState } from 
 import { IChatModelInputState, IChatRequestModeInfo, IInputModel } from '../../../common/model/chatModel.js';
 import { ChatMode, IChatMode, IChatModeService } from '../../../common/chatModes.js';
 import { IChatFollowup, IChatService, IChatSessionContext } from '../../../common/chatService/chatService.js';
-import { AgentOptionId, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
+import { agentOptionId, IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../../common/model/chatUri.js';
 import { ChatRequestVariableSet, IChatRequestVariableEntry, isElementVariableEntry, isImageVariableEntry, isNotebookOutputVariableEntry, isPasteVariableEntry, isPromptFileVariableEntry, isPromptTextVariableEntry, isSCMHistoryItemChangeRangeVariableEntry, isSCMHistoryItemChangeVariableEntry, isSCMHistoryItemVariableEntry, isStringImplicitContextValue, isStringVariableEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { IChatResponseViewModel } from '../../../common/model/chatViewModel.js';
@@ -617,7 +617,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				if (ctx) {
 					this.chatSessionsService.notifySessionOptionsChange(
 						ctx.chatSessionResource,
-						[{ optionId: AgentOptionId, value: mode.isBuiltin ? '' : modeName }]
+						[{ optionId: agentOptionId, value: mode.isBuiltin ? '' : modeName }]
 					).catch(err => this.logService.error('Failed to notify extension of agent change:', err));
 				}
 			}
@@ -1376,7 +1376,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		// Handle agent option from session - set initial mode
 		if (customAgentTarget) {
-			const agentOption = this.chatSessionsService.getSessionOption(ctx.chatSessionResource, AgentOptionId);
+			const agentOption = this.chatSessionsService.getSessionOption(ctx.chatSessionResource, agentOptionId);
 			if (typeof agentOption !== 'undefined') {
 				const agentId = (typeof agentOption === 'string' ? agentOption : agentOption.id) || ChatMode.Agent.id;
 				const currentMode = this._currentModeObservable.get();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1383,7 +1383,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				const isDefaultAgent = agentId === ChatMode.Agent.id;
 				const needsUpdate = isDefaultAgent
 					? currentMode.id !== ChatMode.Agent.id
-					: currentMode.label.get() !== agentId;
+					: currentMode.label.get() !== agentId; // Extensions use Label (name) as identifier for custom agents.
 
 				if (needsUpdate) {
 					this.setChatMode(agentId);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1364,7 +1364,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	} | undefined {
 		const setNoOptions = () => {
 			this.chatSessionHasOptions.set(false);
-			this.chatSessionOptionsValid.set(true); // No options means nothing to validate
+			this.chatSessionOptionsValid.set(true);
 		};
 
 		const sessionResource = this._widget?.viewModel?.model.sessionResource;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -122,7 +122,10 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 			getActions: () => {
 				const modes = chatModeService.getModes();
 				const currentMode = delegate.currentMode.get();
-				const filteredCustomModes = modes.custom.filter(mode => isUserDefinedCustomAgent(mode) && (!mode.target?.get() || mode.target?.get() === customAgentTarget));
+				const filteredCustomModes = modes.custom.filter(mode => {
+					const target = mode.target?.get();
+					return isUserDefinedCustomAgent(mode) && (!target || target === customAgentTarget);
+				});
 
 				// Always include the default "Agent" option first
 				const checked = currentMode.isBuiltin;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -128,7 +128,7 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 				});
 
 				// Always include the default "Agent" option first
-				const checked = currentMode.isBuiltin;
+				const checked = currentMode.id === ChatMode.Agent.id;
 				const defaultAction = { ...makeAction(ChatMode.Agent, ChatMode.Agent), checked };
 
 				// Add filtered custom modes

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -35,8 +35,8 @@ export interface IModePickerDelegate {
 	readonly currentMode: IObservable<IChatMode>;
 	readonly sessionResource: () => URI | undefined;
 	/**
-	 * When set, the mode picker will only show custom agents matching this target.
-	 * If no agents match the target, shows a default "Agent" option.
+	 * When set, the mode picker will show custom agents whose target matches this value.
+	 * Custom agents without a target are always shown in all session types. If no agents match the target, shows a default "Agent" option.
 	 */
 	readonly customAgentTarget?: () => string | undefined;
 }

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -45,6 +45,11 @@ export namespace ChatContextKeys {
 	 * True when the chat widget is locked to the coding agent session.
 	 */
 	export const lockedToCodingAgent = new RawContextKey<boolean>('lockedToCodingAgent', false, { type: 'boolean', description: localize('lockedToCodingAgent', "True when the chat widget is locked to the coding agent session.") });
+	/**
+	 * True when the chat session has a customAgentTarget defined in its contribution,
+	 * which means the mode picker should be shown with filtered custom agents.
+	 */
+	export const chatSessionHasCustomAgentTarget = new RawContextKey<boolean>('chatSessionHasCustomAgentTarget', false, { type: 'boolean', description: localize('chatSessionHasCustomAgentTarget', "True when the chat session has a customAgentTarget defined to filter modes.") });
 	export const agentSupportsAttachments = new RawContextKey<boolean>('agentSupportsAttachments', false, { type: 'boolean', description: localize('agentSupportsAttachments', "True when the chat agent supports attachments.") });
 	export const withinEditSessionDiff = new RawContextKey<boolean>('withinEditSessionDiff', false, { type: 'boolean', description: localize('withinEditSessionDiff', "True when the chat widget dispatches to the edit session chat.") });
 	export const filePartOfEditSession = new RawContextKey<boolean>('filePartOfEditSession', false, { type: 'boolean', description: localize('filePartOfEditSession', "True when the chat widget is within a file with an edit session.") });

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -72,6 +72,13 @@ export interface IChatSessionsExtensionPoint {
 	readonly capabilities?: IChatAgentAttachmentCapabilities;
 	readonly commands?: IChatSessionCommandContribution[];
 	readonly canDelegate?: boolean;
+	/**
+	 * When set, the chat session will show a filtered mode picker with only custom agents
+	 * that have a matching `target` property. This enables contributed chat sessions
+	 * to reuse the standard agent/mode dropdown with filtered custom agents.
+	 * Example: 'github' for background agents.
+	 */
+	readonly customAgentTarget?: string;
 }
 
 export interface IChatSessionItem {
@@ -116,6 +123,11 @@ export type IChatSessionHistoryItem = {
  */
 export const localChatSessionType = 'local';
 
+/**
+ * The option ID used for selecting the agent in chat sessions.
+ */
+export const AgentOptionId = 'agent';
+
 export interface IChatSession extends IDisposable {
 	readonly onWillDispose: Event<void>;
 
@@ -127,7 +139,7 @@ export interface IChatSession extends IDisposable {
 	 * Session options as key-value pairs. Keys correspond to option group IDs (e.g., 'models', 'subagents')
 	 * and values are either the selected option item IDs (string) or full option items (for locked state).
 	 */
-	readonly options?: Record<string, string | IChatSessionProviderOptionItem>;
+	readonly options?: Record<string, string | IChatSessionProviderOptionItem> & { [AgentOptionId]?: string | IChatSessionProviderOptionItem };
 
 	readonly progressObs?: IObservable<IChatProgress[]>;
 	readonly isCompleteObs?: IObservable<boolean>;
@@ -221,6 +233,13 @@ export interface IChatSessionsService {
 	 * Get the capabilities for a specific session type
 	 */
 	getCapabilitiesForSessionType(chatSessionType: string): IChatAgentAttachmentCapabilities | undefined;
+
+	/**
+	 * Get the customAgentTarget for a specific session type.
+	 * When set, the mode picker should show filtered custom agents matching this target.
+	 */
+	getCustomAgentTargetForSessionType(chatSessionType: string): string | undefined;
+
 	onDidChangeOptionGroups: Event<string>;
 
 	getOptionGroupsForSessionType(chatSessionType: string): IChatSessionProviderOptionGroup[] | undefined;

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -73,10 +73,10 @@ export interface IChatSessionsExtensionPoint {
 	readonly commands?: IChatSessionCommandContribution[];
 	readonly canDelegate?: boolean;
 	/**
-	 * When set, the chat session will show a filtered mode picker with only custom agents
+	 * When set, the chat session will show a filtered mode picker with custom agents
 	 * that have a matching `target` property. This enables contributed chat sessions
 	 * to reuse the standard agent/mode dropdown with filtered custom agents.
-	 * Example: 'github' for background agents.
+	 * Custom agents without a `target` property are also shown in all filtered lists
 	 */
 	readonly customAgentTarget?: string;
 }

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -126,7 +126,7 @@ export const localChatSessionType = 'local';
 /**
  * The option ID used for selecting the agent in chat sessions.
  */
-export const AgentOptionId = 'agent';
+export const agentOptionId = 'agent';
 
 export interface IChatSession extends IDisposable {
 	readonly onWillDispose: Event<void>;

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -139,7 +139,7 @@ export interface IChatSession extends IDisposable {
 	 * Session options as key-value pairs. Keys correspond to option group IDs (e.g., 'models', 'subagents')
 	 * and values are either the selected option item IDs (string) or full option items (for locked state).
 	 */
-	readonly options?: Record<string, string | IChatSessionProviderOptionItem> & { [AgentOptionId]?: string | IChatSessionProviderOptionItem };
+	readonly options?: Record<string, string | IChatSessionProviderOptionItem>;
 
 	readonly progressObs?: IObservable<IChatProgress[]>;
 	readonly isCompleteObs?: IObservable<boolean>;

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -194,6 +194,10 @@ export class MockChatSessionsService implements IChatSessionsService {
 		return this.contributions.find(c => c.type === chatSessionType)?.capabilities;
 	}
 
+	getCustomAgentTargetForSessionType(chatSessionType: string): string | undefined {
+		return this.contributions.find(c => c.type === chatSessionType)?.customAgentTarget;
+	}
+
 	getContentProviderSchemes(): string[] {
 		return Array.from(this.contentProviders.keys());
 	}

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -293,7 +293,7 @@ declare module 'vscode' {
 		 * - A ChatSessionProviderOptionItem object to include metadata like locked state
 		 * TODO: Strongly type the keys
 		 */
-		readonly options?: Record<string, string | ChatSessionProviderOptionItem>;
+		readonly options?: Record<string, string | ChatSessionProviderOptionItem> & { agent?: string | ChatSessionProviderOptionItem };
 
 		/**
 		 * Callback invoked by the editor for a currently running response. This allows the session to push items for the
@@ -335,6 +335,8 @@ declare module 'vscode' {
 			 * The new value assigned to the option. When `undefined`, the option is cleared.
 			 */
 			readonly value: string | ChatSessionProviderOptionItem;
+		} & {
+			readonly agent?: string | ChatSessionProviderOptionItem;
 		}>;
 	}
 

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -287,10 +287,11 @@ declare module 'vscode' {
 
 		/**
 		 * Options configured for this session as key-value pairs.
-		 * Keys correspond to option group IDs (e.g., 'models', 'subagents').
+		 * Keys correspond to option group IDs (e.g., 'agent', 'models', 'subagents').
 		 * Values can be either:
 		 * - A string (the option item ID) for backwards compatibility
 		 * - A ChatSessionProviderOptionItem object to include metadata like locked state
+		 * The key 'agent' is reserved for the agent option when using the built-in Agent picker.
 		 * TODO: Strongly type the keys
 		 */
 		readonly options?: Record<string, string | ChatSessionProviderOptionItem> & { agent?: string | ChatSessionProviderOptionItem };

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -335,8 +335,6 @@ declare module 'vscode' {
 			 * The new value assigned to the option. When `undefined`, the option is cleared.
 			 */
 			readonly value: string | ChatSessionProviderOptionItem;
-		} & {
-			readonly agent?: string | ChatSessionProviderOptionItem;
 		}>;
 	}
 

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -287,14 +287,13 @@ declare module 'vscode' {
 
 		/**
 		 * Options configured for this session as key-value pairs.
-		 * Keys correspond to option group IDs (e.g., 'agent', 'models', 'subagents').
+		 * Keys correspond to option group IDs (e.g., 'models', 'subagents').
 		 * Values can be either:
 		 * - A string (the option item ID) for backwards compatibility
 		 * - A ChatSessionProviderOptionItem object to include metadata like locked state
-		 * The key 'agent' is reserved for the agent option when using the built-in Agent picker.
 		 * TODO: Strongly type the keys
 		 */
-		readonly options?: Record<string, string | ChatSessionProviderOptionItem> & { agent?: string | ChatSessionProviderOptionItem };
+		readonly options?: Record<string, string | ChatSessionProviderOptionItem>;
 
 		/**
 		 * Callback invoked by the editor for a currently running response. This allows the session to push items for the


### PR DESCRIPTION
Introduce a custom agent target feature that allows the mode picker to filter and display only relevant custom agents based on the session type. This enhancement improves the user experience by streamlining agent selection in chat sessions.

