### PR TITLE
Fix input shifting when editing request

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1570,7 +1570,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part {
 	margin: 0px 12px;
-	padding: 4px 0 8px 0px;
+	padding: 4px 0 12px 0px;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
@@ -2736,7 +2736,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .chat-row-disabled-overlay,
-.interactive-item-container .chat-edit-input-container .chat-editing-session {
+.interactive-item-container .chat-edit-input-container .chat-editing-session,
+.chat-input-overlay {
 	display: none;
 }
 


### PR DESCRIPTION
Caused by losing the flex gap that applied to an empty chat-input-overlay

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
