### PR TITLE
Improve any key detection

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -210,7 +210,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			}
 			this._cleanupIdleInputListener();
 			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
-			const lastLine = output.trimEnd().split('\n').pop() || '';
+			const lastLine = output.trimEnd().split(/\r?\n/).pop() || '';
 			const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, {
 				prompt: lastLine,
 				options: [],

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -596,9 +596,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				resolve(value);
 			};
 			inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
-				// For "press any key" prompts, accept any input
+				// For "press any key" prompts, accept any non-empty input
 				// For other free-form inputs (like passwords), only accept on Enter
-				if (acceptAnyKey || data === '\r' || data === '\n' || data === '\r\n') {
+				if ((acceptAnyKey && data.length > 0) || (!acceptAnyKey && (data === '\r' || data === '\n' || data === '\r\n'))) {
 					this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
 					settle(true, OutputMonitorState.PollingForIdle);
 				}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -861,6 +861,19 @@ export function detectsNonInteractiveHelpPattern(cursorLine: string): boolean {
 }
 
 /**
+ * Localized task finish messages from VS Code's terminalTaskSystem.
+ * These are the same strings used when tasks complete.
+ */
+const taskFinishMessages = [
+	// "Terminal will be reused by tasks, press any key to close it."
+	localize('closeTerminal', "Terminal will be reused by tasks, press any key to close it."),
+	localize('reuseTerminal', "Terminal will be reused by tasks, press any key to close it."),
+	// "Press any key to close the terminal." (with exit code placeholder removed for matching)
+	localize('exitCode.closeTerminal', "Press any key to close the terminal."),
+	localize('exitCode.reuseTerminal', "Press any key to close the terminal."),
+];
+
+/**
  * Detects VS Code's specific task completion messages like:
  * - "Press any key to close the terminal."
  * - "Terminal will be reused by tasks, press any key to close it."
@@ -871,12 +884,7 @@ export function detectsNonInteractiveHelpPattern(cursorLine: string): boolean {
 export function detectsVSCodeTaskFinishMessage(cursorLine: string): boolean {
 	// Remove all whitespace to handle line wrapping that splits words mid-word
 	const normalized = cursorLine.replace(/\s/g, '').toLowerCase();
-	return [
-		// "Press any key to close the terminal."
-		'pressanykeytoclosetheterminal',
-		// "Terminal will be reused by tasks, press any key to close it."
-		'terminalwillbereusedbytasks,pressanykeytocloseit',
-	].some(pattern => normalized.includes(pattern));
+	return taskFinishMessages.some(msg => normalized.includes(msg.replace(/\s/g, '').toLowerCase()));
 }
 
 /**

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -190,6 +190,42 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			return { shouldContinuePollling: false, output };
 		}
 
+		// Check for VS Code's task finish messages (like "press any key to close the terminal").
+		// These should only be ignored if it's a task AND the task is finished.
+		// Otherwise, "press any key to continue" from scripts should prompt the user.
+		if (detectsVSCodeTaskFinishMessage(output)) {
+			const isTask = this._execution.task !== undefined;
+			const isTaskInactive = this._execution.isActive ? !(await this._execution.isActive()) : true;
+			if (isTask && isTaskInactive) {
+				// Task is finished, ignore the "press any key to close" message
+				return { shouldContinuePollling: false, output };
+			}
+		}
+
+		// Check for generic "press any key" prompts from scripts.
+		// These should be treated as free-form input to let the user press a key.
+		if (detectsGenericPressAnyKeyPattern(output)) {
+			// Register a marker to track this prompt position so we don't re-detect it
+			const currentMarker = this._execution.instance.registerMarker();
+			if (currentMarker) {
+				this._lastPromptMarker = currentMarker;
+			}
+			this._cleanupIdleInputListener();
+			this._outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount++;
+			const lastLine = output.trimEnd().split('\n').pop() || '';
+			const receivedTerminalInput = await this._requestFreeFormTerminalInput(token, this._execution, {
+				prompt: lastLine,
+				options: [],
+				detectedRequestForFreeFormInput: true
+			}, true /* acceptAnyKey */);
+			if (receivedTerminalInput) {
+				await timeout(200);
+				return { shouldContinuePollling: true };
+			} else {
+				return { shouldContinuePollling: false };
+			}
+		}
+
 		// Check if user already inputted since idle was detected (before we even got here)
 		if (this._userInputtedSinceIdleDetected) {
 			this._cleanupIdleInputListener();
@@ -419,19 +455,13 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 			6. Output: "Continue [y/N]"
 				Response: {"prompt": "Continue", "options": ["y", "N"], "freeFormInput": false}
 
-			7. Output: "Press any key to close the terminal."
-				Response: null
-
-			8. Output: "Terminal will be reused by tasks, press any key to close it."
-				Response: null
-
-			9. Output: "Password:"
+			7. Output: "Password:"
 				Response: {"prompt": "Password:", "freeFormInput": true, "options": []}
-			10. Output: "press ctrl-c to detach, ctrl-d to kill"
+			8. Output: "press ctrl-c to detach, ctrl-d to kill"
 				Response: null
-			11. Output: "Continue (y/n)? y"
+			9. Output: "Continue (y/n)? y"
 				Response: null (the prompt was already answered with 'y')
-			12. Output: "Do you want to proceed? (yes/no)\nyes\nProceeding with operation..."
+			10. Output: "Do you want to proceed? (yes/no)\nyes\nProceeding with operation..."
 				Response: null (the prompt was already answered and there is subsequent output)
 
 			Alternatively, the prompt may request free form input, for example:
@@ -439,6 +469,8 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				Response: {"prompt": "Enter your username:", "freeFormInput": true, "options": []}
 			2. Output: "Password:"
 				Response: {"prompt": "Password:", "freeFormInput": true, "options": []}
+			3. Output: "Press any key to continue..."
+				Response: {"prompt": "Press any key to continue...", "freeFormInput": true, "options": []}
 			Now, analyze this output:
 			${lastLines}
 			`;
@@ -534,7 +566,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		return description ? { suggestedOption: { description, option: validOption }, sentToTerminal } : { suggestedOption: validOption, sentToTerminal };
 	}
 
-	private async _requestFreeFormTerminalInput(token: CancellationToken, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<boolean> {
+	private async _requestFreeFormTerminalInput(token: CancellationToken, execution: IExecution, confirmationPrompt: IConfirmationPrompt, acceptAnyKey: boolean = false): Promise<boolean> {
 		const focusTerminalSelection = Symbol('focusTerminalSelection');
 		const { promise: userPrompt, part } = this._createElicitationPart<boolean | typeof focusTerminalSelection>(
 			token,
@@ -566,7 +598,9 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				resolve(value);
 			};
 			inputDataDisposable = this._register(execution.instance.onDidInputData((data) => {
-				if (!data || data === '\r' || data === '\n' || data === '\r\n') {
+				// For "press any key" prompts, accept any input
+				// For other free-form inputs (like passwords), only accept on Enter
+				if (acceptAnyKey || data === '\r' || data === '\n' || data === '\r\n') {
 					this._outputMonitorTelemetryCounters.inputToolFreeFormInputCount++;
 					settle(true, OutputMonitorState.PollingForIdle);
 				}
@@ -597,9 +631,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 
 	private async _confirmRunInTerminal(token: CancellationToken, suggestedOption: SuggestedOption, execution: IExecution, confirmationPrompt: IConfirmationPrompt): Promise<string | boolean | undefined> {
 		const suggestedOptionValue = isString(suggestedOption) ? suggestedOption : suggestedOption.option;
-		if (suggestedOptionValue === 'any key') {
-			return;
-		}
 		const focusTerminalSelection = Symbol('focusTerminalSelection');
 		let inputDataDisposable: IDisposable = Disposable.None;
 		let instanceDisposedDisposable: IDisposable = Disposable.None;
@@ -829,4 +860,31 @@ export function detectsNonInteractiveHelpPattern(cursorLine: string): boolean {
 		/press q\s*(?:\+\s*enter)?\s*(?:to|for)?\s*(?:quit|exit|stop)(?:\s*(?:the )?(?:server|app|process))?/i,
 		/press u\s*(?:\+\s*enter)?\s*(?:to|for)?\s*(?:show|print|display)\s*(?:the )?(?:server )?urls?/i
 	].some(e => e.test(cursorLine));
+}
+
+/**
+ * Detects VS Code's specific task completion messages like:
+ * - "Press any key to close the terminal."
+ * - "Terminal will be reused by tasks, press any key to close it."
+ * These appear when a task finishes and should be ignored if the task is done.
+ */
+export function detectsVSCodeTaskFinishMessage(cursorLine: string): boolean {
+	return [
+		// "Press any key to close the terminal."
+		/press any key to close the terminal/i,
+		// "Terminal will be reused by tasks, press any key to close it."
+		/terminal will be reused by tasks.*press any key to close it/i,
+	].some(e => e.test(cursorLine));
+}
+
+/**
+ * Detects generic "press any key" prompts from scripts (not VS Code task messages).
+ * These should prompt the user to interact with the terminal.
+ */
+export function detectsGenericPressAnyKeyPattern(cursorLine: string): boolean {
+	// Match "press any key" but exclude VS Code task-specific messages
+	if (detectsVSCodeTaskFinishMessage(cursorLine)) {
+		return false;
+	}
+	return /press a(?:ny)? key/i.test(cursorLine);
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { detectsInputRequiredPattern, detectsNonInteractiveHelpPattern, OutputMonitor } from '../../browser/tools/monitoring/outputMonitor.js';
+import { detectsGenericPressAnyKeyPattern, detectsInputRequiredPattern, detectsNonInteractiveHelpPattern, detectsVSCodeTaskFinishMessage, OutputMonitor } from '../../browser/tools/monitoring/outputMonitor.js';
 import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
@@ -284,6 +284,52 @@ suite('OutputMonitor', () => {
 			assert.strictEqual(detectsNonInteractiveHelpPattern('press q to quit'), true);
 			assert.strictEqual(detectsInputRequiredPattern('press u to show server url'), false);
 			assert.strictEqual(detectsNonInteractiveHelpPattern('press u to show server url'), true);
+		});
+	});
+
+	suite('detectsVSCodeTaskFinishMessage', () => {
+		test('detects VS Code task completion messages', () => {
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Press any key to close the terminal.'), true);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Terminal will be reused by tasks, press any key to close it.'), true);
+			// Case insensitive
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('press any key to close the terminal.'), true);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('PRESS ANY KEY TO CLOSE THE TERMINAL.'), true);
+		});
+
+		test('does not match generic press any key messages', () => {
+			// Regular script messages should NOT be matched
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Press any key to continue...'), false);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Press any key to exit'), false);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Press any key'), false);
+		});
+
+		test('does not match other prompts', () => {
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Continue? (y/n)'), false);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('Password:'), false);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage('press h to show help'), false);
+		});
+	});
+
+	suite('detectsGenericPressAnyKeyPattern', () => {
+		test('detects generic press any key prompts from scripts', () => {
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key to continue...'), true);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key to exit'), true);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key'), true);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('press a key to continue'), true);
+			// Case insensitive
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('PRESS ANY KEY TO CONTINUE'), true);
+		});
+
+		test('does not match VS Code task finish messages', () => {
+			// These should be handled by detectsVSCodeTaskFinishMessage, not this function
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key to close the terminal.'), false);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Terminal will be reused by tasks, press any key to close it.'), false);
+		});
+
+		test('does not match other prompts', () => {
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Continue? (y/n)'), false);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('Password:'), false);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern('press h to show help'), false);
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -294,6 +294,9 @@ suite('OutputMonitor', () => {
 			// Case insensitive
 			assert.strictEqual(detectsVSCodeTaskFinishMessage('press any key to close the terminal.'), true);
 			assert.strictEqual(detectsVSCodeTaskFinishMessage('PRESS ANY KEY TO CLOSE THE TERMINAL.'), true);
+			// With " * " prefix (VS Code adds this to task messages)
+			assert.strictEqual(detectsVSCodeTaskFinishMessage(' *  Terminal will be reused by tasks, press any key to close it.'), true);
+			assert.strictEqual(detectsVSCodeTaskFinishMessage(' *  Press any key to close the terminal.'), true);
 		});
 
 		test('does not match generic press any key messages', () => {
@@ -324,6 +327,9 @@ suite('OutputMonitor', () => {
 			// These should be handled by detectsVSCodeTaskFinishMessage, not this function
 			assert.strictEqual(detectsGenericPressAnyKeyPattern('Press any key to close the terminal.'), false);
 			assert.strictEqual(detectsGenericPressAnyKeyPattern('Terminal will be reused by tasks, press any key to close it.'), false);
+			// With " * " prefix
+			assert.strictEqual(detectsGenericPressAnyKeyPattern(' *  Terminal will be reused by tasks, press any key to close it.'), false);
+			assert.strictEqual(detectsGenericPressAnyKeyPattern(' *  Press any key to close the terminal.'), false);
 		});
 
 		test('does not match other prompts', () => {


### PR DESCRIPTION
fixes #286050

VS Code task finish messages ("Press any key to close the terminal") were being blocked, which was correct. But, this blocking was too broad and also prevented legitimate script "Press any key to continue..." prompts from being detected and handled

Now, we distinguish between the two cases:
- VS Code task finish messages: Only ignored when it's a task AND the task is finished (more specific check using `detectsVSCodeTaskFinishMessage`
- Script "press any key" prompts: Now properly detected with `detectsGenericPressAnyKeyPattern` and presented to the user as a free-form input prompt