### PR TITLE
mcp: implement McpUiUpdateModelContextRequest handler

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -600,7 +600,7 @@ export class DefaultChatAttachmentWidget extends AbstractChatAttachmentWidget {
 		}
 
 		// Setup tooltip hover for string context attachments
-		if (isStringVariableEntry(attachment) && attachment.tooltip) {
+		if ((isStringVariableEntry(attachment) || attachment.kind === 'generic') && attachment.tooltip) {
 			this._setupTooltipHover(attachment.tooltip);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
@@ -9,6 +9,8 @@ import { disposableTimeout } from '../../../../../../../base/common/async.js';
 import { decodeBase64 } from '../../../../../../../base/common/buffer.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../../../base/common/event.js';
+import { hash } from '../../../../../../../base/common/hash.js';
+import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../../base/common/lifecycle.js';
 import { autorun, autorunSelfDisposable, derived, IObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { basename } from '../../../../../../../base/common/resources.js';
@@ -396,8 +398,12 @@ export class ChatMcpAppModel extends Disposable {
 					result = await this._handleUiMessage(request.params);
 					break;
 
+				case 'ui/update-model-context':
+					result = await this._handleUpdateModelContext(request.params);
+					break;
+
 				case 'notifications/message':
-					await this._mcpToolCallUI.log(request.params);
+					await this._mcpToolCallUI.log(request.params as MCP.LoggingMessageNotification['params']);
 					break;
 
 				default: {
@@ -474,8 +480,15 @@ export class ChatMcpAppModel extends Disposable {
 				logging: {},
 				sandbox: {
 					csp: this._latestCsp,
-					permissions: { clipboardWrite: true },
+					permissions: { clipboardWrite: {} },
 				},
+				updateModelContext: {
+					audio: {},
+					image: {},
+					resourceLink: {},
+					resource: {},
+					structuredContent: {},
+				}
 			},
 			hostContext: this.hostContext.get(),
 		} satisfies Required<McpApps.McpUiInitializeResult>;
@@ -518,6 +531,68 @@ export class ChatMcpAppModel extends Disposable {
 		widget.focusInput();
 
 		return { isError: false };
+	}
+
+	private async _handleUpdateModelContext(params: McpApps.McpUiUpdateModelContextRequest['params']): Promise<MCP.EmptyResult> {
+		const widget = this._chatWidgetService.getWidgetBySessionResource(this.renderData.sessionResource);
+		if (!widget) {
+			return {};
+		}
+
+		const idPrefix = `mcpui-context-${hash(this.renderData.serverDefinitionId)}-`;
+		const toDelete = widget.attachmentModel.getAttachmentIDs();
+		const idsToDelete = Array.from(toDelete).filter(id => id.startsWith(idPrefix));
+		const entries: IChatRequestVariableEntry[] = [];
+		let entryIndex = 0;
+
+		if (params.content) {
+			for (const block of params.content) {
+				const id = `${idPrefix}${entryIndex++}`;
+				if (block.type === 'image') {
+					entries.push({
+						kind: 'image',
+						value: decodeBase64(block.data).buffer,
+						id,
+						name: 'Image',
+						mimeType: block.mimeType,
+					});
+				} else if (block.type === 'resource_link') {
+					const uri = McpResourceURI.fromServer({ id: this.renderData.serverDefinitionId, label: '' }, block.uri);
+					entries.push({
+						kind: 'file',
+						value: uri,
+						id,
+						name: basename(uri),
+					});
+				} else if (block.type === 'text') {
+					const preview = block.text.replaceAll(/\s+/g, ' ').trim();
+					const truncateTo = 20;
+					entries.push({
+						kind: 'generic',
+						value: block.text,
+						id,
+						tooltip: new MarkdownString().appendCodeblock('plaintext', block.text),
+						name: preview.length > truncateTo ? preview.slice(0, truncateTo) + '…' : preview,
+					});
+				}
+			}
+		}
+
+		if (params.structuredContent && Object.keys(params.structuredContent).length > 0) {
+			const id = `${idPrefix}structured`;
+			const value = JSON.stringify(params.structuredContent, null, 2);
+			entries.push({
+				kind: 'generic',
+				value,
+				tooltip: new MarkdownString().appendCodeblock('json', value),
+				id,
+				name: 'UI Data',
+			});
+		}
+
+		widget.attachmentModel.updateContext(idsToDelete, entries);
+
+		return {};
 	}
 
 	private _handleSizeChanged(params: McpApps.McpUiSizeChangedNotification['params']): void {

--- a/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
+++ b/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
@@ -41,6 +41,7 @@ interface IBaseChatRequestVariableEntry {
 
 export interface IGenericChatRequestVariableEntry extends IBaseChatRequestVariableEntry {
 	kind: 'generic';
+	tooltip?: IMarkdownString;
 }
 
 export interface IChatRequestDirectoryEntry extends IBaseChatRequestVariableEntry {


### PR DESCRIPTION
Implements the ui/update-model-context MCP Apps protocol method to allow
MCP UIs to update the chat widget's model context with structured data and
content attachments. Each update replaces only the context added by that
specific MCP app instance, preserving user-added attachments.

- Maps MCP content blocks to chat attachments:
  - Images become image attachments
  - Resource links become file attachments using McpResourceURI
  - Text blocks become generic attachments with preview and tooltip
- Structured content becomes a single JSON attachment formatted nicely
- Uses hashed server ID prefix to track and replace only app-specific context
- Announces updateModelContext capability in host capabilities

Fixes https://github.com/microsoft/vscode/issues/289473

(Commit message generated by Copilot)