### PR TITLE
Ignore errors when trying to clean up server logs

### DIFF
--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -377,7 +377,12 @@ function twodigits(n: number): string {
 async function cleanupOlderLogs(logsPath: string): Promise<void> {
 	const currentLog = path.basename(logsPath);
 	const logsRoot = path.dirname(logsPath);
-	const children = await Promises.readdir(logsRoot).catch(() => []);
+
+	if (!await Promises.exists(logsRoot)) {
+		return; // Logs root doesn't exist yet, nothing to clean up
+	}
+
+	const children = await Promises.readdir(logsRoot);
 	const allSessions = children.filter(name => /^\d{8}T\d{6}$/.test(name));
 	const oldSessions = allSessions.sort().filter((d) => d !== currentLog);
 	const toDelete = oldSessions.slice(0, Math.max(0, oldSessions.length - 9));

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -377,7 +377,7 @@ function twodigits(n: number): string {
 async function cleanupOlderLogs(logsPath: string): Promise<void> {
 	const currentLog = path.basename(logsPath);
 	const logsRoot = path.dirname(logsPath);
-	const children = await Promises.readdir(logsRoot);
+	const children = await Promises.readdir(logsRoot).catch(() => []);
 	const allSessions = children.filter(name => /^\d{8}T\d{6}$/.test(name));
 	const oldSessions = allSessions.sort().filter((d) => d !== currentLog);
 	const toDelete = oldSessions.slice(0, Math.max(0, oldSessions.length - 9));


### PR DESCRIPTION
Fixing server error found by sanity tests:
[2026-01-27T00:38:15.038Z] ERROR: [Server Error] [00:38:14] Error: ENOENT: no such file or directory, scandir '/tmp/vscode-sanityr4UsY0/data/logs'
at async Object.readdir (node:internal/fs/promises:957:18)
at async b6 (file:///tmp/vscode-sanitygp6yWf/vscode-server-linux-armhf/out/server-main.js:27:91415)
at async Object.Rh (file:///tmp/vscode-sanitygp6yWf/vscode-server-linux-armhf/out/server-main.js:27:91280)
at async VB (file:///tmp/vscode-sanitygp6yWf/vscode-server-linux-armhf/out/server-main.js:190:2819) {
errno: -2,
code: 'ENOENT',
syscall: 'scandir',
path: '/tmp/vscode-sanityr4UsY0/data/logs'
}
