### PR TITLE
mcp: update apps spec to align with stable spec

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
@@ -389,7 +389,9 @@ export class ChatMcpAppModel extends Disposable {
 					break;
 
 				case 'ui/request-display-mode':
-					break; // not supported
+					// VS Code only supports inline display mode
+					result = { mode: 'inline' } satisfies McpApps.McpUiRequestDisplayModeResult;
+					break;
 
 				case 'ui/notifications/initialized':
 					break;
@@ -431,7 +433,7 @@ export class ChatMcpAppModel extends Disposable {
 	}
 
 	/**
-	 * Handles the ui/initialize request from the MCP App.
+	 * Handles the ui/initialize request from the MCP App View.
 	 */
 	private async _handleInitialize(_params: McpApps.McpUiInitializeRequest['params']): Promise<McpApps.McpUiInitializeResult> {
 		this._announcedCapabilities = true;

--- a/src/vs/workbench/contrib/mcp/common/modelContextProtocolApps.ts
+++ b/src/vs/workbench/contrib/mcp/common/modelContextProtocolApps.ts
@@ -68,7 +68,7 @@ export namespace McpApps {
 	 * The SDK automatically handles version negotiation during initialization.
 	 * Apps and hosts don't need to manage protocol versions manually.
 	 */
-	export const LATEST_PROTOCOL_VERSION = "2025-11-21";
+	export const LATEST_PROTOCOL_VERSION = "2026-01-26";
 
 	/**
 	 * @description Color theme preference for the host environment.
@@ -515,12 +515,12 @@ export namespace McpApps {
 		};
 		/** @description Host accepts context updates (ui/update-model-context) to be included in the model's context for future turns. */
 		updateModelContext?: McpUiSupportedContentBlockModalities;
-		/** @description Host supports receiving content messages (ui/message) from the Guest UI. */
+		/** @description Host supports receiving content messages (ui/message) from the View. */
 		message?: McpUiSupportedContentBlockModalities;
 	}
 
 	/**
-	 * @description Capabilities provided by the Guest UI (App).
+	 * @description Capabilities provided by the View (App).
 	 * @see {@link McpUiInitializeRequest} for the initialization request that includes these capabilities
 	 */
 	export interface McpUiAppCapabilities {
@@ -531,6 +531,11 @@ export namespace McpApps {
 			/** @description App supports tools/list_changed notifications. */
 			listChanged?: boolean;
 		};
+		/**
+		 * @description Display modes the app supports. See Display Modes section of the spec for details.
+		 * @example ["inline", "fullscreen"]
+		 */
+		availableDisplayModes?: McpUiDisplayMode[];
 	}
 
 	/**


### PR DESCRIPTION
Align VS Code's MCP Apps implementation with the latest specification
from modelcontextprotocol/ext-apps:

- Add availableDisplayModes to McpUiAppCapabilities interface
  (commit 89f58bf) to allow Views to declare supported display modes
  during initialization. VS Code supports only 'inline' mode currently.

- Fix ui/request-display-mode handler to return { mode: 'inline' }
  per spec requirement, instead of empty response.

- Update JSDoc comments to use 'View' terminology consistently
  instead of 'Guest UI' (following commit 4fc7165).

- Verify CSP handling for script-src/style-src with resourceDomains
  is correct (commit df49e88). Already implemented correctly in
  chatMcpAppModel._injectPreamble().

Note: styles.css.fonts, ui.domain, and other changes either don't
require action or are already implemented.

(Commit message generated by Copilot)