### PR TITLE
fix: add engines property to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "main": "./out/main.js",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=22.21.1",
+    "npm": ">=10"
+  },
   "scripts": {
     "test": "echo Please run any of the test scripts from the scripts folder.",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",


### PR DESCRIPTION
Add engines property to specify the required Node.js and npm versions:
- node: >=22.21.1 (matches .nvmrc)
- npm: >=10 (bundled with Node.js 22)

This helps contributors quickly identify the required versions and throws an error if an unsupported version is used.

Fixes #252372

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
