### PR TITLE
Update CommentRule.lineComment to support LineCommentConfig

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -6478,6 +6478,22 @@ declare module 'vscode' {
 	export type CharacterPair = [string, string];
 
 	/**
+	 * Describes the configuration for a line comment.
+	 */
+
+	export interface LineCommentConfig {
+		/**
+		 * The line comment token, like `// this is a comment`
+		 */
+		comment: string;
+
+		/**
+		 * If true, the line comment token will not be indented.
+		 */
+		noIndent?: boolean;
+	}
+
+	/**
 	 * Describes how comments for a language work.
 	 */
 	export interface CommentRule {
@@ -6485,7 +6501,7 @@ declare module 'vscode' {
 		/**
 		 * The line comment token, like `// this is a comment`
 		 */
-		lineComment?: string;
+		lineComment?: string | LineCommentConfig | null;
 
 		/**
 		 * The block comment character pair, like `/* block comment *&#47;`


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes #290146 

As of VS Code 1.91 (via https://github.com/microsoft/vscode/pull/243283), the lineComment property in CommentRule can be an object (LineCommentConfig) in addition to a string. This PR updates the interface to string | LineCommentConfig to match the runtime behavior and prevent type errors for consumers.