### PR TITLE
Switch default for word-based suggestions

### DIFF
--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -65,7 +65,7 @@ const editorConfiguration: IConfigurationNode = {
 		},
 		'editor.wordBasedSuggestions': {
 			enum: ['off', 'offWithInlineSuggestions', 'currentDocument', 'matchingDocuments', 'allDocuments'],
-			default: 'matchingDocuments',
+			default: 'offWithInlineSuggestions',
 			enumDescriptions: [
 				nls.localize('wordBasedSuggestions.off', 'Turn off Word Based Suggestions.'),
 				nls.localize('wordBasedSuggestions.offWithInlineSuggestions', 'Turn off Word Based Suggestions when Inline Suggestions are present.'),


### PR DESCRIPTION
```Copilot Generated Description:``` Change the default setting for word-based suggestions from 'matchingDocuments' to 'offWithInlineSuggestions'.

