### PR TITLE
Fix Inline Style CSP Error

### DIFF
--- a/src/vs/base/browser/domStylesheets.ts
+++ b/src/vs/base/browser/domStylesheets.ts
@@ -43,6 +43,9 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
 	const style = document.createElement('style');
 	style.type = 'text/css';
 	style.media = 'screen';
+	if (mainWindow.cspNonce) {
+		style.nonce = mainWindow.cspNonce;
+	}
 	beforeAppend?.(style);
 	container.appendChild(style);
 

--- a/src/vs/base/browser/window.ts
+++ b/src/vs/base/browser/window.ts
@@ -5,6 +5,7 @@
 
 export type CodeWindow = Window & typeof globalThis & {
 	readonly vscodeWindowId: number;
+	readonly cspNonce?: string;
 };
 
 export function ensureCodeWindow(targetWindow: Window, fallbackWindowId: number): asserts targetWindow is CodeWindow {

--- a/src/vs/base/common/window.ts
+++ b/src/vs/base/common/window.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export type CodeWindow = Window & typeof globalThis & {
+	readonly cspNonce?: string;
+};
+
+export const mainWindow = window as CodeWindow;

--- a/src/vs/editor/browser/view/domLineBreaksComputer.ts
+++ b/src/vs/editor/browser/view/domLineBreaksComputer.ts
@@ -14,6 +14,7 @@ import { StringBuilder } from '../../common/core/stringBuilder.js';
 import { InjectedTextOptions } from '../../common/model.js';
 import { ILineBreaksComputer, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../common/modelLineProjectionData.js';
 import { LineInjectedText } from '../../common/textModelEvents.js';
+import { mainWindow } from '../../../base/browser/window.js';
 
 const ttPolicy = createTrustedTypesPolicy('domLineBreaksComputer', { createHTML: value => value });
 
@@ -194,18 +195,36 @@ const enum Constants {
 
 function renderLine(lineContent: string, initialVisibleColumn: number, tabSize: number, width: number, sb: StringBuilder, wrappingIndentLength: number): [number[], number[]] {
 
+	if (mainWindow.cspNonce) {
+		const className = 'line-breaks-' + Math.random().toString(36).substring(2);
+		sb.appendString('<div class="');
+		sb.appendString(className);
+		sb.appendString('">');
+		sb.appendString('<style nonce="');
+		sb.appendString(mainWindow.cspNonce);
+		sb.appendString('">.');
+		sb.appendString(className);
+		sb.appendString('{');
+	} else {
+		sb.appendString('<div style="');
+	}
 	if (wrappingIndentLength !== 0) {
 		const hangingOffset = String(wrappingIndentLength);
-		sb.appendString('<div style="text-indent: -');
+		sb.appendString('text-indent: -');
 		sb.appendString(hangingOffset);
 		sb.appendString('px; padding-left: ');
 		sb.appendString(hangingOffset);
 		sb.appendString('px; box-sizing: border-box; width:');
 	} else {
-		sb.appendString('<div style="width:');
+		sb.appendString('width:');
 	}
 	sb.appendString(String(width));
-	sb.appendString('px;">');
+	sb.appendString('px;');
+	if (mainWindow.cspNonce) {
+		sb.appendString('}</style>');
+	} else {
+		sb.appendString('">');
+	}
 	// if (containsRTL) {
 	// 	sb.appendASCIIString('" dir="ltr');
 	// }

--- a/src/vs/editor/browser/view/viewOverlays.ts
+++ b/src/vs/editor/browser/view/viewOverlays.ts
@@ -14,6 +14,7 @@ import { ViewContext } from '../../common/viewModel/viewContext.js';
 import * as viewEvents from '../../common/viewEvents.js';
 import { ViewportData } from '../../common/viewLayout/viewLinesViewportData.js';
 import { EditorOption } from '../../common/config/editorOptions.js';
+import { mainWindow } from '../../../base/browser/window.js';
 
 export class ViewOverlays extends ViewPart {
 	private readonly _visibleLines: VisibleLinesCollection<ViewOverlayLine>;
@@ -174,13 +175,29 @@ export class ViewOverlayLine implements IVisibleLine {
 
 		this._renderedContent = result;
 
-		sb.appendString('<div style="top:');
+		if (mainWindow.cspNonce) {
+			const className = 'view-overlay-line' + lineNumber.toString() + Math.random().toString(36).substring(2);
+			sb.appendString('<div class="');
+			sb.appendString(className);
+			sb.appendString('">');
+			sb.appendString('<style nonce="');
+			sb.appendString(mainWindow.cspNonce);
+			sb.appendString('">.');
+			sb.appendString(className);
+			sb.appendString('{ top:');
+		} else {
+			sb.appendString('<div style="top:');
+		}
 		sb.appendString(String(deltaTop));
 		sb.appendString('px;height:');
 		sb.appendString(String(lineHeight));
 		sb.appendString('px;line-height:');
 		sb.appendString(String(lineHeight));
-		sb.appendString('px;">');
+		if (mainWindow.cspNonce) {
+			sb.appendString('px;}</style>');
+		} else {
+			sb.appendString('px;">');
+		}
 		sb.appendString(result);
 		sb.appendString('</div>');
 

--- a/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
+++ b/src/vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight.ts
@@ -15,6 +15,7 @@ import { Selection } from '../../../common/core/selection.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { isHighContrast } from '../../../../platform/theme/common/theme.js';
 import { Position } from '../../../common/core/position.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 export abstract class AbstractLineHighlightOverlay extends DynamicViewOverlay {
 	private readonly _context: ViewContext;
@@ -208,6 +209,10 @@ export class CurrentLineHighlightOverlay extends AbstractLineHighlightOverlay {
 
 	protected _renderOne(ctx: RenderingContext, exact: boolean): string {
 		const className = 'current-line' + (this._shouldRenderInMargin() ? ' current-line-both' : '') + (exact ? ' current-line-exact' : '');
+		if (mainWindow.cspNonce) {
+			const widthClassName = 'current-line-width' + Math.random().toString(36).substring(2);
+			return `<div class="${className} ${widthClassName}"><style nonce="${mainWindow.cspNonce}">.${widthClassName}{width:${Math.max(ctx.scrollWidth, this._contentWidth)}px;}</style></div>`;
+		}
 		return `<div class="${className}" style="width:${Math.max(ctx.scrollWidth, this._contentWidth)}px;"></div>`;
 	}
 	protected _shouldRenderThis(): boolean {
@@ -224,6 +229,10 @@ export class CurrentLineHighlightOverlay extends AbstractLineHighlightOverlay {
 export class CurrentLineMarginHighlightOverlay extends AbstractLineHighlightOverlay {
 	protected _renderOne(ctx: RenderingContext, exact: boolean): string {
 		const className = 'current-line' + (this._shouldRenderInMargin() ? ' current-line-margin' : '') + (this._shouldRenderOther() ? ' current-line-margin-both' : '') + (this._shouldRenderInMargin() && exact ? ' current-line-exact-margin' : '');
+		if (mainWindow.cspNonce) {
+			const widthClassName = 'current-line-width' + Math.random().toString(36).substring(2);
+			return `<div class="${className} ${widthClassName}"><style nonce="${mainWindow.cspNonce}">.${widthClassName}{width:${this._contentLeft}px;}</style></div>`;
+		}
 		return `<div class="${className}" style="width:${this._contentLeft}px"></div>`;
 	}
 	protected _shouldRenderThis(): boolean {

--- a/src/vs/editor/browser/viewParts/decorations/decorations.ts
+++ b/src/vs/editor/browser/viewParts/decorations/decorations.ts
@@ -11,6 +11,7 @@ import { Range } from '../../../common/core/range.js';
 import * as viewEvents from '../../../common/viewEvents.js';
 import { ViewContext } from '../../../common/viewModel/viewContext.js';
 import { ViewModelDecoration } from '../../../common/viewModel/viewModelDecoration.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 export class DecorationsOverlay extends DynamicViewOverlay {
 
@@ -210,17 +211,32 @@ export class DecorationsOverlay extends DynamicViewOverlay {
 			for (let k = 0, lenK = lineVisibleRanges.ranges.length; k < lenK; k++) {
 				const expandToLeft = shouldFillLineOnLineBreak && lineVisibleRanges.continuesOnNextLine && lenK === 1;
 				const visibleRange = lineVisibleRanges.ranges[k];
+				const className = 'line-decoration-' + Math.random().toString(36).substring(2);
 				const decorationOutput = (
 					'<div class="cdr '
 					+ className
-					+ '" style="left:'
+					+ (mainWindow.cspNonce ?
+						' '
+						+ className
+						+ '"><style nonce="'
+						+ mainWindow.cspNonce
+						+ '">.'
+						+ className
+						+ '{' :
+						'" style="'
+					)
+					+ 'left:'
 					+ String(visibleRange.left)
 					+ 'px;width:'
 					+ (expandToLeft ?
 						'100%;' :
 						(String(visibleRange.width) + 'px;')
 					)
-					+ '"></div>'
+					+ (mainWindow.cspNonce ?
+						'}</style>' :
+						'">'
+					)
+					+ '</div>'
 				);
 				output[lineIndex] += decorationOutput;
 			}

--- a/src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts
+++ b/src/vs/editor/browser/viewParts/indentGuides/indentGuides.ts
@@ -17,6 +17,7 @@ import { Color } from '../../../../base/common/color.js';
 import { isDefined } from '../../../../base/common/types.js';
 import { BracketPairGuidesClassNames } from '../../../common/model/guidesTextModelPart.js';
 import { IndentGuide, HorizontalGuidesState } from '../../../common/textModelGuides.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 /**
  * Indent guides are vertical lines that help identify the indentation level of
@@ -150,7 +151,12 @@ export class IndentGuidesOverlay extends DynamicViewOverlay {
 					)?.left ?? (left + this._spaceWidth)) - left
 					: this._spaceWidth;
 
-				result += `<div class="core-guide ${guide.className} ${className}" style="left:${left}px;width:${width}px"></div>`;
+				if (mainWindow.cspNonce) {
+					const layoutClassName = 'core-guide-layout-' + Math.random().toString(36).substring(2);
+					result += `<div class="core-guide ${guide.className} ${className} ${layoutClassName}"><style nonce="${mainWindow.cspNonce}">.${layoutClassName}{left:${left}px;width:${width}px}</style></div>`;
+				} else {
+					result += `<div class="core-guide ${guide.className} ${className}" style="left:${left}px;width:${width}px"></div>`;
+				}
 			}
 			output[lineIndex] = result;
 		}

--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -14,6 +14,7 @@ import { ViewContext } from '../../../common/viewModel/viewContext.js';
 import * as viewEvents from '../../../common/viewEvents.js';
 import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
 import { editorDimmedLineNumber, editorLineNumbers } from '../../../common/core/editorColorRegistry.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 /**
  * Renders line numbers to the left of the main view lines content.
@@ -196,9 +197,11 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 				extraClassNames += ' active-line-number';
 			}
 
-
+			const layoutClassName = ' line-numbers-layout-' + Math.random().toString(36).substring(2);
 			output[lineIndex] = (
-				`<div class="${LineNumbersOverlay.CLASS_NAME}${lineHeightClassName}${extraClassNames}" style="left:${this._lineNumbersLeft}px;width:${this._lineNumbersWidth}px;">${renderLineNumber}</div>`
+				mainWindow.cspNonce ?
+					`<div class="${LineNumbersOverlay.CLASS_NAME}${layoutClassName}${lineHeightClassName}${extraClassNames}"><style nonce="${mainWindow.cspNonce}">.${layoutClassName}{left:${this._lineNumbersLeft}px;width:${this._lineNumbersWidth}px;}</style>${renderLineNumber}</div>` :
+					`<div class="${LineNumbersOverlay.CLASS_NAME}${lineHeightClassName}${extraClassNames}" style="left:${this._lineNumbersLeft}px;width:${this._lineNumbersWidth}px;">${renderLineNumber}</div>`
 			);
 		}
 

--- a/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
+++ b/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
@@ -9,6 +9,7 @@ import { RenderingContext } from '../../view/renderingContext.js';
 import { ViewContext } from '../../../common/viewModel/viewContext.js';
 import * as viewEvents from '../../../common/viewEvents.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 
 export class LinesDecorationsOverlay extends DedupOverlay {
@@ -95,7 +96,8 @@ export class LinesDecorationsOverlay extends DedupOverlay {
 
 		const left = this._decorationsLeft.toString();
 		const width = this._decorationsWidth.toString();
-		const common = '" style="left:' + left + 'px;width:' + width + 'px;"></div>';
+		const layoutClassName = 'decoration-layout-' + Math.random().toString(36).substring(2);
+		const common = mainWindow.cspNonce ? '"><style nonce="' + mainWindow.cspNonce + '">.' + layoutClassName + '{left:' + left + 'px;width:' + width + 'px;}</style></div>' : '" style="left:' + left + 'px;width:' + width + 'px;"></div>';
 
 		const output: string[] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
@@ -103,7 +105,7 @@ export class LinesDecorationsOverlay extends DedupOverlay {
 			const decorations = toRender[lineIndex].getDecorations();
 			let lineOutput = '';
 			for (const decoration of decorations) {
-				let addition = '<div class="cldr ' + decoration.className;
+				let addition = '<div class="cldr ' + decoration.className + ' ' + layoutClassName;
 				if (decoration.tooltip !== null) {
 					addition += '" title="' + decoration.tooltip; // The tooltip is already escaped.
 				}

--- a/src/vs/editor/browser/viewParts/selections/selections.ts
+++ b/src/vs/editor/browser/viewParts/selections/selections.ts
@@ -12,6 +12,7 @@ import * as viewEvents from '../../../common/viewEvents.js';
 import { editorSelectionForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 const enum CornerStyle {
 	EXTERN,
@@ -256,15 +257,28 @@ export class SelectionsOverlay extends DynamicViewOverlay {
 	}
 
 	private _createSelectionPiece(top: number, bottom: number, className: string, left: number, width: number): string {
+		const layoutClassName = 'selection-' + top.toString() + '-' + bottom.toString() + '-' + left.toString() + '-' + width.toString();
 		return (
 			'<div class="cslr '
 			+ className
-			+ '" style="'
+			+ (mainWindow.cspNonce ?
+				' '
+				+ layoutClassName
+				+ '"><style nonce="'
+				+ mainWindow.cspNonce
+				+ '"> .'
+				+ layoutClassName
+				+ '{' :
+				'" style="'
+			)
 			+ 'top:' + top.toString() + 'px;'
 			+ 'bottom:' + bottom.toString() + 'px;'
 			+ 'left:' + left.toString() + 'px;'
 			+ 'width:' + width.toString() + 'px;'
-			+ '"></div>'
+			+ (mainWindow.cspNonce ?
+				'}</style></div>' :
+				'"></div>'
+			)
 		);
 	}
 

--- a/src/vs/editor/browser/viewParts/viewLines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/viewLines/viewLine.ts
@@ -21,6 +21,7 @@ import { ViewGpuContext } from '../../gpu/viewGpuContext.js';
 import { OffsetRange } from '../../../common/core/ranges/offsetRange.js';
 import { InlineDecorationType } from '../../../common/viewModel/inlineDecorations.js';
 import { TextDirection } from '../../../common/model.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 const canUseFastRenderedViewLine = (function () {
 	if (platform.isNative) {
@@ -171,6 +172,7 @@ export class ViewLine implements IVisibleLine {
 			lineData.textDirection,
 			options.verticalScrollbarSize
 		);
+		const className = 'view-line-' + lineNumber.toString() + '-' + Math.random().toString(36).substring(2);
 
 		if (this._renderedViewLine && this._renderedViewLine.input.equals(renderLineInput)) {
 			// no need to do anything, we have the same render input
@@ -183,7 +185,21 @@ export class ViewLine implements IVisibleLine {
 		} else if (lineData.containsRTL) {
 			sb.appendString('dir="ltr" ');
 		}
-		sb.appendString('style="top:');
+		if (mainWindow.cspNonce) {
+			sb.appendString('class="');
+			sb.appendString(className);
+			sb.appendString(' ');
+			sb.appendString(ViewLine.CLASS_NAME);
+			sb.appendString('"><style nonce="');
+			sb.appendString(mainWindow.cspNonce);
+			sb.appendString('">.');
+			sb.appendString(className);
+			sb.appendString('{top:');
+		} else {
+			sb.appendString('class="');
+			sb.appendString(ViewLine.CLASS_NAME);
+			sb.appendString('" style="top:');
+		}
 		sb.appendString(String(deltaTop));
 		sb.appendString('px;height:');
 		sb.appendString(String(lineHeight));
@@ -193,9 +209,12 @@ export class ViewLine implements IVisibleLine {
 			sb.appendString('px;padding-right:');
 			sb.appendString(String(options.verticalScrollbarSize));
 		}
-		sb.appendString('px;" class="');
-		sb.appendString(ViewLine.CLASS_NAME);
-		sb.appendString('">');
+		sb.appendString('px;');
+		if (mainWindow.cspNonce) {
+			sb.appendString('}</style>');
+		} else {
+			sb.appendString('">');
+		}
 
 		const output = renderViewLine(renderLineInput, sb);
 

--- a/src/vs/editor/browser/viewParts/whitespace/whitespace.ts
+++ b/src/vs/editor/browser/viewParts/whitespace/whitespace.ts
@@ -17,6 +17,7 @@ import { CharCode } from '../../../../base/common/charCode.js';
 import { Position } from '../../../common/core/position.js';
 import { editorWhitespaces } from '../../../common/core/editorColorRegistry.js';
 import { OffsetRange } from '../../../common/core/ranges/offsetRange.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 
 /**
  * The whitespace overlay will visual certain whitespace depending on the
@@ -222,18 +223,28 @@ export class WhitespaceOverlay extends DynamicViewOverlay {
 					result += `<circle cx="${(visibleRange.left + spaceWidth / 2).toFixed(2)}" cy="${(lineHeight / 2).toFixed(2)}" r="${(spaceWidth / 7).toFixed(2)}" />`;
 				}
 			} else {
-				if (chCode === CharCode.Tab) {
-					result += `<div class="mwh" style="left:${visibleRange.left}px;height:${lineHeight}px;">${canUseHalfwidthRightwardsArrow ? String.fromCharCode(0xFFEB) : String.fromCharCode(0x2192)}</div>`;
+				if (mainWindow.cspNonce) {
+					const className = 'mwh-' + Math.random().toString(36).substring(2);
+					result += `<div class="mwh  ${className}"><style nonce="${mainWindow.cspNonce}">.${className}{left:${visibleRange.left}px;height:${lineHeight}px;}</style>`;
 				} else {
-					result += `<div class="mwh" style="left:${visibleRange.left}px;height:${lineHeight}px;">${String.fromCharCode(renderSpaceCharCode)}</div>`;
+					result += `<div class="mwh" style="left:${visibleRange.left}px;height:${lineHeight}px;">`;
+				}
+				if (chCode === CharCode.Tab) {
+					result += `${canUseHalfwidthRightwardsArrow ? String.fromCharCode(0xFFEB) : String.fromCharCode(0x2192)}</div>`;
+				} else {
+					result += `${String.fromCharCode(renderSpaceCharCode)}</div>`;
 				}
 			}
 		}
 
 		if (USE_SVG) {
 			maxLeft = Math.round(maxLeft + spaceWidth);
+			const className = 'whitespaces-' + lineNumber.toString() + '-' + Math.random().toString(36).substring(36);
 			return (
-				`<svg style="bottom:0;position:absolute;width:${maxLeft}px;height:${lineHeight}px" viewBox="0 0 ${maxLeft} ${lineHeight}" xmlns="http://www.w3.org/2000/svg" fill="${color}">`
+				`<svg`
+				+ (mainWindow.cspNonce ? `class=${className}` : `style="bottom:0;position:absolute;width:${maxLeft}px;height:${lineHeight}px" `)
+				+ `viewBox="0 0 ${maxLeft} ${lineHeight}" xmlns="http://www.w3.org/2000/svg" fill="${color}">`
+				+ (mainWindow.cspNonce ? `<style nonce="${mainWindow.cspNonce}">.${className}{bottom:0;position:absolute;width:${maxLeft}px;height:${lineHeight}px;}</style>` : '')
 				+ result
 				+ `</svg>`
 			);

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/renderLines.ts
@@ -17,6 +17,7 @@ import { CharacterMapping, ForeignElementType, RenderLineInput, RenderLineOutput
 import { ViewLineRenderingData } from '../../../../../common/viewModel.js';
 import { InlineDecoration } from '../../../../../common/viewModel/inlineDecorations.js';
 import { getColumnOfNodeOffset } from '../../../../viewParts/viewLines/viewLine.js';
+import { mainWindow } from '../../../../../../base/browser/window.js';
 
 const ttPolicy = createTrustedTypesPolicy('diffEditorWidget', { createHTML: value => value });
 
@@ -274,12 +275,28 @@ function renderOriginalLine(
 		// No char changes
 		sb.appendString(' char-delete');
 	}
-	sb.appendString('" style="top:');
+	if (mainWindow.cspNonce) {
+		const className = 'view-line-' + viewLineIdx.toString() + Math.random().toString(36).substring(2);
+		sb.appendString(' ');
+		sb.appendString(className);
+		sb.appendString('"><style nonce="');
+		sb.appendString(mainWindow.cspNonce);
+		sb.appendString('">.');
+		sb.appendString(className);
+		sb.appendString('{ top:');
+	} else {
+		sb.appendString('" style="top:');
+	}
 	sb.appendString(String(viewLineIdx * options.lineHeight));
 	if (options.setWidth) {
-		sb.appendString('px;width:1000000px;">');
+		sb.appendString('px;width:1000000px;');
 	} else {
-		sb.appendString('px;">');
+		sb.appendString('px;');
+	}
+	if (mainWindow.cspNonce) {
+		sb.appendString('}</style>');
+	} else {
+		sb.appendString('">');
 	}
 
 	const lineContent = lineTokens.getLineContent();

--- a/src/vs/editor/common/languages/textToHtmlTokenizer.ts
+++ b/src/vs/editor/common/languages/textToHtmlTokenizer.ts
@@ -10,6 +10,7 @@ import { ILanguageIdCodec, IState, ITokenizationSupport, TokenizationRegistry } 
 import { LanguageId } from '../encodedTokenAttributes.js';
 import { NullState, nullTokenizeEncoded } from './nullTokenize.js';
 import { ILanguageService } from './language.js';
+import { mainWindow } from '../../../base/common/window.js';
 
 export type IReducedTokenizationSupport = Omit<ITokenizationSupport, 'tokenize'>;
 
@@ -127,7 +128,12 @@ export function tokenizeLineToHTML(text: string, viewLineTokens: IViewLineTokens
 			continue;
 		}
 
-		result += `<span style="${viewLineTokens.getInlineStyle(tokenIndex, colorMap)}">${partContent}</span>`;
+		if (mainWindow.cspNonce) {
+			const className = 'token-style-' + Math.random().toString(36).substring(2);
+			result += `<span class="${className}"><style nonce="${mainWindow.cspNonce}">.${className} { ${viewLineTokens.getInlineStyle(tokenIndex, colorMap)} }</style></span>`;
+		} else {
+			result += `<span style="${viewLineTokens.getInlineStyle(tokenIndex, colorMap)}">${partContent}</span>`;
+		}
 
 		if (tokenEndIndex > endOffset || charIndex >= endOffset || startOffset >= endOffset) {
 			break;

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -45,6 +45,7 @@ import { ICustomLineHeightData } from '../viewLayout/lineHeights.js';
 import { TextModelEditSource } from '../textModelEditSource.js';
 import { InlineDecoration } from './inlineDecorations.js';
 import { ICoordinatesConverter } from '../coordinatesConverter.js';
+import { mainWindow } from '../../../base/common/window.js';
 
 const USE_IDENTITY_LINES_COLLECTION = true;
 
@@ -1062,10 +1063,21 @@ export class ViewModel extends Disposable implements IViewModel {
 			fontFamily = `${fontFamily}, ${EDITOR_FONT_DEFAULTS.fontFamily}`;
 		}
 
+		const className = 'view-copy-container-' + Math.random().toString(36).substring(2);
 		return {
 			mode: languageId,
 			html: (
-				`<div style="`
+				`<div `
+				+ (mainWindow.cspNonce ?
+					'class="'
+					+ className
+					+ '"><style nonce="'
+					+ mainWindow.cspNonce
+					+ '>.'
+					+ className
+					+ '{' :
+					`style="`
+				)
 				+ `color: ${colorMap[ColorId.DefaultForeground]};`
 				+ `background-color: ${colorMap[ColorId.DefaultBackground]};`
 				+ `font-family: ${fontFamily};`
@@ -1073,7 +1085,10 @@ export class ViewModel extends Disposable implements IViewModel {
 				+ `font-size: ${fontInfo.fontSize}px;`
 				+ `line-height: ${fontInfo.lineHeight}px;`
 				+ `white-space: pre;`
-				+ `">`
+				+ (mainWindow.cspNonce ?
+					`}</style>` :
+					`">`
+				)
 				+ this._getHTMLToCopy(range, colorMap)
 				+ '</div>'
 			)

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.ts
@@ -36,6 +36,7 @@ import { InlineCompletionViewData } from '../inlineEdits/inlineEditsViewInterfac
 import { InlineDecorationType } from '../../../../../common/viewModel/inlineDecorations.js';
 import { equals, sum } from '../../../../../../base/common/arrays.js';
 import { equalsIfDefinedC, IEquatable, thisEqualsC } from '../../../../../../base/common/equals.js';
+import { mainWindow } from '../../../../../../base/browser/window.js';
 
 export interface IGhostTextWidgetData {
 	readonly ghostText: GhostText | GhostTextReplacement;
@@ -634,9 +635,26 @@ function renderLines(domNode: HTMLElement, tabSize: number, lines: readonly Line
 		const lineData = lines[i];
 		const lineTokens = lineData.content;
 		sb.appendString('<div class="view-line');
-		sb.appendString('" style="top:');
+		if (mainWindow.cspNonce) {
+			const className = 'ghost-text-line' + i.toString() + Math.random().toString(36).substring(2);
+			sb.appendString(' ');
+			sb.appendString(className);
+			sb.appendString('"><style nonce="');
+			sb.appendString(mainWindow.cspNonce);
+			sb.appendString('">.');
+			sb.appendString(className);
+			sb.appendString('{');
+		} else {
+			sb.appendString('" style="');
+		}
+		sb.appendString('top:');
 		sb.appendString(String(i * lineHeight));
-		sb.appendString('px;width:1000000px;">');
+		sb.appendString('px;width:1000000px;');
+		if (mainWindow.cspNonce) {
+			sb.appendString('}</style>');
+		} else {
+			sb.appendString('">');
+		}
 
 		const line = lineTokens.getLineContent();
 		const isBasicASCII = strings.isBasicASCII(line);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
While enforcing nonce for CSP style directive in our web application, which uses Monaco Editor, multiple violations were found, originating from two areas:
1. While creating style tags at https://github.com/microsoft/vscode/blob/bf56edffb59c43fa0de636c3aa1d548770b168b8/src/vs/base/browser/domStylesheets.ts#L51 since it is missing the nonce attribute
2. Due to inline style usages such as https://github.com/microsoft/vscode/blob/bf56edffb59c43fa0de636c3aa1d548770b168b8/src/vs/editor/browser/view/viewOverlays.ts#L177

Hence, the proposed changes include:
1. Converting each inline style usage to a style tag, if a nonce exists
2. Adding the nonce attribute to the generated style tag.

Issues related to this change:
https://github.com/microsoft/monaco-editor/issues/4927
https://github.com/microsoft/monaco-editor/issues/271