### PR TITLE
Add support for debugging renderer and extension host in new window actions

### DIFF
--- a/src/vs/platform/debug/common/extensionHostDebug.ts
+++ b/src/vs/platform/debug/common/extensionHostDebug.ts
@@ -29,6 +29,7 @@ export interface ICloseSessionEvent {
 
 export interface IOpenExtensionWindowResult {
 	rendererDebugAddr?: string;
+	port?: number;
 	success: boolean;
 }
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -19,7 +19,7 @@ import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer } from '../
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { RuntimeExtensionsInput } from '../common/runtimeExtensionsInput.js';
-import { DebugExtensionHostInNewWindowAction, DebugExtensionsContribution, DebugExtensionHostInDevToolsAction } from './debugExtensionHostAction.js';
+import { DebugExtensionHostInNewWindowAction, DebugExtensionsContribution, DebugExtensionHostInDevToolsAction, DebugRendererInNewWindowAction, DebugExtensionHostAndRendererAction } from './debugExtensionHostAction.js';
 import { ExtensionHostProfileService } from './extensionProfileService.js';
 import { CleanUpExtensionsFolderAction, OpenExtensionsFolderAction } from './extensionsActions.js';
 import { ExtensionsAutoProfiler } from './extensionsAutoProfiler.js';
@@ -77,6 +77,8 @@ workbenchRegistry.registerWorkbenchContribution(DebugExtensionsContribution, Lif
 // Register Commands
 
 registerAction2(DebugExtensionHostInNewWindowAction);
+registerAction2(DebugRendererInNewWindowAction);
+registerAction2(DebugExtensionHostAndRendererAction);
 registerAction2(StartExtensionHostProfileAction);
 registerAction2(StopExtensionHostProfileAction);
 registerAction2(SaveExtensionHostProfileAction);


### PR DESCRIPTION
I tested all three commands on OSS (they work :rocket:)