### PR TITLE
adding the line height into the model decorations returned by font token decorations provider

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -222,7 +222,7 @@ export interface IModelDecorationOptions {
 	 */
 	glyphMargin?: IModelDecorationGlyphMarginOptions | null;
 	/**
-	 * If set, the decoration will override the line height of the lines it spans. Maximum value is 300px.
+	 * If set, the decoration will override the line height of the lines it spans. This value is a multiplier to the default line height.
 	 */
 	lineHeight?: number | null;
 	/**

--- a/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
+++ b/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
@@ -137,6 +137,7 @@ export class TokenizationFontDecorationProvider extends Disposable implements De
 				options: {
 					description: 'FontOptionDecoration',
 					inlineClassName: className,
+					lineHeight: anno.fontToken.lineHeightMultiplier,
 					affectsFont
 				},
 				ownerId: 0,

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -199,6 +199,7 @@ export class ViewModel extends Disposable implements IViewModel {
 		if (!allowVariableLineHeights) {
 			return [];
 		}
+		const defaultLineHeight = this._configuration.options.get(EditorOption.lineHeight);
 		const decorations = this.model.getCustomLineHeightsDecorations(this._editorId);
 		return decorations.map((d) => {
 			const lineNumber = d.range.startLineNumber;
@@ -207,7 +208,7 @@ export class ViewModel extends Disposable implements IViewModel {
 				decorationId: d.id,
 				startLineNumber: viewRange.startLineNumber,
 				endLineNumber: viewRange.endLineNumber,
-				lineHeight: d.options.lineHeight || 0
+				lineHeight: d.options.lineHeight ? d.options.lineHeight * defaultLineHeight : 0
 			};
 		});
 	}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1747,7 +1747,7 @@ declare namespace monaco.editor {
 		 */
 		glyphMargin?: IModelDecorationGlyphMarginOptions | null;
 		/**
-		 * If set, the decoration will override the line height of the lines it spans. Maximum value is 300px.
+		 * If set, the decoration will override the line height of the lines it spans. This value is a multiplier to the default line height.
 		 */
 		lineHeight?: number | null;
 		/**


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/288847