### PR TITLE
fix: prevent duplicate disable action when extension is disabled globally

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1752,7 +1752,8 @@ export class DisableGloballyAction extends ExtensionAction {
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
 				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
-				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
+				&& this.extensionEnablementService.canChangeEnablement(this.extension.local)
+				&& !this.extensionEnablementService.isDisabledGlobally(this.extension.local);
 		}
 	}
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsActions.test.ts
@@ -961,6 +961,18 @@ suite('ExtensionsActions', () => {
 			});
 	});
 
+	test('Test DisableGloballyAction when extension is disabled globally but enabled in workspace', async () => {
+		const local = aLocalExtension('a');
+		const enablementService = instantiationService.get(IWorkbenchExtensionEnablementService);
+		await enablementService.setEnablement([local], EnablementState.DisabledGlobally);
+		await enablementService.setEnablement([local], EnablementState.EnabledWorkspace);
+		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', [local]);
+		const extensions = await instantiationService.get(IExtensionsWorkbenchService).queryLocal();
+		const testObject: ExtensionsActions.DisableGloballyAction = disposables.add(instantiationService.createInstance(ExtensionsActions.DisableGloballyAction));
+		testObject.extension = extensions[0];
+		assert.ok(!testObject.enabled);
+	});
+
 });
 
 suite('ExtensionRuntimeStateAction', () => {


### PR DESCRIPTION
Fixes #244138

**Description**
The "Disable" button was incorrectly appearing in the extension dropdown menu even when the extension was already disabled globally (but enabled for the current workspace). This resulted in both "Disable" and "Disable (Workspace)" appearing simultaneously, which is redundant.

This fix adds a check to `DisableGloballyAction.update()` to ensure the global "Disable" action is hidden if the extension is already globally disabled.

**Testing**
1. Installed a built-in extension (e.g., Markdown Language Features).
2. Disabled it globally.
3. Opened a folder to create a workspace context.
4. Enabled the extension for the current workspace.
5. Verified that the dropdown now only shows "Disable (Workspace)" and correctly hides the redundant "Disable" option.

**Screenshots**
Before:
<img width="244" height="388" alt="Screenshot 2026-01-21 134016" src="https://github.com/user-attachments/assets/6e6b1505-8f86-492d-9bb0-6d5150409631" />

After:
<img width="246" height="387" alt="Screenshot 2026-01-21 135004" src="https://github.com/user-attachments/assets/6954c1de-682b-4f92-85f8-349e17262d69" />