### PR TITLE
Support reading files outside of the workspace

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -398,7 +398,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
 				prepareTimeWatch.stop();
 
-				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters);
+				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, dto.context?.sessionResource);
 
 
 				// Important: a tool invocation that will be autoconfirmed should never
@@ -445,7 +445,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				prepareTimeWatch = StopWatch.create(true);
 				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
 				prepareTimeWatch.stop();
-				if (preparedInvocation?.confirmationMessages?.title && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters))) {
+				if (preparedInvocation?.confirmationMessages?.title && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, undefined))) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
 						throw new CancellationError();
@@ -468,7 +468,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			this.ensureToolDetails(dto, toolResult, tool.data);
 
 			if (toolInvocation?.didExecuteTool(toolResult).type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
-				const autoConfirmedPost = await this.shouldAutoConfirmPostExecution(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters);
+				const autoConfirmedPost = await this.shouldAutoConfirmPostExecution(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, dto.context?.sessionResource);
 				if (autoConfirmedPost) {
 					IChatToolInvocation.confirmWith(toolInvocation, autoConfirmedPost);
 				}
@@ -757,7 +757,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return true;
 	}
 
-	private async shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown): Promise<ConfirmedReason | undefined> {
+	private async shouldAutoConfirm(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown, chatSessionResource: URI | undefined): Promise<ConfirmedReason | undefined> {
 		const tool = this._tools.get(toolId);
 		if (!tool) {
 			return undefined;
@@ -767,7 +767,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			return undefined;
 		}
 
-		const reason = this._confirmationService.getPreConfirmAction({ toolId, source, parameters });
+		const reason = this._confirmationService.getPreConfirmAction({ toolId, source, parameters, chatSessionResource });
 		if (reason) {
 			return reason;
 		}
@@ -794,12 +794,12 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		return undefined;
 	}
 
-	private async shouldAutoConfirmPostExecution(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown): Promise<ConfirmedReason | undefined> {
+	private async shouldAutoConfirmPostExecution(toolId: string, runsInWorkspace: boolean | undefined, source: ToolDataSource, parameters: unknown, chatSessionResource: URI | undefined): Promise<ConfirmedReason | undefined> {
 		if (this._configurationService.getValue<boolean>(ChatConfiguration.GlobalAutoApprove) && await this._checkGlobalAutoApprove()) {
 			return { type: ToolConfirmKind.Setting, id: ChatConfiguration.GlobalAutoApprove };
 		}
 
-		return this._confirmationService.getPostConfirmAction({ toolId, source, parameters });
+		return this._confirmationService.getPostConfirmAction({ toolId, source, parameters, chatSessionResource });
 	}
 
 	private async _checkGlobalAutoApprove(): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -93,7 +93,8 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 			const confirmActions = this.confirmationService.getPreConfirmActions({
 				toolId: this.toolInvocation.toolId,
 				source: this.toolInvocation.source,
-				parameters: state.parameters
+				parameters: state.parameters,
+				chatSessionResource: this.context.element.sessionResource
 			});
 
 			for (const action of confirmActions) {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/chatExternalPathConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/chatExternalPathConfirmation.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { dirname } from '../../../../../../base/common/path.js';
+import { extUriBiasedIgnorePathCase } from '../../../../../../base/common/resources.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { localize } from '../../../../../../nls.js';
+import { ConfirmedReason, ToolConfirmKind } from '../../chatService/chatService.js';
+import {
+	ILanguageModelToolConfirmationActions,
+	ILanguageModelToolConfirmationContribution,
+	ILanguageModelToolConfirmationRef
+} from '../languageModelToolsConfirmationService.js';
+
+export interface IExternalPathInfo {
+	path: string;
+	isDirectory: boolean;
+}
+
+/**
+ * Confirmation contribution for read_file and list_dir tools that allows users to approve
+ * accessing paths outside the workspace, with an option to allow all access
+ * from a containing folder for the current chat session.
+ */
+export class ChatExternalPathConfirmationContribution implements ILanguageModelToolConfirmationContribution {
+	readonly canUseDefaultApprovals = false;
+
+	// Map<sessionResourceString, Set<folderUriString>>
+	private readonly _sessionFolderAllowlist = new Map<string, Set<string>>();
+
+	constructor(
+		private readonly _getPathInfo: (ref: ILanguageModelToolConfirmationRef) => IExternalPathInfo | undefined,
+	) { }
+
+	getPreConfirmAction(ref: ILanguageModelToolConfirmationRef): ConfirmedReason | undefined {
+		const pathInfo = this._getPathInfo(ref);
+		if (!pathInfo || !ref.chatSessionResource) {
+			return undefined;
+		}
+
+		const sessionKey = ref.chatSessionResource.toString();
+		const allowedFolders = this._sessionFolderAllowlist.get(sessionKey);
+		if (!allowedFolders || allowedFolders.size === 0) {
+			return undefined;
+		}
+
+		// Parse the file path to a URI
+		let pathUri: URI;
+		try {
+			pathUri = URI.file(pathInfo.path);
+		} catch {
+			return undefined;
+		}
+
+		// Check if path is under any allowed folder
+		for (const folderUriStr of allowedFolders) {
+			const folderUri = URI.parse(folderUriStr);
+			if (extUriBiasedIgnorePathCase.isEqualOrParent(pathUri, folderUri)) {
+				return { type: ToolConfirmKind.UserAction };
+			}
+		}
+
+		return undefined;
+	}
+
+	getPreConfirmActions(ref: ILanguageModelToolConfirmationRef): ILanguageModelToolConfirmationActions[] {
+		const pathInfo = this._getPathInfo(ref);
+		if (!pathInfo || !ref.chatSessionResource) {
+			return [];
+		}
+
+		// Parse the path to a URI
+		let pathUri: URI;
+		try {
+			pathUri = URI.file(pathInfo.path);
+		} catch {
+			return [];
+		}
+
+		// For directories, use the path itself; for files, use the parent directory
+		const folderUri = pathInfo.isDirectory ? pathUri : pathUri.with({ path: dirname(pathUri.path) });
+		const sessionKey = ref.chatSessionResource.toString();
+
+		return [
+			{
+				label: localize('allowFolderSession', 'Allow this folder in this session'),
+				detail: localize('allowFolderSessionDetail', 'Allow reading files from this folder without further confirmation in this chat session'),
+				select: async () => {
+					let folders = this._sessionFolderAllowlist.get(sessionKey);
+					if (!folders) {
+						folders = new Set();
+						this._sessionFolderAllowlist.set(sessionKey, folders);
+					}
+					folders.add(folderUri.toString());
+					return true;
+				}
+			}
+		];
+	}
+
+	/**
+	 * Clear the folder allowlist for a specific chat session.
+	 * Should be called when a chat session is disposed.
+	 */
+	clearSession(sessionResource: URI): void {
+		this._sessionFolderAllowlist.delete(sessionResource.toString());
+	}
+
+	reset(): void {
+		this._sessionFolderAllowlist.clear();
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/chatExternalPathConfirmation.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/chatExternalPathConfirmation.ts
@@ -96,16 +96,4 @@ export class ChatExternalPathConfirmationContribution implements ILanguageModelT
 			}
 		];
 	}
-
-	/**
-	 * Clear the folder allowlist for a specific chat session.
-	 * Should be called when a chat session is disposed.
-	 */
-	clearSession(sessionResource: URI): void {
-		this._sessionFolderAllowlist.delete(sessionResource);
-	}
-
-	reset(): void {
-		this._sessionFolderAllowlist.clear();
-	}
 }

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsConfirmationService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsConfirmationService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IQuickInputButton, IQuickTreeItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ConfirmedReason } from '../chatService/chatService.js';
@@ -24,6 +25,7 @@ export interface ILanguageModelToolConfirmationRef {
 	toolId: string;
 	source: ToolDataSource;
 	parameters: unknown;
+	chatSessionResource?: URI;
 }
 
 export interface ILanguageModelToolConfirmationActionProducer {

--- a/src/vs/workbench/contrib/chat/electron-browser/builtInTools/tools.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/builtInTools/tools.ts
@@ -6,6 +6,7 @@
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { ChatExternalPathConfirmationContribution } from '../../common/tools/builtinTools/chatExternalPathConfirmation.js';
 import { ChatUrlFetchingConfirmationContribution } from '../../common/tools/builtinTools/chatUrlFetchingConfirmation.js';
 import { ILanguageModelToolsConfirmationService } from '../../common/tools/languageModelToolsConfirmationService.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
@@ -32,6 +33,32 @@ export class NativeBuiltinToolsContribution extends Disposable implements IWorkb
 				ChatUrlFetchingConfirmationContribution,
 				params => (params as IFetchWebPageToolParams).urls
 			)
+		));
+
+		// Register external path confirmation contribution for read_file and list_dir
+		// They share the same allowlist so approving a folder for reading files also allows listing that directory
+		const externalPathConfirmation = new ChatExternalPathConfirmationContribution(
+			(ref) => {
+				const params = ref.parameters as { filePath?: string; path?: string };
+				// read_file uses filePath (it's a file), list_dir uses path (it's a directory)
+				if (params?.filePath) {
+					return { path: params.filePath, isDirectory: false };
+				}
+				if (params?.path) {
+					return { path: params.path, isDirectory: true };
+				}
+				return undefined;
+			}
+		);
+
+		this._register(confirmationService.registerConfirmationContribution(
+			'copilot_readFile',
+			externalPathConfirmation
+		));
+
+		this._register(confirmationService.registerConfirmationContribution(
+			'copilot_listDirectory',
+			externalPathConfirmation
 		));
 	}
 }


### PR DESCRIPTION
Introduce functionality to allow users to read files and list directories outside the workspace. This includes a confirmation contribution that enables users to approve access to external paths, with an option to allow all access from a containing folder for the current chat session. The implementation includes necessary updates to handle chat session resources.

