### PR TITLE
make status bar in debugging mode to look less error-like

### DIFF
--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -107,7 +107,7 @@
 		"statusBarItem.hoverBackground": "#1F1F1F11",
 		"statusBarItem.hoverForeground": "#000000",
 		"statusBarItem.compactHoverBackground": "#CCCCCC",
-		"statusBar.debuggingBackground": "#fc8835",
+		"statusBar.debuggingBackground": "#FC8835",
 		"statusBar.debuggingForeground": "#000000",
 		"statusBar.focusBorder": "#005FB8",
 		"statusBar.noFolderBackground": "#F8F8F8",

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -107,7 +107,7 @@
 		"statusBarItem.hoverBackground": "#1F1F1F11",
 		"statusBarItem.hoverForeground": "#000000",
 		"statusBarItem.compactHoverBackground": "#CCCCCC",
-		"statusBar.debuggingBackground": "#FD716C",
+		"statusBar.debuggingBackground": "#fc8835",
 		"statusBar.debuggingForeground": "#000000",
 		"statusBar.focusBorder": "#005FB8",
 		"statusBar.noFolderBackground": "#F8F8F8",


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/175694

<img width="6720" height="2836" alt="CleanShot 2026-01-19 at 15 34 01@2x" src="https://github.com/user-attachments/assets/e2ec7068-7636-450d-9a57-e25dbfbb2417" />


how to play with the color: 

```
  "workbench.colorCustomizations": {
    "statusBar.debuggingBackground": "#fc8835",
...
```