### PR TITLE
layout - reduce scope of `workbench.secondarySideBar.forceMaximized` to only apply when editors are closed

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -425,7 +425,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			// Auxiliary Sidebar
 			if (e.affectsConfiguration(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED)) {
 				const forceMaximized = this.configurationService.getValue(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED);
-				if (forceMaximized === true) {
+				if (forceMaximized === true && this.mainPartEditorService.visibleEditors.length === 0) {
 					this.setAuxiliaryBarMaximized(true);
 				} else if (forceMaximized === false && this.isAuxiliaryBarMaximized()) {
 					this.setAuxiliaryBarMaximized(false);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -354,12 +354,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			}
 		};
 
-		// Maybe maximize auxiliary bar when no editors, sidebar hidden, and panel hidden
+		// Maybe maximize auxiliary bar when no editors are visible
 		const maybeMaximizeAuxiliaryBar = () => {
 			if (
 				this.mainPartEditorService.visibleEditors.length === 0 &&
-				!this.isVisible(Parts.SIDEBAR_PART) &&
-				!this.isVisible(Parts.PANEL_PART) &&
 				this.configurationService.getValue(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED) === true
 			) {
 				this.setAuxiliaryBarMaximized(true);
@@ -382,13 +380,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				}
 			}));
 			this._register(this.editorGroupService.mainPart.onDidActivateGroup(showEditorIfHidden));
-
-			// Maybe maximize auxiliary bar when sidebar or panel hides
-			this._register(this.onDidChangePartVisibility(({ partId, visible }) => {
-				if (!visible && (partId === Parts.SIDEBAR_PART || partId === Parts.PANEL_PART)) {
-					maybeMaximizeAuxiliaryBar();
-				}
-			}));
 
 			// Revalidate center layout when active editor changes: diff editor quits centered mode
 			this._register(this.mainPartEditorService.onDidActiveEditorChange(() => this.centerMainEditorLayout(this.stateModel.getRuntimeValue(LayoutStateKeys.MAIN_EDITOR_CENTERED))));
@@ -434,7 +425,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			// Auxiliary Sidebar
 			if (e.affectsConfiguration(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED)) {
 				const forceMaximized = this.configurationService.getValue(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED);
-				if (forceMaximized === true && this.mainPartEditorService.visibleEditors.length === 0) {
+				if (forceMaximized === true) {
 					this.setAuxiliaryBarMaximized(true);
 				} else if (forceMaximized === false && this.isAuxiliaryBarMaximized()) {
 					this.setAuxiliaryBarMaximized(false);

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -589,7 +589,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'boolean',
 				'default': false,
 				tags: ['experimental'],
-				'description': localize('secondarySideBarForceMaximized', "Controls whether the secondary side bar is enforced to always show maximized unless other parts or editors are showing."),
+				'description': localize('secondarySideBarForceMaximized', "Controls whether the secondary side bar is enforced to always show maximized on startup and in certain layouts where it can show maximized."),
 			},
 			'workbench.secondarySideBar.showLabels': {
 				'type': 'boolean',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -589,7 +589,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'boolean',
 				'default': false,
 				tags: ['experimental'],
-				'description': localize('secondarySideBarForceMaximized', "Controls whether the secondary side bar is enforced to always show maximized on startup and in certain layouts where it can show maximized."),
+				'description': localize('secondarySideBarForceMaximized', "Controls whether the secondary side bar is enforced to always show maximized on startup and when there are no open editors, in layouts that support a maximized secondary side bar."),
 			},
 			'workbench.secondarySideBar.showLabels': {
 				'type': 'boolean',


### PR DESCRIPTION
We later need to revisit how a better layout would be for focus on sessions, but the current implementation has too many bugs.

fix https://github.com/microsoft/vscode/issues/291080