### PR TITLE
Dynamic picker rendering based on available size

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.ts
@@ -5,6 +5,7 @@
 
 import { getActiveWindow } from '../../../../../../base/browser/dom.js';
 import { IAction } from '../../../../../../base/common/actions.js';
+import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownOptions } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
@@ -20,6 +21,8 @@ export interface IChatInputPickerOptions {
 	readonly getOverflowAnchor?: () => HTMLElement | undefined;
 
 	readonly actionContext?: IChatExecuteActionContext;
+
+	readonly onlyShowIconsForDefaultActions: IObservable<boolean>;
 }
 
 /**
@@ -31,7 +34,7 @@ export abstract class ChatInputPickerActionViewItem extends ActionWidgetDropdown
 	constructor(
 		action: IAction,
 		actionWidgetOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'>,
-		private readonly pickerOptions: IChatInputPickerOptions,
+		protected readonly pickerOptions: IChatInputPickerOptions,
 		@IActionWidgetService actionWidgetService: IActionWidgetService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -43,6 +46,13 @@ export abstract class ChatInputPickerActionViewItem extends ActionWidgetDropdown
 		};
 
 		super(action, optionsWithAnchor, actionWidgetService, keybindingService, contextKeyService);
+
+		this._register(autorun(reader => {
+			this.pickerOptions.onlyShowIconsForDefaultActions.read(reader);
+			if (this.element) {
+				this.renderLabel(this.element);
+			}
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -243,7 +243,7 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		if (icon) {
 			labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
 		}
-		if (!isDefault || !icon) {
+		if (!isDefault || !icon || !this.pickerOptions.onlyShowIconsForDefaultActions.get()) {
 			labelElements.push(dom.$('span.chat-input-picker-label', undefined, state));
 		}
 		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -192,7 +192,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 		const labelElements = [];
 		labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
-		if (currentType !== AgentSessionProviders.Local) {
+		if (currentType !== AgentSessionProviders.Local || !this.pickerOptions.onlyShowIconsForDefaultActions.get()) {
 			labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
 		}
 		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));


### PR DESCRIPTION
```Copilot Generated Description:``` Implement dynamic rendering of picker icons based on the available size of the input editor. Introduce a new observable property to control the visibility of icons for default actions. Adjust the picker components to utilize this new property for rendering decisions.

closes https://github.com/microsoft/vscode/issues/289284