### PR TITLE
chat: handle internal model IDs and group-scoped cache

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -756,7 +756,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 			if ((selector.vendor === undefined || model.vendor === selector.vendor)
 				&& (selector.family === undefined || model.family === selector.family)
 				&& (selector.version === undefined || model.version === selector.version)
-				&& (selector.id === undefined || model.id === selector.id)) {
+				&& (selector.id === undefined || model.id === selector.id || internalModelIdentifier === selector.id)) {
 				result.push(internalModelIdentifier);
 			}
 		}

--- a/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/languageModels.test.ts
@@ -123,6 +123,42 @@ suite('LanguageModels', function () {
 		assert.deepStrictEqual(result1[0], 'test-id-1');
 	});
 
+	test('selector.id matches internal model identifier', async function () {
+
+		store.add(languageModels.registerLanguageModelProvider('actual-vendor', {
+			onDidChange: Event.None,
+			provideLanguageModelChatInfo: async () => {
+				const modelMetadata = [
+					{
+						extension: nullExtensionDescription.identifier,
+						name: 'Pretty Name',
+						vendor: 'actual-vendor',
+						family: 'actual-family',
+						version: 'actual-version',
+						modelPickerCategory: DEFAULT_MODEL_PICKER_CATEGORY,
+						id: 'actual-lm',
+						maxInputTokens: 100,
+						maxOutputTokens: 100,
+						isDefaultForLocation: {}
+					} satisfies ILanguageModelChatMetadata
+				];
+				return modelMetadata.map(m => ({
+					metadata: m,
+					identifier: `${m.vendor}/Azure/${m.id}`,
+				}));
+			},
+			sendChatRequest: async () => {
+				throw new Error();
+			},
+			provideTokenCount: async () => {
+				throw new Error();
+			}
+		}));
+
+		const result = await languageModels.selectLanguageModels({ id: 'actual-vendor/Azure/actual-lm' });
+		assert.deepStrictEqual(result, ['actual-vendor/Azure/actual-lm']);
+	});
+
 	test('no warning that a matching model was not found #213716', async function () {
 		const result1 = await languageModels.selectLanguageModels({ vendor: 'test-vendor' });
 		assert.deepStrictEqual(result1.length, 2);


### PR DESCRIPTION
Fixes chat language model selection and caching for grouped providers.

- Allow `selector.id` to match the full internal model identifier (e.g. `vendor/group/id`).
- Avoid vendor-wide cache eviction in the extension host when resolving models; only evict stale entries for the specific `(vendor, group)` being refreshed (prevents grouped models being cleared by empty ungrouped resolves).
- Add test coverage for `selector.id` matching the internal identifier.

Fixes #289529.