### PR TITLE
Fix terminal chat auto-expand for commands without visible output

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -602,10 +602,11 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				if (cursorLine > command.executedMarker.line) {
 					return true;
 				}
-				// If we've received multiple data events, treat it as real output even if cursor
+				// If we've received many data events, treat it as real output even if cursor
 				// hasn't moved past the marker (e.g., progress bars updating on same line)
-				// Shell integration sequences typically fire once, so multiple events indicate real data
-				return receivedDataCount > 1;
+				// Shell integration sequences fire multiple times per command (PromptStart, CommandStart,
+				// CommandExecuted, CommandFinished, etc.), so we need a higher threshold
+				return receivedDataCount > 4;
 			};
 
 			// Use the extracted auto-expand logic


### PR DESCRIPTION
fix #290480

Shell integration sequences (PromptStart, CommandStart, CommandExecuted, CommandFinished) fire multiple data events even for commands with no visible output. The old threshold of > 1 was too low, causing `hasRealOutput` to return true for sleep 2 since it receives ~4 SI sequence events. Raising the threshold to > 4 means only commands with actual ongoing output (like progress bars) will trigger the fallback, while silent long-running commands like sleep won't falsely auto-expand.

cc @tyriar