### PR TITLE
feature: Add dropdown for InlineChatDefaultModel setting selection

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './inlineChatDefaultModel.js';
+
 import { EditorContributionInstantiation, registerEditorContribution } from '../../../../editor/browser/editorExtensions.js';
 import { IMenuItem, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { InlineChatController } from './inlineChatController.js';

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
@@ -8,16 +8,17 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '.
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { ILanguageModelsService } from '../../chat/common/languageModels.js';
+import { ILanguageModelsService, ILanguageModelChatMetadata } from '../../chat/common/languageModels.js';
 import { InlineChatConfigKeys } from '../common/inlineChat.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 
 export class InlineChatDefaultModel extends Disposable {
+	static readonly ID = 'workbench.contrib.inlineChatDefaultModel';
 	static readonly configName = InlineChatConfigKeys.DefaultModel;
 
-	static modelIds: (string | null)[] = [];
-	static modelLabels: string[] = [];
-	static modelDescriptions: string[] = [];
+	static modelIds: string[] = [''];
+	static modelLabels: string[] = [localize('defaultModel', 'Auto (Vendor Default)')];
+	static modelDescriptions: string[] = [localize('defaultModelDescription', 'Use the vendor\'s default model')];
 
 	constructor(
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
@@ -37,13 +38,13 @@ export class InlineChatDefaultModel extends Disposable {
 
 			// Add default/empty option
 			InlineChatDefaultModel.modelIds.push('');
-			InlineChatDefaultModel.modelLabels.push(localize('defaultModel', 'Default'));
+			InlineChatDefaultModel.modelLabels.push(localize('defaultModel', 'Auto (Vendor Default)'));
 			InlineChatDefaultModel.modelDescriptions.push(localize('defaultModelDescription', 'Use the vendor\'s default model'));
 
 			// Get all available models
 			const modelIds = this.languageModelsService.getLanguageModelIds();
 
-			const models: { identifier: string; metadata: import('../../chat/common/languageModels.js').ILanguageModelChatMetadata }[] = [];
+			const models: { identifier: string; metadata: ILanguageModelChatMetadata }[] = [];
 
 			// Look up each model's metadata
 			for (const modelId of modelIds) {
@@ -93,13 +94,13 @@ export class InlineChatDefaultModel extends Disposable {
 	}
 }
 
-registerWorkbenchContribution2(InlineChatDefaultModel.name, InlineChatDefaultModel, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(InlineChatDefaultModel.ID, InlineChatDefaultModel, WorkbenchPhase.BlockRestore);
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...{ id: 'inlineChat', title: localize('inlineChatConfigurationTitle', 'Inline Chat'), order: 30, type: 'object' },
 	properties: {
 		[InlineChatDefaultModel.configName]: {
-			description: localize('inlineChatDefaultModelDescription', "The default model to use for inline chat. If not set or empty, the vendor's default model will be used."),
+			description: localize('inlineChatDefaultModelDescription', "Select the default language model to use for inline chat from the available providers. Model names may include the provider in parentheses, for example 'GPT-4o (copilot)'."),
 			type: 'string',
 			default: '',
 			enum: InlineChatDefaultModel.modelIds,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { ILanguageModelsService } from '../../chat/common/languageModels.js';
+import { InlineChatConfigKeys } from '../common/inlineChat.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+
+export class InlineChatDefaultModel extends Disposable {
+	static readonly configName = InlineChatConfigKeys.DefaultModel;
+
+	static modelIds: (string | null)[] = [];
+	static modelLabels: string[] = [];
+	static modelDescriptions: string[] = [];
+
+	constructor(
+		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+		this._register(languageModelsService.onDidChangeLanguageModels(() => this._updateModelValues()));
+		this._updateModelValues();
+	}
+
+	private _updateModelValues(): void {
+		try {
+			// Clear arrays
+			InlineChatDefaultModel.modelIds.length = 0;
+			InlineChatDefaultModel.modelLabels.length = 0;
+			InlineChatDefaultModel.modelDescriptions.length = 0;
+
+			// Add default/empty option
+			InlineChatDefaultModel.modelIds.push('');
+			InlineChatDefaultModel.modelLabels.push(localize('defaultModel', 'Default'));
+			InlineChatDefaultModel.modelDescriptions.push(localize('defaultModelDescription', 'Use the vendor\'s default model'));
+
+			// Get all available models
+			const modelIds = this.languageModelsService.getLanguageModelIds();
+
+			const models: { identifier: string; metadata: import('../../chat/common/languageModels.js').ILanguageModelChatMetadata }[] = [];
+
+			// Look up each model's metadata
+			for (const modelId of modelIds) {
+				try {
+					const metadata = this.languageModelsService.lookupLanguageModel(modelId);
+					if (metadata) {
+						models.push({ identifier: modelId, metadata });
+					} else {
+						this.logService.warn(`[InlineChatDefaultModel] No metadata found for model ID: ${modelId}`);
+					}
+				} catch (e) {
+					this.logService.error(`[InlineChatDefaultModel] Error looking up model ${modelId}:`, e);
+				}
+			}
+
+			// Filter models that are:
+			// 1. User selectable
+			// 2. Support tool calling (required for inline chat v2)
+			const supportedModels = models.filter(model => {
+				if (!model.metadata?.isUserSelectable) {
+					return false;
+				}
+				// Check if model supports inline chat - needs tool calling capability
+				if (!model.metadata.capabilities?.toolCalling) {
+					return false;
+				}
+				return true;
+			});
+
+			// Sort alphabetically by name
+			supportedModels.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+
+			// Populate arrays with filtered models
+			for (const model of supportedModels) {
+				try {
+					const qualifiedName = `${model.metadata.name} (${model.metadata.vendor})`;
+					InlineChatDefaultModel.modelIds.push(qualifiedName);
+					InlineChatDefaultModel.modelLabels.push(model.metadata.name);
+					InlineChatDefaultModel.modelDescriptions.push(model.metadata.tooltip ?? model.metadata.detail ?? '');
+				} catch (e) {
+					this.logService.error(`[InlineChatDefaultModel] Error adding model ${model.metadata.name}:`, e);
+				}
+			}
+		} catch (e) {
+			this.logService.error('[InlineChatDefaultModel] Error updating model values:', e);
+		}
+	}
+}
+
+registerWorkbenchContribution2(InlineChatDefaultModel.name, InlineChatDefaultModel, WorkbenchPhase.BlockRestore);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...{ id: 'inlineChat', title: localize('inlineChatConfigurationTitle', 'Inline Chat'), order: 30, type: 'object' },
+	properties: {
+		[InlineChatDefaultModel.configName]: {
+			description: localize('inlineChatDefaultModelDescription', "The default model to use for inline chat. If not set or empty, the vendor's default model will be used."),
+			type: 'string',
+			default: '',
+			enum: InlineChatDefaultModel.modelIds,
+			enumItemLabels: InlineChatDefaultModel.modelLabels,
+			markdownEnumDescriptions: InlineChatDefaultModel.modelDescriptions
+		}
+	}
+});

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -55,11 +55,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				mode: 'startup'
 			}
 		},
-		[InlineChatConfigKeys.DefaultModel]: {
-			markdownDescription: localize('defaultModel', "The default model to use for inline chat. The value can be the model's qualified name (e.g., `{0}`) or the model name for Copilot models (e.g., `{1}`). If not set, the vendor's default model for inline chat is used.", 'GPT-4o (copilot)', 'GPT-4o'),
-			default: '',
-			type: 'string'
-		},
 		[InlineChatConfigKeys.Affordance]: {
 			description: localize('affordance', "Controls whether an inline chat affordance is shown when text is selected."),
 			default: 'off',


### PR DESCRIPTION
now for the setting inlineChat.defaultModel instead of it having a "string" feild where the user must type in the exact correct name, it is a dropdown they can select from