### PR TITLE
Fix alternative action picker bug

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -91,6 +91,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 					class: ThemeIcon.asClassName(Codicon.tools),
 					enabled: true,
 					run: async () => {
+						// Hide the picker before opening the tools configuration
+						actionWidgetService.hide();
 						// First switch to the mode if not already selected
 						if (currentMode.id !== mode.id) {
 							await commandService.executeCommand(


### PR DESCRIPTION
```Copilot Generated Description:``` Hide the picker before opening the tools configuration in the alternative action picker.

