### PR TITLE
chat: remove fragile timeout in revealSessionIfAlreadyOpen

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidgetService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../base/browser/dom.js';
-import { raceCancellablePromises, timeout } from '../../../../../base/common/async.js';
+import { timeout } from '../../../../../base/common/async.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { combinedDisposable, Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { isEqual } from '../../../../../base/common/resources.js';
@@ -153,11 +153,8 @@ export class ChatWidgetService extends Disposable implements IChatWidgetService 
 			const isGroupActive = () => dom.getWindow(this.layoutService.activeContainer).vscodeWindowId === existingEditorWindowId;
 
 			let ensureFocusTransfer: Promise<void> | undefined;
-			if (!isGroupActive()) {
-				ensureFocusTransfer = raceCancellablePromises([
-					timeout(500),
-					Event.toPromise(Event.once(Event.filter(this.layoutService.onDidChangeActiveContainer, isGroupActive))),
-				]);
+			if (!isGroupActive() && !options?.preserveFocus) {
+				ensureFocusTransfer = Event.toPromise(Event.once(Event.filter(this.layoutService.onDidChangeActiveContainer, isGroupActive)));
 			}
 
 			const pane = await existingEditor.group.openEditor(existingEditor.editor, options);


### PR DESCRIPTION
Removes the 500ms timeout fallback that was a hack to wait for focus
transfer to auxiliary windows. Instead, only waits for focus transfer when
preserveFocus is false, since preserveFocus: true means the window won't
get focus and the layout service won't fire onDidChangeActiveContainer.

- Remove unused raceCancellablePromises import
- Add preserveFocus check to avoid waiting when focus won't transfer
- Remove timeout(500) that could cause UI to appear in wrong location

Fixes https://github.com/microsoft/vscode/issues/279738

(Commit message generated by Copilot)
