### PR TITLE
thinking style cleanup/padding fixes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -19,14 +19,12 @@
 
 	/* shimmer animation stuffs */
 	.chat-thinking-spinner-item .chat-thinking-spinner-label {
-		background: linear-gradient(
-			90deg,
-			var(--vscode-descriptionForeground) 0%,
-			var(--vscode-descriptionForeground) 30%,
-			var(--vscode-chat-thinkingShimmer) 50%,
-			var(--vscode-descriptionForeground) 70%,
-			var(--vscode-descriptionForeground) 100%
-		);
+		background: linear-gradient(90deg,
+				var(--vscode-descriptionForeground) 0%,
+				var(--vscode-descriptionForeground) 30%,
+				var(--vscode-chat-thinkingShimmer) 50%,
+				var(--vscode-descriptionForeground) 70%,
+				var(--vscode-descriptionForeground) 100%);
 		background-size: 400% 100%;
 		background-clip: text;
 		-webkit-background-clip: text;
@@ -61,7 +59,8 @@
 				padding-left: 2px;
 			}
 
-			.progress-container, .chat-confirmation-widget-container {
+			.progress-container,
+			.chat-confirmation-widget-container {
 				margin: 0 0 2px 6px;
 			}
 
@@ -69,35 +68,6 @@
 				display: none;
 			}
 
-			.chat-terminal-thinking-content {
-				overflow: hidden;
-				padding: 10px 10px 10px 2px;
-
-				.codicon:not(.codicon-check, .codicon-loading) {
-					display: inline-flex;
-				}
-			}
-
-			.chat-terminal-thinking-collapsible {
-				display: flex;
-				flex-direction: column;
-				width: 100%;
-				margin: 1px 0 0 4px;
-
-				.chat-used-context-list.chat-terminal-thinking-content {
-					border: none;
-					padding: 0;
-					margin-bottom: 2px;
-
-					.progress-container {
-						margin: 0;
-					}
-				}
-
-				.chat-terminal-thinking-content .rendered-markdown [data-code] {
-					margin-bottom: 0px;
-				}
-			}
 		}
 
 		.chat-thinking-item.markdown-content {
@@ -217,6 +187,31 @@
 
 	.rendered-markdown > p {
 		margin: 0;
+	}
+}
+
+.interactive-session .interactive-response .value .chat-used-context.chat-terminal-thinking-collapsible {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+
+	.chat-used-context-list.chat-terminal-thinking-content {
+		border: none;
+		padding: 0;
+		margin-bottom: 2px;
+		overflow: hidden;
+
+		.codicon:not(.codicon-check, .codicon-loading) {
+			display: inline-flex;
+		}
+
+		.progress-container {
+			margin: 0;
+		}
+	}
+
+	.chat-terminal-thinking-content .rendered-markdown [data-code] {
+		margin-bottom: 0px;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -814,9 +814,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	private renderChatResponseBasic(element: IChatResponseViewModel, index: number, templateData: IChatListItemTemplate) {
 		templateData.rowContainer.classList.toggle('chat-response-loading', (isResponseVM(element) && !element.isComplete));
 
-		if (element.isCanceled) {
+		if (element.isComplete || element.isCanceled) {
 			const lastThinking = this.getLastThinkingPart(templateData.renderedParts);
-			if (lastThinking?.domNode) {
+			if (lastThinking?.domNode && lastThinking.getIsActive()) {
 				lastThinking.finalizeTitleIfDefault();
 				lastThinking.markAsInactive();
 			}
@@ -869,6 +869,16 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// never show working progress when there is an active thinking piece
 		const lastThinking = this.getLastThinkingPart(templateData.renderedParts);
 		if (lastThinking) {
+			return false;
+		}
+
+		const collapsedToolsMode = this.configService.getValue<CollapsedToolsDisplayMode>('chat.agent.thinking.collapsedTools');
+		if (collapsedToolsMode !== CollapsedToolsDisplayMode.Off &&
+			partsToRender.some(part =>
+				(part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') &&
+				part.presentation !== 'hidden' &&
+				this.shouldPinPart(part, element)
+			)) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -274,7 +274,7 @@
 }
 
 .interactive-item-container > .value .chat-used-context {
-	margin-bottom: 8px;
+	margin-bottom: 10px;
 }
 
 .interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {
@@ -572,7 +572,7 @@
 	}
 
 	&:not(:last-child) {
-		margin-bottom: 8px;
+		margin-bottom: 12px;
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes a few issues:
1. terminal padding/border when it is the only thing inside
2. wonky margins on solo tool calls and thinking headers
3. better check for working spinner again