### PR TITLE
Enforce font size and color for unified send button icon

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
@@ -77,7 +77,8 @@
 }
 
 .unified-send-button .codicon {
-	font-size: 14px;
+	font-size: 14px !important;
+	color: var(--vscode-button-foreground) !important;
 }
 
 .unified-send-label {


### PR DESCRIPTION
Ensure consistent styling for the unified send button icon by enforcing the font size and color through CSS. This change improves the visual appearance and alignment with the overall theme.

