### PR TITLE
Update theme colors and enhance widget styles

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -4,7 +4,7 @@
 	"type": "dark",
 	"colors": {
 		"foreground": "#bfbfbf",
-		"disabledForeground": "#444444",
+		"disabledForeground": "#666666",
 		"errorForeground": "#f48771",
 		"descriptionForeground": "#888888",
 		"icon.foreground": "#888888",
@@ -131,7 +131,7 @@
 		"editorCodeLens.foreground": "#888888",
 		"editorBracketMatch.background": "#3994BC55",
 		"editorBracketMatch.border": "#2A2B2CFF",
-		"editorWidget.background": "#202122",
+		"editorWidget.background": "#20212266",
 		"editorWidget.border": "#2A2B2CFF",
 		"editorWidget.foreground": "#bfbfbf",
 		"editorSuggestWidget.background": "#202122",

--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -131,7 +131,7 @@
 		"editorCodeLens.foreground": "#666666",
 		"editorBracketMatch.background": "#1A5CFF55",
 		"editorBracketMatch.border": "#ECEDEEFF",
-		"editorWidget.background": "#FFFFFF",
+		"editorWidget.background": "#FFFFFF33",
 		"editorWidget.border": "#ECEDEEFF",
 		"editorWidget.foreground": "#202020",
 		"editorSuggestWidget.background": "#FFFFFF",

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -156,7 +156,11 @@
 .monaco-workbench.vs .monaco-editor .suggest-widget { background: rgba(252, 252, 253, 0.85) !important; }
 
 /* Find Widget */
-.monaco-workbench .monaco-editor .find-widget { box-shadow: 0 0 8px rgba(0, 0, 0, 0.12); border: none; border-radius: 8px; }
+.monaco-workbench .monaco-editor .find-widget {
+	box-shadow: 0 0 8px rgba(0, 0, 0, 0.12); border: none; border-radius: 8px;
+	backdrop-filter: blur(20px) saturate(180%); -webkit-backdrop-filter: blur(20px) saturate(180%);
+	top: 4px !important;
+}
 
 /* Dialog */
 .monaco-workbench .monaco-dialog-box { box-shadow: 0 0 20px rgba(0, 0, 0, 0.18); border: none; border-radius: 12px; overflow: hidden; }


### PR DESCRIPTION
Adjust the disabled foreground color and improve the background opacity of editor widgets in themes for better visibility and aesthetics. Additionally, enhance the find widget with a backdrop filter for improved clarity.

