### PR TITLE
lineHeights : removing code with unknown origin

### DIFF
--- a/src/vs/editor/common/viewLayout/lineHeights.ts
+++ b/src/vs/editor/common/viewLayout/lineHeights.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { binarySearch2 } from '../../../base/common/arrays.js';
-import { intersection } from '../../../base/common/collections.js';
 
 export class CustomLine {
 
@@ -243,45 +242,9 @@ export class LineHeightsManager {
 		} else {
 			startIndexOfInsertion = -(candidateStartIndexOfInsertion + 1);
 		}
-		const toReAdd: ICustomLineHeightData[] = [];
-		const decorationsImmediatelyAfter = new Set<string>();
-		for (let i = startIndexOfInsertion; i < this._orderedCustomLines.length; i++) {
-			if (this._orderedCustomLines[i].lineNumber === fromLineNumber) {
-				decorationsImmediatelyAfter.add(this._orderedCustomLines[i].decorationId);
-			}
-		}
-		const decorationsImmediatelyBefore = new Set<string>();
-		for (let i = startIndexOfInsertion - 1; i >= 0; i--) {
-			if (this._orderedCustomLines[i].lineNumber === fromLineNumber - 1) {
-				decorationsImmediatelyBefore.add(this._orderedCustomLines[i].decorationId);
-			}
-		}
-		const decorationsWithGaps = intersection(decorationsImmediatelyBefore, decorationsImmediatelyAfter);
 		for (let i = startIndexOfInsertion; i < this._orderedCustomLines.length; i++) {
 			this._orderedCustomLines[i].lineNumber += insertCount;
 			this._orderedCustomLines[i].prefixSum += this._defaultLineHeight * insertCount;
-		}
-
-		if (decorationsWithGaps.size > 0) {
-			for (const decorationId of decorationsWithGaps) {
-				const decoration = this._decorationIDToCustomLine.get(decorationId);
-				if (decoration) {
-					const startLineNumber = decoration.reduce((min, l) => Math.min(min, l.lineNumber), fromLineNumber); // min
-					const endLineNumber = decoration.reduce((max, l) => Math.max(max, l.lineNumber), fromLineNumber); // max
-					const lineHeight = decoration.reduce((max, l) => Math.max(max, l.specialHeight), 0);
-					toReAdd.push({
-						decorationId,
-						startLineNumber,
-						endLineNumber,
-						lineHeight
-					});
-				}
-			}
-
-			for (const dec of toReAdd) {
-				this.insertOrChangeCustomLineHeight(dec.decorationId, dec.startLineNumber, dec.endLineNumber, dec.lineHeight);
-			}
-			this.commit();
 		}
 	}
 


### PR DESCRIPTION
I am not able to recall where the code removed here comes from. I'd like to avoid code that does not serve a purpose and entirely understand the whole codebase as related to the line heights manager. As such I'd like to remove this code, and readd it when issues arise and when I understand why this code was added.