### PR TITLE
Browser: "New Tab" command

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -25,6 +25,9 @@ import { logBrowserOpen } from './browserViewTelemetry.js';
 const BROWSER_EDITOR_ACTIVE = ContextKeyExpr.equals('activeEditor', BrowserEditor.ID);
 
 const BrowserCategory = localize2('browserCategory', "Browser");
+const ActionGroupTabs = '1_tabs';
+const ActionGroupPage = '2_page';
+const ActionGroupSettings = '3_settings';
 
 class OpenIntegratedBrowserAction extends Action2 {
 	constructor() {
@@ -32,13 +35,7 @@ class OpenIntegratedBrowserAction extends Action2 {
 			id: 'workbench.action.browser.open',
 			title: localize2('browser.openAction', "Open Integrated Browser"),
 			category: BrowserCategory,
-			f1: true,
-			keybinding: {
-				// When already in a browser, Ctrl/Cmd + T opens a new tab
-				when: BROWSER_EDITOR_ACTIVE,
-				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over search actions
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
-			}
+			f1: true
 		});
 	}
 
@@ -48,6 +45,38 @@ class OpenIntegratedBrowserAction extends Action2 {
 		const resource = BrowserViewUri.forUrl(url);
 
 		logBrowserOpen(telemetryService, url ? 'commandWithUrl' : 'commandWithoutUrl');
+
+		await editorService.openEditor({ resource });
+	}
+}
+
+class NewTabAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.browser.newTab',
+			title: localize2('browser.newTabAction', "New Tab"),
+			category: BrowserCategory,
+			f1: true,
+			menu: {
+				id: MenuId.BrowserActionsToolbar,
+				group: ActionGroupTabs,
+				order: 1,
+			},
+			keybinding: {
+				// When already in a browser, Ctrl/Cmd + T opens a new tab
+				when: BROWSER_EDITOR_ACTIVE,
+				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over search actions
+				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor, _browserEditor = accessor.get(IEditorService).activeEditorPane): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const telemetryService = accessor.get(ITelemetryService);
+		const resource = BrowserViewUri.forUrl(undefined);
+
+		logBrowserOpen(telemetryService, 'newTabCommand');
 
 		await editorService.openEditor({ resource });
 	}
@@ -226,8 +255,8 @@ class ToggleDevToolsAction extends Action2 {
 			toggled: ContextKeyExpr.equals(CONTEXT_BROWSER_DEVTOOLS_OPEN.key, true),
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '1_developer',
-				order: 1,
+				group: ActionGroupPage,
+				order: 5,
 			},
 			keybinding: {
 				when: BROWSER_EDITOR_ACTIVE,
@@ -256,8 +285,8 @@ class OpenInExternalBrowserAction extends Action2 {
 			f1: false,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '2_page',
-				order: 1
+				group: ActionGroupPage,
+				order: 10
 			}
 		});
 	}
@@ -285,7 +314,7 @@ class ClearGlobalBrowserStorageAction extends Action2 {
 			f1: true,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '3_settings',
+				group: ActionGroupSettings,
 				order: 1,
 				when: ContextKeyExpr.equals(CONTEXT_BROWSER_STORAGE_SCOPE.key, BrowserViewStorageScope.Global)
 			}
@@ -310,7 +339,7 @@ class ClearWorkspaceBrowserStorageAction extends Action2 {
 			f1: true,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '3_settings',
+				group: ActionGroupSettings,
 				order: 1,
 				when: ContextKeyExpr.equals(CONTEXT_BROWSER_STORAGE_SCOPE.key, BrowserViewStorageScope.Workspace)
 			}
@@ -362,7 +391,7 @@ class OpenBrowserSettingsAction extends Action2 {
 			f1: false,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '3_settings',
+				group: ActionGroupSettings,
 				order: 2
 			}
 		});
@@ -387,8 +416,8 @@ class ShowBrowserFindAction extends Action2 {
 			f1: false,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
-				group: '2_page',
-				order: 2,
+				group: ActionGroupPage,
+				order: 1,
 			},
 			keybinding: {
 				when: BROWSER_EDITOR_ACTIVE,
@@ -492,6 +521,7 @@ class BrowserFindPreviousAction extends Action2 {
 
 // Register actions
 registerAction2(OpenIntegratedBrowserAction);
+registerAction2(NewTabAction);
 registerAction2(GoBackAction);
 registerAction2(GoForwardAction);
 registerAction2(ReloadAction);

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewTelemetry.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewTelemetry.ts
@@ -12,6 +12,7 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
  *   This typically means the user ran the command manually from the Command Palette.
  * - `'commandWithUrl'`: opened via the "Open Integrated Browser" command with a URL argument.
  *   This typically means another extension or component invoked the command programmatically.
+ * - `'newTabCommand'`: opened via the "New Tab" command from an existing tab.
  * - `'localhostLinkOpener'`: opened via the localhost link opener when the
  *   `workbench.browser.openLocalhostLinks` setting is enabled. This happens when clicking
  *   localhost links from the terminal, chat, or other sources.
@@ -22,7 +23,7 @@ import { ITelemetryService } from '../../../../platform/telemetry/common/telemet
  * - `'copyToNewWindow'`: opened when the user copies a browser editor to a new window
  *   via "Copy into New Window".
  */
-export type IntegratedBrowserOpenSource = 'commandWithoutUrl' | 'commandWithUrl' | 'localhostLinkOpener' | 'browserLinkForeground' | 'browserLinkBackground' | 'copyToNewWindow';
+export type IntegratedBrowserOpenSource = 'commandWithoutUrl' | 'commandWithUrl' | 'newTabCommand' | 'localhostLinkOpener' | 'browserLinkForeground' | 'browserLinkBackground' | 'copyToNewWindow';
 
 type IntegratedBrowserOpenEvent = {
 	source: IntegratedBrowserOpenSource;


### PR DESCRIPTION
Use a new command for `Ctrl+T` behavior, and add to the overflow menu as well. Also rearranges the menu items a bit:
<img width="280" height="231" alt="image" src="https://github.com/user-attachments/assets/8e2d6259-0f4c-4131-9dd4-04a89129cd61" />

Closes #291003