### PR TITLE
allow prompt for input detection in bg terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -782,6 +782,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			RunInTerminalTool._activeExecutions.set(termId, execution);
 
 			// Set up OutputMonitor when start marker is created
+			const startMarkerPromise = Event.toPromise(execution.strategy.onDidCreateStartMarker);
 			store.add(execution.strategy.onDidCreateStartMarker(startMarker => {
 				if (!outputMonitor) {
 					outputMonitor = store.add(this._instantiationService.createInstance(
@@ -805,6 +806,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			if (args.isBackground) {
 				// Background mode: wait for OutputMonitor to detect idle, then return
 				this._logService.debug(`RunInTerminalTool: Starting background execution \`${command}\``);
+				// Wait for the start marker to be created (which creates the outputMonitor)
+				await startMarkerPromise;
 				if (outputMonitor) {
 					await Event.toPromise(outputMonitor.onDidFinishCommand);
 					pollingResult = outputMonitor.pollingResult;


### PR DESCRIPTION
fix #290983

The `outputMonitor` is created inside an event handler that fires when the command starts executing. For foreground terminals this worked because the code awaits the full command execution, giving the event time to fire and create the monitor. But for background terminals, the code checked `if (outputMonitor)` immediately after calling `execution.start()`, before the event had a chance to fire. So `outputMonitor` was always undefined and the input prompting was skipped entirely. The fix adds `await startMarkerPromise` before checking `outputMonitor`, ensuring the monitor actually exists before we try to use it.

<img width="399" height="264" alt="Screenshot 2026-01-28 at 11 27 38 AM" src="https://github.com/user-attachments/assets/9ec1690a-703b-40ab-978f-bd08dc2e2f57" />