### PR TITLE
Ensure embedded chat terminal output expands on real data

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -592,7 +592,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const autoExpand = store.add(new TerminalToolAutoExpand({
 				commandDetection,
 				onWillData: terminalInstance.onWillData,
-				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed,
+				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed  && !expandedStateByInvocation.get(this.toolInvocation),
 				hasRealOutput,
 			}));
 			store.add(autoExpand.onDidRequestExpand(() => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -24,6 +24,7 @@ import { IChatRendererContent } from '../../../../common/model/chatViewModel.js'
 import '../media/chatTerminalToolProgressPart.css';
 import type { ICodeBlockRenderOptions } from '../codeBlockPart.js';
 import { Action, IAction } from '../../../../../../../base/common/actions.js';
+import { timeout } from '../../../../../../../base/common/async.js';
 import { IChatTerminalToolProgressPart, ITerminalChatService, ITerminalConfigurationService, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../../../../base/common/event.js';
@@ -1064,7 +1065,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		if (!hasOutput) {
 			const maxRetries = 10;
 			for (let retry = 0; retry < maxRetries && !hasOutput; retry++) {
-				await new Promise(resolve => setTimeout(resolve, 100));
+				await timeout(100);
 				if (this._store.isDisposed) {
 					return true;
 				}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -889,7 +889,6 @@ class ChatTerminalToolOutputSection extends Disposable {
 			return true;
 		}
 
-		// For expanding, prepare content first but don't show until we have something to display
 		if (!this._scrollableContainer) {
 			await this._createScrollableContainer();
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -566,40 +566,65 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const hasRealOutput = (): boolean => {
 				// Check for snapshot output
 				if (this._terminalData.terminalCommandOutput?.text?.trim()) {
+					console.log('[TerminalToolProgress] hasRealOutput: true (snapshot output)');
 					return true;
 				}
 				// Check for live output (cursor moved past executed marker)
 				const command = this._getResolvedCommand(terminalInstance);
 				if (!command?.executedMarker || terminalInstance.isDisposed) {
+					console.log('[TerminalToolProgress] hasRealOutput: false (no executedMarker or disposed)', { hasExecutedMarker: !!command?.executedMarker, isDisposed: terminalInstance.isDisposed });
 					return false;
 				}
 				const buffer = terminalInstance.xterm?.raw.buffer.active;
 				if (!buffer) {
+					console.log('[TerminalToolProgress] hasRealOutput: false (no buffer)');
 					return false;
 				}
 				const cursorLine = buffer.baseY + buffer.cursorY;
-				return cursorLine > command.executedMarker.line;
+				const result = cursorLine > command.executedMarker.line;
+				console.log('[TerminalToolProgress] hasRealOutput:', result, { cursorLine, executedMarkerLine: command.executedMarker.line });
+				return result;
 			};
 
 			// Use the extracted auto-expand logic
+			console.log('[TerminalToolProgress] Creating TerminalToolAutoExpand, isInThinkingContainer:', this._isInThinkingContainer);
 			const autoExpand = store.add(new TerminalToolAutoExpand({
 				commandDetection,
 				onWillData: terminalInstance.onWillData,
-				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed,
+				shouldAutoExpand: () => {
+					const result = !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed;
+					console.log('[TerminalToolProgress] shouldAutoExpand:', result, { isExpanded: this._outputView.isExpanded, userToggledOutput: this._userToggledOutput, isDisposed: this._store.isDisposed, isInThinkingContainer: this._isInThinkingContainer });
+					return result;
+				},
 				hasRealOutput,
 			}));
-			store.add(autoExpand.onDidRequestExpand(() => this._toggleOutput(true)));
+			store.add(autoExpand.onDidRequestExpand(() => {
+				console.log('[TerminalToolProgress] onDidRequestExpand fired, isInThinkingContainer:', this._isInThinkingContainer);
+				if (this._isInThinkingContainer) {
+					console.log('[TerminalToolProgress] Expanding collapsible wrapper');
+					this.expandCollapsibleWrapper();
+				}
+				console.log('[TerminalToolProgress] Toggling output to expanded');
+				this._toggleOutput(true);
+			}));
 
 			store.add(commandDetection.onCommandExecuted(() => {
+				console.log('[TerminalToolProgress] onCommandExecuted, isInThinkingContainer:', this._isInThinkingContainer);
 				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 			}));
 
 			store.add(commandDetection.onCommandFinished(() => {
+				console.log('[TerminalToolProgress] onCommandFinished, isInThinkingContainer:', this._isInThinkingContainer, 'isExpanded:', this._outputView.isExpanded);
 				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 				const resolvedCommand = this._getResolvedCommand(terminalInstance);
 
+				// Auto-expand on completion when in thinking container
+				if (this._isInThinkingContainer && !this._outputView.isExpanded && !this._userToggledOutput) {
+					console.log('[TerminalToolProgress] Auto-expanding on finish in thinking container');
+					this._toggleOutput(true);
+				}
 				// Auto-collapse on success (except for thinking)
-				if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
+				else if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
 					this._toggleOutput(false);
 				}
 				// keep outer wrapper expanded on error
@@ -615,8 +640,12 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const resolvedImmediately = await tryResolveCommand();
 			if (resolvedImmediately?.endMarker) {
 				commandDetectionListener.clear();
+				// Auto-expand on completion when in thinking container
+				if (this._isInThinkingContainer && !this._outputView.isExpanded && !this._userToggledOutput) {
+					this._toggleOutput(true);
+				}
 				// Auto-collapse on success (except for thinking)
-				if (resolvedImmediately.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
+				else if (resolvedImmediately.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
 					this._toggleOutput(false);
 				}
 				// keep outer wrapper expanded on error

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -615,12 +615,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 				const resolvedCommand = this._getResolvedCommand(terminalInstance);
 
-				// Auto-expand on completion when in thinking container
-				if (this._isInThinkingContainer && !this._outputView.isExpanded && !this._userToggledOutput) {
-					this._toggleOutput(true);
-				}
-				// Auto-collapse on success (except for thinking)
-				else if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
+				// Auto-collapse on success
+				if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput) {
 					this._toggleOutput(false);
 				}
 				// keep outer wrapper expanded on error
@@ -636,12 +632,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const resolvedImmediately = await tryResolveCommand();
 			if (resolvedImmediately?.endMarker) {
 				commandDetectionListener.clear();
-				// Auto-expand on completion when in thinking container
-				if (this._isInThinkingContainer && !this._outputView.isExpanded && !this._userToggledOutput) {
-					this._toggleOutput(true);
-				}
-				// Auto-collapse on success (except for thinking)
-				else if (resolvedImmediately.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput && !this._isInThinkingContainer) {
+				// Auto-collapse on success
+				if (resolvedImmediately.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput) {
 					this._toggleOutput(false);
 				}
 				// keep outer wrapper expanded on error

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -592,7 +592,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const autoExpand = store.add(new TerminalToolAutoExpand({
 				commandDetection,
 				onWillData: terminalInstance.onWillData,
-				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed  && !expandedStateByInvocation.get(this.toolInvocation),
+				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed && !expandedStateByInvocation.get(this.toolInvocation),
 				hasRealOutput,
 			}));
 			store.add(autoExpand.onDidRequestExpand(() => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/terminalToolAutoExpand.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/terminalToolAutoExpand.ts
@@ -77,20 +77,19 @@ export class TerminalToolAutoExpand extends Disposable {
 		const commandDetection = this._options.commandDetection;
 
 		store.add(commandDetection.onCommandExecuted(() => {
-			console.log('[TerminalToolAutoExpand] onCommandExecuted, shouldAutoExpand:', this._options.shouldAutoExpand());
 			// Auto-expand for long-running commands:
 			if (this._options.shouldAutoExpand() && !this._noDataTimeout) {
-				console.log('[TerminalToolAutoExpand] Starting NoData timeout (' + TerminalToolAutoExpandTimeout.NoData + 'ms)');
 				this._noDataTimeout = disposableTimeout(() => {
 					this._noDataTimeout = undefined;
 					const shouldExpand = this._options.shouldAutoExpand();
 					const hasOutput = this._options.hasRealOutput();
-					console.log('[TerminalToolAutoExpand] NEW CODE - NoData timeout fired, shouldAutoExpand:', shouldExpand, 'hasRealOutput:', hasOutput);
 					// Don't check receivedData here - data events can fire before onCommandExecuted
 					// (shell integration sequences), and the DataEvent path may not have expanded
 					// if hasRealOutput was false at that time
 					if (shouldExpand && hasOutput) {
-						console.log('[TerminalToolAutoExpand] Firing onDidRequestExpand (NoData path)');
+						// Cancel the DataEvent timeout since we're expanding via the NoData path
+						this._dataEventTimeout?.dispose();
+						this._dataEventTimeout = undefined;
 						this._onDidRequestExpand.fire();
 					}
 				}, TerminalToolAutoExpandTimeout.NoData, store);
@@ -99,25 +98,24 @@ export class TerminalToolAutoExpand extends Disposable {
 
 		// 2. Wait for first data event - when hit, wait 50ms and expand if command not yet finished
 		// Also checks for real output since shell integration sequences trigger onWillData
+		// Important: We don't cancel _noDataTimeout here because early data might just be shell
+		// integration sequences. The NoData path should still run if the DataEvent path doesn't
+		// find real output.
 		store.add(this._options.onWillData(() => {
-			console.log('[TerminalToolAutoExpand] onWillData, receivedData before:', this._receivedData);
 			if (this._receivedData) {
 				return;
 			}
 			this._receivedData = true;
-			this._noDataTimeout?.dispose();
-			this._noDataTimeout = undefined;
-			console.log('[TerminalToolAutoExpand] First data event, shouldAutoExpand:', this._options.shouldAutoExpand());
 			// Wait 50ms and expand if command hasn't finished yet and has real output
 			if (this._options.shouldAutoExpand() && !this._dataEventTimeout) {
-				console.log('[TerminalToolAutoExpand] Starting DataEvent timeout (' + TerminalToolAutoExpandTimeout.DataEvent + 'ms)');
 				this._dataEventTimeout = disposableTimeout(() => {
 					this._dataEventTimeout = undefined;
 					const shouldExpand = this._options.shouldAutoExpand();
 					const hasOutput = this._options.hasRealOutput();
-					console.log('[TerminalToolAutoExpand] DataEvent timeout fired, commandFinished:', this._commandFinished, 'shouldAutoExpand:', shouldExpand, 'hasRealOutput:', hasOutput);
 					if (!this._commandFinished && shouldExpand && hasOutput) {
-						console.log('[TerminalToolAutoExpand] Firing onDidRequestExpand (DataEvent path)');
+						// Cancel the NoData timeout since we're expanding via the DataEvent path
+						this._noDataTimeout?.dispose();
+						this._noDataTimeout = undefined;
 						this._onDidRequestExpand.fire();
 					}
 				}, TerminalToolAutoExpandTimeout.DataEvent, store);
@@ -125,7 +123,6 @@ export class TerminalToolAutoExpand extends Disposable {
 		}));
 
 		store.add(commandDetection.onCommandFinished(() => {
-			console.log('[TerminalToolAutoExpand] onCommandFinished, clearing timeouts');
 			this._commandFinished = true;
 			this._clearAutoExpandTimeouts();
 		}));

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/terminalToolAutoExpand.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/terminalToolAutoExpand.test.ts
@@ -310,4 +310,51 @@ suite('TerminalToolAutoExpand', () => {
 		assert.strictEqual(isExpanded, true, 'Should expand exactly once after first data');
 		onCommandFinished.fire(undefined);
 	}));
+
+	test('progress bar output detected via multiple data events (receivedDataCount > 1)', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		// Simulates progress bars that update on the same line - cursor doesn't move past marker
+		// but multiple data events indicate real output
+		let dataEventCount = 0;
+
+		// Create a mock command detection capability
+		const mockCommandDetection = {
+			onCommandExecuted: onCommandExecuted.event,
+			onCommandFinished: onCommandFinished.event,
+		} as Pick<ICommandDetectionCapability, 'onCommandExecuted' | 'onCommandFinished'> as ICommandDetectionCapability;
+
+		// Track data events to simulate receivedDataCount logic
+		store.add(onWillData.event(() => {
+			dataEventCount++;
+		}));
+
+		const autoExpand = store.add(new TerminalToolAutoExpand({
+			commandDetection: mockCommandDetection,
+			onWillData: onWillData.event,
+			shouldAutoExpand: () => !isExpanded && !userToggledOutput,
+			// Simulate: cursor hasn't moved past marker, but multiple data events = real output
+			hasRealOutput: () => dataEventCount > 1,
+		}));
+		store.add(autoExpand.onDidRequestExpand(() => {
+			isExpanded = true;
+		}));
+
+		// Command executes
+		onCommandExecuted.fire(undefined);
+
+		// First data event (shell sequence) - hasRealOutput returns false (dataEventCount = 1)
+		onWillData.fire('shell-sequence');
+
+		// Wait for DataEvent timeout - should NOT expand yet (hasRealOutput = false)
+		await timeout(TerminalToolAutoExpandTimeout.DataEvent + 10);
+		assert.strictEqual(isExpanded, false, 'Should NOT expand after first data event');
+
+		// Second data event (progress bar update) - hasRealOutput returns true (dataEventCount = 2)
+		onWillData.fire('progress');
+
+		// Wait for NoData timeout - should expand via NoData path
+		await timeout(TerminalToolAutoExpandTimeout.NoData);
+		assert.strictEqual(isExpanded, true, 'Should expand when multiple data events detected as real output');
+
+		onCommandFinished.fire(undefined);
+	}));
 });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/terminalToolAutoExpand.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/terminalToolAutoExpand.test.ts
@@ -261,7 +261,7 @@ suite('TerminalToolAutoExpand', () => {
 		await timeout(TerminalToolAutoExpandTimeout.DataEvent + 10);
 		assert.strictEqual(isExpanded, false, 'Should NOT expand when DataEvent fires without real output');
 
-		// Now real output appears before NoData timeout
+		// Now real output appears during the NoData timeout window (after DataEvent timeout but before NoData timeout completes)
 		hasRealOutputValue = true;
 
 		// Wait for NoData timeout to fire (500ms from command executed)


### PR DESCRIPTION
When running commands like `npm run watch`, the terminal output in chat wasn't auto-expanding to show the output. The root cause is that shell integration sequences arrive as "data" events before any actual command output appears. The old implementation cancelled the 500ms fallback timeout as soon as any data arrived, then relied on a 50ms timeout to check for real output. But at that point, only shell sequences had arrived - **no actual output yet** - so nothing expanded. The 500ms path had already been cancelled, so there was no second chance.

The fix allows both timeout paths to run concurrently instead of having the first data event cancel the longer timeout. Now, when a command executes, the 500ms "NoData" timeout starts. If data arrives, a 50ms "DataEvent" timeout also starts, but it no longer cancels the NoData path. **Whichever path finds real output first** will expand the terminal and cancel the other. This means if shell integration sequences arrive early but real output comes later (within 500ms), the NoData path will still successfully expand the output.

Additionally, the PR adds detection for progress-bar style output that updates the same terminal line. Previously, the `hasRealOutput()` check only looked at whether the cursor had moved past the command's executed marker. Progress bars that overwrite the same line (as is the case for `npm i`) wouldn't move the cursor, so they weren't detected as real output. Now, if multiple data events are received `receivedDataCount > 1`, it's treated as real output since shell integration sequences typically only fire once.

The PR also improves the visual experience by delaying the expanded state until content is actually ready to display, preventing an empty flash. A polling mechanism waits up to 1 second for terminal content before showing the "no output" message, handling cases where the buffer isn't immediately ready. Finally, terminal commands inside thinking containers now auto-collapse on success like regular commands, and auto-expand the thinking wrapper when output appears or errors occur.

Also added tests for these cases.

fixes #288352

cc @tyriar