### PR TITLE
Add `chat.editorAssociations` setting to configure editors for files opened from chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -13,14 +13,12 @@ import { createInstantHoverDelegate } from '../../../../../base/browser/ui/hover
 import { HoverPosition } from '../../../../../base/browser/ui/hover/hoverWidget.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import * as event from '../../../../../base/common/event.js';
-import * as glob from '../../../../../base/common/glob.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { basename, dirname } from '../../../../../base/common/path.js';
-import { basename as resourceBasename } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IRange } from '../../../../../editor/common/core/range.js';
@@ -48,6 +46,7 @@ import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IMarkdownRendererService } from '../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IOpenerService, OpenInternalOptions } from '../../../../../platform/opener/common/opener.js';
 import { FolderThemeIcon, IThemeService } from '../../../../../platform/theme/common/themeService.js';
+import { globMatchesResource } from '../../../../services/editor/common/editorResolverService.js';
 import { fillEditorsDragData } from '../../../../browser/dnd.js';
 import { IFileLabelOptions, IResourceLabel, ResourceLabels } from '../../../../browser/labels.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
@@ -84,11 +83,10 @@ const commonHoverLifecycleOptions: IHoverLifecycleOptions = {
  */
 export function getEditorOverrideForChatResource(resource: URI, configurationService: IConfigurationService): string | undefined {
 	const associations = configurationService.getValue<Record<string, string>>(ChatConfiguration.EditorAssociations) ?? {};
+	// Sort patterns by length (longer patterns are more specific)
 	const sortedPatterns = Object.keys(associations).sort((a, b) => b.length - a.length);
 	for (const pattern of sortedPatterns) {
-		const matchOnPath = pattern.indexOf('/') >= 0;
-		const target = matchOnPath ? resource.path : resourceBasename(resource);
-		if (glob.match(pattern, target, { ignoreCase: true })) {
+		if (globMatchesResource(pattern, resource)) {
 			return associations[pattern];
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -290,6 +290,15 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.inlineReferences.style', "Controls how file and symbol references are displayed in chat messages."),
 			default: 'box'
 		},
+		[ChatConfiguration.EditorAssociations]: {
+			type: 'object',
+			markdownDescription: nls.localize('chat.editorAssociations', "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for opening files from chat (for example `\"*.md\": \"vscode.markdown.preview.editor\"`)."),
+			additionalProperties: {
+				type: 'string'
+			},
+			default: {
+			}
+		},
 		'chat.notifyWindowOnConfirmation': {
 			type: 'boolean',
 			description: nls.localize('chat.notifyWindowOnConfirmation', "Controls whether a chat session should present the user with an OS notification when a confirmation is needed while the window is not in focus. This includes a window badge as well as notification toast."),

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -280,14 +280,15 @@ export class InlineAnchorWidget extends Disposable {
 		this._register(dom.addDisposableListener(element, 'click', async (e) => {
 			dom.EventHelper.stop(e, true);
 			const editorOverride = getEditorOverrideForChatResource(location.uri, this.configurationService);
-			// Encode selection in URI fragment for editors that support it
-			const fragment = location.range ? `${location.range.startLineNumber},${location.range.startColumn}` : '';
-			const uriToOpen = fragment ? location.uri.with({ fragment }) : location.uri;
-			await this.openerService.open(uriToOpen, {
+			const editorOptions: { override: string | undefined; selection?: IRange } = {
+				override: editorOverride,
+			};
+			if (location.range) {
+				editorOptions.selection = location.range;
+			}
+			await this.openerService.open(location.uri, {
 				fromUserGesture: true,
-				editorOptions: {
-					override: editorOverride
-				}
+				editorOptions
 			});
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -99,7 +99,7 @@ import { ChatSessionPrimaryPickerAction, ChatSubmitAction, IChatExecuteActionCon
 import { AgentSessionProviders, getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
 import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
-import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, getEditorOverrideForChatResource, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
+import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 import { ChatImplicitContexts } from '../../attachments/chatImplicitContext.js';
 import { ChatRelatedFiles } from '../../attachments/chatInputRelatedFilesContrib.js';
 import { ImplicitContextAttachmentWidget } from '../../attachments/implicitContextAttachment.js';
@@ -2616,10 +2616,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 					const entry = chatEditingSession?.getEntry(modifiedFileUri);
 
-					const editorOverride = getEditorOverrideForChatResource(modifiedFileUri, this.configurationService);
 					const pane = await this.editorService.openEditor({
 						resource: modifiedFileUri,
-						options: { ...e.editorOptions, override: editorOverride }
+						options: e.editorOptions
 					}, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
 
 					if (pane) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -99,7 +99,7 @@ import { ChatSessionPrimaryPickerAction, ChatSubmitAction, IChatExecuteActionCon
 import { AgentSessionProviders, getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
 import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
-import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
+import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, getEditorOverrideForChatResource, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 import { ChatImplicitContexts } from '../../attachments/chatImplicitContext.js';
 import { ChatRelatedFiles } from '../../attachments/chatInputRelatedFilesContrib.js';
 import { ImplicitContextAttachmentWidget } from '../../attachments/implicitContextAttachment.js';
@@ -2616,9 +2616,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 					const entry = chatEditingSession?.getEntry(modifiedFileUri);
 
+					const editorOverride = getEditorOverrideForChatResource(modifiedFileUri, this.configurationService);
 					const pane = await this.editorService.openEditor({
 						resource: modifiedFileUri,
-						options: e.editorOptions
+						options: { ...e.editorOptions, override: editorOverride }
 					}, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
 
 					if (pane) {

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -11,6 +11,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 export enum ChatConfiguration {
 	AgentEnabled = 'chat.agent.enabled',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
+	EditorAssociations = 'chat.editorAssociations',
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',
 	AgentSessionProjectionEnabled = 'chat.agentSessionProjection.enabled',
 	EditModeHidden = 'chat.editMode.hidden',


### PR DESCRIPTION
Fixes #289759

## Summary

Add a new setting `chat.editorAssociations` that allows configuring glob patterns to editor IDs for files opened from chat.

### Setting format

```json
"chat.editorAssociations": {
  "*.md": "vscode.markdown.preview.editor"
}
```

The setting is an object where:
- Keys are glob patterns (matched against basename, or full path if pattern contains `/`)
- Values are editor IDs

### Affected locations

Files opened from these locations respect the setting:
- File attachment widgets
- Inline file/symbol anchors in chat responses
- "Open to Side" action for anchors
- Working set file list ("N files changed")

### Implementation details

- Added `ChatConfiguration.EditorAssociations` constant
- Created `getEditorOverrideForChatResource()` utility function that matches globs and returns the editor override
- Modified all file-opening code paths in chat to use the utility
- Selection/range is still provided via URI fragment or editor options - editors that don't support it will simply open to the file

### Default value

Empty object `{}` - no overrides by default, files open in text editor as before. Users can opt-in to specific behaviors.