### PR TITLE
Remove inline chat affordance suppression logic

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
@@ -99,7 +99,6 @@ export class InlineChatEditorAffordance extends Disposable implements IContentWi
 	constructor(
 		private readonly _editor: ICodeEditor,
 		selection: IObservable<Selection | undefined>,
-		suppressAffordance: ISettableObservable<boolean>,
 		_hover: ISettableObservable<{ rect: DOMRect; above: boolean; lineNumber: number } | undefined>,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
@@ -124,8 +123,7 @@ export class InlineChatEditorAffordance extends Disposable implements IContentWi
 
 		this._store.add(autorun(r => {
 			const sel = selection.read(r);
-			const suppressed = suppressAffordance.read(r);
-			if (sel && !suppressed) {
+			if (sel) {
 				this._show(sel);
 			} else {
 				this._hide();

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatGutterAffordance.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatGutterAffordance.ts
@@ -24,7 +24,6 @@ export class InlineChatGutterAffordance extends InlineEditsGutterIndicator {
 	constructor(
 		private readonly _myEditorObs: ObservableCodeEditor,
 		selection: IObservable<Selection | undefined>,
-		suppressAffordance: ISettableObservable<boolean>,
 		private readonly _hover: ISettableObservable<{ rect: DOMRect; above: boolean; lineNumber: number } | undefined>,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IHoverService hoverService: HoverService,
@@ -34,7 +33,7 @@ export class InlineChatGutterAffordance extends InlineEditsGutterIndicator {
 	) {
 		const data = derived<InlineEditsGutterIndicatorData | undefined>(r => {
 			const value = selection.read(r);
-			if (!value || suppressAffordance.read(r)) {
+			if (!value) {
 				return undefined;
 			}
 


### PR DESCRIPTION
Users disliked that the inline chat affordance (sparkle icon) would only show once per selection and require changing the selection to see it again. This change removes the suppressAffordance mechanism so the affordance remains visible as long as there is a valid text selection.

Fixes #291036