### PR TITLE
Subagent confirmation polish

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSubagentContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatSubagentContent.css
@@ -28,6 +28,12 @@
 			margin-left: 2px;
 			padding-left: 2px;
 		}
+
+		/* Hide the border for subagent prompt/result sections */
+		.chat-used-context-list {
+			border: none;
+			padding: 0px 2px;
+		}
 	}
 
 	.chat-thinking-tool-wrapper {
@@ -40,6 +46,11 @@
 		/* renable icons in confirmation widget */
 		.chat-confirmation-widget-container .codicon:not(.codicon-terminal) {
 			display: inline-flex;
+		}
+
+		/* Remove padding from tool invocation part when it displays a confirmation widget */
+		.chat-tool-invocation-part.has-confirmation {
+			padding: 4px;
 		}
 
 		.chat-collapsible-markdown-content {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -97,6 +97,13 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 			subPartDomNode.replaceWith(this.subPart.domNode);
 			subPartDomNode = this.subPart.domNode;
 
+			// Add class when displaying a confirmation widget
+			const isConfirmation = this.subPart instanceof ToolConfirmationSubPart ||
+				this.subPart instanceof ChatTerminalToolConfirmationSubPart ||
+				this.subPart instanceof ExtensionsInstallConfirmationWidgetSubPart ||
+				this.subPart instanceof ChatToolPostExecuteConfirmationPart;
+			this.domNode.classList.toggle('has-confirmation', isConfirmation);
+
 			partStore.add(this.subPart.onNeedsRerender(render));
 		};
 


### PR DESCRIPTION
Also expand for post-confirmations (fix #290049)

Make confirmations look nicer

Remove border from prompt/result markdown blocks