### PR TITLE
inline chat input: clamp widget to viewport when scrolling with content

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChatOverlayWidget.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChatOverlayWidget.css
@@ -3,6 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.inline-chat-gutter-menu.clamped {
+	transition: top 100ms;
+}
+
 .inline-chat-gutter-menu .input .monaco-editor-background {
 	background-color: var(--vscode-menu-background);
 }


### PR DESCRIPTION
When the input has content, the widget now stays visible and clamps to viewport edges (respecting sticky scroll height) instead of hiding when the anchor line scrolls out of view.

Fixes https://github.com/microsoft/vscode/issues/291075