### PR TITLE
Adjust position of state indicator in chat CSS

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1629,7 +1629,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.chat-mcp-state-indicator {
 		position: absolute;
 		bottom: 0;
-		right: 0;
+		left: 12px;
 		font-size: 12px !important;
 		background: var(--vscode-input-background);
 		width: fit-content;


### PR DESCRIPTION
Update the position of the state indicator in the chat to improve layout and visibility. Test by checking the chat interface to ensure the indicator appears correctly positioned.

Before:

<img width="127" height="50" alt="image" src="https://github.com/user-attachments/assets/b66b7559-e612-4fdc-ad03-10f43ad93f85" />


After:

<img width="182" height="71" alt="image" src="https://github.com/user-attachments/assets/6102872b-9399-44c0-bd1c-0bbc070b31bd" />


