### PR TITLE
chat: fix SecurityError with cross-origin MCP App iframes and enable by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -499,7 +499,7 @@ configurationRegistry.registerConfiguration({
 		[mcpAppsEnabledConfig]: {
 			type: 'boolean',
 			description: nls.localize('chat.mcp.ui.enabled', "Controls whether MCP servers can provide custom UI for tool invocations."),
-			default: false,
+			default: true,
 			tags: ['experimental'],
 		},
 		[mcpServerSamplingSection]: {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
@@ -310,7 +310,7 @@ export class ChatMcpAppModel extends Disposable {
 					if (type === 'message') {
 						const originalListener = listener;
 						const wrappedListener = (event) => {
-							if (event.source.origin === document.location.origin && event.source !== window) { event = setMessageSource(event, window.parent); }
+							if (event.origin === document.location.origin && event.source !== window) { event = setMessageSource(event, window.parent); }
 							originalListener(event);
 						};
 						wrappedFns.set(originalListener, wrappedListener);


### PR DESCRIPTION
- Change event.source.origin check to event.origin to avoid SecurityError
  when accessing cross-origin frames in patched postMessage handlers
- Enable MCP Apps UI by default (mcpAppsEnabledConfig changed from false
  to true) since the feature is now stable and ready for general use

Fixes https://github.com/microsoft/vscode/issues/289386

(Commit message generated by Copilot)