### PR TITLE
feat: Add handoff category grouping and model-based filtering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -218,6 +218,12 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			tags: ['experimental'],
 		},
+		[ChatConfiguration.FastImplementModel]: {
+			type: 'string',
+			markdownDescription: nls.localize('chat.fastImplementModel', "The model to use for fast implementation handoffs. The value can be the model's qualified name (e.g., `{0}`) or the model name for Copilot models (e.g., `{1}`). If not set, handoffs using `${{github.copilot.chat.fastImplement}}` will be hidden.", 'GPT-4o (copilot)', 'GPT-4o'),
+			default: '',
+			tags: ['experimental'],
+		},
 		'chat.implicitContext.enabled': {
 			type: 'object',
 			description: nls.localize('chat.implicitContext.enabled.1', "Enables automatically using the active editor as chat context for specified chat locations."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -220,7 +220,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.FastImplementModel]: {
 			type: 'string',
-			markdownDescription: nls.localize('chat.fastImplementModel', "The model to use for fast implementation handoffs. The value can be the model's qualified name (e.g., `{0}`) or the model name for Copilot models (e.g., `{1}`). If not set, handoffs using `${{github.copilot.chat.fastImplement}}` will be hidden.", 'GPT-4o (copilot)', 'GPT-4o'),
+			markdownDescription: nls.localize('chat.fastImplementModel', "The model to use for fast implementation handoffs. The value can be the model's qualified name (e.g., `{0}`) or the model name for Copilot models (e.g., `{1}`). If not set, handoffs using `${github.copilot.chat.fastImplement}` will be hidden.", 'GPT-4o (copilot)', 'GPT-4o'),
 			default: '',
 			tags: ['experimental'],
 		},

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1171,7 +1171,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (shouldShow) {
 			// Log telemetry only when widget transitions from hidden to visible
 			const wasHidden = this.chatSuggestNextWidget.domNode.style.display === 'none';
-			this.chatSuggestNextWidget.render(currentMode);
+			this.chatSuggestNextWidget.render(currentMode, (model) => this.input.canSwitchToModel(model));
 
 			if (wasHidden) {
 				this.telemetryService.publicLog2<ChatHandoffWidgetShownEvent, ChatHandoffWidgetShownClassification>('chat.handoffWidgetShown', {
@@ -1216,6 +1216,16 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		} else if (handoff.agent) {
 			// Regular handoff to specified agent
 			this._switchToAgentByName(handoff.agent);
+
+			// Switch to the specified model if provided
+			if (handoff.model) {
+				// Resolve template references (e.g., ${github.copilot.chat.fastImplement})
+				const resolvedModel = this.chatSuggestNextWidget.resolveModelReference(handoff.model);
+				if (resolvedModel) {
+					this.input.switchModelByQualifiedName(resolvedModel);
+				}
+			}
+
 			// Insert the handoff prompt into the input
 			this.input.setValue(promptToUse, false);
 			this.input.focus();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -697,14 +697,29 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 	}
 
-	public switchModelByQualifiedName(qualifiedModelName: string): boolean {
-		const models = this.getModels();
-		const model = models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedModelName, m.metadata));
+	/**
+	 * Check if a model can be switched to by qualified name without actually switching.
+	 */
+	public canSwitchToModel(qualifiedName: string): boolean {
+		return this.findModelByQualifiedName(qualifiedName) !== undefined;
+	}
+
+	public switchModelByQualifiedName(qualifiedName: string): boolean {
+		const model = this.findModelByQualifiedName(qualifiedName);
 		if (model) {
 			this.setCurrentLanguageModel(model);
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Find a model by qualified name (e.g., "GPT-4o (copilot)").
+	 * Returns undefined if no matching model is found in the available models.
+	 */
+	private findModelByQualifiedName(qualifiedName: string): ILanguageModelChatMetadataAndIdentifier | undefined {
+		const models = this.getModels();
+		return models.find(m => ILanguageModelChatMetadata.matchesQualifiedName(qualifiedName, m.metadata));
 	}
 
 	public switchToNextModel(): void {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -12,6 +12,7 @@ export enum ChatConfiguration {
 	AgentEnabled = 'chat.agent.enabled',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',
+	FastImplementModel = 'github.copilot.chat.fastImplement',
 	AgentSessionProjectionEnabled = 'chat.agentSessionProjection.enabled',
 	EditModeHidden = 'chat.editMode.hidden',
 	Edits2Enabled = 'chat.edits2.enabled',

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSuggestNextWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSuggestNextWidget.test.ts
@@ -1,0 +1,358 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Codicon } from '../../../../../../../base/common/codicons.js';
+import { Emitter } from '../../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { constObservable } from '../../../../../../../base/common/observable.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../../../../../platform/contextkey/browser/contextKeyService.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatSuggestNextWidget } from '../../../../browser/widget/chatContentParts/chatSuggestNextWidget.js';
+import { IChatMode } from '../../../../common/chatModes.js';
+import { IChatSessionsService, IChatSessionsExtensionPoint } from '../../../../common/chatSessionsService.js';
+import { ChatModeKind, ChatConfiguration } from '../../../../common/constants.js';
+import { ILanguageModelsService, ILanguageModelChatMetadata } from '../../../../common/languageModels.js';
+import { IHandOff } from '../../../../common/promptSyntax/promptFileParser.js';
+import { PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
+
+suite('ChatSuggestNextWidget', () => {
+
+	let store: DisposableStore;
+	let widget: ChatSuggestNextWidget;
+	let mockLanguageModelsService: MockLanguageModelsService;
+	let testConfigurationService: TestConfigurationService;
+
+	class MockLanguageModelsService {
+		private models = new Map<string, ILanguageModelChatMetadata>();
+
+		registerModel(id: string, metadata: Partial<ILanguageModelChatMetadata>): void {
+			this.models.set(id, {
+				id,
+				vendor: 'test',
+				name: metadata.name ?? id,
+				family: 'test',
+				version: '1.0',
+				isUserSelectable: metadata.isUserSelectable ?? true,
+				isDefaultForLocation: {},
+				...metadata,
+			} as ILanguageModelChatMetadata);
+		}
+
+		clearModels(): void {
+			this.models.clear();
+		}
+
+		lookupLanguageModel(id: string): ILanguageModelChatMetadata | undefined {
+			return this.models.get(id);
+		}
+
+		getLanguageModelIds(): string[] {
+			return Array.from(this.models.keys());
+		}
+	}
+
+	class MockChatSessionsService implements Partial<IChatSessionsService> {
+		private readonly _onDidChangeChatSessions = new Emitter<void>();
+		readonly onDidChangeChatSessions = this._onDidChangeChatSessions.event;
+
+		getAllChatSessionContributions(): IChatSessionsExtensionPoint[] {
+			return [];
+		}
+	}
+
+	function createMockMode(handoffs: IHandOff[]): IChatMode {
+		return {
+			id: 'test-mode',
+			kind: ChatModeKind.Agent,
+			label: constObservable('Test Mode'),
+			name: constObservable('Test Mode'),
+			icon: constObservable(Codicon.commentDiscussion),
+			description: constObservable(''),
+			isBuiltin: false,
+			handOffs: constObservable(handoffs),
+			source: { storage: PromptsStorage.local },
+		};
+	}
+
+	setup(() => {
+		store = new DisposableStore();
+
+		mockLanguageModelsService = new MockLanguageModelsService();
+		const mockChatSessionsService = new MockChatSessionsService();
+		testConfigurationService = new TestConfigurationService();
+
+		const instaService = workbenchInstantiationService({
+			contextKeyService: () => store.add(new ContextKeyService(testConfigurationService)),
+		}, store);
+
+		instaService.stub(ILanguageModelsService, mockLanguageModelsService);
+		instaService.stub(IChatSessionsService, mockChatSessionsService);
+		instaService.stub(IConfigurationService, testConfigurationService);
+
+		store.add(instaService);
+		widget = store.add(instaService.createInstance(ChatSuggestNextWidget));
+	});
+
+	teardown(() => {
+		store.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('Model filtering', () => {
+
+		test('shows handoff when model is not specified', () => {
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt' }
+			];
+			const mode = createMockMode(handoffs);
+
+			widget.render(mode);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+			assert.strictEqual(widget.getCurrentMode(), mode, 'Mode should be set');
+		});
+
+		test('shows handoff when model exists and isModelAvailable returns true', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'gpt-4' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// isModelAvailable callback returns true (simulates modelSupportedForDefaultAgent = yes)
+			widget.render(mode, () => true);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+		});
+
+		test('hides handoff when isModelAvailable returns false (modelSupportedForDefaultAgent = no)', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'gpt-4' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// isModelAvailable callback returns false (simulates modelSupportedForDefaultAgent = no)
+			widget.render(mode, () => false);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when model not supported');
+		});
+
+		test('hides handoff when model does not exist (fallback check)', () => {
+			// Don't register any models
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test Handoff', prompt: 'Test prompt', model: 'non-existent-model' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// No isModelAvailable callback - falls back to lookupLanguageModel check
+			widget.render(mode);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when model not found');
+		});
+
+		test('shows some handoffs while filtering others based on model availability', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+			mockLanguageModelsService.registerModel('gpt-3.5', { name: 'GPT-3.5', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Use GPT-4', prompt: 'With GPT-4', model: 'gpt-4' },
+				{ agent: 'Default', label: 'Use GPT-3.5', prompt: 'With GPT-3.5', model: 'gpt-3.5' },
+				{ agent: 'Default', label: 'No Model', prompt: 'No model specified' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// Track which models were checked by the callback
+			const checkedModels: string[] = [];
+			widget.render(mode, (model) => {
+				checkedModels.push(model);
+				// Only allow gpt-4, not gpt-3.5 (simulates modelSupportedForDefaultAgent being selective)
+				return model === 'gpt-4';
+			});
+
+			// Widget should be visible because at least one handoff (gpt-4 and no-model) passed the filter
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+			// Verify the callback was called for both handoffs with models
+			assert.deepStrictEqual(checkedModels.sort(), ['gpt-3.5', 'gpt-4'], 'Callback should be called for handoffs with models');
+		});
+
+		test('hides entire widget when all handoffs are filtered out', () => {
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Use GPT-4', prompt: 'With GPT-4', model: 'gpt-4' },
+				{ agent: 'Default', label: 'Use GPT-3.5', prompt: 'With GPT-3.5', model: 'gpt-3.5' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// Reject all models
+			widget.render(mode, () => false);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when all handoffs filtered');
+		});
+
+		test('uses fallback lookup by model name when isModelAvailable not provided', () => {
+			mockLanguageModelsService.registerModel('model-id-123', { name: 'GPT-4' });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test', model: 'model-id-123' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// No callback - uses basic existence check via lookupLanguageModel
+			widget.render(mode);
+
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible when model exists');
+		});
+	});
+
+	suite('isModelAvailable callback scenarios', () => {
+
+		test('callback receives correct model string', () => {
+			mockLanguageModelsService.registerModel('my-model', { name: 'My Model' });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test', model: 'my-model' }
+			];
+			const mode = createMockMode(handoffs);
+
+			let receivedModel: string | undefined;
+			widget.render(mode, (model) => {
+				receivedModel = model;
+				return true;
+			});
+
+			assert.strictEqual(receivedModel, 'my-model', 'Callback should receive the model string from handoff');
+		});
+
+		test('callback not called for handoffs without model', () => {
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Test', prompt: 'Test' }
+			];
+			const mode = createMockMode(handoffs);
+
+			let callbackCalled = false;
+			widget.render(mode, () => {
+				callbackCalled = true;
+				return true;
+			});
+
+			assert.strictEqual(callbackCalled, false, 'Callback should not be called for handoffs without model');
+		});
+	});
+
+	suite('Setting template syntax resolution', () => {
+
+		test('resolves ${github.copilot.chat.fastImplement} to setting value', async () => {
+			// Set the fastImplementModel setting to a specific model
+			await testConfigurationService.setUserConfiguration(ChatConfiguration.FastImplementModel, 'gpt-4-turbo');
+			mockLanguageModelsService.registerModel('gpt-4-turbo', { name: 'GPT-4 Turbo', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Fast Implement', prompt: 'Implement quickly', model: '${github.copilot.chat.fastImplement}' }
+			];
+			const mode = createMockMode(handoffs);
+
+			// isModelAvailable callback checks for the resolved model
+			let receivedModel: string | undefined;
+			widget.render(mode, (model) => {
+				receivedModel = model;
+				return true;
+			});
+
+			assert.strictEqual(receivedModel, 'gpt-4-turbo', 'Template should resolve to setting value');
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+		});
+
+		test('hides handoff when ${github.copilot.chat.fastImplement} setting is empty', async () => {
+			// Setting is empty/unset - should hide the handoff
+			await testConfigurationService.setUserConfiguration(ChatConfiguration.FastImplementModel, '');
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Fast Implement', prompt: 'Implement quickly', model: '${github.copilot.chat.fastImplement}' }
+			];
+			const mode = createMockMode(handoffs);
+
+			widget.render(mode, () => true);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when setting is empty');
+		});
+
+		test('hides handoff when ${github.copilot.chat.fastImplement} setting is not set', () => {
+			// Setting is not set at all (undefined) - should hide the handoff
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Fast Implement', prompt: 'Implement quickly', model: '${github.copilot.chat.fastImplement}' }
+			];
+			const mode = createMockMode(handoffs);
+
+			widget.render(mode, () => true);
+
+			assert.strictEqual(widget.domNode.style.display, 'none', 'Widget should be hidden when setting is not set');
+		});
+
+		test('resolveModelReference returns undefined for empty setting', async () => {
+			await testConfigurationService.setUserConfiguration(ChatConfiguration.FastImplementModel, '');
+
+			const result = widget.resolveModelReference('${github.copilot.chat.fastImplement}');
+			assert.strictEqual(result, undefined, 'Should return undefined for empty setting');
+		});
+
+		test('resolveModelReference returns literal value for non-template model', () => {
+			const result = widget.resolveModelReference('gpt-4');
+			assert.strictEqual(result, 'gpt-4', 'Should return literal model string unchanged');
+		});
+
+		test('resolveModelReference returns undefined for unknown template', () => {
+			const result = widget.resolveModelReference('${unknown.setting}');
+			assert.strictEqual(result, undefined, 'Should return undefined for unknown setting template');
+		});
+
+		test('shows some handoffs while hiding template handoffs with empty setting', async () => {
+			// fastImplementModel setting is empty
+			await testConfigurationService.setUserConfiguration(ChatConfiguration.FastImplementModel, '');
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Fast Implement', prompt: 'Fast', model: '${github.copilot.chat.fastImplement}' },
+				{ agent: 'Default', label: 'Regular GPT-4', prompt: 'With GPT-4', model: 'gpt-4' },
+				{ agent: 'Default', label: 'No Model', prompt: 'No model specified' }
+			];
+			const mode = createMockMode(handoffs);
+
+			widget.render(mode, () => true);
+
+			// Widget should be visible because gpt-4 and no-model handoffs passed
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+		});
+
+		test('template syntax works with category grouping', async () => {
+			await testConfigurationService.setUserConfiguration(ChatConfiguration.FastImplementModel, 'gpt-4');
+			mockLanguageModelsService.registerModel('gpt-4', { name: 'GPT-4', isUserSelectable: true });
+
+			const handoffs: IHandOff[] = [
+				{ agent: 'Default', label: 'Fast Implement', prompt: 'Fast', model: '${github.copilot.chat.fastImplement}', category: 'implement' },
+				{ agent: 'Default', label: 'Regular Implement', prompt: 'Regular', category: 'implement' }
+			];
+			const mode = createMockMode(handoffs);
+
+			let receivedModel: string | undefined;
+			widget.render(mode, (model) => {
+				receivedModel = model;
+				return true;
+			});
+
+			assert.strictEqual(receivedModel, 'gpt-4', 'Template should resolve even with category');
+			assert.notStrictEqual(widget.domNode.style.display, 'none', 'Widget should be visible');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
@@ -228,6 +228,70 @@ suite('NewPromptsParser', () => {
 		assert.deepEqual(result.header.handOffs[0].model, undefined);
 	});
 
+	test('mode with handoff and category parameter', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Option A"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Do A"',
+			/* 07 */'    category: "myCategory"',
+			/* 08 */'  - label: "Option B"',
+			/* 09 */'    agent: Default',
+			/* 10 */'    prompt: "Do B"',
+			/* 11 */'    category: "myCategory"',
+			/* 12 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs, [
+			{ label: 'Option A', agent: 'Default', prompt: 'Do A', category: 'myCategory' },
+			{ label: 'Option B', agent: 'Default', prompt: 'Do B', category: 'myCategory' }
+		]);
+	});
+
+	test('category defaults to undefined when not specified', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs[0].category, undefined);
+	});
+
+	test('ignores category when value is not a string', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'    category: 123',
+			/* 08 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		// category should be undefined because 123 is a number, not a string
+		assert.deepEqual(result.header.handOffs[0].category, undefined);
+	});
+
 	test('instructions', async () => {
 		const uri = URI.parse('file:///test/prompt1.md');
 		const content = [

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/newPromptsParser.test.ts
@@ -165,6 +165,69 @@ suite('NewPromptsParser', () => {
 		assert.deepEqual(result.header.handOffs[0].showContinueOn, undefined);
 	});
 
+	test('mode with handoff and model parameter', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Implement with GPT-4"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Implement the plan"',
+			/* 07 */'    model: "gpt-4"',
+			/* 08 */'  - label: "Save"',
+			/* 09 */'    agent: Default',
+			/* 10 */'    prompt: "Save the plan"',
+			/* 11 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs, [
+			{ label: 'Implement with GPT-4', agent: 'Default', prompt: 'Implement the plan', model: 'gpt-4' },
+			{ label: 'Save', agent: 'Default', prompt: 'Save the plan' }
+		]);
+	});
+
+	test('model defaults to undefined when not specified per handoff', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		assert.deepEqual(result.header.handOffs[0].model, undefined);
+	});
+
+	test('ignores model when value is not a string', async () => {
+		const uri = URI.parse('file:///test/test.agent.md');
+		const content = [
+			/* 01 */'---',
+			/* 02 */`description: "Agent test"`,
+			/* 03 */'handoffs:',
+			/* 04 */'  - label: "Save"',
+			/* 05 */'    agent: Default',
+			/* 06 */'    prompt: "Save the plan"',
+			/* 07 */'    model: true',
+			/* 08 */'---',
+		].join('\n');
+		const result = new PromptFileParser().parse(uri, content);
+		assert.deepEqual(result.uri, uri);
+		assert.ok(result.header);
+		assert.ok(result.header.handOffs);
+		// model should be undefined because 'true' is a boolean, not a string
+		assert.deepEqual(result.header.handOffs[0].model, undefined);
+	});
+
 	test('instructions', async () => {
 		const uri = URI.parse('file:///test/prompt1.md');
 		const content = [


### PR DESCRIPTION
## Handoff Model Filtering and Category Grouping

This PR adds two new fields to handoff definitions in agent mode YAML frontmatter:

**`model`** - When specified, the handoff button only appears if that model is available and supported. This enables conditional handoffs that depend on specific model capabilities.

The model field supports a template syntax `${settingKey}` to reference VS Code settings. Currently supports `${github.copilot.chat.fastImplement}` which resolves to the new setting introduced below.

**`category`** - Groups multiple handoffs under a single button. Handoffs sharing the same category value render as one button with a dropdown containing the alternatives. Within a category, handoffs with available models are prioritized as the main button.

### New Setting

`github.copilot.chat.fastImplement` - Specifies a model (by qualified name like `GPT-4o (copilot)`) for fast implementation handoffs. When empty, handoffs referencing this setting via `${github.copilot.chat.fastImplement}` are hidden.

### Example Usage

```yaml
handoffs:
  - label: Start Implementation
    agent: agent
    category: implementHandoff
    prompt: Start implementation
    showContinueOn: true
  - label: Open in Editor
    agent: agent
    prompt: "#createFile the plan as is into an untitled file (`untitled:plan-${camelCaseName}.prompt.md` without frontmatter) for further refinement."
    category: savePromptHandoff
    showContinueOn: false
    send: true
  - label: Start Fast Implementation
    model: ${github.copilot.chat.fastImplement}
    agent: agent
    prompt: Start implementation
    send: true
    category: implementHandoff
    showContinueOn: true
```

If the fast implement model is configured and available, "Start Fast Implementation" becomes the main button with "Start Implementation" in the dropdown. Otherwise, only "Start Implementation" appears. 
<img width="1643" height="902" alt="Screenshot 2026-01-21 at 10 18 48 PM" src="https://github.com/user-attachments/assets/deb19536-f84d-475a-8545-f13369eb2ed9" />

additional example of how the "category" concept could be used
<img width="607" height="893" alt="Screenshot 2026-01-21 at 10 17 54 PM" src="https://github.com/user-attachments/assets/213c519d-aa1f-4956-9069-834db191b235" />
