### PR TITLE
chat: add null check in isToolSet function

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -372,7 +372,7 @@ export interface IToolSet {
 export type IToolAndToolSetEnablementMap = ReadonlyMap<IToolData | IToolSet, boolean>;
 
 export function isToolSet(obj: IToolData | IToolSet | undefined): obj is IToolSet {
-	return (obj as IToolSet).getTools !== undefined;
+	return !!obj && (obj as IToolSet).getTools !== undefined;
 }
 
 export class ToolSet implements IToolSet {


### PR DESCRIPTION
Adds a null check to prevent accessing .getTools property on undefined or null objects. This ensures the function safely handles undefined input.

Fixes https://github.com/microsoft/vscode/issues/289968

(Commit message generated by Copilot)