### PR TITLE
Fix hover feedback over separator in chat widget

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -93,9 +93,10 @@
 	border-radius: 0;
 }
 
+.action-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-row.separator:hover,
 .action-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-row.separator.focused {
 	outline: 0 solid;
-	background-color: transparent;
+	background-color: transparent !important;
 	border-radius: 0;
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the background color for the hover state of the separator in the chat widget to ensure it remains transparent.

Fixes microsoft/vscode#289372

