### PR TITLE
Revert "Disable chat input in welcome view until ext is ready"

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -48,8 +48,6 @@ import { AgentSessionsControl, IAgentSessionsControlOptions } from '../../chat/b
 import { IAgentSessionsFilter } from '../../chat/browser/agentSessions/agentSessionsViewer.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IResolvedWalkthrough, IWalkthroughsService } from '../../welcomeGettingStarted/browser/gettingStartedService.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { GettingStartedEditorOptions, GettingStartedInput } from '../../welcomeGettingStarted/browser/gettingStartedInput.js';
 import { IMarkdownRendererService } from '../../../../platform/markdown/browser/markdownRenderer.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
@@ -101,7 +99,6 @@ export class AgentSessionsWelcomePage extends EditorPane {
 		@IProductService private readonly productService: IProductService,
 		@IWalkthroughsService private readonly walkthroughsService: IWalkthroughsService,
 		@IChatService private readonly chatService: IChatService,
-		@IExtensionService private readonly extensionService: IExtensionService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
@@ -302,32 +299,8 @@ export class AgentSessionsWelcomePage extends EditorPane {
 			this.chatWidget?.focusInput();
 		}));
 
-		// Disable the chat input until the chat extension is installed and activated
-		const defaultChatAgent = this.productService.defaultChatAgent;
-		const updateInputEnabled = () => {
-			let chatExtensionActivated = false;
-			if (defaultChatAgent) {
-				const extensionStatus = this.extensionService.getExtensionsStatus();
-				const status = extensionStatus[defaultChatAgent.chatExtensionId];
-				chatExtensionActivated = !!status?.activationTimes;
-			}
-			this.chatWidget?.inputEditor.updateOptions({ readOnly: !chatExtensionActivated });
-		};
-		updateInputEnabled();
-
-		// Listen for extension status changes to enable the input when the extension activates
-		if (defaultChatAgent) {
-			this.contentDisposables.add(this.extensionService.onDidChangeExtensionsStatus(event => {
-				for (const ext of event) {
-					if (ExtensionIdentifier.equals(defaultChatAgent.chatExtensionId, ext.value)) {
-						updateInputEnabled();
-						return;
-					}
-				}
-			}));
-			// Check for prefill data from a workspace transfer
-			this.applyPrefillData();
-		}
+		// Check for prefill data from a workspace transfer
+		this.applyPrefillData();
 	}
 
 	private getWorkspaceLabel(workspace: IRecentWorkspace | IRecentFolder): string {


### PR DESCRIPTION
Reverts microsoft/vscode#289276

Need to rethink this, for no-auth users we still allow chat without the extension installed