### PR TITLE
Revert "Optimize rendering performance by scheduling DOM updates at the next animation frame in NativeEditContext and TextAreaEditContext"

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -5,11 +5,10 @@
 
 import './nativeEditContext.css';
 import { isFirefox } from '../../../../../base/browser/browser.js';
-import { addDisposableListener, getActiveElement, getWindow, getWindowId, scheduleAtNextAnimationFrame } from '../../../../../base/browser/dom.js';
+import { addDisposableListener, getActiveElement, getWindow, getWindowId } from '../../../../../base/browser/dom.js';
 import { FastDomNode } from '../../../../../base/browser/fastDomNode.js';
 import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
-import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { EndOfLinePreference, IModelDeltaDecoration } from '../../../../common/model.js';
@@ -69,7 +68,6 @@ export class NativeEditContext extends AbstractEditContext {
 	private _targetWindowId: number = -1;
 	private _scrollTop: number = 0;
 	private _scrollLeft: number = 0;
-	private _selectionAndControlBoundsUpdateDisposable: IDisposable | undefined;
 
 	private readonly _focusTracker: FocusTracker;
 
@@ -257,8 +255,6 @@ export class NativeEditContext extends AbstractEditContext {
 		this.domNode.domNode.blur();
 		this.domNode.domNode.remove();
 		this._imeTextArea.domNode.remove();
-		this._selectionAndControlBoundsUpdateDisposable?.dispose();
-		this._selectionAndControlBoundsUpdateDisposable = undefined;
 		super.dispose();
 	}
 
@@ -531,19 +527,7 @@ export class NativeEditContext extends AbstractEditContext {
 		}
 	}
 
-	private _updateSelectionAndControlBoundsAfterRender(): void {
-		if (this._selectionAndControlBoundsUpdateDisposable) {
-			return;
-		}
-		// Schedule this work after render so we avoid triggering a layout while still painting.
-		const targetWindow = getWindow(this.domNode.domNode);
-		this._selectionAndControlBoundsUpdateDisposable = scheduleAtNextAnimationFrame(targetWindow, () => {
-			this._selectionAndControlBoundsUpdateDisposable = undefined;
-			this._applySelectionAndControlBounds();
-		});
-	}
-
-	private _applySelectionAndControlBounds(): void {
+	private _updateSelectionAndControlBoundsAfterRender() {
 		const options = this._context.configuration.options;
 		const contentLeft = options.get(EditorOption.layoutInfo).contentLeft;
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -6,7 +6,6 @@
 import './textAreaEditContext.css';
 import * as nls from '../../../../../nls.js';
 import * as browser from '../../../../../base/browser/browser.js';
-import { scheduleAtNextAnimationFrame, getWindow } from '../../../../../base/browser/dom.js';
 import { FastDomNode, createFastDomNode } from '../../../../../base/browser/fastDomNode.js';
 import { IKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import * as platform from '../../../../../base/common/platform.js';
@@ -32,7 +31,6 @@ import { MOUSE_CURSOR_TEXT_CSS_CLASS_NAME } from '../../../../../base/browser/ui
 import { TokenizationRegistry } from '../../../../common/languages.js';
 import { ColorId, ITokenPresentation } from '../../../../common/encodedTokenAttributes.js';
 import { Color } from '../../../../../base/common/color.js';
-import { IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IME } from '../../../../../base/common/ime.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -141,7 +139,6 @@ export class TextAreaEditContext extends AbstractEditContext {
 	 * This is useful for hit-testing and determining the mouse position.
 	 */
 	private _lastRenderPosition: Position | null;
-	private _scheduledRender: IDisposable | null = null;
 
 	public readonly textArea: FastDomNode<HTMLTextAreaElement>;
 	public readonly textAreaCover: FastDomNode<HTMLElement>;
@@ -467,8 +464,6 @@ export class TextAreaEditContext extends AbstractEditContext {
 	}
 
 	public override dispose(): void {
-		this._scheduledRender?.dispose();
-		this._scheduledRender = null;
 		super.dispose();
 		this.textArea.domNode.remove();
 		this.textAreaCover.domNode.remove();
@@ -692,20 +687,7 @@ export class TextAreaEditContext extends AbstractEditContext {
 
 	public render(ctx: RestrictedRenderingContext): void {
 		this._textAreaInput.writeNativeTextAreaContent('render');
-		this._scheduleRender();
-	}
-
-	// Delay expensive DOM updates until the next animation frame to reduce reflow pressure.
-	private _scheduleRender(): void {
-		if (this._scheduledRender) {
-			return;
-		}
-
-		const targetWindow = getWindow(this.textArea.domNode);
-		this._scheduledRender = scheduleAtNextAnimationFrame(targetWindow, () => {
-			this._scheduledRender = null;
-			this._render();
-		});
+		this._render();
 	}
 
 	private _render(): void {


### PR DESCRIPTION
Reverts microsoft/vscode#285906

All view parts already undergo extensive and super careful coordination. I think the root cause that was attempted to be fixed is that someone forces synchronous layout on the editors. A better fix in https://github.com/microsoft/vscode/pull/289079