### PR TITLE
fix: adjust padding and gap for unified quick access tabs and buttons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/unifiedQuickAccess.css
@@ -8,25 +8,23 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 6px 12px;
-	border-top: 1px solid var(--vscode-pickerGroup-border, transparent);
+	padding: 2px 6px 8px;
 	gap: 8px;
-	background: var(--vscode-quickInput-background);
 }
 
 /* Radio tabs styling override for unified quick access */
 .unified-quick-access-tabs .monaco-custom-radio {
 	display: flex;
 	align-items: center;
-	gap: 2px;
+	gap: 4px;
 	flex: 1;
 }
 
 .unified-quick-access-tabs .monaco-custom-radio .monaco-button {
-	padding: 4px 10px;
+	padding: 5px 10px;
 	font-size: 12px;
 	font-weight: 500;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 	background: transparent;
 	color: var(--vscode-quickInput-foreground);
 	opacity: 0.7;
@@ -43,6 +41,10 @@
 	opacity: 1;
 	background: var(--vscode-quickInputList-focusBackground);
 	color: var(--vscode-quickInputList-focusForeground);
+}
+
+.unified-quick-access-tabs .monaco-custom-radio .monaco-button:focus {
+	outline-offset: 0 !important;
 }
 
 /* Send button container */


### PR DESCRIPTION
This pull request updates the styling for the unified quick access tabs in the chat agent sessions feature. The main focus is on improving spacing, padding, and accessibility for radio tab buttons.

**Styling improvements for unified quick access tabs:**

* Reduced padding and adjusted spacing for `.unified-quick-access-tabs` container and radio tab elements to improve layout and alignment.
* Increased the gap between radio tab elements and updated button padding for better visual balance.
* Changed the border radius of radio tab buttons to use the theme variable for consistency with other UI elements.
* Added a focused state style for radio tab buttons to improve accessibility by setting `outline-offset: 0`.