### PR TITLE
Make ghost text suggestions more visible

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/ghostText/ghostTextView.css
@@ -64,6 +64,13 @@
 	border-bottom: 4px double var(--vscode-editorWarning-border);
 }
 
+.monaco-editor .ghost-text-decoration.short-text,
+.monaco-editor .ghost-text-decoration-preview.short-text,
+.monaco-editor .suggest-preview-text .ghost-text.short-text {
+	text-decoration: underline dotted var(--vscode-editorGhostText-foreground);
+	text-underline-position: under;
+}
+
 .ghost-text-view-warning-widget-icon {
 	.codicon {
 		color: var(--vscode-editorWarning-foreground) !important;

--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineSuggestionsView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineSuggestionsView.ts
@@ -146,6 +146,7 @@ export class InlineSuggestionsView extends Disposable {
 			}),
 			{
 				useSyntaxHighlighting: this._editorObs.getOption(EditorOption.inlineSuggest).map(v => v.syntaxHighlightingEnabled),
+				highlightShortSuggestions: true,
 			},
 		);
 	}


### PR DESCRIPTION
```Copilot Generated Description:``` Enhance the visibility of short ghost text suggestions by applying a dotted underline style and adjusting class names based on the length of the suggestions.

closes https://github.com/microsoft/vscode/issues/284517
closes https://github.com/microsoft/vscode/issues/273138