### PR TITLE
ListView doesn't update the cached dynamic height in all cases

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1613,7 +1613,10 @@ export class ListView<T> implements IListView<T> {
 	private probeDynamicHeight(index: number): number {
 		const item = this.items[index];
 		const diff = this.probeDynamicHeightForItem(item, index);
-		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+		if (diff > 0) {
+			this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+		}
+
 		return diff;
 	}
 

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1612,7 +1612,12 @@ export class ListView<T> implements IListView<T> {
 
 	private probeDynamicHeight(index: number): number {
 		const item = this.items[index];
+		const diff = this.probeDynamicHeightForItem(item, index);
+		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
+		return diff;
+	}
 
+	private probeDynamicHeightForItem(item: IItem<T>, index: number): number {
 		if (!!this.virtualDelegate.getDynamicHeight) {
 			const newSize = this.virtualDelegate.getDynamicHeight(item.element);
 			if (newSize !== null) {
@@ -1660,8 +1665,6 @@ export class ListView<T> implements IListView<T> {
 		renderer.renderElement(item.element, index, row.templateData);
 		item.size = row.domNode.offsetHeight;
 		renderer.disposeElement?.(item.element, index, row.templateData);
-
-		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
 
 		item.lastDynamicHeightWidth = this.renderWidth;
 		row.domNode.remove();


### PR DESCRIPTION
Fix #290265

cc @joaomoreno @rebornix 

The list would store the correct height of a row, but then not call setDynamicHeight so CachedListVirtualDelegate would return the wrong height and we'd scroll to the wrong place.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
