### PR TITLE
Add toolMetadata to LanguageModelToolResult for trajectory tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watch-extensions": "npm run gulp watch-extensions watch-extension-media",
     "watch-extensionsd": "deemon npm run watch-extensions",
     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
-    "precommit": "node build/hygiene.ts",
+    "precommit": "node --experimental-strip-types build/hygiene.ts",
     "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
     "electron": "node build/lib/electron.ts",
     "7z": "7z",

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3717,8 +3717,8 @@ export namespace LanguageModelToolSource {
 }
 
 export namespace LanguageModelToolResult {
-	export function to(result: IToolResult): vscode.LanguageModelToolResult {
-		return new types.LanguageModelToolResult(result.content.map(item => {
+	export function to(result: IToolResult): vscode.ExtendedLanguageModelToolResult {
+		const toolResult = new types.LanguageModelToolResult(result.content.map(item => {
 			if (item.kind === 'text') {
 				return new types.LanguageModelTextPart(item.value, item.audience);
 			} else if (item.kind === 'data') {
@@ -3726,7 +3726,11 @@ export namespace LanguageModelToolResult {
 			} else {
 				return new types.LanguageModelPromptTsxPart(item.value);
 			}
-		}));
+		})) as vscode.ExtendedLanguageModelToolResult;
+		if (result.toolMetadata !== undefined) {
+			toolResult.toolMetadata = result.toolMetadata;
+		}
+		return toolResult;
 	}
 
 	export function from(result: vscode.ExtendedLanguageModelToolResult2, extension: IExtensionDescription): Dto<IToolResult> | SerializableObjectWithBuffers<Dto<IToolResult>> {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -240,7 +240,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				variables: { variables: variableSet.asArray() },
 				location: ChatAgentLocation.Chat,
 				subAgentInvocationId: invocation.callId,
-				subAgentName: args.agentName,
+				subAgentName: args.agentName ?? 'subagent',
 				userSelectedModelId: modeModelId,
 				userSelectedTools: modeTools,
 				modeInstructions,
@@ -267,7 +267,18 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				invocation.toolSpecificData.result = resultText;
 			}
 
-			return createToolSimpleTextResult(resultText);
+			// Return result with toolMetadata containing subAgentInvocationId for trajectory tracking
+			return {
+				content: [{
+					kind: 'text',
+					value: resultText
+				}],
+				toolMetadata: {
+					subAgentInvocationId,
+					description: args.description,
+					agentName: agentRequest.subAgentName,
+				}
+			};
 
 		} catch (error) {
 			const errorMessage = `Error invoking subagent: ${error instanceof Error ? error.message : 'Unknown error'}`;


### PR DESCRIPTION
Adds `toolMetadata` support to tool results, enabling trajectory tracking features in Copilot Chat.

## Changes

### API Extension
- `LanguageModelToolResult.to()` now returns `ExtendedLanguageModelToolResult` with optional `toolMetadata`
- Passes through `toolMetadata` from `IToolResult` to the VS Code API result

### RunSubagent Tool
- Default `subAgentName` to `'subagent'` when not specified
- Returns `toolMetadata` containing:
  - `subAgentInvocationId`: Links parent tool call to subagent trajectory
  - `description`: Original task description
  - `agentName`: Resolved agent name

## Usage
This enables [vscode-copilot-chat#2893](https://github.com/microsoft/vscode-copilot-chat/pull/2893) to link parent agent tool calls with their spawned subagent trajectories via the `subAgentInvocationId` in `toolMetadata`.