### PR TITLE
Start thinking parts as collapsed when possible so they benefit from lazy rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -171,7 +171,10 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 			this.setExpanded(false);
 		} else if (configuredMode === ThinkingDisplayMode.CollapsedPreview) {
 			// Start expanded if still in progress
-			this.setExpanded(!this.element.isComplete);
+			// Use streamingCompleted to support look-ahead completion: when we know
+			// this thinking part is done (based on subsequent non-pinnable parts)
+			// even though the overall response is not complete
+			this.setExpanded(!this.streamingCompleted && !this.element.isComplete);
 		} else {
 			this.setExpanded(false);
 		}
@@ -241,7 +244,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	}
 
 	protected override shouldInitEarly(): boolean {
-		return this.fixedScrollingMode;
+		return this.fixedScrollingMode && !this.streamingCompleted;
 	}
 
 	// @TODO: @justschen Convert to template for each setting?


### PR DESCRIPTION
Fix #290207 This is a bit backwards because we shouldn't really have this separate isThinkingLookAheadComplete method, I think we should have a logical model structure that tells us what we are going to render. But right now it's set up render everything one at a time and only make these decisions after the thinking part has already been created, so there's no way to know whether we are rendering an already completed thinking part without doing this look-ahead.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
