### PR TITLE
chat: fix handling of old session states

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -380,6 +380,7 @@ export class ChatService extends Disposable implements IChatService {
 			.filter(entry => !this._sessionModels.has(LocalChatSessionUri.forSession(entry.sessionId)) && entry.initialLocation === ChatAgentLocation.Chat && !entry.isEmpty)
 			.map((entry): IChatDetail => {
 				const sessionResource = LocalChatSessionUri.forSession(entry.sessionId);
+				const lastResponseState = entry.lastResponseState ?? ResponseModelState.Complete;
 				return ({
 					...entry,
 					sessionResource,
@@ -391,7 +392,8 @@ export class ChatService extends Disposable implements IChatService {
 					},
 					isActive: this._sessionModels.has(sessionResource),
 					// TODO@roblourens- missing for old data- normalize inside the store
-					lastResponseState: entry.lastResponseState ?? ResponseModelState.Complete,
+					// TODO@connor4312: the check here guards old sessions from Insiders pre PR #288161 and it can be safely removed after a transition period.
+					lastResponseState: lastResponseState === ResponseModelState.Pending || lastResponseState === ResponseModelState.NeedsInput ? ResponseModelState.Complete : lastResponseState,
 				});
 			});
 	}


### PR DESCRIPTION
Guard old sessions from Insiders that may have Pending or NeedsInput states,
converting them to Complete state for consistency. This ensures proper handling
of sessions migrated from pre-PR #288161 versions.

- Added check to convert Pending/NeedsInput states to Complete state
- Preserves backward compatibility with old session data
- Prevents state display issues in migrated sessions

(Commit message generated by Copilot)