### PR TITLE
Fix incorrect telemetry for inline completions

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/provideInlineCompletions.ts
@@ -380,7 +380,7 @@ export class InlineSuggestData {
 	public async reportInlineEditShown(commandService: ICommandService, updatedInsertText: string, viewKind: InlineCompletionViewKind, viewData: InlineCompletionViewData, editKind: InlineSuggestionEditKind | undefined, timeWhenShown: number): Promise<void> {
 		this.updateShownDuration(viewKind);
 
-		if (this._didShow) {
+		if (this._didShow || this._didReportEndOfLife) {
 			return;
 		}
 		this.addPerformanceMarker('shown');
@@ -427,6 +427,12 @@ export class InlineSuggestData {
 
 		if (!reason) {
 			reason = this._lastSetEndOfLifeReason ?? { kind: InlineCompletionEndOfLifeReasonKind.Ignored, userTypingDisagreed: false, supersededBy: undefined };
+		}
+
+		// A suggestion can only be "rejected" if it was actually shown to the user.
+		// If the suggestion was never shown, downgrade to "ignored".
+		if (reason.kind === InlineCompletionEndOfLifeReasonKind.Rejected && !this._didShow) {
+			reason = { kind: InlineCompletionEndOfLifeReasonKind.Ignored, userTypingDisagreed: false, supersededBy: undefined };
 		}
 
 		if (reason.kind === InlineCompletionEndOfLifeReasonKind.Rejected && this.source.provider.handleRejection) {


### PR DESCRIPTION
```Copilot Generated Description:``` Correct the telemetry reporting for inline completions that are not shown to the user, ensuring that only relevant events are tracked.

