### PR TITLE
Fix race condition in extension details causing tab switch to hang

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -646,7 +646,6 @@ export class ExtensionEditor extends EditorPane {
 
 	private onNavbarChange(extension: IExtension, { id, focus }: { id: string | null; focus: boolean }, template: IExtensionEditorTemplate): void {
 		this.contentDisposables.clear();
-		this.transientDisposables.clear();
 		template.content.innerText = '';
 		this.activeElement = null;
 		if (id) {


### PR DESCRIPTION
### Reproduce of the issue:

- Open extensions in sidebar.
- Search an extension, click it.
- Before the `details`  is rendered, quickly switch to the `changelog` tab.
- Do that back and forth, and then Code will froze and hang (The whole `code` window is slow at response, and can't be closed without terminate it from taskmgr).


### Cause:

The original `renderMarkdown` func seem to has a race condition in it: when switching between Tabs, `onNavbarChange` is invoked, and `CancellationTokenSource` is called. However, `renderMarkdown` fails to be stopped and still works in background while the component is disposed, causing flicker and froze.

### Potential fix:

Use in-built `raceCancellation` function to replace the original `token.isCancellationRequested` for better handling of the race condition.

### Repro video

https://github.com/user-attachments/assets/b7488721-0825-4044-a5d4-86ceffd8e873



