### PR TITLE
chore: bump windows-foreground-love

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
         "zx": "^8.8.5"
       },
       "optionalDependencies": {
-        "windows-foreground-love": "0.5.0"
+        "windows-foreground-love": "0.6.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -18063,10 +18063,11 @@
       "dev": true
     },
     "node_modules/windows-foreground-love": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/windows-foreground-love/-/windows-foreground-love-0.5.0.tgz",
-      "integrity": "sha512-yjBwmKEmQBDk3Z7yg/U9hizGWat8C6Pe4MQWl5bN6mvPU81Bt6HV2k/6mGlK3ETJLW1hCLhYx2wcGh+ykUUCyA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/windows-foreground-love/-/windows-foreground-love-0.6.1.tgz",
+      "integrity": "sha512-uusaXCkDfifZkV/EJMnfJ/i9hsY1BGS9YIQs7LGGRrg1+au7er4ONADtMp6svQWlwgztTgWu31g0nT5OPyYLwg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -239,6 +239,6 @@
     "url": "https://github.com/microsoft/vscode/issues"
   },
   "optionalDependencies": {
-    "windows-foreground-love": "0.5.0"
+    "windows-foreground-love": "0.6.1"
   }
 }


### PR DESCRIPTION
Brings in the latest BinSkim fixes.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=395191&view=results