### PR TITLE
ci: restore reliability of terrapin check

### DIFF
--- a/build/azure-pipelines/product-npm-package-validate.yml
+++ b/build/azure-pipelines/product-npm-package-validate.yml
@@ -105,6 +105,12 @@ jobs:
         timeoutInMinutes: 400
         condition: and(succeeded(), eq(variables['SHOULD_VALIDATE'], 'true'))
 
+      - script: |
+          set -e
+          find . -name 'package-lock.json' -exec sed -i "s|$NPM_REGISTRY|https://registry.npmjs.org/|g" {} \;
+        displayName: Restore registry URLs in package-lock.json
+        condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'), eq(variables['SHOULD_VALIDATE'], 'true'))
+
       - script: .github/workflows/check-clean-git-state.sh
         displayName: Check clean git state
         condition: and(succeeded(), eq(variables['SHOULD_VALIDATE'], 'true'))

--- a/build/azure-pipelines/product-npm-package-validate.yml
+++ b/build/azure-pipelines/product-npm-package-validate.yml
@@ -17,7 +17,6 @@ jobs:
       name: 1es-ubuntu-22.04-x64
       os: linux
     timeoutInMinutes: 40000
-    continueOnError: true
     variables:
       VSCODE_ARCH: x64
     steps:

--- a/build/npm/postinstall.ts
+++ b/build/npm/postinstall.ts
@@ -11,6 +11,7 @@ import { dirs } from './dirs.ts';
 
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const root = path.dirname(path.dirname(import.meta.dirname));
+const rootNpmrcConfigKeys = getNpmrcConfigKeys(path.join(root, '.npmrc'));
 
 function log(dir: string, message: string) {
 	if (process.stdout.isTTY) {
@@ -125,6 +126,36 @@ function removeParcelWatcherPrebuild(dir: string) {
 	}
 }
 
+function getNpmrcConfigKeys(npmrcPath: string): string[] {
+	if (!fs.existsSync(npmrcPath)) {
+		return [];
+	}
+	const lines = fs.readFileSync(npmrcPath, 'utf8').split('\n');
+	const keys: string[] = [];
+	for (const line of lines) {
+		const trimmedLine = line.trim();
+		if (trimmedLine && !trimmedLine.startsWith('#')) {
+			const eqIndex = trimmedLine.indexOf('=');
+			if (eqIndex > 0) {
+				keys.push(trimmedLine.substring(0, eqIndex).trim());
+			}
+		}
+	}
+	return keys;
+}
+
+function clearInheritedNpmrcConfig(dir: string, env: NodeJS.ProcessEnv): void {
+	const dirNpmrcPath = path.join(root, dir, '.npmrc');
+	if (fs.existsSync(dirNpmrcPath)) {
+		return;
+	}
+
+	for (const key of rootNpmrcConfigKeys) {
+		const envKey = `npm_config_${key.replace(/-/g, '_')}`;
+		delete env[envKey];
+	}
+}
+
 for (const dir of dirs) {
 
 	if (dir === '') {
@@ -179,7 +210,10 @@ for (const dir of dirs) {
 		continue;
 	}
 
-	npmInstall(dir, opts);
+	// For directories that don't define their own .npmrc, clear inherited config
+	const env = { ...process.env };
+	clearInheritedNpmrcConfig(dir, env);
+	npmInstall(dir, { env });
 }
 
 child_process.execSync('git config pull.rebase merges');

--- a/test/mcp/package-lock.json
+++ b/test/mcp/package-lock.json
@@ -839,6 +839,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",


### PR DESCRIPTION
Noticed a couple of things in terrapin check while working on https://github.com/microsoft/vscode/pull/291471

1) Added a step to restore changes from our `setup-npm-registry.ts` script, this should allow only real changes in `Check clean git state` step
2) Removed `continueOnError` which I believe was added to hide false errors from 1) but it also hides any real failures from CI as github status would just report passing https://monacotools.visualstudio.com/Monaco/_build/results?buildId=399247&view=results
3) Drive by change in 1483d466683fae53b0f1353bf42dfef9b2d70656, `npm i` in subfolders that don't define their own `.npmrc` were incorrectly inheriting configurations from root specifically the [legacy-peer-deps](https://github.com/microsoft/vscode/blob/c6c601febd59b5c94ce3b00caba713893a7650a2/.npmrc#L6) config can break behavior depending on it being defined or not (whether to auto install peer dependency). This can be seen breaking a peer dependency under `test/mcp` (surprised didn't show up sooner!), see the unrelated commits touching https://github.com/microsoft/vscode/commits/main/test/mcp/package-lock.json. This is users running `npm i` directly under `test/mcp` vs running from the root via our postinstall.