### PR TITLE
Update foreground color for comment settings in 2026 Light theme

### DIFF
--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -262,7 +262,7 @@
 				"comment"
 			],
 			"settings": {
-				"foreground": "#4F5B4F"
+				"foreground": "#60984D"
 			}
 		},
 		{


### PR DESCRIPTION
Change the foreground color for comment settings to enhance visibility in the 2026 Light theme. Test by applying the theme and verifying the updated color in the comment settings.

Addresses: https://github.com/microsoft/vscode/issues/291245
