### PR TITLE
Context window usage indicator

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatContextUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatContextUsageWidget.ts
@@ -304,8 +304,6 @@ export class ChatContextUsageWidget extends Disposable {
 			quotaSubLabel.style.color = 'var(--vscode-descriptionForeground)';
 		}
 
-		// dom.append(container, $('.chat-context-usage-hover-separator'));
-
 		// List
 		const list = dom.append(container, $('.chat-context-usage-hover-list'));
 		this._hoverItemValues.clear();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatContextUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatContextUsageWidget.ts
@@ -1,0 +1,260 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './media/chatContextUsageWidget.css';
+import * as dom from '../../../../../../base/browser/dom.js';
+import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { IChatModel } from '../../../common/model/chatModel.js';
+import { ILanguageModelsService } from '../../../common/languageModels.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { localize } from '../../../../../../nls.js';
+import { RunOnceScheduler } from '../../../../../../base/common/async.js';
+
+const $ = dom.$;
+
+export class ChatContextUsageWidget extends Disposable {
+
+	public readonly domNode: HTMLElement;
+	private readonly ringProgress: SVGCircleElement;
+
+	private readonly _modelListener = this._register(new MutableDisposable());
+	private _currentModel: IChatModel | undefined;
+
+	private readonly _updateScheduler: RunOnceScheduler;
+
+	// Stats
+	private _totalTokenCount = 0;
+	private _promptsTokenCount = 0;
+	private _filesTokenCount = 0;
+	private _toolsTokenCount = 0;
+	private _contextTokenCount = 0;
+
+	private _maxTokenCount = 4096; // Default fallback
+	private _usagePercent = 0;
+
+	constructor(
+		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super();
+
+		this.domNode = $('.chat-context-usage-widget');
+		this.domNode.style.display = 'none';
+
+		// Create SVG Ring
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		svg.setAttribute('class', 'chat-context-usage-ring');
+		svg.setAttribute('width', '16');
+		svg.setAttribute('height', '16');
+		svg.setAttribute('viewBox', '0 0 16 16');
+
+		const background = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+		background.setAttribute('class', 'chat-context-usage-ring-background');
+		background.setAttribute('cx', '8');
+		background.setAttribute('cy', '8');
+		background.setAttribute('r', '7');
+		svg.appendChild(background);
+
+		this.ringProgress = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+		this.ringProgress.setAttribute('class', 'chat-context-usage-ring-progress');
+		this.ringProgress.setAttribute('cx', '8');
+		this.ringProgress.setAttribute('cy', '8');
+		this.ringProgress.setAttribute('r', '7');
+		svg.appendChild(this.ringProgress);
+
+		this.domNode.appendChild(svg);
+
+		this._updateScheduler = this._register(new RunOnceScheduler(() => this._refreshUsage(), 2000));
+
+		this._register(this.hoverService.setupDelayedHover(this.domNode, () => ({
+			content: this._getHoverDomNode(),
+			appearance: {
+				showPointer: true,
+				skipFadeInAnimation: true
+			}
+		})));
+
+		this._register(dom.addDisposableListener(this.domNode, dom.EventType.CLICK, () => {
+			this.hoverService.showInstantHover({
+				content: this._getHoverDomNode(),
+				target: this.domNode,
+				appearance: {
+					showPointer: true,
+					skipFadeInAnimation: true
+				},
+				persistence: {
+					sticky: true
+				}
+			}, true);
+		}));
+	}
+
+	setModel(model: IChatModel | undefined) {
+		if (this._currentModel === model) {
+			return;
+		}
+
+		this._currentModel = model;
+		this._modelListener.clear();
+
+		if (model) {
+			this._modelListener.value = model.onDidChange(() => {
+				this._updateScheduler.schedule();
+			});
+			this._updateScheduler.schedule(0);
+			this.domNode.style.display = '';
+		} else {
+			this.domNode.style.display = 'none';
+		}
+	}
+
+	private async _refreshUsage() {
+		if (!this._currentModel) {
+			return;
+		}
+
+		this._promptsTokenCount = 0;
+		this._filesTokenCount = 0;
+		this._toolsTokenCount = 0;
+		this._contextTokenCount = 0;
+
+		const requests = this._currentModel.getRequests();
+
+		let modelId: string | undefined;
+
+		const inputState = this._currentModel.inputModel.state.get();
+		if (inputState?.selectedModel) {
+			modelId = inputState.selectedModel.identifier;
+			if (inputState.selectedModel.metadata.maxInputTokens) {
+				this._maxTokenCount = inputState.selectedModel.metadata.maxInputTokens;
+			}
+		}
+
+		const countTokens = async (text: string): Promise<number> => {
+			if (modelId) {
+				return this.languageModelsService.computeTokenLength(modelId, text, CancellationToken.None);
+			}
+			return text.length / 4;
+		};
+
+		for (const request of requests) {
+			// Prompts: User message
+			const messageText = typeof request.message === 'string' ? request.message : request.message.text;
+			this._promptsTokenCount += await countTokens(messageText);
+
+			// Variables (Files, Context)
+			if (request.variableData && request.variableData.variables) {
+				for (const variable of request.variableData.variables) {
+					// Estimate usage for variables as getting full content might be expensive/complex async
+					// Using a safe estimate for now per item type
+					const defaultEstimate = 500;
+
+					if (variable.kind === 'file') {
+						this._filesTokenCount += defaultEstimate;
+					} else {
+						this._contextTokenCount += defaultEstimate;
+					}
+				}
+			}
+
+			// Tools & Response
+			if (request.response) {
+				const responseString = request.response.response.toString();
+				this._promptsTokenCount += await countTokens(responseString);
+
+				// Loop through response parts for tool invocations
+				for (const part of request.response.response.value) {
+					if (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') {
+						// Estimate tool invocation cost
+						this._toolsTokenCount += 200;
+					}
+				}
+			}
+		}
+
+		this._totalTokenCount = Math.round(this._promptsTokenCount + this._filesTokenCount + this._toolsTokenCount + this._contextTokenCount);
+		this._usagePercent = Math.min(100, (this._totalTokenCount / this._maxTokenCount) * 100);
+
+		this._updateRing();
+	}
+
+	private _updateRing() {
+		const r = 7;
+		const c = 2 * Math.PI * r;
+		const offset = c - (this._usagePercent / 100) * c;
+		this.ringProgress.style.strokeDashoffset = String(offset);
+
+		this.domNode.classList.remove('warning', 'error');
+		if (this._usagePercent > 90) {
+			this.domNode.classList.add('error');
+		} else if (this._usagePercent > 75) {
+			this.domNode.classList.add('warning');
+		}
+	}
+
+	private _getHoverDomNode(): HTMLElement {
+		const container = $('.chat-context-usage-hover');
+
+		const percentStr = `${this._usagePercent.toFixed(0)}%`;
+		const formatTokens = (value: number) => {
+			if (value >= 1000) {
+				const thousands = value / 1000;
+				return `${thousands >= 10 ? Math.round(thousands) : thousands.toFixed(1)}k`;
+			}
+			return `${value}`;
+		};
+		const usageStr = `${formatTokens(this._totalTokenCount)} / ${formatTokens(this._maxTokenCount)}`;
+
+		// Header
+		// const header = dom.append(container, $('.header'));
+		// dom.append(header, $('span', undefined, localize('contextUsage', "Context Usage")));
+
+		// Quota Indicator (Progress Bar)
+		const quotaIndicator = dom.append(container, $('.quota-indicator'));
+		const quotaBar = dom.append(quotaIndicator, $('.quota-bar'));
+		const quotaBit = dom.append(quotaBar, $('.quota-bit'));
+		quotaBit.style.width = `${this._usagePercent}%`;
+
+		const quotaLabel = dom.append(quotaIndicator, $('.quota-label'));
+		dom.append(quotaLabel, $('span.quota-title', undefined, localize('totalUsageLabel', "Total usage")));
+		dom.append(quotaLabel, $('span.quota-value', undefined, `${usageStr} • ${percentStr}`));
+
+
+		if (this._usagePercent > 90) {
+			quotaIndicator.classList.add('error');
+		} else if (this._usagePercent > 75) {
+			quotaIndicator.classList.add('warning');
+		}
+
+		dom.append(container, $('.chat-context-usage-hover-separator'));
+
+		// List
+		const list = dom.append(container, $('.chat-context-usage-hover-list'));
+
+		const addItem = (label: string, value: number) => {
+			const item = dom.append(list, $('.chat-context-usage-hover-item'));
+			dom.append(item, $('span.label', undefined, label));
+
+			// Calculate percentage for breakdown
+			const percent = this._maxTokenCount > 0 ? (value / this._maxTokenCount) * 100 : 0;
+			const displayValue = `${percent.toFixed(0)}%`;
+			dom.append(item, $('span.value', undefined, displayValue));
+		};
+
+		addItem(localize('prompts', "Prompts"), Math.round(this._promptsTokenCount));
+		addItem(localize('files', "Files"), Math.round(this._filesTokenCount));
+		addItem(localize('tools', "Tools"), Math.round(this._toolsTokenCount));
+		addItem(localize('context', "Context"), Math.round(this._contextTokenCount));
+
+		if (this._usagePercent > 80) {
+			const remaining = Math.max(0, this._maxTokenCount - this._totalTokenCount);
+			const warning = dom.append(container, $('div', { style: 'margin-top: 8px; color: var(--vscode-editorWarning-foreground);' }));
+			warning.textContent = localize('contextLimitWarning', "Approaching limit. {0} tokens remaining.", remaining);
+		}
+
+		return container;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -119,6 +119,7 @@ import { IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { SearchableOptionPickerActionItem } from '../../chatSessions/searchableOptionPickerActionItem.js';
 import { mixin } from '../../../../../../base/common/objects.js';
+import { ChatContextUsageWidget } from './chatContextUsageWidget.js';
 
 const $ = dom.$;
 
@@ -268,6 +269,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatInputTodoListWidgetContainer!: HTMLElement;
 	private chatInputWidgetsContainer!: HTMLElement;
 	private readonly _widgetController = this._register(new MutableDisposable<ChatInputPartWidgetController>());
+	private readonly _contextUsageWidget = this._register(new MutableDisposable<ChatContextUsageWidget>());
 
 	readonly inputPartHeight = observableValue<number>(this, 0);
 
@@ -1605,6 +1607,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this.updateAgentSessionTypeContextKey();
 			this.refreshChatSessionPickers();
 			this.tryUpdateWidgetController();
+			this._contextUsageWidget.value?.setModel(widget.viewModel?.model);
 		}));
 
 		let elements;
@@ -1669,6 +1672,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.chatEditingSessionWidgetContainer = elements.chatEditingSessionWidgetContainer;
 		this.chatInputTodoListWidgetContainer = elements.chatInputTodoListWidgetContainer;
 		this.chatInputWidgetsContainer = elements.chatInputWidgetsContainer;
+
+		this._contextUsageWidget.value = this.instantiationService.createInstance(ChatContextUsageWidget);
+		elements.editorContainer.appendChild(this._contextUsageWidget.value.domNode);
+		if (this._widget?.viewModel) {
+			this._contextUsageWidget.value.setModel(this._widget.viewModel.model);
+		}
 
 		if (this.options.enableImplicitContext && !this._implicitContext) {
 			this._implicitContext = this._register(

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -53,7 +53,7 @@
 	padding: 8px;
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: 8px;
 	font-size: 12px;
 }
 
@@ -114,7 +114,6 @@
 .chat-context-usage-hover-separator {
 	height: 1px;
 	background-color: var(--vscode-widget-border);
-	opacity: 0.3;
 }
 
 .chat-context-usage-hover-list {
@@ -135,4 +134,14 @@
 
 .chat-context-usage-hover-item .value {
 	color: var(--vscode-descriptionForeground);
+}
+
+.chat-context-usage-action-link {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.chat-context-usage-action-link:hover {
+	text-decoration: underline;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -111,6 +111,12 @@
 	background-color: var(--vscode-gauge-errorForeground);
 }
 
+.chat-context-usage-hover .quota-indicator .quota-sub-label {
+	font-size: 12px;
+	text-align: right;
+	color: var(--vscode-descriptionForeground);
+}
+
 .chat-context-usage-hover-list {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.chat-context-usage-widget {
+	position: absolute;
+	top: 10px;
+	right: 10px;
+	width: 16px;
+	height: 16px;
+	z-index: 10;
+	cursor: pointer;
+	opacity: 0.6;
+}
+
+.chat-context-usage-widget:hover {
+	opacity: 1;
+}
+
+.chat-context-usage-ring {
+	transform: rotate(-90deg);
+}
+
+.chat-context-usage-ring-background {
+	fill: none;
+	stroke: var(--vscode-icon-foreground);
+	stroke-width: 2;
+	opacity: 0.3;
+}
+
+.chat-context-usage-ring-progress {
+	fill: none;
+	stroke: var(--vscode-icon-foreground);
+	stroke-width: 2;
+	stroke-dasharray: 44; /* 2 * PI * r (r=7) */
+	stroke-dashoffset: 44;
+	transition: stroke-dashoffset 0.5s ease;
+}
+
+.chat-context-usage-widget.warning .chat-context-usage-ring-progress {
+	stroke: var(--vscode-editorWarning-foreground);
+}
+
+.chat-context-usage-widget.error .chat-context-usage-ring-progress {
+	stroke: var(--vscode-editorError-foreground);
+}
+
+/* Hover Content */
+
+.chat-context-usage-hover {
+	min-width: 250px;
+	padding: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+}
+
+.chat-context-usage-hover .header {
+	font-weight: 600;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 4px;
+}
+
+/* .chat-context-usage-hover .quota-indicator {
+	margin-bottom: 6px;
+} */
+
+.chat-context-usage-hover .quota-indicator .quota-label {
+	display: flex;
+	justify-content: space-between;
+	gap: 20px;
+	margin-bottom: 3px;
+}
+
+.chat-context-usage-hover .quota-indicator .quota-label{
+	color: var(--vscode-descriptionForeground);
+}
+
+.chat-context-usage-hover .quota-indicator .quota-label .quota-value{
+	color: var(--vscode-foreground);
+}
+
+.chat-context-usage-hover .quota-indicator .quota-bar {
+	width: 100%;
+	height: 4px;
+	background-color: var(--vscode-gauge-background);
+	border-radius: 4px;
+	border: 1px solid var(--vscode-gauge-border);
+	margin: 4px 0;
+}
+
+.chat-context-usage-hover .quota-indicator .quota-bar .quota-bit {
+	height: 100%;
+	background-color: var(--vscode-gauge-foreground);
+	border-radius: 4px;
+}
+
+.chat-context-usage-hover .quota-indicator.warning .quota-bar {
+	background-color: var(--vscode-gauge-warningBackground);
+}
+
+.chat-context-usage-hover .quota-indicator.warning .quota-bar .quota-bit {
+	background-color: var(--vscode-gauge-warningForeground);
+}
+
+.chat-context-usage-hover .quota-indicator.error .quota-bar {
+	background-color: var(--vscode-gauge-errorBackground);
+}
+
+.chat-context-usage-hover .quota-indicator.error .quota-bar .quota-bit {
+	background-color: var(--vscode-gauge-errorForeground);
+}
+
+.chat-context-usage-hover-separator {
+	height: 1px;
+	background-color: var(--vscode-widget-border);
+	opacity: 0.3;
+}
+
+.chat-context-usage-hover-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.chat-context-usage-hover-item {
+	display: flex;
+	justify-content: space-between;
+}
+
+.chat-context-usage-hover-item .label {
+	color: var(--vscode-descriptionForeground);
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -49,7 +49,7 @@
 /* Hover Content */
 
 .chat-context-usage-hover {
-	min-width: 250px;
+	min-width: 200px;
 	padding: 8px;
 	display: flex;
 	flex-direction: column;
@@ -65,10 +65,6 @@
 	margin-bottom: 4px;
 }
 
-/* .chat-context-usage-hover .quota-indicator {
-	margin-bottom: 6px;
-} */
-
 .chat-context-usage-hover .quota-indicator .quota-label {
 	display: flex;
 	justify-content: space-between;
@@ -77,11 +73,11 @@
 }
 
 .chat-context-usage-hover .quota-indicator .quota-label{
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-foreground);
 }
 
 .chat-context-usage-hover .quota-indicator .quota-label .quota-value{
-	color: var(--vscode-foreground);
+	color: var(--vscode-descriptionForeground);
 }
 
 .chat-context-usage-hover .quota-indicator .quota-bar {
@@ -133,5 +129,10 @@
 }
 
 .chat-context-usage-hover-item .label {
+	color: var(--vscode-foreground);
+}
+
+
+.chat-context-usage-hover-item .value {
 	color: var(--vscode-descriptionForeground);
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -146,3 +146,18 @@
 .chat-context-usage-action-link:hover {
 	text-decoration: underline;
 }
+
+.chat-context-usage-hover-separator {
+	height: 1px;
+	background-color: var(--vscode-menu-separatorBackground); /* Use menu separator color */
+	margin: 4px 0;
+	width: 100%;
+	opacity: 0.5;
+}
+
+.chat-context-usage-hover-title {
+	font-weight: 600;
+	margin-top: 4px;
+	margin-bottom: 4px;
+	color: var(--vscode-descriptionForeground);
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/media/chatContextUsageWidget.css
@@ -111,11 +111,6 @@
 	background-color: var(--vscode-gauge-errorForeground);
 }
 
-.chat-context-usage-hover-separator {
-	height: 1px;
-	background-color: var(--vscode-widget-border);
-}
-
 .chat-context-usage-hover-list {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This pull request introduces a new "context usage" indicator widget to the chat input UI, providing users with a visual representation of token usage and a detailed breakdown on hover. The widget helps users understand how close they are to the model's context window limit and encourages best practices by suggesting a new session if the limit is approached or reached. The implementation includes both the widget's logic and its styling, as well as integration into the chat input component.

<img width="456" height="432" alt="image" src="https://github.com/user-attachments/assets/a9fb6c84-ff70-45f5-a32c-de8f36936990" />

**New Feature: Context Usage Widget**
- Added `ChatContextUsageWidget` component, which displays a circular progress indicator for token usage in the chat input area and provides a detailed hover breakdown of token consumption by category (system, messages, files, etc.). The widget visually warns users as they approach or exceed the context window limit and offers an action to start a new session.
- Created a new stylesheet `chatContextUsageWidget.css` to style the widget, including its ring indicator, hover details, warning/error states, and action links.

**Integration with Chat Input UI**
- Registered the new widget in `ChatInputPart`, ensuring it is instantiated, attached to the editor container, and updated with the current chat model as the session changes. [[1]](diffhunk://#diff-69ced3e1af7f4c29f10d46d5da82aa1b2af8f0160d9d5c5a9cb59616c6c0101eR122) [[2]](diffhunk://#diff-69ced3e1af7f4c29f10d46d5da82aa1b2af8f0160d9d5c5a9cb59616c6c0101eR272) [[3]](diffhunk://#diff-69ced3e1af7f4c29f10d46d5da82aa1b2af8f0160d9d5c5a9cb59616c6c0101eR1676-R1681) [[4]](diffhunk://#diff-69ced3e1af7f4c29f10d46d5da82aa1b2af8f0160d9d5c5a9cb59616c6c0101eR1610)<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
