### PR TITLE
Adding helpful message when domains are restricted due to sandboxing

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -812,7 +812,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					}
 				}));
 				const executeResult = await strategy.execute(command, executeCancellation.token, commandId);
-
 				// if sandboxing is enabled and the command files due to domains not allowed by the sandbox, provide a helpful message.
 				if (exitCode !== 0 && this._sandboxService.isEnabled()) {
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -28,6 +28,7 @@ export interface ITerminalSandboxService {
 	getSandboxConfigPath(forceRefresh?: boolean): Promise<string | undefined>;
 	getTempDir(): URI | undefined;
 	setNeedsForceUpdateConfigFile(): void;
+	checkIfDomainsAreSandboxed(urls: string[]): boolean;
 }
 
 export class TerminalSandboxService implements ITerminalSandboxService {
@@ -39,6 +40,7 @@ export class TerminalSandboxService implements ITerminalSandboxService {
 	private _tempDir: URI | undefined;
 	private _sandboxSettingsId: string | undefined;
 	private _os: OperatingSystem = OS;
+	private _sandboxDomains: Set<string> = new Set<string>();
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -91,8 +93,25 @@ export class TerminalSandboxService implements ITerminalSandboxService {
 		if (!this._sandboxConfigPath || forceRefresh || this._needsForceUpdateConfigFile) {
 			this._sandboxConfigPath = await this._createSandboxConfig();
 			this._needsForceUpdateConfigFile = false;
+			this._setSandboxedDomains();
 		}
 		return this._sandboxConfigPath;
+	}
+
+	public checkIfDomainsAreSandboxed(domains: string[]): boolean {
+		for (const domain of domains) {
+			const lowerCaseDomain = domain.toLowerCase();
+			if (this._sandboxDomains.has(lowerCaseDomain)) {
+				return true;
+			}
+
+			for (const sandboxedDomain of this._sandboxDomains) {
+				if (sandboxedDomain.startsWith('*') && lowerCaseDomain.endsWith(`${sandboxedDomain.slice(1)}`)) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	private async _createSandboxConfig(): Promise<string | undefined> {
@@ -138,4 +157,17 @@ export class TerminalSandboxService implements ITerminalSandboxService {
 			}
 		}
 	}
+
+	private _setSandboxedDomains(): void {
+		const networkSettings = this._configurationService.getValue<ITerminalSandboxSettings['network']>(TerminalChatAgentToolsSettingId.TerminalSandboxNetwork) ?? {};
+		const allowedDomains = networkSettings.allowedDomains ?? [];
+		const deniedDomains = networkSettings.deniedDomains ?? [];
+		this._sandboxDomains.clear();
+		for (const domain of [...allowedDomains, ...deniedDomains]) {
+			if (domain) {
+				this._sandboxDomains.add(domain.toLowerCase());
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
By default when sandboxing is enabled, all the domains are restricted unless the domain is added to allowed list. Added a message when a command fails if the requested domain is not specified in the network settings.