### PR TITLE
Enhance 2026 Dark theme styling

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -124,7 +124,7 @@
 		"editorCodeLens.foreground": "#888888",
 		"editorBracketMatch.background": "#3994BC55",
 		"editorBracketMatch.border": "#2A2B2CFF",
-		"editorWidget.background": "#20212280",
+		"editorWidget.background": "#202122AA",
 		"editorWidget.border": "#2A2B2CFF",
 		"editorWidget.foreground": "#bfbfbf",
 		"editorSuggestWidget.background": "#202122",

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -210,7 +210,14 @@
 }
 
 /* Peek View */
-.monaco-workbench .monaco-editor .peekview-widget { box-shadow: var(--shadow-hover); border: none; background: var(--vscode-editor-background) !important; backdrop-filter: var(--backdrop-blur-sm); -webkit-backdrop-filter: var(--backdrop-blur-sm); overflow: hidden; }
+.monaco-workbench .monaco-editor .peekview-widget {
+	box-shadow: var(--shadow-hover);
+	border: none;
+	background: var(--vscode-editor-background) !important;
+	backdrop-filter: var(--backdrop-blur-sm);
+	-webkit-backdrop-filter: var(--backdrop-blur-sm);
+	overflow: hidden;
+}
 .monaco-workbench .monaco-editor .peekview-widget .head,
 .monaco-workbench .monaco-editor .peekview-widget .body { background: transparent !important; }
 
@@ -239,6 +246,16 @@
 	border: 1px solid var(--vscode-editorWidget-border);
 }
 
+.monaco-workbench .chat-editor-overlay-widget, .monaco-workbench .chat-diff-change-content-widget {
+	box-shadow: var(--shadow-md);
+	backdrop-filter: var(--backdrop-blur-md);
+	-webkit-backdrop-filter: var(--backdrop-blur-md);
+}
+
+.monaco-workbench.vs-dark .chat-editor-overlay-widget, .monaco-workbench.vs-dark .chat-diff-change-content-widget
+{
+	border: 1px solid var(--vscode-editorWidget-border);
+}
 /* Settings */
 .monaco-workbench .settings-editor .settings-toc-container { box-shadow: var(--shadow-sm); }
 


### PR DESCRIPTION
Adjust the editor widget background opacity and improve the styling of the peek view to enhance the overall appearance in the 2026 Dark theme.

