### PR TITLE
Filter out global slash command suggestions for chatSession-contributed participants

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -340,7 +340,9 @@ class AgentCompletions extends Disposable {
 					.filter(a => a.locations.includes(widget.location));
 
 				// Filter out chatSessions contributions for slash command completions
-				const agentsForSlashCommands = agents.filter(a => !this.chatSessionsService.getChatSessionContribution(a.id));
+				const chatSessionContributions = this.chatSessionsService.getAllChatSessionContributions();
+				const chatSessionAgentIds = new Set(chatSessionContributions.map(contribution => contribution.id));
+				const agentsForSlashCommands = agents.filter(a => !chatSessionAgentIds.has(a.id));
 
 				// When the input is only `/`, items are sorted by sortText.
 				// When typing, filterText is used to score and sort.

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -341,7 +341,7 @@ class AgentCompletions extends Disposable {
 
 				// Filter out chatSessions contributions for slash command completions
 				const chatSessionContributions = this.chatSessionsService.getAllChatSessionContributions();
-				const chatSessionAgentIds = new Set(chatSessionContributions.map(contribution => contribution.id));
+				const chatSessionAgentIds = new Set(chatSessionContributions.map(contribution => contribution.type));
 				const agentsForSlashCommands = agents.filter(a => !chatSessionAgentIds.has(a.id));
 
 				// When the input is only `/`, items are sorted by sortText.


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/288172


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

### Doesn't show in the 'global' slash suggestions:
<img width="545" height="401" alt="Image" src="https://github.com/user-attachments/assets/0db4c31e-6746-4b63-bffa-f8ed3ea5477d" />

### DOES show when selecting the specific participant
<img width="772" height="334" alt="Image" src="https://github.com/user-attachments/assets/9a9e8f50-1193-44e8-ad9e-ba9fbd4f33b5" />
<img width="719" height="188" alt="image" src="https://github.com/user-attachments/assets/d9297d81-1d15-493c-9c54-3136ce30f0af" />
