### PR TITLE
chat: position session hover above when in bottom panel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -175,8 +175,24 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 		return {
 			position: sideSessionsOnRightPosition ? Position.RIGHT : Position.LEFT,
-			location: viewLocation ?? ViewContainerLocation.AuxiliaryBar
+			location: viewLocation ?? ViewContainerLocation.AuxiliaryBar,
 		};
+	}
+
+	private getSessionHoverPosition() {
+		const viewLocation = this.viewDescriptorService.getViewLocationById(this.id);
+		const sideBarPosition = this.layoutService.getSideBarPosition();
+
+		if (this.sessionsViewerOrientation === AgentSessionsViewerOrientation.SideBySide) {
+			return viewLocation === ViewContainerLocation.Sidebar && sideBarPosition === Position.RIGHT ? HoverPosition.LEFT : HoverPosition.RIGHT;
+		}
+
+		return {
+			[Position.LEFT]: HoverPosition.RIGHT,
+			[Position.RIGHT]: HoverPosition.LEFT,
+			[Position.TOP]: HoverPosition.BELOW,
+			[Position.BOTTOM]: HoverPosition.ABOVE
+		}[viewLocation === ViewContainerLocation.Panel ? this.layoutService.getPanelPosition() : sideBarPosition];
 	}
 
 	private updateViewPaneClasses(fromEvent: boolean): void {
@@ -369,10 +385,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			source: 'chatViewPane',
 			filter: sessionsFilter,
 			overrideStyles: this.getLocationBasedColors().listOverrideStyles,
-			getHoverPosition: () => {
-				const { position } = this.getViewPositionAndLocation();
-				return position === Position.RIGHT ? HoverPosition.LEFT : HoverPosition.RIGHT;
-			},
+			getHoverPosition: () => this.getSessionHoverPosition(),
 			trackActiveEditorSession: () => {
 				return !this._widget || this._widget.isEmpty(); // only track and reveal if chat widget is empty
 			},


### PR DESCRIPTION
Extracts hover position logic into a dedicated getSessionHoverPosition()
method that correctly handles all viewport locations and orientations.
When the agent session view is in the bottom panel, the hover now appears
above the session rather than to the left, preventing it from hiding
session buttons.

- Adds getSessionHoverPosition() method to ChatViewPane
- Checks view location and returns appropriate HoverPosition
- Returns HoverPosition.ABOVE when panel position is BOTTOM
- Handles both sidebar and panel locations with panel position awareness

Fixes https://github.com/microsoft/vscode/issues/289369

(Commit message generated by Copilot)