### PR TITLE
add setting for controlling terminal chat output expansion

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -433,6 +433,17 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.checkpoints.showFileChanges', "Controls whether to show chat checkpoint file changes."),
 			default: false
 		},
+		[ChatConfiguration.TerminalOutputExpansion]: {
+			type: 'string',
+			enum: ['onError', 'always', 'never'],
+			enumDescriptions: [
+				nls.localize('chat.terminalOutput.expansion.onError', "Expand terminal output when output is received and collapse on success (default)."),
+				nls.localize('chat.terminalOutput.expansion.always', "Always keep terminal output expanded."),
+				nls.localize('chat.terminalOutput.expansion.never', "Never auto-expand terminal output.")
+			],
+			default: 'onError',
+			markdownDescription: nls.localize('chat.terminalOutput.expansion', "Controls when terminal output is automatically expanded in chat responses. See also {0}.", '`#chat.agent.thinking.terminalTools#`'),
+		},
 		[mcpAccessConfig]: {
 			type: 'string',
 			description: nls.localize('chat.mcp.access', "Controls access to installed Model Context Protocol servers."),

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -28,6 +28,7 @@ export enum ChatConfiguration {
 	ThinkingStyle = 'chat.agent.thinkingStyle',
 	ThinkingGenerateTitles = 'chat.agent.thinking.generateTitles',
 	TerminalToolsInThinking = 'chat.agent.thinking.terminalTools',
+	TerminalOutputExpansion = 'chat.terminalOutput.expansion',
 	TodosShowWidget = 'chat.tools.todos.showWidget',
 	NotifyWindowOnResponseReceived = 'chat.notifyWindowOnResponseReceived',
 	ChatViewSessionsEnabled = 'chat.viewSessions.enabled',
@@ -38,6 +39,21 @@ export enum ChatConfiguration {
 	RestoreLastPanelSession = 'chat.restoreLastPanelSession',
 	ExitAfterDelegation = 'chat.exitAfterDelegation',
 	CommandCenterTriStateToggle = 'chat.commandCenter.triStateToggle',
+}
+
+export enum TerminalOutputExpansionMode {
+	/**
+	 * Auto-expand when command starts, collapse on success (default behavior).
+	 */
+	OnError = 'onError',
+	/**
+	 * Always keep terminal output expanded.
+	 */
+	Always = 'always',
+	/**
+	 * Never auto-expand terminal output.
+	 */
+	Never = 'never',
 }
 
 /**


### PR DESCRIPTION
fix #287588

New setting: `chat.terminalOutput.expansion` with 3 modes:

- `onError (default)` - Expands terminal output when command starts, collapses on success
- `always` - Always keeps terminal output expanded
- `never` - Never auto-expands terminal output