### PR TITLE
Add `sessionResource` to proposed apis

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -20,6 +20,7 @@ import { Dto, SerializableObjectWithBuffers } from '../../services/extensions/co
 import { ExtHostLanguageModelToolsShape, IMainContext, IToolDataDto, MainContext, MainThreadLanguageModelToolsShape } from './extHost.protocol.js';
 import { ExtHostLanguageModels } from './extHostLanguageModels.js';
 import * as typeConvert from './extHostTypeConverters.js';
+import { URI } from '../../../base/common/uri.js';
 
 class Tool {
 
@@ -184,6 +185,7 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			options.chatRequestId = dto.chatRequestId;
 			options.chatInteractionId = dto.chatInteractionId;
 			options.chatSessionId = dto.context?.sessionId;
+			options.chatSessionResource = URI.revive(dto.context?.sessionResource);
 			options.subAgentInvocationId = dto.subAgentInvocationId;
 		}
 
@@ -262,6 +264,7 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			rawInput: context.rawInput,
 			chatRequestId: context.chatRequestId,
 			chatSessionId: context.chatSessionId,
+			chatSessionResource: context.chatSessionResource,
 			chatInteractionId: context.chatInteractionId
 		};
 
@@ -285,6 +288,7 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			input: context.parameters,
 			chatRequestId: context.chatRequestId,
 			chatSessionId: context.chatSessionId,
+			chatSessionResource: context.chatSessionResource,
 			chatInteractionId: context.chatInteractionId
 		};
 		if (item.tool.prepareInvocation) {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3148,6 +3148,7 @@ export namespace ChatAgentRequest {
 			enableCommandDetection: request.enableCommandDetection ?? true,
 			isParticipantDetected: request.isParticipantDetected ?? false,
 			sessionId,
+			sessionResource: request.sessionResource,
 			references: variableReferences
 				.map(v => ChatPromptReference.to(v, diagnostics, logService))
 				.filter(isDefined),

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -294,7 +294,9 @@ export interface IToolInvocationStreamContext {
 	toolCallId: string;
 	rawInput: unknown;
 	chatRequestId?: string;
+	/** @deprecated Use {@link chatSessionResource} instead */
 	chatSessionId?: string;
+	chatSessionResource?: URI;
 	chatInteractionId?: string;
 }
 

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -695,7 +695,9 @@ declare module 'vscode' {
 		readonly rawInput?: unknown;
 
 		readonly chatRequestId?: string;
+		/** @deprecated Use {@link chatSessionResource} instead */
 		readonly chatSessionId?: string;
+		readonly chatSessionResource?: Uri;
 		readonly chatInteractionId?: string;
 	}
 

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -61,9 +61,16 @@ declare module 'vscode' {
 		readonly attempt: number;
 
 		/**
-		 * The session identifier for this chat request
+		 * The session identifier for this chat request.
+		 *
+		 * @deprecated Use {@link chatSessionResource} instead.
 		 */
 		readonly sessionId: string;
+
+		/**
+		 * The resource URI for the chat session this request belongs to.
+		 */
+		readonly sessionResource: Uri;
 
 		/**
 		 * If automatic command detection is enabled.
@@ -239,7 +246,9 @@ declare module 'vscode' {
 
 	export interface LanguageModelToolInvocationOptions<T> {
 		chatRequestId?: string;
+		/** @deprecated Use {@link chatSessionResource} instead */
 		chatSessionId?: string;
+		chatSessionResource?: Uri;
 		chatInteractionId?: string;
 		terminalCommand?: string;
 		/**
@@ -254,7 +263,9 @@ declare module 'vscode' {
 		 */
 		input: T;
 		chatRequestId?: string;
+		/** @deprecated Use {@link chatSessionResource} instead */
 		chatSessionId?: string;
+		chatSessionResource?: Uri;
 		chatInteractionId?: string;
 	}
 


### PR DESCRIPTION
For #274403

Replacing chatSessionId in a few API proposals. Keeping around the old fields for now until we can adopt this everywhere

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
