### PR TITLE
Remove box-shadow and background styles from breadcrumbs control in editor

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -182,7 +182,6 @@
 .monaco-workbench .extensions-list .extension-list-item:hover { box-shadow: 0 0 6px rgba(0, 0, 0, 0.10); }
 
 /* Breadcrumbs */
-.monaco-workbench .part.editor > .content .editor-group-container > .title .breadcrumbs-control { box-shadow: 0 0 6px rgba(0, 0, 0, 0.08) !important; background: rgba(252, 252, 253, 0.65) !important; backdrop-filter: blur(40px) saturate(180%) !important; -webkit-backdrop-filter: blur(40px) saturate(180%) !important; }
 .monaco-workbench.vs-dark .part.editor > .content .editor-group-container > .title .breadcrumbs-control,
 
 /* Input Boxes */


### PR DESCRIPTION
Eliminate unnecessary box-shadow and background styles from the breadcrumbs control in the editor for a cleaner appearance. This change enhances the visual consistency of the editor interface.

