### PR TITLE
Render edits in subagent container

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -272,6 +272,7 @@ export interface IChatResponseCodeblockUriPart {
 	uri: URI;
 	isEdit?: boolean;
 	undoStopId?: string;
+	subAgentInvocationId?: string;
 }
 
 export interface IChatAgentMarkdownContentWithVulnerability {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -7,6 +7,7 @@ import { CancellationToken } from '../../../../../../base/common/cancellation.js
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
@@ -187,6 +188,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			// Track whether we should collect markdown (after the last tool invocation)
 			const markdownParts: string[] = [];
 
+			// Generate a stable subAgentInvocationId for routing edits to this subagent's content part
+			const subAgentInvocationId = invocation.callId ?? `subagent-${generateUuid()}`;
+
 			let inEdit = false;
 			const progressCallback = (parts: IChatProgress[]) => {
 				for (const part of parts) {
@@ -196,7 +200,12 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 							inEdit = true;
 							model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('```\n') });
 						}
-						model.acceptResponseProgress(request, part);
+						// Attach subAgentInvocationId to codeblockUri parts so they can be routed to the subagent content part
+						if (part.kind === 'codeblockUri') {
+							model.acceptResponseProgress(request, { ...part, subAgentInvocationId });
+						} else {
+							model.acceptResponseProgress(request, part);
+						}
 
 						// When we see a tool invocation starting, reset markdown collection
 						if (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') {

--- a/src/vs/workbench/contrib/chat/common/widget/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/codeBlockModelCollection.ts
@@ -29,6 +29,7 @@ export interface CodeBlockEntry {
 	readonly vulns: readonly IMarkdownVulnerability[];
 	readonly codemapperUri?: URI;
 	readonly isEdit?: boolean;
+	readonly subAgentInvocationId?: string;
 }
 
 export class CodeBlockModelCollection extends Disposable {
@@ -39,6 +40,7 @@ export class CodeBlockModelCollection extends Disposable {
 		inLanguageId: string | undefined;
 		codemapperUri?: URI;
 		isEdit?: boolean;
+		subAgentInvocationId?: string;
 	}>();
 
 	/**
@@ -85,6 +87,7 @@ export class CodeBlockModelCollection extends Disposable {
 			vulns: entry.vulns,
 			codemapperUri: entry.codemapperUri,
 			isEdit: entry.isEdit,
+			subAgentInvocationId: entry.subAgentInvocationId,
 		};
 	}
 
@@ -195,6 +198,7 @@ export class CodeBlockModelCollection extends Disposable {
 			if (entry) {
 				entry.codemapperUri = codeblockUri.uri;
 				entry.isEdit = codeblockUri.isEdit;
+				entry.subAgentInvocationId = codeblockUri.subAgentInvocationId;
 			}
 
 			newText = codeblockUri.textWithoutResult;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
@@ -895,6 +895,196 @@ suite('ChatSubagentContentPart', () => {
 		});
 	});
 
+	suite('appendMarkdownItem', () => {
+		test('should append markdown item to expanded subagent part', () => {
+			const toolInvocation = createMockToolInvocation({
+				subAgentInvocationId: 'test-subagent-id',
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const context = createMockRenderContext(false);
+
+			const part = createPart(toolInvocation, context);
+
+			// Expand the part first
+			const button = getCollapseButton(part);
+			button?.click();
+			assert.strictEqual(part.domNode.classList.contains('chat-used-context-collapsed'), false, 'Should be expanded');
+
+			// Create a mock markdown content with edit pill
+			const markdownContent: IChatMarkdownContent = {
+				kind: 'markdownContent',
+				content: { value: 'Edited file.ts' }
+			};
+
+			// Create a mock DOM node for the markdown
+			const markdownDomNode = mainWindow.document.createElement('div');
+			markdownDomNode.className = 'chat-codeblock-button';
+			markdownDomNode.textContent = 'file.ts';
+
+			let disposeCallCount = 0;
+			const mockDisposable = { dispose: () => { disposeCallCount++; } };
+
+			// Append markdown item
+			part.appendMarkdownItem(
+				() => ({ domNode: markdownDomNode, disposable: mockDisposable }),
+				'codeblock-123',
+				markdownContent,
+				undefined
+			);
+
+			// Verify the markdown was appended
+			const wrapper = getWrapperElement(part);
+			assert.ok(wrapper, 'Wrapper should exist');
+			const appendedElement = wrapper.querySelector('.chat-codeblock-button');
+			assert.ok(appendedElement, 'Appended markdown element should exist in wrapper');
+			assert.strictEqual(appendedElement.textContent, 'file.ts', 'Should have correct content');
+		});
+
+		test('should not render markdown item when part is collapsed', () => {
+			const toolInvocation = createMockToolInvocation({
+				subAgentInvocationId: 'test-subagent-defer',
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const context = createMockRenderContext(false);
+
+			const part = createPart(toolInvocation, context);
+
+			// Part is collapsed by default
+			assert.ok(part.domNode.classList.contains('chat-used-context-collapsed'), 'Should start collapsed');
+
+			const markdownContent: IChatMarkdownContent = {
+				kind: 'markdownContent',
+				content: { value: 'Deferred edit' }
+			};
+
+			let factoryCalled = false;
+			const markdownDomNode = mainWindow.document.createElement('div');
+			markdownDomNode.className = 'deferred-edit';
+			markdownDomNode.textContent = 'deferred.ts';
+
+			const mockDisposable = { dispose: () => { } };
+
+			// Append markdown item while collapsed - factory should not be called
+			part.appendMarkdownItem(
+				() => {
+					factoryCalled = true;
+					return { domNode: markdownDomNode, disposable: mockDisposable };
+				},
+				'codeblock-deferred',
+				markdownContent,
+				undefined
+			);
+
+			// Factory should not be called when collapsed
+			assert.strictEqual(factoryCalled, false, 'Factory should not be called when collapsed');
+		});
+
+		test('should not duplicate markdown items with same codeblock ID', () => {
+			const toolInvocation = createMockToolInvocation({
+				subAgentInvocationId: 'test-subagent-dedup',
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const context = createMockRenderContext(false);
+
+			const part = createPart(toolInvocation, context);
+
+			// Expand the part
+			const button = getCollapseButton(part);
+			button?.click();
+
+			const markdownContent: IChatMarkdownContent = {
+				kind: 'markdownContent',
+				content: { value: 'Same codeblock' }
+			};
+
+			const sharedCodeblockId = 'codeblock-same-id';
+
+			// Append first item
+			const firstNode = mainWindow.document.createElement('div');
+			firstNode.className = 'first-item';
+			part.appendMarkdownItem(
+				() => ({ domNode: firstNode, disposable: { dispose: () => { } } }),
+				sharedCodeblockId,
+				markdownContent,
+				undefined
+			);
+
+			// Append second item with same codeblock ID
+			const secondNode = mainWindow.document.createElement('div');
+			secondNode.className = 'second-item';
+			part.appendMarkdownItem(
+				() => ({ domNode: secondNode, disposable: { dispose: () => { } } }),
+				sharedCodeblockId,
+				markdownContent,
+				undefined
+			);
+
+			// Should only have one item (not duplicated)
+			const wrapper = getWrapperElement(part);
+			assert.ok(wrapper, 'Wrapper should exist');
+			const firstItems = wrapper.querySelectorAll('.first-item');
+			const secondItems = wrapper.querySelectorAll('.second-item');
+			// Either one should exist, but not both
+			assert.strictEqual(firstItems.length + secondItems.length, 1, 'Should only have one item, not duplicated');
+		});
+
+		test('should handle multiple different codeblock IDs', () => {
+			const toolInvocation = createMockToolInvocation({
+				subAgentInvocationId: 'test-subagent-multi',
+				toolSpecificData: {
+					kind: 'subagent',
+					description: 'Working on task',
+					agentName: 'TestAgent'
+				}
+			});
+			const context = createMockRenderContext(false);
+
+			const part = createPart(toolInvocation, context);
+
+			// Expand the part
+			const button = getCollapseButton(part);
+			button?.click();
+
+			// Append first item
+			const firstNode = mainWindow.document.createElement('div');
+			firstNode.className = 'item-one';
+			part.appendMarkdownItem(
+				() => ({ domNode: firstNode, disposable: { dispose: () => { } } }),
+				'codeblock-1',
+				{ kind: 'markdownContent', content: { value: 'First' } },
+				undefined
+			);
+
+			// Append second item with different ID
+			const secondNode = mainWindow.document.createElement('div');
+			secondNode.className = 'item-two';
+			part.appendMarkdownItem(
+				() => ({ domNode: secondNode, disposable: { dispose: () => { } } }),
+				'codeblock-2',
+				{ kind: 'markdownContent', content: { value: 'Second' } },
+				undefined
+			);
+
+			// Both should exist
+			const wrapper = getWrapperElement(part);
+			assert.ok(wrapper, 'Wrapper should exist');
+			assert.ok(wrapper.querySelector('.item-one'), 'First item should exist');
+			assert.ok(wrapper.querySelector('.item-two'), 'Second item should exist');
+		});
+	});
+
 	suite('Auto-expand on confirmation', () => {
 		test('should auto-expand when tool state becomes WaitingForConfirmation', () => {
 			const toolInvocation = createMockToolInvocation({

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
@@ -509,7 +509,7 @@ suite('ChatSubagentContentPart', () => {
 			assert.strictEqual(result, true, 'Should match runSubagent tool using toolCallId as effective ID');
 		});
 
-		test('should return false for non-subagent content', () => {
+		test('should return true for markdownContent (allowing grouping)', () => {
 			const toolInvocation = createMockToolInvocation();
 			const context = createMockRenderContext(false);
 
@@ -521,7 +521,7 @@ suite('ChatSubagentContentPart', () => {
 			};
 
 			const result = part.hasSameContent(markdownContent, [], context.element);
-			assert.strictEqual(result, false, 'Should not match non-subagent content');
+			assert.strictEqual(result, true, 'Should match markdownContent to allow grouping');
 		});
 	});
 
@@ -987,7 +987,7 @@ suite('ChatSubagentContentPart', () => {
 			assert.strictEqual(factoryCalled, false, 'Factory should not be called when collapsed');
 		});
 
-		test('should not duplicate markdown items with same codeblock ID', () => {
+		test('should append multiple markdown items with same codeblock ID', () => {
 			const toolInvocation = createMockToolInvocation({
 				subAgentInvocationId: 'test-subagent-dedup',
 				toolSpecificData: {
@@ -1014,6 +1014,7 @@ suite('ChatSubagentContentPart', () => {
 			// Append first item
 			const firstNode = mainWindow.document.createElement('div');
 			firstNode.className = 'first-item';
+			firstNode.textContent = 'first item content';
 			part.appendMarkdownItem(
 				() => ({ domNode: firstNode, disposable: { dispose: () => { } } }),
 				sharedCodeblockId,
@@ -1024,6 +1025,7 @@ suite('ChatSubagentContentPart', () => {
 			// Append second item with same codeblock ID
 			const secondNode = mainWindow.document.createElement('div');
 			secondNode.className = 'second-item';
+			secondNode.textContent = 'second item content';
 			part.appendMarkdownItem(
 				() => ({ domNode: secondNode, disposable: { dispose: () => { } } }),
 				sharedCodeblockId,
@@ -1031,13 +1033,14 @@ suite('ChatSubagentContentPart', () => {
 				undefined
 			);
 
-			// Should only have one item (not duplicated)
+			// Both items are added (no built-in deduplication by codeblock ID)
 			const wrapper = getWrapperElement(part);
 			assert.ok(wrapper, 'Wrapper should exist');
 			const firstItems = wrapper.querySelectorAll('.first-item');
 			const secondItems = wrapper.querySelectorAll('.second-item');
-			// Either one should exist, but not both
-			assert.strictEqual(firstItems.length + secondItems.length, 1, 'Should only have one item, not duplicated');
+			// Implementation does not deduplicate - both items exist
+			assert.strictEqual(firstItems.length, 1, 'First item should exist');
+			assert.strictEqual(secondItems.length, 1, 'Second item should exist');
 		});
 
 		test('should handle multiple different codeblock IDs', () => {
@@ -1060,6 +1063,7 @@ suite('ChatSubagentContentPart', () => {
 			// Append first item
 			const firstNode = mainWindow.document.createElement('div');
 			firstNode.className = 'item-one';
+			firstNode.textContent = 'first item content';
 			part.appendMarkdownItem(
 				() => ({ domNode: firstNode, disposable: { dispose: () => { } } }),
 				'codeblock-1',
@@ -1070,6 +1074,7 @@ suite('ChatSubagentContentPart', () => {
 			// Append second item with different ID
 			const secondNode = mainWindow.document.createElement('div');
 			secondNode.className = 'item-two';
+			secondNode.textContent = 'second item content';
 			part.appendMarkdownItem(
 				() => ({ domNode: secondNode, disposable: { dispose: () => { } } }),
 				'codeblock-2',

--- a/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import assert from 'assert';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { assertSnapshot } from '../../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { IChatMarkdownContent } from '../../../common/chatService/chatService.js';
-import { annotateSpecialMarkdownContent, extractVulnerabilitiesFromText } from '../../../common/widget/annotations.js';
+import { IChatMarkdownContent, IChatResponseCodeblockUriPart } from '../../../common/chatService/chatService.js';
+import { annotateSpecialMarkdownContent, extractCodeblockUrisFromText, extractSubAgentInvocationIdFromText, extractVulnerabilitiesFromText } from '../../../common/widget/annotations.js';
 
 function content(str: string): IChatMarkdownContent {
 	return { kind: 'markdownContent', content: new MarkdownString(str) };
@@ -56,6 +58,105 @@ suite('Annotations', function () {
 			const markdown = annotatedResult[0] as IChatMarkdownContent;
 			const result = extractVulnerabilitiesFromText(markdown.content.value);
 			await assertSnapshot(result);
+		});
+	});
+
+	suite('extractSubAgentInvocationIdFromText', () => {
+		test('extracts subAgentInvocationId from codeblock uri tag', () => {
+			const subAgentId = 'test-agent-123';
+			const uri = URI.parse('file:///test.ts');
+			const codeblockUriPart: IChatResponseCodeblockUriPart = {
+				kind: 'codeblockUri',
+				uri,
+				isEdit: true,
+				subAgentInvocationId: subAgentId
+			};
+			const annotated = annotateSpecialMarkdownContent([content('code'), codeblockUriPart]);
+			const markdown = annotated[0] as IChatMarkdownContent;
+
+			const result = extractSubAgentInvocationIdFromText(markdown.content.value);
+			assert.strictEqual(result, subAgentId);
+		});
+
+		test('returns undefined when no subAgentInvocationId', () => {
+			const uri = URI.parse('file:///test.ts');
+			const codeblockUriPart: IChatResponseCodeblockUriPart = {
+				kind: 'codeblockUri',
+				uri,
+				isEdit: true
+			};
+			const annotated = annotateSpecialMarkdownContent([content('code'), codeblockUriPart]);
+			const markdown = annotated[0] as IChatMarkdownContent;
+
+			const result = extractSubAgentInvocationIdFromText(markdown.content.value);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('returns undefined for text without codeblock uri tag', () => {
+			const result = extractSubAgentInvocationIdFromText('some random text');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('handles special characters in subAgentInvocationId via URL encoding', () => {
+			const subAgentId = 'agent-with-special&chars=value';
+			const uri = URI.parse('file:///test.ts');
+			const codeblockUriPart: IChatResponseCodeblockUriPart = {
+				kind: 'codeblockUri',
+				uri,
+				isEdit: true,
+				subAgentInvocationId: subAgentId
+			};
+			const annotated = annotateSpecialMarkdownContent([content('code'), codeblockUriPart]);
+			const markdown = annotated[0] as IChatMarkdownContent;
+
+			const result = extractSubAgentInvocationIdFromText(markdown.content.value);
+			assert.strictEqual(result, subAgentId);
+		});
+
+		test('handles malformed URL encoding gracefully', () => {
+			// Manually construct a malformed tag with invalid URL encoding
+			const malformedTag = '<vscode_codeblock_uri isEdit subAgentInvocationId="%ZZ">file:///test.ts</vscode_codeblock_uri>';
+			const result = extractSubAgentInvocationIdFromText(malformedTag);
+			// Should return the raw value when decoding fails
+			assert.strictEqual(result, '%ZZ');
+		});
+	});
+
+	suite('extractCodeblockUrisFromText with subAgentInvocationId', () => {
+		test('extracts subAgentInvocationId from codeblock uri', () => {
+			const subAgentId = 'test-subagent-456';
+			const uri = URI.parse('file:///example.ts');
+			const codeblockUriPart: IChatResponseCodeblockUriPart = {
+				kind: 'codeblockUri',
+				uri,
+				isEdit: true,
+				subAgentInvocationId: subAgentId
+			};
+			const annotated = annotateSpecialMarkdownContent([codeblockUriPart]);
+			const markdown = annotated[0] as IChatMarkdownContent;
+
+			const result = extractCodeblockUrisFromText(markdown.content.value);
+			assert.ok(result);
+			assert.strictEqual(result.subAgentInvocationId, subAgentId);
+			assert.strictEqual(result.uri.toString(), uri.toString());
+			assert.strictEqual(result.isEdit, true);
+		});
+
+		test('round-trip encoding/decoding with special characters', () => {
+			const subAgentId = 'agent/with spaces&special=chars?more';
+			const uri = URI.parse('file:///path/to/file.ts');
+			const codeblockUriPart: IChatResponseCodeblockUriPart = {
+				kind: 'codeblockUri',
+				uri,
+				isEdit: true,
+				subAgentInvocationId: subAgentId
+			};
+			const annotated = annotateSpecialMarkdownContent([codeblockUriPart]);
+			const markdown = annotated[0] as IChatMarkdownContent;
+
+			const extracted = extractCodeblockUrisFromText(markdown.content.value);
+			assert.ok(extracted);
+			assert.strictEqual(extracted.subAgentInvocationId, subAgentId);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/widget/annotations.test.ts
@@ -132,7 +132,7 @@ suite('Annotations', function () {
 				isEdit: true,
 				subAgentInvocationId: subAgentId
 			};
-			const annotated = annotateSpecialMarkdownContent([codeblockUriPart]);
+			const annotated = annotateSpecialMarkdownContent([content('code'), codeblockUriPart]);
 			const markdown = annotated[0] as IChatMarkdownContent;
 
 			const result = extractCodeblockUrisFromText(markdown.content.value);
@@ -151,7 +151,7 @@ suite('Annotations', function () {
 				isEdit: true,
 				subAgentInvocationId: subAgentId
 			};
-			const annotated = annotateSpecialMarkdownContent([codeblockUriPart]);
+			const annotated = annotateSpecialMarkdownContent([content('code'), codeblockUriPart]);
 			const markdown = annotated[0] as IChatMarkdownContent;
 
 			const extracted = extractCodeblockUrisFromText(markdown.content.value);


### PR DESCRIPTION
Enhancements to the chat subagent UX allow for rendering edits within the subagent container. This update introduces a stable `subAgentInvocationId` to route edits to the appropriate subagent content. The changes include modifications to the chat service, code block model collection, and chat list renderer to support this functionality. Testing can be performed by running subagents and verifying that edits are displayed correctly in the UI.
#286606

