### PR TITLE
Improve layout of interactive item container

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -943,6 +943,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-direction: row;
 	gap: 4px;
 	margin-top: 6px;
+	margin-right: 20px;
 	flex-wrap: wrap;
 	cursor: default;
 }


### PR DESCRIPTION
Add a right margin to the interactive item container to avoid overlapping with context window usage widget. This change improves the visual separation between items.

Addresses: https://github.com/microsoft/vscode/issues/288975
