### PR TITLE
chat: hide edit hover in agent session hover widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget.ts
@@ -122,7 +122,7 @@ export class AgentSessionHoverWidget extends Disposable {
 				rendererOptions: {
 					renderStyle: 'compact',
 					noHeader: true,
-					editableCodeBlock: false,
+					editable: false,
 				},
 				currentChatMode: () => ChatModeKind.Ask,
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -173,7 +173,6 @@ export interface IChatListItemRendererOptions {
 	readonly renderStyle?: 'compact' | 'minimal';
 	readonly noHeader?: boolean;
 	readonly noFooter?: boolean;
-	readonly editableCodeBlock?: boolean;
 	readonly renderDetectedCommandsWithRequest?: boolean;
 	readonly restorable?: boolean;
 	readonly editable?: boolean;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -663,7 +663,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		templateData.rowContainer.classList.toggle('editing', editing && !isInput);
 		templateData.rowContainer.classList.toggle('editing-input', editing && isInput);
 		templateData.requestHover.classList.toggle('editing', editing && isInput);
-		templateData.requestHover.classList.toggle('hidden', (!!this.viewModel?.editing && !editing) || isResponseVM(element));
+		templateData.requestHover.classList.toggle('hidden', (!!this.viewModel?.editing && !editing) || isResponseVM(element) || !this.rendererOptions.editable);
 		templateData.requestHover.classList.toggle('expanded', this.configService.getValue<string>('chat.editRequests') === 'hover');
 		templateData.requestHover.classList.toggle('checkpoints-enabled', checkpointEnabled);
 		templateData.elementDisposables.add(dom.addStandardDisposableListener(templateData.rowContainer, dom.EventType.CLICK, (e) => {


### PR DESCRIPTION
Hides the request edit hover UI in the chat list widget used by agent session hover since request editing is not supported in that context.

- Add 'editable: false' to rendererOptions in agentSessionHoverWidget
- Hide requestHover element when editable is false in chatListRenderer
- Remove unused editableCodeBlock property from IChatListItemRendererOptions

Fixes https://github.com/microsoft/vscode/issues/289373

(Commit message generated by Copilot)