### PR TITLE
chat: add more JS lock files to sensitive files regex

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -323,8 +323,10 @@ configurationRegistry.registerConfiguration({
 				'**/*': true,
 				'**/.vscode/*.json': false,
 				'**/.git/**': false,
-				'**/{package.json,package-lock.json,server.xml,build.rs,web.config,.gitattributes,.env}': false,
+				'**/{package.json,server.xml,build.rs,web.config,.gitattributes,.env}': false,
 				'**/*.{code-workspace,csproj,fsproj,vbproj,vcxproj,proj,targets,props}': false,
+				'**/*.lock': false, // yarn.lock, bun.lock, etc.
+				'**/*-lock.{yaml,json}': false, // pnpm-lock.yaml, package-lock.json
 			},
 			markdownDescription: nls.localize('chat.tools.autoApprove.edits', "Controls whether edits made by chat are automatically approved. The default is to approve all edits except those made to certain files which have the potential to cause immediate unintended side-effects, such as `**/.vscode/*.json`.\n\nSet to `true` to automatically approve edits to matching files, `false` to always require explicit approval. The last pattern matching a given file will determine whether the edit is automatically approved."),
 			type: 'object',


### PR DESCRIPTION
Add yarn.lock, bun.lock, pnpm-lock.yaml, and other lock files to the default sensitive files list that require explicit approval before auto-applying edits.

- Add **/*.lock pattern to catch yarn.lock and bun.lock files
- Add **/*-lock.{yaml,json} pattern to catch pnpm-lock.yaml and package-lock.json
- Remove package-lock.json from explicit list as it's now covered by the more general patterns

Fixes https://github.com/microsoft/vscode-internalbacklog/issues/6541

(Commit message generated by Copilot)