### PR TITLE
fix: correct rebase conflict detection for adjacent edits

### DIFF
--- a/src/vs/editor/common/core/edits/stringEdit.ts
+++ b/src/vs/editor/common/core/edits/stringEdit.ts
@@ -113,7 +113,7 @@ export abstract class BaseStringEdit<T extends BaseStringReplacement<T> = BaseSt
 					ourEdit.newText
 				));
 				ourIdx++;
-			} else if (ourEdit.replaceRange.intersectsOrTouches(baseEdit.replaceRange)) {
+			} else if (ourEdit.replaceRange.intersects(baseEdit.replaceRange) || areConcurrentInserts(ourEdit.replaceRange, baseEdit.replaceRange)) {
 				ourIdx++; // Don't take our edit, as it is conflicting -> skip
 				if (noOverlap) {
 					return undefined;
@@ -573,3 +573,11 @@ export class AnnotatedStringReplacement<T extends IEditData<T>> extends BaseStri
 	}
 }
 
+/**
+ * Returns true if both ranges are empty (inserts) at the exact same position.
+ * In this case, although they don't "intersect" in the traditional sense,
+ * they conflict because the order of insertion matters.
+ */
+function areConcurrentInserts(r1: OffsetRange, r2: OffsetRange): boolean {
+	return r1.isEmpty && r2.isEmpty && r1.start === r2.start;
+}

--- a/src/vs/editor/test/common/core/stringEdit.test.ts
+++ b/src/vs/editor/test/common/core/stringEdit.test.ts
@@ -5,10 +5,10 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { Random } from './random.js';
+import { ArrayEdit, ArrayReplacement } from '../../../common/core/edits/arrayEdit.js';
 import { StringEdit, StringReplacement } from '../../../common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../../common/core/ranges/offsetRange.js';
-import { ArrayEdit, ArrayReplacement } from '../../../common/core/edits/arrayEdit.js';
+import { Random } from './random.js';
 
 suite('Edit', () => {
 
@@ -122,6 +122,37 @@ suite('Edit', () => {
 			assert.strictEqual(delta, 2);
 			assert.strictEqual(edit.replacements[0].getLengthDelta(), 3);
 			assert.strictEqual(edit.replacements[1].getLengthDelta(), -1);
+		});
+
+		test('adjacent edit and insert should rebase successfully', () => {
+			// A replacement ending at X followed by an insert at X should not conflict
+			const firstEdit = StringEdit.create([
+				StringReplacement.replace(new OffsetRange(1826, 1838), 'function fib(n: number): number {'),
+			]);
+			const followupEdit = StringEdit.create([
+				StringReplacement.replace(new OffsetRange(1838, 1838), '\n\tif (n <= 1) {\n\t\treturn n;\n\t}\n\treturn fib(n - 1) + fib(n - 2);\n}'),
+			]);
+			const rebasedEdit = followupEdit.tryRebase(firstEdit);
+
+			// Since firstEdit replaces [1826, 1838) with text of length 33,
+			// the insert at 1838 should be rebased to 1826 + 33 = 1859
+			assert.ok(rebasedEdit);
+			assert.strictEqual(rebasedEdit?.replacements[0].replaceRange.start, 1859);
+			assert.strictEqual(rebasedEdit?.replacements[0].replaceRange.endExclusive, 1859);
+		});
+
+		test('concurrent inserts at same position should conflict', () => {
+			// Two inserts at the exact same position conflict because order matters
+			const firstEdit = StringEdit.create([
+				StringReplacement.replace(new OffsetRange(1838, 1838), '1'),
+			]);
+			const followupEdit = StringEdit.create([
+				StringReplacement.replace(new OffsetRange(1838, 1838), '2'),
+			]);
+			const rebasedEdit = followupEdit.tryRebase(firstEdit);
+
+			// This should return undefined because both are inserts at the same position
+			assert.strictEqual(rebasedEdit, undefined);
 		});
 	});
 


### PR DESCRIPTION
The `tryRebase` method was incorrectly marking adjacent edits as conflicting. Previously, the condition used `intersectsOrTouches`, which would flag a replacement ending at position X and an insert at position X as conflicting, even though these edits can be safely rebased.

The fix replaces `intersectsOrTouches` with a more precise check:
- `intersects`: actual overlapping ranges still conflict
- `areConcurrentInserts`: two inserts at the exact same position conflict because their order cannot be determined

This distinction is important because:
1. A replacement [1826, 1838) followed by an insert at 1838 should rebase correctly - the insert moves to account for the
   replacement's length change
2. Two inserts at position 1838 cannot be rebased because there's no way to determine which should come first

Added tests covering both scenarios to prevent regression.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
