### PR TITLE
feat(server): add remote storage persistence for VS Code Web

### DIFF
--- a/remote/package.json
+++ b/remote/package.json
@@ -12,6 +12,7 @@
     "@vscode/proxy-agent": "^0.36.0",
     "@vscode/ripgrep": "^1.15.13",
     "@vscode/spdlog": "^0.15.2",
+    "@vscode/sqlite3": "5.1.10-vscode",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",
     "@vscode/windows-process-tree": "^0.6.0",

--- a/src/vs/platform/storage/node/storageMain.ts
+++ b/src/vs/platform/storage/node/storageMain.ts
@@ -1,0 +1,438 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import { top } from '../../../base/common/arrays.js';
+import { DeferredPromise } from '../../../base/common/async.js';
+import { Emitter, Event } from '../../../base/common/event.js';
+import { Disposable, IDisposable } from '../../../base/common/lifecycle.js';
+import { join } from '../../../base/common/path.js';
+import { StopWatch } from '../../../base/common/stopwatch.js';
+import { URI } from '../../../base/common/uri.js';
+import { Promises } from '../../../base/node/pfs.js';
+import { InMemoryStorageDatabase, IStorage, Storage, StorageHint, StorageState } from '../../../base/parts/storage/common/storage.js';
+import { ISQLiteStorageDatabaseLoggingOptions, SQLiteStorageDatabase } from '../../../base/parts/storage/node/storage.js';
+import { IEnvironmentService } from '../../environment/common/environment.js';
+import { IFileService } from '../../files/common/files.js';
+import { ILogService, LogLevel } from '../../log/common/log.js';
+import { IS_NEW_KEY } from '../common/storage.js';
+import { IUserDataProfile, IUserDataProfilesService } from '../../userDataProfile/common/userDataProfile.js';
+import { currentSessionDateStorageKey, firstSessionDateStorageKey, lastSessionDateStorageKey } from '../../telemetry/common/telemetry.js';
+import { isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier, IAnyWorkspaceIdentifier } from '../../workspace/common/workspace.js';
+import { Schemas } from '../../../base/common/network.js';
+
+export interface IStorageMainOptions {
+
+	/**
+	 * If enabled, storage will not persist to disk
+	 * but into memory.
+	 */
+	readonly useInMemoryStorage?: boolean;
+}
+
+/**
+ * Provides access to application, profile and workspace storage from
+ * a Node.js process that owns storage connections.
+ */
+export interface IStorageMain extends IDisposable {
+
+	/**
+	 * Emitted whenever data is updated or deleted.
+	 */
+	readonly onDidChangeStorage: Event<IStorageChangeEvent>;
+
+	/**
+	 * Emitted when the storage is closed.
+	 */
+	readonly onDidCloseStorage: Event<void>;
+
+	/**
+	 * Access to all cached items of this storage service.
+	 */
+	readonly items: Map<string, string>;
+
+	/**
+	 * Allows to join on the `init` call having completed
+	 * to be able to safely use the storage.
+	 */
+	readonly whenInit: Promise<void>;
+
+	/**
+	 * Provides access to the `IStorage` implementation which will be
+	 * in-memory for as long as the storage has not been initialized.
+	 */
+	readonly storage: IStorage;
+
+	/**
+	 * The file path of the underlying storage file if any.
+	 */
+	readonly path: string | undefined;
+
+	/**
+	 * Required call to ensure the service can be used.
+	 */
+	init(): Promise<void>;
+
+	/**
+	 * Retrieve an element stored with the given key from storage. Use
+	 * the provided defaultValue if the element is null or undefined.
+	 */
+	get(key: string, fallbackValue: string): string;
+	get(key: string, fallbackValue?: string): string | undefined;
+
+	/**
+	 * Store a string value under the given key to storage. The value will
+	 * be converted to a string.
+	 */
+	set(key: string, value: string | boolean | number | undefined | null): void;
+
+	/**
+	 * Delete an element stored under the provided key from storage.
+	 */
+	delete(key: string): void;
+
+	/**
+	 * Whether the storage is using in-memory persistence or not.
+	 */
+	isInMemory(): boolean;
+
+	/**
+	 * Attempts to reduce the DB size via optimization commands if supported.
+	 */
+	optimize(): Promise<void>;
+
+	/**
+	 * Close the storage connection.
+	 */
+	close(): Promise<void>;
+}
+
+export interface IStorageChangeEvent {
+	readonly key: string;
+}
+
+export abstract class BaseStorageMain extends Disposable implements IStorageMain {
+
+	private static readonly LOG_SLOW_CLOSE_THRESHOLD = 2000;
+
+	protected readonly _onDidChangeStorage = this._register(new Emitter<IStorageChangeEvent>());
+	readonly onDidChangeStorage = this._onDidChangeStorage.event;
+
+	private readonly _onDidCloseStorage = this._register(new Emitter<void>());
+	readonly onDidCloseStorage = this._onDidCloseStorage.event;
+
+	private _storage = this._register(new Storage(new InMemoryStorageDatabase(), { hint: StorageHint.STORAGE_IN_MEMORY })); // storage is in-memory until initialized
+	get storage(): IStorage { return this._storage; }
+
+	abstract get path(): string | undefined;
+
+	private initializePromise: Promise<void> | undefined = undefined;
+
+	private readonly whenInitPromise = new DeferredPromise<void>();
+	readonly whenInit = this.whenInitPromise.p;
+
+	private state = StorageState.None;
+
+	constructor(
+		protected readonly logService: ILogService,
+		private readonly fileService: IFileService
+	) {
+		super();
+	}
+
+	isInMemory(): boolean {
+		return this._storage.isInMemory();
+	}
+
+	init(): Promise<void> {
+		if (!this.initializePromise) {
+			this.initializePromise = (async () => {
+				if (this.state !== StorageState.None) {
+					return; // either closed or already initialized
+				}
+
+				try {
+
+					// Create storage via subclasses
+					const storage = this._register(await this.doCreate());
+
+					// Replace our in-memory storage with the real
+					// once as soon as possible without awaiting
+					// the init call.
+					this._storage.dispose();
+					this._storage = storage;
+
+					// Re-emit storage changes via event
+					this._register(storage.onDidChangeStorage(e => this._onDidChangeStorage.fire(e)));
+
+					// Await storage init
+					await this.doInit(storage);
+
+					// Ensure we track whether storage is new or not
+					const isNewStorage = storage.getBoolean(IS_NEW_KEY);
+					if (isNewStorage === undefined) {
+						storage.set(IS_NEW_KEY, true);
+					} else if (isNewStorage) {
+						storage.set(IS_NEW_KEY, false);
+					}
+				} catch (error) {
+					this.logService.error(`[storage main] initialize(): Unable to init storage due to ${error}`);
+				} finally {
+
+					// Update state
+					this.state = StorageState.Initialized;
+
+					// Mark init promise as completed
+					this.whenInitPromise.complete();
+				}
+			})();
+		}
+
+		return this.initializePromise;
+	}
+
+	protected createLoggingOptions(): ISQLiteStorageDatabaseLoggingOptions {
+		return {
+			logTrace: (this.logService.getLevel() === LogLevel.Trace) ? msg => this.logService.trace(msg) : undefined,
+			logError: error => this.logService.error(error)
+		};
+	}
+
+	protected doInit(storage: IStorage): Promise<void> {
+		return storage.init();
+	}
+
+	protected abstract doCreate(): Promise<Storage>;
+
+	get items(): Map<string, string> { return this._storage.items; }
+
+	get(key: string, fallbackValue: string): string;
+	get(key: string, fallbackValue?: string): string | undefined;
+	get(key: string, fallbackValue?: string): string | undefined {
+		return this._storage.get(key, fallbackValue);
+	}
+
+	set(key: string, value: string | boolean | number | undefined | null): Promise<void> {
+		return this._storage.set(key, value);
+	}
+
+	delete(key: string): Promise<void> {
+		return this._storage.delete(key);
+	}
+
+	optimize(): Promise<void> {
+		return this._storage.optimize();
+	}
+
+	async close(): Promise<void> {
+
+		// Measure how long it takes to close storage
+		const watch = new StopWatch(false);
+		await this.doClose();
+		watch.stop();
+
+		// If close() is taking a long time, there is
+		// a chance that the underlying DB is large
+		// either on disk or in general. In that case
+		// log some additional info to further diagnose
+		if (watch.elapsed() > BaseStorageMain.LOG_SLOW_CLOSE_THRESHOLD) {
+			await this.logSlowClose(watch);
+		}
+
+		// Signal as event
+		this._onDidCloseStorage.fire();
+	}
+
+	private async logSlowClose(watch: StopWatch) {
+		if (!this.path) {
+			return;
+		}
+
+		try {
+			const largestEntries = top(Array.from(this._storage.items.entries())
+				.map(([key, value]) => ({ key, length: value.length })), (entryA, entryB) => entryB.length - entryA.length, 5)
+				.map(entry => `${entry.key}:${entry.length}`).join(', ');
+			const dbSize = (await this.fileService.stat(URI.file(this.path))).size;
+
+			this.logService.warn(`[storage main] detected slow close() operation: Time: ${watch.elapsed()}ms, DB size: ${dbSize}b, Large Keys: ${largestEntries}`);
+		} catch (error) {
+			this.logService.error('[storage main] figuring out stats for slow DB on close() resulted in an error', error);
+		}
+	}
+
+	private async doClose(): Promise<void> {
+
+		// Ensure we are not accidentally leaving
+		// a pending initialized storage behind in
+		// case `close()` was called before `init()`
+		// finishes.
+		if (this.initializePromise) {
+			await this.initializePromise;
+		}
+
+		// Update state
+		this.state = StorageState.Closed;
+
+		// Propagate to storage lib
+		await this._storage.close();
+	}
+}
+
+class BaseProfileAwareStorageMain extends BaseStorageMain {
+
+	private static readonly STORAGE_NAME = 'state.vscdb';
+
+	get path(): string | undefined {
+		if (!this.options.useInMemoryStorage) {
+			return join(this.profile.globalStorageHome.with({ scheme: Schemas.file }).fsPath, BaseProfileAwareStorageMain.STORAGE_NAME);
+		}
+
+		return undefined;
+	}
+
+	constructor(
+		private readonly profile: IUserDataProfile,
+		private readonly options: IStorageMainOptions,
+		logService: ILogService,
+		fileService: IFileService
+	) {
+		super(logService, fileService);
+	}
+
+	protected async doCreate(): Promise<Storage> {
+		return new Storage(new SQLiteStorageDatabase(this.path ?? SQLiteStorageDatabase.IN_MEMORY_PATH, {
+			logging: this.createLoggingOptions()
+		}), !this.path ? { hint: StorageHint.STORAGE_IN_MEMORY } : undefined);
+	}
+}
+
+export class ProfileStorageMain extends BaseProfileAwareStorageMain {
+
+}
+
+export class ApplicationStorageMain extends BaseProfileAwareStorageMain {
+
+	constructor(
+		options: IStorageMainOptions,
+		userDataProfileService: IUserDataProfilesService,
+		logService: ILogService,
+		fileService: IFileService
+	) {
+		super(userDataProfileService.defaultProfile, options, logService, fileService);
+	}
+
+	protected override async doInit(storage: IStorage): Promise<void> {
+		await super.doInit(storage);
+
+		// Apply telemetry values as part of the application storage initialization
+		this.updateTelemetryState(storage);
+	}
+
+	private updateTelemetryState(storage: IStorage): void {
+
+		// First session date (once)
+		const firstSessionDate = storage.get(firstSessionDateStorageKey, undefined);
+		if (firstSessionDate === undefined) {
+			storage.set(firstSessionDateStorageKey, new Date().toUTCString());
+		}
+
+		// Last / current session (always)
+		// previous session date was the "current" one at that time
+		// current session date is "now"
+		const lastSessionDate = storage.get(currentSessionDateStorageKey, undefined);
+		const currentSessionDate = new Date().toUTCString();
+		storage.set(lastSessionDateStorageKey, typeof lastSessionDate === 'undefined' ? null : lastSessionDate);
+		storage.set(currentSessionDateStorageKey, currentSessionDate);
+	}
+}
+
+export class WorkspaceStorageMain extends BaseStorageMain {
+
+	private static readonly WORKSPACE_STORAGE_NAME = 'state.vscdb';
+	private static readonly WORKSPACE_META_NAME = 'workspace.json';
+
+	get path(): string | undefined {
+		if (!this.options.useInMemoryStorage) {
+			return join(this.environmentService.workspaceStorageHome.with({ scheme: Schemas.file }).fsPath, this.workspace.id, WorkspaceStorageMain.WORKSPACE_STORAGE_NAME);
+		}
+
+		return undefined;
+	}
+
+	constructor(
+		private workspace: IAnyWorkspaceIdentifier,
+		private readonly options: IStorageMainOptions,
+		logService: ILogService,
+		private readonly environmentService: IEnvironmentService,
+		fileService: IFileService
+	) {
+		super(logService, fileService);
+	}
+
+	protected async doCreate(): Promise<Storage> {
+		const { storageFilePath, wasCreated } = await this.prepareWorkspaceStorageFolder();
+
+		return new Storage(new SQLiteStorageDatabase(storageFilePath, {
+			logging: this.createLoggingOptions()
+		}), { hint: this.options.useInMemoryStorage ? StorageHint.STORAGE_IN_MEMORY : wasCreated ? StorageHint.STORAGE_DOES_NOT_EXIST : undefined });
+	}
+
+	private async prepareWorkspaceStorageFolder(): Promise<{ storageFilePath: string; wasCreated: boolean }> {
+
+		// Return early if using inMemory storage
+		if (this.options.useInMemoryStorage) {
+			return { storageFilePath: SQLiteStorageDatabase.IN_MEMORY_PATH, wasCreated: true };
+		}
+
+		// Otherwise, ensure the storage folder exists on disk
+		const workspaceStorageFolderPath = join(this.environmentService.workspaceStorageHome.with({ scheme: Schemas.file }).fsPath, this.workspace.id);
+		const workspaceStorageDatabasePath = join(workspaceStorageFolderPath, WorkspaceStorageMain.WORKSPACE_STORAGE_NAME);
+
+		const storageExists = await Promises.exists(workspaceStorageFolderPath);
+		if (storageExists) {
+			return { storageFilePath: workspaceStorageDatabasePath, wasCreated: false };
+		}
+
+		// Ensure storage folder exists
+		await fs.promises.mkdir(workspaceStorageFolderPath, { recursive: true });
+
+		// Write metadata into folder (but do not await)
+		this.ensureWorkspaceStorageFolderMeta(workspaceStorageFolderPath);
+
+		return { storageFilePath: workspaceStorageDatabasePath, wasCreated: true };
+	}
+
+	private async ensureWorkspaceStorageFolderMeta(workspaceStorageFolderPath: string): Promise<void> {
+		let meta: object | undefined = undefined;
+		if (isSingleFolderWorkspaceIdentifier(this.workspace)) {
+			meta = { folder: this.workspace.uri.toString() };
+		} else if (isWorkspaceIdentifier(this.workspace)) {
+			meta = { workspace: this.workspace.configPath.toString() };
+		}
+
+		if (meta) {
+			try {
+				const workspaceStorageMetaPath = join(workspaceStorageFolderPath, WorkspaceStorageMain.WORKSPACE_META_NAME);
+				const storageExists = await Promises.exists(workspaceStorageMetaPath);
+				if (!storageExists) {
+					await Promises.writeFile(workspaceStorageMetaPath, JSON.stringify(meta, undefined, 2));
+				}
+			} catch (error) {
+				this.logService.error(`[storage main] ensureWorkspaceStorageFolderMeta(): Unable to create workspace storage metadata due to ${error}`);
+			}
+		}
+	}
+}
+
+export class InMemoryStorageMain extends BaseStorageMain {
+
+	get path(): string | undefined {
+		return undefined; // in-memory has no path
+	}
+
+	protected async doCreate(): Promise<Storage> {
+		return new Storage(new InMemoryStorageDatabase(), { hint: StorageHint.STORAGE_IN_MEMORY });
+	}
+}

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -57,6 +57,7 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 	'enable-sync': { type: 'boolean' },
 	'github-auth': { type: 'string' },
 	'use-test-resolver': { type: 'boolean' },
+	'enable-remote-storage': { type: 'boolean', cat: 'o', description: nls.localize('enable-remote-storage', 'Persist browser storage (settings, state, etc.) on the server instead of browser IndexedDB. Enables state portability across browsers/devices.') },
 
 	/* ----- extension management ----- */
 
@@ -187,6 +188,7 @@ export interface ServerParsedArgs {
 	'enable-sync'?: boolean;
 	'github-auth'?: string;
 	'use-test-resolver'?: boolean;
+	'enable-remote-storage'?: boolean;
 
 	/* ----- extension management ----- */
 

--- a/src/vs/server/node/serverStorageIpc.ts
+++ b/src/vs/server/node/serverStorageIpc.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../base/common/event.js';
+import { Disposable } from '../../base/common/lifecycle.js';
+import { revive } from '../../base/common/marshalling.js';
+import { IServerChannel } from '../../base/parts/ipc/common/ipc.js';
+import { ILogService } from '../../platform/log/common/log.js';
+import { IBaseSerializableStorageRequest, ISerializableItemsChangeEvent, ISerializableUpdateRequest, Key, Value } from '../../platform/storage/common/storageIpc.js';
+import { IStorageMain, IStorageChangeEvent } from '../../platform/storage/node/storageMain.js';
+import { IServerStorageMainService } from './storageMainService.js';
+import { IUserDataProfile } from '../../platform/userDataProfile/common/userDataProfile.js';
+import { reviveIdentifier, IAnyWorkspaceIdentifier } from '../../platform/workspace/common/workspace.js';
+
+export class ServerStorageDatabaseChannel extends Disposable implements IServerChannel {
+
+	private static readonly STORAGE_CHANGE_DEBOUNCE_TIME = 100;
+
+	private readonly onDidChangeApplicationStorageEmitter = this._register(new Emitter<ISerializableItemsChangeEvent>());
+
+	private readonly mapProfileToOnDidChangeProfileStorageEmitter = new Map<string /* profile ID */, Emitter<ISerializableItemsChangeEvent>>();
+
+	constructor(
+		private readonly logService: ILogService,
+		private readonly storageMainService: IServerStorageMainService
+	) {
+		super();
+
+		this.registerStorageChangeListeners(storageMainService.applicationStorage, this.onDidChangeApplicationStorageEmitter);
+	}
+
+	//#region Storage Change Events
+
+	private registerStorageChangeListeners(storage: IStorageMain, emitter: Emitter<ISerializableItemsChangeEvent>): void {
+
+		// Listen for changes in provided storage to send to listeners
+		// that are listening. Use a debouncer to reduce IPC traffic.
+
+		this._register(Event.debounce(storage.onDidChangeStorage, (prev: IStorageChangeEvent[] | undefined, cur: IStorageChangeEvent) => {
+			if (!prev) {
+				prev = [cur];
+			} else {
+				prev.push(cur);
+			}
+
+			return prev;
+		}, ServerStorageDatabaseChannel.STORAGE_CHANGE_DEBOUNCE_TIME)(events => {
+			if (events.length) {
+				emitter.fire(this.serializeStorageChangeEvents(events, storage));
+			}
+		}));
+	}
+
+	private serializeStorageChangeEvents(events: IStorageChangeEvent[], storage: IStorageMain): ISerializableItemsChangeEvent {
+		const changed = new Map<Key, Value>();
+		const deleted = new Set<Key>();
+		events.forEach(event => {
+			const existing = storage.get(event.key);
+			if (typeof existing === 'string') {
+				changed.set(event.key, existing);
+			} else {
+				deleted.add(event.key);
+			}
+		});
+
+		return {
+			changed: Array.from(changed.entries()),
+			deleted: Array.from(deleted.values())
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	listen(_: unknown, event: string, arg: IBaseSerializableStorageRequest): Event<any> {
+		switch (event) {
+			case 'onDidChangeStorage': {
+				const profile = arg.profile ? revive<IUserDataProfile>(arg.profile) : undefined;
+
+				// Without profile: application scope
+				if (!profile) {
+					return this.onDidChangeApplicationStorageEmitter.event;
+				}
+
+				// With profile: profile scope for the profile
+				let profileStorageChangeEmitter = this.mapProfileToOnDidChangeProfileStorageEmitter.get(profile.id);
+				if (!profileStorageChangeEmitter) {
+					profileStorageChangeEmitter = this._register(new Emitter<ISerializableItemsChangeEvent>());
+					this.registerStorageChangeListeners(this.storageMainService.profileStorage(profile), profileStorageChangeEmitter);
+					this.mapProfileToOnDidChangeProfileStorageEmitter.set(profile.id, profileStorageChangeEmitter);
+				}
+
+				return profileStorageChangeEmitter.event;
+			}
+		}
+
+		throw new Error(`Event not found: ${event}`);
+	}
+
+	//#endregion
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	async call(_: unknown, command: string, arg: IBaseSerializableStorageRequest): Promise<any> {
+		const profile = arg.profile ? revive<IUserDataProfile>(arg.profile) : undefined;
+		const workspace = reviveIdentifier(arg.workspace);
+
+		// Get storage to be ready
+		const storage = await this.withStorageInitialized(profile, workspace);
+
+		// handle call
+		switch (command) {
+			case 'getItems': {
+				return Array.from(storage.items.entries());
+			}
+
+			case 'updateItems': {
+				const items: ISerializableUpdateRequest = arg;
+
+				if (items.insert) {
+					for (const [key, value] of items.insert) {
+						storage.set(key, value);
+					}
+				}
+
+				items.delete?.forEach(key => storage.delete(key));
+
+				break;
+			}
+
+			case 'optimize': {
+				return storage.optimize();
+			}
+
+			case 'isUsed': {
+				const path = arg.payload as string | undefined;
+				if (typeof path === 'string') {
+					return this.storageMainService.isUsed(path);
+				}
+				return false;
+			}
+
+			default:
+				throw new Error(`Call not found: ${command}`);
+		}
+	}
+
+	private async withStorageInitialized(profile: IUserDataProfile | undefined, workspace: IAnyWorkspaceIdentifier | undefined): Promise<IStorageMain> {
+		let storage: IStorageMain;
+		if (workspace) {
+			storage = this.storageMainService.workspaceStorage(workspace);
+		} else if (profile) {
+			storage = this.storageMainService.profileStorage(profile);
+		} else {
+			storage = this.storageMainService.applicationStorage;
+		}
+
+		try {
+			await storage.init();
+		} catch (error) {
+			this.logService.error(`ServerStorageIPC#init: Unable to init ${workspace ? 'workspace' : profile ? 'profile' : 'application'} storage due to ${error}`);
+		}
+
+		return storage;
+	}
+}

--- a/src/vs/server/node/storageMainService.ts
+++ b/src/vs/server/node/storageMainService.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from '../../base/common/event.js';
+import { Disposable } from '../../base/common/lifecycle.js';
+import { createDecorator } from '../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../platform/log/common/log.js';
+import { IFileService } from '../../platform/files/common/files.js';
+import { IEnvironmentService } from '../../platform/environment/common/environment.js';
+import { IUserDataProfilesService, IUserDataProfile } from '../../platform/userDataProfile/common/userDataProfile.js';
+import { isProfileUsingDefaultStorage } from '../../platform/storage/common/storage.js';
+import { IStorageMain, IStorageMainOptions, IStorageChangeEvent, ApplicationStorageMain, ProfileStorageMain, WorkspaceStorageMain } from '../../platform/storage/node/storageMain.js';
+import { IAnyWorkspaceIdentifier } from '../../platform/workspace/common/workspace.js';
+
+//#region Server Storage Main Service
+
+export const IServerStorageMainService = createDecorator<IServerStorageMainService>('serverStorageMainService');
+
+export interface IProfileStorageChangeEvent extends IStorageChangeEvent {
+	readonly storage: IStorageMain;
+	readonly profile: IUserDataProfile;
+}
+
+export interface IServerStorageMainService {
+
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Provides access to the application storage shared across all
+	 * windows and all profiles.
+	 */
+	readonly applicationStorage: IStorageMain;
+
+	/**
+	 * Emitted whenever data is updated or deleted in profile scoped storage.
+	 */
+	readonly onDidChangeProfileStorage: Event<IProfileStorageChangeEvent>;
+
+	/**
+	 * Provides access to the profile storage shared across all windows
+	 * for the provided profile.
+	 */
+	profileStorage(profile: IUserDataProfile): IStorageMain;
+
+	/**
+	 * Provides access to the workspace storage specific to a single window.
+	 */
+	workspaceStorage(workspace: IAnyWorkspaceIdentifier): IStorageMain;
+
+	/**
+	 * Checks if the provided path is currently in use for a storage database.
+	 *
+	 * @param path the path to the storage file or parent folder
+	 */
+	isUsed(path: string): boolean;
+}
+
+export class ServerStorageMainService extends Disposable implements IServerStorageMainService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidChangeProfileStorage = this._register(new Emitter<IProfileStorageChangeEvent>());
+	readonly onDidChangeProfileStorage = this._onDidChangeProfileStorage.event;
+
+	readonly applicationStorage: IStorageMain;
+
+	constructor(
+		@ILogService private readonly logService: ILogService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService,
+		@IUserDataProfilesService private readonly userDataProfilesService: IUserDataProfilesService,
+		@IFileService private readonly fileService: IFileService
+	) {
+		super();
+
+		this.applicationStorage = this._register(this.createApplicationStorage());
+
+		this.registerListeners();
+	}
+
+	protected getStorageOptions(): IStorageMainOptions {
+		return {
+			useInMemoryStorage: false
+		};
+	}
+
+	private registerListeners(): void {
+		// Initialize application storage immediately
+		this.applicationStorage.init();
+
+		// Listen for profile changes
+		this._register(this.userDataProfilesService.onDidChangeProfiles(e => {
+			// Create storage for added profiles
+			for (const profile of e.added) {
+				(async () => {
+					if (!(await this.fileService.exists(profile.globalStorageHome))) {
+						await this.fileService.createFolder(profile.globalStorageHome);
+					}
+				})();
+			}
+
+			// Close storage for removed profiles
+			for (const profile of e.removed) {
+				const storage = this.mapProfileToStorage.get(profile.id);
+				if (storage) {
+					storage.close();
+					this.mapProfileToStorage.delete(profile.id);
+				}
+			}
+		}));
+	}
+
+	//#region Application Storage
+
+	private createApplicationStorage(): IStorageMain {
+		this.logService.trace(`ServerStorageMainService: creating application storage`);
+
+		const applicationStorage = new ApplicationStorageMain(this.getStorageOptions(), this.userDataProfilesService, this.logService, this.fileService);
+
+		this._register(Event.once(applicationStorage.onDidCloseStorage)(() => {
+			this.logService.trace(`ServerStorageMainService: closed application storage`);
+		}));
+
+		return applicationStorage;
+	}
+
+	//#endregion
+
+	//#region Profile Storage
+
+	private readonly mapProfileToStorage = new Map<string /* profile ID */, IStorageMain>();
+
+	profileStorage(profile: IUserDataProfile): IStorageMain {
+		if (isProfileUsingDefaultStorage(profile)) {
+			return this.applicationStorage; // for profiles using default storage, use application storage
+		}
+
+		let profileStorage = this.mapProfileToStorage.get(profile.id);
+		if (!profileStorage) {
+			this.logService.trace(`ServerStorageMainService: creating profile storage (${profile.name})`);
+
+			profileStorage = this._register(this.createProfileStorage(profile));
+			this.mapProfileToStorage.set(profile.id, profileStorage);
+
+			const listener = this._register(profileStorage.onDidChangeStorage(e => this._onDidChangeProfileStorage.fire({
+				...e,
+				storage: profileStorage!,
+				profile
+			})));
+
+			this._register(Event.once(profileStorage.onDidCloseStorage)(() => {
+				this.logService.trace(`ServerStorageMainService: closed profile storage (${profile.name})`);
+
+				this.mapProfileToStorage.delete(profile.id);
+				listener.dispose();
+			}));
+		}
+
+		return profileStorage;
+	}
+
+	private createProfileStorage(profile: IUserDataProfile): IStorageMain {
+		return new ProfileStorageMain(profile, this.getStorageOptions(), this.logService, this.fileService);
+	}
+
+	//#endregion
+
+
+	//#region Workspace Storage
+
+	private readonly mapWorkspaceToStorage = new Map<string /* workspace ID */, IStorageMain>();
+
+	workspaceStorage(workspace: IAnyWorkspaceIdentifier): IStorageMain {
+		let workspaceStorage = this.mapWorkspaceToStorage.get(workspace.id);
+		if (!workspaceStorage) {
+			this.logService.trace(`ServerStorageMainService: creating workspace storage (${workspace.id})`);
+
+			workspaceStorage = this._register(this.createWorkspaceStorage(workspace));
+			this.mapWorkspaceToStorage.set(workspace.id, workspaceStorage);
+
+			this._register(Event.once(workspaceStorage.onDidCloseStorage)(() => {
+				this.logService.trace(`ServerStorageMainService: closed workspace storage (${workspace.id})`);
+
+				this.mapWorkspaceToStorage.delete(workspace.id);
+			}));
+		}
+
+		return workspaceStorage;
+	}
+
+	private createWorkspaceStorage(workspace: IAnyWorkspaceIdentifier): IStorageMain {
+		return new WorkspaceStorageMain(workspace, this.getStorageOptions(), this.logService, this.environmentService, this.fileService);
+	}
+
+	//#endregion
+
+	isUsed(path: string): boolean {
+		// For server, we don't need to track file usage like the electron-main service
+		// This is primarily used for external file operations in the desktop app
+		return false;
+	}
+}
+
+//#endregion

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -367,7 +367,8 @@ export class WebClientServer {
 			folderUri: resolveWorkspaceURI(this._environmentService.args['default-folder']),
 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
 			productConfiguration,
-			callbackRoute: callbackRoute
+			callbackRoute: callbackRoute,
+			remoteStorageEnabled: this._environmentService.args['enable-remote-storage'] ? true : undefined
 		};
 
 		const cookies = cookie.parse(req.headers.cookie || '');

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -382,6 +382,19 @@ export interface IWorkbenchConstructionOptions {
 
 	//#endregion
 
+
+	//#region Storage options
+
+	/**
+	 * When true and connected to a remote authority, persist storage
+	 * (settings, state, etc.) on the remote server instead of browser IndexedDB.
+	 * This enables state portability across browsers/devices.
+	 * @default false
+	 */
+	readonly remoteStorageEnabled?: boolean;
+
+	//#endregion
+
 }
 
 


### PR DESCRIPTION
Fixes #288878

Add --enable-remote-storage CLI option to persist browser storage (settings, state, layout) on the server instead of browser IndexedDB.

This enables state portability across browsers and devices when using VS Code Web with a remote server.

Changes:
- Add ServerStorageMainService for server-side SQLite storage
- Add ServerStorageDatabaseChannel for storage IPC
- Add RemoteBrowserStorageService for web client
- Add --enable-remote-storage CLI option
- Add remoteStorageEnabled API option
- Move shared storage classes to vs/platform/storage/node
- Add @vscode/sqlite3 dependency for remote package

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
