### PR TITLE
chat: make tool invocation source property optional

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1337,7 +1337,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		// Don't pin MCP tools
-		const isMcpTool = (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') && part.source.type === 'mcp';
+		const isMcpTool = (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') && part.source?.type === 'mcp';
 		if (isMcpTool) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -788,7 +788,7 @@ export interface IChatToolInvocationSerialized {
 	isComplete: boolean;
 	toolCallId: string;
 	toolId: string;
-	source: ToolDataSource;
+	source: ToolDataSource | undefined; // undefined on pre-1.104 versions
 	readonly subAgentInvocationId?: string;
 	generatedTitle?: string;
 	kind: 'toolInvocationSerialized';


### PR DESCRIPTION
Fixes compatibility with pre-1.104 versions where the source property
may be undefined for deserialized tool invocations. Uses optional chaining
when accessing the source property to prevent errors.

- Make source property optional in IChatToolInvocationSerialized interface
- Use optional chaining operator when checking source.type in chat renderer
- Add comment explaining the pre-1.104 compatibility requirement

Ref https://github.com/microsoft/vscode/issues/288489

(Commit message generated by Copilot)