### PR TITLE
In sandbox mode for chatUI, the command should be displayed without sandbox command and environment variables

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -274,7 +274,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		]);
 		this._titleElement = elements.title;
 
-		const command = (terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original).trimStart();
+		const command = (terminalData.commandLine.forDisplay ?? terminalData.commandLine.userEdited ?? terminalData.commandLine.toolEdited ?? terminalData.commandLine.original).trimStart();
 		this._commandText = command;
 		this._terminalOutputContextKey = ChatContextKeys.inChatTerminalToolOutput.bindTo(this._contextKeyService);
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -413,6 +413,8 @@ export interface IChatTerminalToolInvocationData {
 		original: string;
 		userEdited?: string;
 		toolEdited?: string;
+		// command to show in the chat UI (potentially different from what is actually run in the terminal)
+		forDisplay?: string;
 	};
 	/** The working directory URI for the terminal */
 	cwd?: UriComponents;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
@@ -22,4 +22,6 @@ export interface ICommandLineRewriterOptions {
 export interface ICommandLineRewriterResult {
 	rewritten: string;
 	reasoning: string;
+	//for scenarios where we want to show a different command in the chat UI than what is actually run in the terminal
+	forDisplay?: string;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
@@ -29,7 +29,8 @@ export class CommandLineSandboxRewriter extends Disposable implements ICommandLi
 		const wrappedCommand = this._sandboxService.wrapCommand(options.commandLine);
 		return {
 			rewritten: wrappedCommand,
-			reasoning: 'Wrapped command for sandbox execution'
+			reasoning: 'Wrapped command for sandbox execution',
+			forDisplay: options.commandLine, // show the command that is passed as input. In this case, the output from CommandLinePreventHistoryRewriter
 		};
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -456,6 +456,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const terminalCommandId = `tool-${generateUuid()}`;
 
 		let rewrittenCommand: string | undefined = args.command;
+		let forDisplayCommand: string | undefined = undefined;
 		for (const rewriter of this._commandLineRewriters) {
 			const rewriteResult = await rewriter.rewrite({
 				commandLine: rewrittenCommand,
@@ -465,6 +466,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			});
 			if (rewriteResult) {
 				rewrittenCommand = rewriteResult.rewritten;
+				forDisplayCommand = rewriteResult.forDisplay;
 				this._logService.info(`RunInTerminalTool: Command rewritten by ${rewriter.constructor.name}: ${rewriteResult.reasoning}`);
 			}
 		}
@@ -476,6 +478,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			commandLine: {
 				original: args.command,
 				toolEdited: rewrittenCommand === args.command ? undefined : rewrittenCommand,
+				forDisplay: forDisplayCommand,
 			},
 			cwd,
 			language,


### PR DESCRIPTION
fixes:#291672
Before the change:
<img width="453" height="113" alt="image" src="https://github.com/user-attachments/assets/8b6a3b30-48ab-4908-b76b-57faf884b75c" />

After the change: 

<img width="528" height="220" alt="image" src="https://github.com/user-attachments/assets/d0c8daf3-ea79-4452-9891-f0fefd861220" />
