### PR TITLE
Add test for arm64 Linux with 64K page size

### DIFF
--- a/build/azure-pipelines/common/sanity-tests.yml
+++ b/build/azure-pipelines/common/sanity-tests.yml
@@ -17,6 +17,9 @@ parameters:
   - name: baseImage
     type: string
     default: ""
+  - name: pageSize
+    type: string
+    default: ""
   - name: args
     type: string
     default: ""
@@ -92,7 +95,9 @@ jobs:
             cacheHitVar: DOCKER_CACHE_HIT
           displayName: Download Docker Image
 
-        - bash: docker load -i "$(DOCKER_CACHE_FILE)"
+        - bash: |
+            docker load -i "$(DOCKER_CACHE_FILE)"
+            rm -f "$(DOCKER_CACHE_FILE)"
           condition: eq(variables.DOCKER_CACHE_HIT, 'true')
           displayName: Load Docker Image
 
@@ -101,6 +106,7 @@ jobs:
               --container "${{ parameters.container }}" \
               --arch "${{ parameters.arch }}" \
               --base-image "${{ parameters.baseImage }}" \
+              --page-size "${{ parameters.pageSize }}" \
               --quality "$(BUILD_QUALITY)" \
               --commit "$(BUILD_COMMIT)" \
               --test-results "/root/results.xml" \
@@ -108,11 +114,12 @@ jobs:
           workingDirectory: $(TEST_DIR)
           displayName: Run Sanity Tests
 
-        - bash: |
-            mkdir -p "$(DOCKER_CACHE_DIR)"
-            docker save -o "$(DOCKER_CACHE_FILE)" "${{ parameters.container }}"
-          condition: and(succeeded(), ne(variables.DOCKER_CACHE_HIT, 'true'))
-          displayName: Save Docker Image
+        - ${{ if eq(parameters.pageSize, '') }}:
+          - bash: |
+              mkdir -p "$(DOCKER_CACHE_DIR)"
+              docker save -o "$(DOCKER_CACHE_FILE)" "${{ parameters.container }}"
+            condition: and(succeeded(), ne(variables.DOCKER_CACHE_HIT, 'true'))
+            displayName: Save Docker Image
 
       - task: PublishTestResults@2
         inputs:

--- a/build/azure-pipelines/product-sanity-tests.yml
+++ b/build/azure-pipelines/product-sanity-tests.yml
@@ -313,3 +313,13 @@ extends:
               container: ubuntu
               baseImage: ubuntu:24.04
               arch: arm64
+
+          - template: build/azure-pipelines/common/sanity-tests.yml@self
+            parameters:
+              name: ubuntu_24_04_arm64_64k
+              displayName: Ubuntu 24.04 arm64 (64K page)
+              poolName: 1es-ubuntu-22.04-x64
+              container: ubuntu
+              baseImage: ubuntu:24.04
+              arch: arm64
+              pageSize: 64k

--- a/test/sanity/containers/entrypoint.sh
+++ b/test/sanity/containers/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+echo "System: $(uname -s) $(uname -r) $(uname -m), page size: $(getconf PAGESIZE) bytes"
+
 if command -v Xvfb > /dev/null 2>&1; then
 	echo "Starting X11 Server"
 	export DISPLAY=:99

--- a/test/sanity/containers/ubuntu.dockerfile
+++ b/test/sanity/containers/ubuntu.dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 # Utilities
 RUN apt-get update && \
-apt-get install -y curl
+apt-get install -y curl iproute2
 
 # Node.js 22
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \

--- a/test/sanity/scripts/qemu-init.sh
+++ b/test/sanity/scripts/qemu-init.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+echo "Mounting essential filesystems"
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mkdir -p /dev/pts
+mount -t devpts devpts /dev/pts
+mkdir -p /dev/shm
+mount -t tmpfs tmpfs /dev/shm
+mount -t tmpfs tmpfs /tmp
+chmod 1777 /tmp
+mount -t tmpfs tmpfs /run
+mkdir -p /run/dbus
+mkdir -p /run/user/0
+chmod 700 /run/user/0
+mount -t tmpfs tmpfs /var/tmp
+
+echo "Setting up machine-id for D-Bus"
+cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id
+
+echo "Setting system clock"
+date -s "$(cat /host-time)"
+
+echo "Setting up networking"
+ip link set lo up
+ip link set eth0 up
+ip addr add 10.0.2.15/24 dev eth0
+ip route add default via 10.0.2.2
+echo "nameserver 10.0.2.3" > /etc/resolv.conf
+
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export XDG_RUNTIME_DIR=/run/user/0
+
+echo "Starting entrypoint"
+ARGS=$(cat /test-args)
+/entrypoint.sh $ARGS
+EXIT_CODE=$?
+echo $EXIT_CODE > /exit-code
+sync
+
+echo "Powering off"
+echo o > /proc/sysrq-trigger

--- a/test/sanity/scripts/run-docker.sh
+++ b/test/sanity/scripts/run-docker.sh
@@ -4,6 +4,7 @@ set -e
 CONTAINER=""
 ARCH="amd64"
 BASE_IMAGE=""
+PAGE_SIZE=""
 ARGS=""
 
 while [ $# -gt 0 ]; do
@@ -11,6 +12,7 @@ while [ $# -gt 0 ]; do
 		--container) CONTAINER="$2"; shift 2 ;;
 		--arch) ARCH="$2"; shift 2 ;;
 		--base-image) BASE_IMAGE="$2"; shift 2 ;;
+		--page-size) PAGE_SIZE="$2"; shift 2 ;;
 		*) ARGS="$ARGS $1"; shift ;;
 	esac
 done
@@ -25,6 +27,11 @@ ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # Only build if image doesn't exist (i.e., not loaded from cache)
 if ! docker image inspect "$CONTAINER" > /dev/null 2>&1; then
+	if [ "$ARCH" != "amd64" ]; then
+		echo "Setting up QEMU user-mode emulation for $ARCH"
+		docker run --privileged --rm tonistiigi/binfmt --install "$ARCH"
+	fi
+
 	echo "Building container image: $CONTAINER"
 	docker buildx build \
 		--platform "linux/$ARCH" \
@@ -36,10 +43,17 @@ else
 	echo "Using cached container image: $CONTAINER"
 fi
 
-echo "Running sanity tests in container"
-docker run \
-	--rm \
-	--platform "linux/$ARCH" \
-	--volume "$ROOT_DIR:/root" \
-	"$CONTAINER" \
-	$ARGS
+# For 64K page size, use QEMU system emulation with a 64K kernel
+if [ "$PAGE_SIZE" = "64k" ]; then
+	exec "$SCRIPT_DIR/run-qemu-64k.sh" \
+		--container "$CONTAINER" \
+		-- $ARGS
+else
+	echo "Running sanity tests in container"
+	docker run \
+		--rm \
+		--platform "linux/$ARCH" \
+		--volume "$ROOT_DIR:/root" \
+		"$CONTAINER" \
+		$ARGS
+fi

--- a/test/sanity/scripts/run-qemu-64k.sh
+++ b/test/sanity/scripts/run-qemu-64k.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -e
+
+CONTAINER=""
+ARGS=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--container) CONTAINER="$2"; shift 2 ;;
+		--) shift; ARGS="$*"; break ;;
+		*) echo "Unknown option: $1"; exit 1 ;;
+	esac
+done
+
+if [ -z "$CONTAINER" ]; then
+	echo "Usage: $0 --container CONTAINER [-- ARGS...]"
+	exit 1
+fi
+
+echo "Installing QEMU system emulation and tools"
+sudo apt-get update && sudo apt-get install -y qemu-system-arm binutils
+
+echo "Exporting container filesystem"
+CONTAINER_ID=$(docker create --platform linux/arm64 "$CONTAINER")
+ROOTFS_DIR=$(mktemp -d)
+docker export "$CONTAINER_ID" | sudo tar -xf - -C "$ROOTFS_DIR"
+docker rm -f "$CONTAINER_ID"
+
+echo "Removing container image to free disk space"
+docker rmi "$CONTAINER" || true
+docker system prune -f || true
+
+echo "Copying test files into root filesystem"
+TEST_DIR=$(cd "$(dirname "$0")/.." && pwd)
+sudo cp -r "$TEST_DIR"/* "$ROOTFS_DIR/root/"
+
+echo "Downloading Ubuntu 24.04 generic-64k kernel for ARM64"
+KERNEL_URL="http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/linux-image-unsigned-6.8.0-90-generic-64k_6.8.0-90.91_arm64.deb"
+KERNEL_DIR=$(mktemp -d)
+curl -fL "$KERNEL_URL" -o "$KERNEL_DIR/kernel.deb"
+
+echo "Extracting kernel"
+(cd "$KERNEL_DIR" && ar x kernel.deb && tar xf data.tar*)
+VMLINUZ="$KERNEL_DIR/boot/vmlinuz-6.8.0-90-generic-64k"
+if [ ! -f "$VMLINUZ" ]; then
+	echo "Error: Could not find kernel at $VMLINUZ"
+	exit 1
+fi
+
+echo "Storing test arguments and installing init script"
+echo "$ARGS" > "$ROOTFS_DIR/test-args"
+date -u '+%Y-%m-%d %H:%M:%S' > "$ROOTFS_DIR/host-time"
+sudo mv "$ROOTFS_DIR/root/scripts/qemu-init.sh" "$ROOTFS_DIR/init"
+sudo chmod +x "$ROOTFS_DIR/init"
+
+echo "Creating disk image with root filesystem"
+DISK_IMG=$(mktemp)
+dd if=/dev/zero of="$DISK_IMG" bs=1M count=2048 status=none
+sudo mkfs.ext4 -q -d "$ROOTFS_DIR" "$DISK_IMG"
+sudo rm -rf "$ROOTFS_DIR"
+
+echo "Starting QEMU VM with 64K page size kernel"
+timeout 1800 qemu-system-aarch64 \
+	-M virt \
+	-cpu max,pauth-impdef=on \
+	-accel tcg,thread=multi \
+	-m 4096 \
+	-smp 2 \
+	-kernel "$VMLINUZ" \
+	-append "console=ttyAMA0 root=/dev/vda rw init=/init net.ifnames=0" \
+	-drive file="$DISK_IMG",format=raw,if=virtio \
+	-netdev user,id=net0 \
+	-device virtio-net-pci,netdev=net0 \
+	-nographic \
+	-no-reboot \
+	|| true
+
+echo "Extracting test results from disk image"
+MOUNT_DIR=$(mktemp -d)
+sudo mount -o loop "$DISK_IMG" "$MOUNT_DIR"
+if [ -f "$MOUNT_DIR/root/results.xml" ]; then
+	cp "$MOUNT_DIR/root/results.xml" "$TEST_DIR/results.xml"
+fi
+EXIT_CODE=$(cat "$MOUNT_DIR/exit-code" 2>/dev/null || echo 1)
+sudo umount "$MOUNT_DIR"
+exit $EXIT_CODE


### PR DESCRIPTION
64k page config cannot be set in a running VM, so using emulator with core replacement to run this test.

Related to #268354

This test is kind of slow, so we may want to run it more selectively.
