### PR TITLE
vscode-dts: Fix typedoc for WebviewPanel.dispose()

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -10138,7 +10138,7 @@ declare module 'vscode' {
 		 *
 		 * This closes the panel if it showing and disposes of the resources owned by the webview.
 		 * Webview panels are also disposed when the user closes the webview panel. Both cases
-		 * fire the `onDispose` event.
+		 * fire the `onDidDispose` event.
 		 */
 		dispose(): any;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Sync the change from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74140 back to this repo.

This change can be justified by the source code from `src/vs/workbench/api/common/extHostWebviewPanels.ts`.
```ts
public override dispose() {
  if (this.#isDisposed) {
    return;
  }

  this.#isDisposed = true;
  this.#onDidDispose.fire();

  this.#proxy.$disposeWebview(this.#handle);
  this.#webview.dispose();

  super.dispose();
}
```
