### PR TITLE
Tool picker reintroduced in chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -614,7 +614,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.AlternativeToolAction]: {
 			type: 'boolean',
 			description: nls.localize('chat.alternativeToolAction', "When enabled, shows the Configure Tools action in the mode picker dropdown on hover instead of in the chat input."),
-			default: true,
+			default: false,
 			tags: ['experimental'],
 			experiment: {
 				mode: 'auto'

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -32,6 +32,7 @@ import { PromptsStorage } from '../../../common/promptSyntax/service/promptsServ
 import { getOpenChatActionIdForMode } from '../../actions/chatActions.js';
 import { IToggleChatModeArgs, ToggleAgentModeActionId } from '../../actions/chatExecuteActions.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 
 export interface IModePickerDelegate {
 	readonly currentMode: IObservable<IChatMode>;
@@ -60,7 +61,8 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		@IMenuService private readonly menuService: IMenuService,
 		@ICommandService commandService: ICommandService,
 		@IProductService private readonly _productService: IProductService,
-		@ITelemetryService telemetryService: ITelemetryService
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IOpenerService openerService: IOpenerService
 	) {
 		// Get custom agent target (if filtering is enabled)
 		const customAgentTarget = delegate.customAgentTarget?.();
@@ -71,7 +73,6 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		const policyDisabledCategory = { label: localize('managedByOrganization', "Managed by your organization"), order: 999, showHeader: true };
 
 		const agentModeDisabledViaPolicy = configurationService.inspect<boolean>(ChatConfiguration.AgentEnabled).policyValue === false;
-		const alternativeToolActionEnabled = configurationService.getValue<boolean>(ChatConfiguration.AlternativeToolAction);
 
 		const makeAction = (mode: IChatMode, currentMode: IChatMode): IActionWidgetDropdownAction => {
 			const isDisabledViaPolicy =
@@ -80,30 +81,55 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 
 			const tooltip = chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, mode.kind)?.description ?? action.tooltip;
 
+			// Add toolbar actions for Agent modes
 			const toolbarActions: IAction[] = [];
-			if (alternativeToolActionEnabled && mode.kind === ChatModeKind.Agent && !isDisabledViaPolicy) {
-				// Add toolbar actions for Agent modes when alternative tool action is enabled
-				const label = localize('configureToolsFor', "Configure tools for {0} {1}", mode.label.get(), isModeConsideredBuiltIn(mode, this._productService) ? 'mode' : 'agent');
-				toolbarActions.push({
-					id: 'configureToolsForMode',
-					label: label,
-					tooltip: label,
-					class: ThemeIcon.asClassName(Codicon.tools),
-					enabled: true,
-					run: async () => {
-						// Hide the picker before opening the tools configuration
-						actionWidgetService.hide();
-						// First switch to the mode if not already selected
-						if (currentMode.id !== mode.id) {
-							await commandService.executeCommand(
-								ToggleAgentModeActionId,
-								{ modeId: mode.id, sessionResource: this.delegate.sessionResource() } satisfies IToggleChatModeArgs
-							);
-						}
-						// Then open the tools picker
-						await commandService.executeCommand('workbench.action.chat.configureTools', pickerOptions.actionContext, { source: 'modePicker' });
+			if (mode.kind === ChatModeKind.Agent && !isDisabledViaPolicy) {
+				if (mode.uri) {
+					let label, icon, id;
+					if (mode.source?.storage === PromptsStorage.extension) {
+						icon = Codicon.eye;
+						id = `viewAgent:${mode.id}`;
+						label = localize('viewModeConfiguration', "View {0} agent", mode.label.get());
+					} else {
+						icon = Codicon.edit;
+						id = `editAgent:${mode.id}`;
+						label = localize('editModeConfiguration', "Edit {0} agent", mode.label.get());
 					}
-				});
+
+					const modeResource = mode.uri;
+					toolbarActions.push({
+						id,
+						label,
+						tooltip: label,
+						class: ThemeIcon.asClassName(icon),
+						enabled: true,
+						run: async () => {
+							openerService.open(modeResource.get());
+						}
+					});
+				} else {
+					const label = localize('configureToolsFor', "Configure tools for {0} agent", mode.label.get());
+					toolbarActions.push({
+						id: `configureTools:${mode.id}`,
+						label,
+						tooltip: label,
+						class: ThemeIcon.asClassName(Codicon.tools),
+						enabled: true,
+						run: async () => {
+							// Hide the picker before opening the tools configuration
+							actionWidgetService.hide();
+							// First switch to the mode if not already selected
+							if (currentMode.id !== mode.id) {
+								await commandService.executeCommand(
+									ToggleAgentModeActionId,
+									{ modeId: mode.id, sessionResource: this.delegate.sessionResource() } satisfies IToggleChatModeArgs
+								);
+							}
+							// Then open the tools picker
+							await commandService.executeCommand('workbench.action.chat.configureTools', pickerOptions.actionContext, { source: 'modePicker' });
+						}
+					});
+				}
 			}
 
 			return {


### PR DESCRIPTION
```Copilot Generated Description:``` Reintroduce the tool picker in the chat input, allowing users to configure tools for agents directly from the mode picker. Adjust the configuration to show the tool action in the dropdown on hover.

