### PR TITLE
Tools picker should honour workbench.quickOpen.closeOnFocusLost setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolPicker.ts
@@ -469,7 +469,6 @@ export async function showToolsPicker(
 	const treePicker = store.add(quickPickService.createQuickTree<AnyTreeItem>());
 
 	treePicker.placeholder = placeHolder;
-	treePicker.ignoreFocusOut = true;
 	treePicker.description = description;
 	treePicker.matchOnDescription = true;
 	treePicker.matchOnLabel = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/282504