### PR TITLE
alert on collapse/expand of tree for macOS

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3242,6 +3242,14 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		this.onDidChangeCollapseStateRelay.input = model.onDidChangeCollapseState;
 		this.onDidChangeRenderNodeCountRelay.input = model.onDidChangeRenderNodeCount;
 		this.onDidSpliceModelRelay.input = model.onDidSpliceModel;
+
+		// Announce collapse state changes for screen readers (VoiceOver doesn't reliably
+		// announce aria-expanded changes on already-focused elements)
+		this.modelDisposables.add(model.onDidChangeCollapseState(({ node }) => {
+			if (node.collapsible && this.isDOMFocused()) {
+				alert(node.collapsed ? localize('treeNodeCollapsed', "collapsed") : localize('treeNodeExpanded', "expanded"));
+			}
+		}));
 	}
 
 	navigate(start?: TRef): ITreeNavigator<T> {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -29,6 +29,7 @@ import { Emitter, Event, EventBufferer, Relay } from '../../../common/event.js';
 import { fuzzyScore, FuzzyScore } from '../../../common/filters.js';
 import { KeyCode } from '../../../common/keyCodes.js';
 import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from '../../../common/lifecycle.js';
+import { isMacintosh } from '../../../common/platform.js';
 import { clamp } from '../../../common/numbers.js';
 import { ScrollEvent } from '../../../common/scrollable.js';
 import './media/tree.css';
@@ -3245,12 +3246,14 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 
 		// Announce collapse state changes for screen readers (VoiceOver doesn't reliably
 		// announce aria-expanded changes on already-focused elements)
-		this.modelDisposables.add(model.onDidChangeCollapseState(e => {
-			const { node, deep } = e;
-			if (node.collapsible && !deep && this.isDOMFocused()) {
-				alert(node.collapsed ? localize('treeNodeCollapsed', "collapsed") : localize('treeNodeExpanded', "expanded"));
-			}
-		}));
+		if (isMacintosh) {
+			this.modelDisposables.add(model.onDidChangeCollapseState(e => {
+				const { node, deep } = e;
+				if (node.collapsible && !deep && this.isDOMFocused()) {
+					alert(node.collapsed ? localize('treeNodeCollapsed', "collapsed") : localize('treeNodeExpanded', "expanded"));
+				}
+			}));
+		}
 	}
 
 	navigate(start?: TRef): ITreeNavigator<T> {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3245,8 +3245,9 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 
 		// Announce collapse state changes for screen readers (VoiceOver doesn't reliably
 		// announce aria-expanded changes on already-focused elements)
-		this.modelDisposables.add(model.onDidChangeCollapseState(({ node }) => {
-			if (node.collapsible && this.isDOMFocused()) {
+		this.modelDisposables.add(model.onDidChangeCollapseState(e => {
+			const { node, deep } = e;
+			if (node.collapsible && !deep && this.isDOMFocused()) {
 				alert(node.collapsed ? localize('treeNodeCollapsed', "collapsed") : localize('treeNodeExpanded', "expanded"));
 			}
 		}));


### PR DESCRIPTION
fixes #286751

cc @rperez030 @accesswatch @jooyoungseo

This change adds an alert when tree items are collapsed or expanded, but only on macOS. VoiceOver has a known limitation where it doesn't reliably announce aria-expanded attribute changes on elements that already have focus. The state is typically only read when focus first arrives. Other screen readers like NVDA and JAWS handle this correctly, so the workaround is scoped to macOS to avoid redundant announcements on other platforms.

