### PR TITLE
sessions: remove old diff representation from ext api

### DIFF
--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -45,7 +45,7 @@ class ChatSessionItemImpl implements vscode.ChatSessionItem {
 	#archived?: boolean;
 	#tooltip?: string | vscode.MarkdownString;
 	#timing?: ChatSessionTiming;
-	#changes?: readonly vscode.ChatSessionChangedFile[] | { files: number; insertions: number; deletions: number };
+	#changes?: readonly vscode.ChatSessionChangedFile[];
 	#onChanged: () => void;
 
 	readonly resource: vscode.Uri;
@@ -144,11 +144,11 @@ class ChatSessionItemImpl implements vscode.ChatSessionItem {
 		}
 	}
 
-	get changes(): readonly vscode.ChatSessionChangedFile[] | { files: number; insertions: number; deletions: number } | undefined {
+	get changes(): readonly vscode.ChatSessionChangedFile[] | undefined {
 		return this.#changes;
 	}
 
-	set changes(value: readonly vscode.ChatSessionChangedFile[] | { files: number; insertions: number; deletions: number } | undefined) {
+	set changes(value: readonly vscode.ChatSessionChangedFile[] | undefined) {
 		if (this.#changes !== value) {
 			this.#changes = value;
 			this.#onChanged();
@@ -478,13 +478,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 				lastRequestStarted,
 				lastRequestEnded,
 			},
-			changes: sessionContent.changes instanceof Array
-				? sessionContent.changes :
-				(sessionContent.changes && {
-					files: sessionContent.changes?.files ?? 0,
-					insertions: sessionContent.changes?.insertions ?? 0,
-					deletions: sessionContent.changes?.deletions ?? 0,
-				}),
+			changes: sessionContent.changes instanceof Array ? sessionContent.changes : undefined,
 		};
 	}
 

--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -231,22 +231,7 @@ declare module 'vscode' {
 		/**
 		 * Statistics about the chat session.
 		 */
-		changes?: readonly ChatSessionChangedFile[] | readonly ChatSessionChangedFile2[] | {
-			/**
-			 * Number of files edited during the session.
-			 */
-			files: number;
-
-			/**
-			 * Number of insertions made during the session.
-			 */
-			insertions: number;
-
-			/**
-			 * Number of deletions made during the session.
-			 */
-			deletions: number;
-		};
+		changes?: readonly ChatSessionChangedFile[] | readonly ChatSessionChangedFile2[];
 	}
 
 	export class ChatSessionChangedFile {


### PR DESCRIPTION
Remove the old diff format for simplification in #289936. Old usage is still present in the IAgentSession as local sessions still use internally, for future cleanup in debt week.

Refs #289936

(Commit message generated by Copilot)