### PR TITLE
Support grouping of selections

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -73,8 +73,12 @@ export interface IListContextMenuEvent<T> {
 	readonly anchor: HTMLElement | IMouseEvent;
 }
 
+export const NotSelectableGroupId = 'notSelectable';
+export type NotSelectableGroupIdType = typeof NotSelectableGroupId;
+
 export interface IIdentityProvider<T> {
 	getId(element: T): { toString(): string };
+	getGroupId?(element: T): number | NotSelectableGroupIdType;
 }
 
 export interface IKeyboardNavigationLabelProvider<T> {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -162,7 +162,10 @@ function asListOptions<T, TFilterData, TRef>(modelProvider: () => ITreeModel<T, 
 		identityProvider: options.identityProvider && {
 			getId(el) {
 				return options.identityProvider!.getId(el.element);
-			}
+			},
+			getGroupId: options.identityProvider!.getGroupId ? (el) => {
+				return options.identityProvider!.getGroupId!(el.element);
+			} : undefined
 		},
 		dnd: options.dnd && disposableStore.add(new TreeNodeListDragAndDrop(modelProvider, options.dnd)),
 		multipleSelectionController: options.multipleSelectionController && {

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -424,7 +424,10 @@ function asObjectTreeOptions<TInput, T, TFilterData>(options?: IAsyncDataTreeOpt
 		identityProvider: options.identityProvider && {
 			getId(el) {
 				return options.identityProvider!.getId(el.element as T);
-			}
+			},
+			getGroupId: options.identityProvider!.getGroupId ? (el) => {
+				return options.identityProvider!.getGroupId!(el.element as T);
+			} : undefined
 		},
 		dnd: options.dnd && new AsyncDataTreeNodeListDragAndDrop(options.dnd),
 		multipleSelectionController: options.multipleSelectionController && {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -6,7 +6,7 @@
 import './media/agentsessionsviewer.css';
 import { h } from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
-import { IIdentityProvider, IListVirtualDelegate } from '../../../../../base/browser/ui/list/list.js';
+import { IIdentityProvider, IListVirtualDelegate, NotSelectableGroupId, NotSelectableGroupIdType } from '../../../../../base/browser/ui/list/list.js';
 import { IListAccessibilityProvider } from '../../../../../base/browser/ui/list/listWidget.js';
 import { ITreeCompressionDelegate } from '../../../../../base/browser/ui/tree/asyncDataTree.js';
 import { ICompressedTreeNode } from '../../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
@@ -763,6 +763,13 @@ export class AgentSessionsIdentityProvider implements IIdentityProvider<IAgentSe
 		}
 
 		return 'agent-sessions-id';
+	}
+
+	getGroupId(element: IAgentSessionsModel | AgentSessionListItem): number | NotSelectableGroupIdType {
+		if (isAgentSessionSection(element) || isAgentSessionsModel(element)) {
+			return NotSelectableGroupId;
+		}
+		return 1;
 	}
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce functionality to group selections based on a new `getGroupId` method in the identity provider. This allows for filtering of selectable elements in lists and trees, preventing selection of non-selectable groups.

related https://github.com/microsoft/vscode/issues/280598