### PR TITLE
Speed up code block rendering

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1230,6 +1230,11 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	render(forceRedraw?: boolean): void;
 
 	/**
+	 * Render the editor at the next animation frame.
+	 */
+	renderAsync(forceRedraw?: boolean): void;
+
+	/**
 	 * Get the hit test target at coordinates `clientX` and `clientY`.
 	 * The coordinates are relative to the top-left of the viewport.
 	 *

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1703,6 +1703,15 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		});
 	}
 
+	public renderAsync(forceRedraw: boolean = false): void {
+		if (!this._modelData || !this._modelData.hasRealView) {
+			return;
+		}
+		this._modelData.viewModel.batchEvents(() => {
+			this._modelData!.view.render(false, forceRedraw);
+		});
+	}
+
 	public setAriaOptions(options: editorBrowser.IEditorAriaOptions): void {
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6390,6 +6390,10 @@ declare namespace monaco.editor {
 		 */
 		render(forceRedraw?: boolean): void;
 		/**
+		 * Render the editor at the next animation frame.
+		 */
+		renderAsync(forceRedraw?: boolean): void;
+		/**
 		 * Get the hit test target at coordinates `clientX` and `clientY`.
 		 * The coordinates are relative to the top-left of the viewport.
 		 *

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -447,6 +447,14 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		this.mathLayoutParticipants.forEach(layout => layout());
 	}
 
+	onDidRemount(): void {
+		for (const ref of this.allRefs) {
+			if (ref.object instanceof CodeBlockPart) {
+				ref.object.onDidRemount();
+			}
+		}
+	}
+
 	addDisposable(disposable: IDisposable): void {
 		this._register(disposable);
 	}


### PR DESCRIPTION
Fixes #289070

This PR optimizes the rendering performance of code block editors in the chat widget when elements are recycled through list virtualization.

### Changes

1. **Batch editor renders with `postponeRendering`** - Modified `CodeBlockPart.layout()` to use `postponeRendering: true`, allowing multiple editors to batch their render operations together when the chat list scrolls and remounts several code blocks simultaneously.

2. **Async re-render on remount** - Added `onDidRemount()` to `CodeBlockPart` that calls `renderAsync(true)` instead of synchronous `render()`, ensuring editor repaints don't block the main thread after virtualization.

3. **Propagate remount notifications** - `ChatMarkdownContentPart.onDidRemount()` now forwards the callback to all nested `CodeBlockPart` instances from the editor pool.

### Why this improves performance

When scrolling through a chat with many code blocks, the list virtualizes elements and reuses DOM nodes. Previously, remounted editors would render synchronously and individually. Now:
- Multiple editors batch their renders together via `postponeRendering`
- Renders happen asynchronously via `renderAsync()`, avoiding frame drops during scroll