### PR TITLE
Fix chat input shifting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -987,7 +987,8 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 				sessionsHeight = availableSessionsHeight;
 			}
 
-			sessionsHeight = Math.min(availableSessionsHeight, sessionsHeight);
+			const borderBottom = 1;
+			sessionsHeight = Math.min(availableSessionsHeight, sessionsHeight) - borderBottom;
 
 			this.sessionsControlContainer.style.height = `${sessionsHeight}px`;
 			this.sessionsControlContainer.style.width = ``;


### PR DESCRIPTION
offsetHeight returns 1 more than expected, because it includes the session container's border. That leads to us allocating 1px less for the chat widget than it needs. So compensate for this.

cc @bpasero

https://github.com/user-attachments/assets/81a47ad2-81e2-46ef-a101-0d0c62fba767


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
