### PR TITLE
Adjust padding for add model button in chat models widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/media/chatModelsWidget.css
@@ -43,7 +43,7 @@
 
 .models-widget .models-search-and-button-container .section-title-actions .models-add-model-button {
 	white-space: nowrap;
-	padding: 4px 8px 4px 4px;
+	padding: 5px 8px 5px 4px;
 }
 
 /** Table styling **/


### PR DESCRIPTION
Increase the padding for the add model button in the chat models widget to improve visual spacing. Test the changes by checking the button's appearance in the widget.

