### PR TITLE
Fix: Transform to Snake Case now handles kebab-case input

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -1242,6 +1242,7 @@ export class SnakeCaseAction extends AbstractCaseAction {
 
 	public static caseBoundary = new BackwardsCompatibleRegExp('(\\p{Ll})(\\p{Lu})', 'gmu');
 	public static singleLetters = new BackwardsCompatibleRegExp('(\\p{Lu}|\\p{N})(\\p{Lu})(\\p{Ll})', 'gmu');
+	public static hyphenBoundary = new BackwardsCompatibleRegExp('(\\S)(-)(\\S)', 'gm');
 
 	constructor() {
 		super({
@@ -1255,11 +1256,13 @@ export class SnakeCaseAction extends AbstractCaseAction {
 	protected _modifyText(text: string, wordSeparators: string): string {
 		const caseBoundary = SnakeCaseAction.caseBoundary.get();
 		const singleLetters = SnakeCaseAction.singleLetters.get();
-		if (!caseBoundary || !singleLetters) {
+		const hyphenBoundary = SnakeCaseAction.hyphenBoundary.get();
+		if (!caseBoundary || !singleLetters || !hyphenBoundary) {
 			// cannot support this
 			return text;
 		}
 		return (text
+			.replace(hyphenBoundary, '$1_$3')
 			.replace(caseBoundary, '$1_$2')
 			.replace(singleLetters, '$1_$2$3')
 			.toLocaleLowerCase()

--- a/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts
@@ -921,7 +921,8 @@ suite('Editor Contrib - Line Operations', () => {
 				helloWorld();`.replace(/^\s+/gm, ''),
 				`'JavaScript'`,
 				'parseHTML4String',
-				'_accessor: ServicesAccessor'
+				'_accessor: ServicesAccessor',
+				'hello-this-is-kebab-case'
 			], {}, (editor) => {
 				const model = editor.getModel()!;
 				const uppercaseAction = new UpperCaseAction();
@@ -1046,6 +1047,11 @@ suite('Editor Contrib - Line Operations', () => {
 				executeAction(snakecaseAction, editor);
 				assert.strictEqual(model.getLineContent(20), '_accessor: services_accessor');
 				assertSelection(editor, new Selection(20, 1, 20, 29));
+
+				editor.setSelection(new Selection(21, 1, 21, 25));
+				executeAction(snakecaseAction, editor);
+				assert.strictEqual(model.getLineContent(21), 'hello_this_is_kebab_case');
+				assertSelection(editor, new Selection(21, 1, 21, 25));
 			}
 		);
 


### PR DESCRIPTION
## Summary
- Added `hyphenBoundary` regex pattern to `SnakeCaseAction` to handle kebab-case input
- Text like `hello-this-is-kebab-case` now correctly transforms to `hello_this_is_kebab_case`

## Changes
- `src/vs/editor/contrib/linesOperations/browser/linesOperations.ts`: Added hyphen boundary detection using the same pattern as `KebabCaseAction` uses for underscores
- `src/vs/editor/contrib/linesOperations/test/browser/linesOperations.test.ts`: Added test case for kebab-case to snake_case conversion

## Test plan
- [x] Added unit test for kebab-case to snake_case conversion
- [x] Verified existing snake_case transformation tests still work
- [x] Manually tested transformation logic with various inputs including:
  - `hello-this-is-kebab-case` → `hello_this_is_kebab_case`
  - `kebab-case-WITH-Mixed` → `kebab_case_with_mixed`
  - `audio-converter.convert-M4A-to-MP3` → `audio_converter.convert_m4a_to_mp3`

Fixes #288603