### PR TITLE
fix: treat provider-registered modes from default extension as built-in

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -196,5 +196,7 @@ function isModeConsideredBuiltIn(mode: IChatMode, productService: IProductServic
 	if (mode.isBuiltin) {
 		return true;
 	}
-	return mode.source?.storage === PromptsStorage.extension && mode.source.extensionId.value === productService.defaultChatAgent?.chatExtensionId && mode.source.type === ExtensionAgentSourceType.contribution;
+	return mode.source?.storage === PromptsStorage.extension &&
+		mode.source.extensionId.value === productService.defaultChatAgent?.chatExtensionId &&
+		(mode.source.type === ExtensionAgentSourceType.contribution || mode.source.type === ExtensionAgentSourceType.provider);
 }


### PR DESCRIPTION
Modes registered via the provider API (`ExtensionAgentSourceType.provider`) from the default chat extension were not being recognized as built-in modes, causing them to appear in the "Custom" category instead of "Built-In" in the mode picker.

This fixes the `isModeConsideredBuiltIn` function to also accept `provider` type alongside `contribution` type when the mode comes from the default chat agent extension.