### PR TITLE
Fix bad use of ResourcePool - register disposables to wrapper, not pool class

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -10,7 +10,7 @@ import { coalesce } from '../../../../../../base/common/arrays.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { matchesSomeScheme, Schemas } from '../../../../../../base/common/network.js';
 import { basename } from '../../../../../../base/common/path.js';
 import { basenameOrAuthority, isEqualAuthority } from '../../../../../../base/common/resources.js';
@@ -180,10 +180,14 @@ export class ChatUsedReferencesListContentPart extends ChatCollapsibleListConten
 	}
 }
 
-export class CollapsibleListPool extends Disposable {
-	private _pool: ResourcePool<WorkbenchList<IChatCollapsibleListItem>>;
+interface ICollapsibleListWrapper extends IDisposable {
+	list: WorkbenchList<IChatCollapsibleListItem>;
+}
 
-	public get inUse(): ReadonlySet<WorkbenchList<IChatCollapsibleListItem>> {
+export class CollapsibleListPool extends Disposable {
+	private _pool: ResourcePool<ICollapsibleListWrapper>;
+
+	public get inUse(): ReadonlySet<ICollapsibleListWrapper> {
 		return this._pool.inUse;
 	}
 
@@ -199,11 +203,12 @@ export class CollapsibleListPool extends Disposable {
 		this._pool = this._register(new ResourcePool(() => this.listFactory()));
 	}
 
-	private listFactory(): WorkbenchList<IChatCollapsibleListItem> {
-		const resourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility }));
+	private listFactory(): ICollapsibleListWrapper {
+		const store = new DisposableStore();
+		const resourceLabels = store.add(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility }));
 
 		const container = $('.chat-used-context-list');
-		this._register(createFileIconThemableTreeContainerScope(container, this.themeService));
+		store.add(createFileIconThemableTreeContainerScope(container, this.themeService));
 
 		const list = this.instantiationService.createInstance(
 			WorkbenchList<IChatCollapsibleListItem>,
@@ -260,18 +265,21 @@ export class CollapsibleListPool extends Disposable {
 				},
 			});
 
-		return list;
+		return {
+			list,
+			dispose: () => store.dispose()
+		};
 	}
 
 	get(): IDisposableReference<WorkbenchList<IChatCollapsibleListItem>> {
-		const object = this._pool.get();
+		const wrapper = this._pool.get();
 		let stale = false;
 		return {
-			object,
+			object: wrapper.list,
 			isStale: () => stale,
 			dispose: () => {
 				stale = true;
-				this._pool.release(object);
+				this._pool.release(wrapper);
 			}
 		};
 	}


### PR DESCRIPTION
Fixes #290328

## Problem
The factory methods in `CollapsibleListPool` and `TreePool` were registering disposables (like `ResourceLabels` and tree container scopes) to the pool class via `this._register()` instead of associating them with the pool item. This meant they would only be disposed when the entire pool was disposed, not when individual items were cleared or released.

## Solution
This copies the correct strategy used by `CollapsibleChangesSummaryListPool`:
- Create wrapper types (`ICollapsibleListWrapper`, `ITreePoolWrapper`) that implement `IDisposable`
- Use a local `DisposableStore` in the factory method to track the item's disposables
- Return a wrapper object with its own `dispose()` method that cleans up the store
- Update `get()` to unwrap and return the inner list/tree while properly releasing the wrapper