### PR TITLE
Fix title toolbar right side ignoring mouse events (#290170)

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -73,6 +73,7 @@
 	z-index: 2501;
 	-webkit-app-region: no-drag;
 }
+
 .monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-left {
 	order: 0;
 	width: 20%;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -71,6 +71,12 @@
 	align-items: center;
 }
 
+.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right {
+	position: relative;
+	z-index: 2501;
+	-webkit-app-region: no-drag;
+}
+
 .monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-left {
 	order: 0;
 	width: 20%;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -69,14 +69,10 @@
 	display: flex;
 	height: 100%;
 	align-items: center;
-}
-
-.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-right {
 	position: relative;
 	z-index: 2501;
 	-webkit-app-region: no-drag;
 }
-
 .monaco-workbench .part.titlebar > .titlebar-container.has-center > .titlebar-left {
 	order: 0;
 	width: 20%;


### PR DESCRIPTION
Fixes #290170

**Bug Analysis**
The `titlebar-drag-region` was positioned absolutely and covered the entire area, causing the `titlebar-right` empty space to be obscured. This prevented mouse events (like clicking to close context menus) from propagating to the `MOUSE_DOWN` handler in `contextMenuHandler.ts`.

**Fix**
![fix-#290170](https://github.com/user-attachments/assets/f26ffd2c-b6e0-48ad-beb0-590ab42797ef)

I have applied the following CSS changes to `.titlebar-right` in `titlebarpart.css`:
- `position: relative`: To allow z-index positioning.
- `z-index: 2501`: To place it above the drag region (which has no z-index but was overlaying).
- `-webkit-app-region: no-drag`: To ensure mouse events are not consumed by the window drag behavior and can propagate correctly.