### PR TITLE
inline chat: fix placeholder text and remove unused parameter

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatAffordance.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatAffordance.ts
@@ -87,8 +87,7 @@ export class InlineChatAffordance extends Disposable {
 		this._store.add(this._instantiationService.createInstance(
 			InlineChatEditorAffordance,
 			this._editor,
-			derived(r => affordance.read(r) === 'editor' ? selectionData.read(r) : undefined),
-			this._menuData
+			derived(r => affordance.read(r) === 'editor' ? selectionData.read(r) : undefined)
 		));
 
 		this._store.add(autorun(r => {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
@@ -10,7 +10,7 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../base
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from '../../../../editor/browser/editorBrowser.js';
 import { EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { Selection, SelectionDirection } from '../../../../editor/common/core/selection.js';
-import { autorun, IObservable, ISettableObservable } from '../../../../base/common/observable.js';
+import { autorun, IObservable } from '../../../../base/common/observable.js';
 import { MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -99,7 +99,6 @@ export class InlineChatEditorAffordance extends Disposable implements IContentWi
 	constructor(
 		private readonly _editor: ICodeEditor,
 		selection: IObservable<Selection | undefined>,
-		_hover: ISettableObservable<{ rect: DOMRect; above: boolean; lineNumber: number } | undefined>,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
@@ -106,7 +106,6 @@ export class InlineChatInputWidget extends Disposable {
 
 		const model = this._store.add(modelService.createModel('', null, URI.parse(`gutter-input:${Date.now()}`), true));
 		this._input.setModel(model);
-		this._input.layout({ width: 200, height: 18 });
 
 		// Initialize sticky scroll height observable
 		const stickyScrollController = StickyScrollController.get(this._editorObs.editor);
@@ -117,11 +116,10 @@ export class InlineChatInputWidget extends Disposable {
 			const selection = this._editorObs.cursorSelection.read(r);
 			const hasSelection = selection && !selection.isEmpty();
 			const placeholderText = hasSelection
-				? localize('placeholderWithSelection', "Edit selection")
+				? localize('placeholderWithSelection', "Modify selected code")
 				: localize('placeholderNoSelection', "Generate code");
-			this._input.updateOptions({
-				placeholder: this._keybindingService.appendKeybinding(placeholderText, ACTION_START)
-			});
+
+			this._input.updateOptions({ placeholder: this._keybindingService.appendKeybinding(placeholderText, ACTION_START) });
 		}));
 
 		// Listen to content size changes and resize the input editor (max 3 lines)
@@ -202,8 +200,7 @@ export class InlineChatInputWidget extends Disposable {
 
 		// Clear input state
 		this._input.getModel().setValue('');
-		this._inputContainer.style.height = '26px';
-		this._input.layout({ width: 200, height: 18 });
+		this._updateInputHeight(this._input.getContentHeight());
 
 		// Refresh actions from menu
 		this._refreshActions();


### PR DESCRIPTION
- Change selection placeholder to 'Modify selected code'
- Remove unused _hover parameter from InlineChatEditorAffordance
- Fix input height reset in show() to use _updateInputHeight()

Fixes #291070, fixes #291032