### PR TITLE
agent indicator tweaks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
@@ -365,7 +365,11 @@
 	outline-offset: -1px;
 }
 
-/* Unread section - smaller dot */
+/* Unread section - smaller dot with adjusted padding for visual balance */
+.agent-status-badge-section.unread {
+	padding: 0 8px 0 6px;
+}
+
 .agent-status-badge-section.unread .agent-status-icon {
 	font-size: 8px;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
@@ -239,6 +239,7 @@
 
 .agent-status-badge-section:first-child { border-radius: 5px 0 0 5px; }
 .agent-status-badge-section:last-child { border-radius: 0 5px 5px 0; }
+.agent-status-badge-section:only-child { border-radius: 5px; }
 .agent-status-badge-section:hover { background-color: var(--vscode-commandCenter-activeBackground); }
 .agent-status-badge-section:focus {
 	outline: 1px solid var(--vscode-focusBorder);
@@ -307,6 +308,7 @@
 	align-items: center;
 	justify-content: center;
 	height: 100%;
+	overflow: hidden;
 }
 
 .agent-status-badge-section.sparkle .action-container {
@@ -317,6 +319,12 @@
 .agent-status-badge-section.sparkle .dropdown-action-container {
 	width: 18px;
 	padding: 0;
+	border-radius: 0;
+}
+
+/* When sparkle is the only section, dropdown needs rounded right corners */
+.agent-status-badge-section.sparkle:last-child .dropdown-action-container {
+	border-radius: 0 5px 5px 0;
 }
 
 .agent-status-badge-section.sparkle .action-container:hover,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
@@ -369,3 +369,8 @@
 .agent-status-badge-section.unread .agent-status-icon {
 	font-size: 8px;
 }
+
+/* Active section in needs-input state - uses report icon with warning color */
+.agent-status-badge-section.active.needs-input .agent-status-icon {
+	color: var(--vscode-notificationsWarningIcon-foreground);
+}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/media/agenttitlebarstatuswidget.css
@@ -40,7 +40,6 @@
 	align-items: center;
 	justify-content: flex-start;
 	gap: 4px;
-	padding-right: 22px;
 	-webkit-app-region: no-drag;
 	overflow: visible;
 	color: var(--vscode-commandCenter-foreground);


### PR DESCRIPTION
refs https://github.com/microsoft/vscode/issues/290647, https://github.com/microsoft/vscode-internalbacklog/issues/6561

fixes https://github.com/microsoft/vscode/issues/290742



1. Fix cursor hit area extending beyond control bounds (69066ff)

   - Removed padding-right: 22px from [.agent-status-container](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) that caused the pointer cursor and click behavior to extend ~30px beyond the visible badge

2. Add "input required" indicator (bb25992)

   - When any session needs user input, the "in progress" badge section transforms to show a report icon (⚠️) with the needs-input count
Icon uses warning color (--vscode-notificationsWarningIcon-foreground) for visibility
Tooltip changes to "{n} session(s) need input"

3. Fix uneven padding in unread sessions button (b0f9b00)

   - Adjusted left padding on unread section from 8px to 6px to visually balance the small dot icon

4. Fix inconsistent border radius (58dc0f1)

   - Added :only-child rule for fully rounded corners when sparkle is the only visible section
Added overflow: hidden to clip hover backgrounds to border-radius
Fixed dropdown twistie to have flat right edge when adjacent sections exist

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
