### PR TITLE
Fix issue with runSubagent result text

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -9,7 +9,7 @@ import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
@@ -129,6 +129,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 		const request = model.getRequests().at(-1)!;
 
+		// Subscribe to tool invocations to clear markdown parts when a tool is invoked
+		const store = new DisposableStore();
+
 		try {
 			// Get the default agent
 			const defaultAgent = this.chatAgentService.getDefaultAgent(ChatAgentLocation.Chat, ChatModeKind.Agent);
@@ -194,7 +197,7 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			const progressCallback = (parts: IChatProgress[]) => {
 				for (const part of parts) {
 					// Write certain parts immediately to the model
-					if (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized' || part.kind === 'textEdit' || part.kind === 'notebookEdit' || part.kind === 'codeblockUri') {
+					if (part.kind === 'textEdit' || part.kind === 'notebookEdit' || part.kind === 'codeblockUri') {
 						if (part.kind === 'codeblockUri' && !inEdit) {
 							inEdit = true;
 							model.acceptResponseProgress(request, { kind: 'markdownContent', content: new MarkdownString('```\n') });
@@ -204,11 +207,6 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 							model.acceptResponseProgress(request, { ...part, subAgentInvocationId });
 						} else {
 							model.acceptResponseProgress(request, part);
-						}
-
-						// When we see a tool invocation starting, reset markdown collection
-						if (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') {
-							markdownParts.length = 0; // Clear previously collected markdown
 						}
 					} else if (part.kind === 'markdownContent') {
 						if (inEdit) {
@@ -246,6 +244,13 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				modeInstructions,
 			};
 
+			// Subscribe to tool invocations to clear markdown parts when a tool is invoked
+			store.add(this.languageModelToolsService.onDidInvokeTool(e => {
+				if (e.subagentInvocationId === subAgentInvocationId) {
+					markdownParts.length = 0;
+				}
+			}));
+
 			// Invoke the agent
 			const result = await this.chatAgentService.invokeAgent(
 				defaultAgent.id,
@@ -260,7 +265,9 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 				return createToolSimpleTextResult(`Agent error: ${result.errorDetails.message}`);
 			}
 
-			const resultText = markdownParts.join('') || 'Agent completed with no output';
+			// This is a hack due to the fact that edits are represented as empty codeblocks with URIs. That needs to be cleaned up,
+			// in the meantime, just strip an empty codeblock left behind.
+			const resultText = markdownParts.join('').replace(/^\n*```\n+```\n*/g, '').trim() || 'Agent completed with no output';
 
 			// Store result in toolSpecificData for serialization
 			if (invocation.toolSpecificData?.kind === 'subagent') {
@@ -284,6 +291,8 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 			const errorMessage = `Error invoking subagent: ${error instanceof Error ? error.message : 'Unknown error'}`;
 			this.logService.error(errorMessage, error);
 			return createToolSimpleTextResult(errorMessage);
+		} finally {
+			store.dispose();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool.ts
@@ -129,7 +129,6 @@ export class RunSubagentTool extends Disposable implements IToolImpl {
 
 		const request = model.getRequests().at(-1)!;
 
-		// Subscribe to tool invocations to clear markdown parts when a tool is invoked
 		const store = new DisposableStore();
 
 		try {

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -470,6 +470,13 @@ export interface IBeginToolCallOptions {
 	subagentInvocationId?: string;
 }
 
+export interface IToolInvokedEvent {
+	readonly toolId: string;
+	readonly sessionResource: URI | undefined;
+	readonly requestId: string | undefined;
+	readonly subagentInvocationId: string | undefined;
+}
+
 export const ILanguageModelToolsService = createDecorator<ILanguageModelToolsService>('ILanguageModelToolsService');
 
 export type CountTokensCallback = (input: string, token: CancellationToken) => Promise<number>;
@@ -482,6 +489,7 @@ export interface ILanguageModelToolsService {
 	readonly agentToolSet: ToolSet;
 	readonly onDidChangeTools: Event<void>;
 	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ readonly sessionResource: URI; readonly toolData: IToolData }>;
+	readonly onDidInvokeTool: Event<IToolInvokedEvent>;
 	registerToolData(toolData: IToolData): IDisposable;
 	registerToolImplementation(id: string, tool: IToolImpl): IDisposable;
 	registerTool(toolData: IToolData, tool: IToolImpl): IDisposable;

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/runSubagentTool.test.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { RunSubagentTool } from '../../../../common/tools/builtinTools/runSubagentTool.js';
+import { MockLanguageModelToolsService } from '../mockLanguageModelToolsService.js';
+import { IChatAgentService } from '../../../../common/participants/chatAgents.js';
+import { IChatModeService } from '../../../../common/chatModes.js';
+import { IChatService } from '../../../../common/chatService/chatService.js';
+import { ILanguageModelsService } from '../../../../common/languageModels.js';
+import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js';
+
+suite('RunSubagentTool', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('resultText trimming', () => {
+		test('trims leading empty codeblocks (```\\n```) from result', () => {
+			// This tests the regex: /^\n*```\n+```\n*/g
+			const testCases = [
+				{ input: '```\n```\nActual content', expected: 'Actual content' },
+				{ input: '\n```\n```\nActual content', expected: 'Actual content' },
+				{ input: '\n\n```\n\n```\n\nActual content', expected: 'Actual content' },
+				{ input: '```\n```\n```\n```\nActual content', expected: '```\n```\nActual content' }, // Only trims leading
+				{ input: 'No codeblock here', expected: 'No codeblock here' },
+				{ input: '```\n```\n', expected: '' },
+				{ input: '', expected: '' },
+			];
+
+			for (const { input, expected } of testCases) {
+				const result = input.replace(/^\n*```\n+```\n*/g, '').trim();
+				assert.strictEqual(result, expected, `Failed for input: ${JSON.stringify(input)}`);
+			}
+		});
+	});
+
+	suite('prepareToolInvocation', () => {
+		test('returns correct toolSpecificData', async () => {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService();
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				{} as IChatModeService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				{} as IInstantiationService,
+			));
+
+			const result = await tool.prepareToolInvocation(
+				{
+					parameters: {
+						prompt: 'Test prompt',
+						description: 'Test task',
+						agentName: 'CustomAgent',
+					},
+					chatSessionResource: URI.parse('test://session'),
+				},
+				CancellationToken.None
+			);
+
+			assert.ok(result);
+			assert.strictEqual(result.invocationMessage, 'Test task');
+			assert.deepStrictEqual(result.toolSpecificData, {
+				kind: 'subagent',
+				description: 'Test task',
+				agentName: 'CustomAgent',
+				prompt: 'Test prompt',
+			});
+		});
+	});
+
+	suite('getToolData', () => {
+		test('returns basic tool data', () => {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService();
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				{} as IChatModeService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				{} as IInstantiationService,
+			));
+
+			const toolData = tool.getToolData();
+
+			assert.strictEqual(toolData.id, 'runSubagent');
+			assert.ok(toolData.inputSchema);
+			assert.ok(toolData.inputSchema.properties?.prompt);
+			assert.ok(toolData.inputSchema.properties?.description);
+			assert.deepStrictEqual(toolData.inputSchema.required, ['prompt', 'description']);
+		});
+
+		test('includes agentName property when SubagentToolCustomAgents is enabled', () => {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const configService = new TestConfigurationService({
+				'chat.customAgentInSubagent.enabled': true,
+			});
+
+			const tool = testDisposables.add(new RunSubagentTool(
+				{} as IChatAgentService,
+				{} as IChatService,
+				{} as IChatModeService,
+				mockToolsService,
+				{} as ILanguageModelsService,
+				new NullLogService(),
+				mockToolsService,
+				configService,
+				{} as IInstantiationService,
+			));
+
+			const toolData = tool.getToolData();
+
+			assert.ok(toolData.inputSchema?.properties?.agentName, 'agentName should be in schema when custom agents enabled');
+		});
+	});
+
+	suite('onDidInvokeTool event', () => {
+		test('mock service fires onDidInvokeTool events with correct data', () => {
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const sessionResource = URI.parse('test://session');
+			const receivedEvents: { toolId: string; sessionResource: URI | undefined; requestId: string | undefined; subagentInvocationId: string | undefined }[] = [];
+
+			testDisposables.add(mockToolsService.onDidInvokeTool(e => {
+				receivedEvents.push(e);
+			}));
+
+			mockToolsService.fireOnDidInvokeTool({
+				toolId: 'test-tool',
+				sessionResource,
+				requestId: 'request-123',
+				subagentInvocationId: 'subagent-456',
+			});
+
+			assert.strictEqual(receivedEvents.length, 1);
+			assert.deepStrictEqual(receivedEvents[0], {
+				toolId: 'test-tool',
+				sessionResource,
+				requestId: 'request-123',
+				subagentInvocationId: 'subagent-456',
+			});
+		});
+
+		test('events with different subagentInvocationId are distinguishable', () => {
+			// This tests the filtering logic used in RunSubagentTool.invoke()
+			// The tool subscribes to onDidInvokeTool and checks if e.subagentInvocationId matches its own callId
+			const mockToolsService = testDisposables.add(new MockLanguageModelToolsService());
+			const targetSubagentId = 'target-subagent';
+
+			const matchingEvents: string[] = [];
+			testDisposables.add(mockToolsService.onDidInvokeTool(e => {
+				if (e.subagentInvocationId === targetSubagentId) {
+					matchingEvents.push(e.toolId);
+				}
+			}));
+
+			// Fire events with different subagentInvocationIds
+			mockToolsService.fireOnDidInvokeTool({
+				toolId: 'unrelated-tool',
+				sessionResource: undefined,
+				requestId: undefined,
+				subagentInvocationId: 'different-subagent',
+			});
+			mockToolsService.fireOnDidInvokeTool({
+				toolId: 'matching-tool',
+				sessionResource: undefined,
+				requestId: undefined,
+				subagentInvocationId: targetSubagentId,
+			});
+			mockToolsService.fireOnDidInvokeTool({
+				toolId: 'another-unrelated-tool',
+				sessionResource: undefined,
+				requestId: undefined,
+				subagentInvocationId: undefined,
+			});
+
+			// Only the matching event should be captured
+			assert.deepStrictEqual(matchingEvents, ['matching-tool']);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/tools/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/mockLanguageModelToolsService.ts
@@ -5,29 +5,38 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { Event } from '../../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { constObservable, IObservable, IReader } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { IProgressStep } from '../../../../../../platform/progress/common/progress.js';
 import { ChatRequestToolReferenceEntry } from '../../../common/attachments/chatVariableEntries.js';
 import { IVariableReference } from '../../../common/chatModes.js';
 import { IChatToolInvocation } from '../../../common/chatService/chatService.js';
-import { CountTokensCallback, IBeginToolCallOptions, ILanguageModelToolsService, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolResult, IToolSet, ToolDataSource, ToolSet } from '../../../common/tools/languageModelToolsService.js';
-import { URI } from '../../../../../../base/common/uri.js';
 import { ILanguageModelChatMetadata } from '../../../common/languageModels.js';
+import { CountTokensCallback, IBeginToolCallOptions, ILanguageModelToolsService, IToolAndToolSetEnablementMap, IToolData, IToolImpl, IToolInvocation, IToolInvokedEvent, IToolResult, IToolSet, ToolDataSource, ToolSet } from '../../../common/tools/languageModelToolsService.js';
 
-export class MockLanguageModelToolsService implements ILanguageModelToolsService {
+export class MockLanguageModelToolsService extends Disposable implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
 	vscodeToolSet: ToolSet = new ToolSet('vscode', 'vscode', ThemeIcon.fromId(Codicon.code.id), ToolDataSource.Internal);
 	executeToolSet: ToolSet = new ToolSet('execute', 'execute', ThemeIcon.fromId(Codicon.terminal.id), ToolDataSource.Internal);
 	readToolSet: ToolSet = new ToolSet('read', 'read', ThemeIcon.fromId(Codicon.book.id), ToolDataSource.Internal);
 	agentToolSet: ToolSet = new ToolSet('agent', 'agent', ThemeIcon.fromId(Codicon.agent.id), ToolDataSource.Internal);
 
-	constructor() { }
+	private readonly _onDidInvokeTool = this._register(new Emitter<IToolInvokedEvent>());
+
+	constructor() {
+		super();
+	}
 
 	readonly onDidChangeTools: Event<void> = Event.None;
 	readonly onDidPrepareToolCallBecomeUnresponsive: Event<{ sessionResource: URI; toolData: IToolData }> = Event.None;
+	readonly onDidInvokeTool = this._onDidInvokeTool.event;
+
+	fireOnDidInvokeTool(event: IToolInvokedEvent): void {
+		this._onDidInvokeTool.fire(event);
+	}
 
 	registerToolData(toolData: IToolData): IDisposable {
 		return Disposable.None;


### PR DESCRIPTION
It was collecting text between tool calls when it should only collect the text after the final tool calls.

And edits in subagents left behind an empty codeblock in the result text.

Fix https://github.com/microsoft/vscode/issues/291159

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
