### PR TITLE
Fix padding in chat scroll down button in interactive list

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -30,6 +30,10 @@
 	display: none !important;
 }
 
+.interactive-list > .chat-scroll-down {
+	padding: 4px;
+}
+
 .interactive-item-container {
 	padding: 12px 16px;
 	display: flex;


### PR DESCRIPTION
Adjust the padding for the chat scroll down button in the interactive list to improve the visual layout. This change enhances the user interface by ensuring better spacing. Testing can be done by checking the appearance of the chat scroll down button in the interactive list.

