### PR TITLE
only hide word suggestions when inline completions are enabled

### DIFF
--- a/src/vs/editor/browser/services/editorWorkerService.ts
+++ b/src/vs/editor/browser/services/editorWorkerService.ts
@@ -37,6 +37,7 @@ import { EditorWorkerHost } from '../../common/services/editorWorkerHost.js';
 import { StringEdit } from '../../common/core/edits/stringEdit.js';
 import { OffsetRange } from '../../common/core/ranges/offsetRange.js';
 import { FileAccess } from '../../../base/common/network.js';
+import { isCompletionsEnabledWithTextResourceConfig } from '../../common/services/completionsEnablement.js';
 
 /**
  * Stop the worker if it was not needed for 5 min.
@@ -280,7 +281,9 @@ class WordBasedCompletionItemProvider implements languages.CompletionItemProvide
 			return undefined;
 		}
 
-		if (config.wordBasedSuggestions === 'offWithInlineSuggestions' && this.languageFeaturesService.inlineCompletionsProvider.has(model)) {
+		if (config.wordBasedSuggestions === 'offWithInlineSuggestions'
+			&& this.languageFeaturesService.inlineCompletionsProvider.has(model)
+			&& isCompletionsEnabledWithTextResourceConfig(this._configurationService, model.getLanguageId())) {
 			return undefined;
 		}
 

--- a/src/vs/editor/browser/services/editorWorkerService.ts
+++ b/src/vs/editor/browser/services/editorWorkerService.ts
@@ -283,7 +283,7 @@ class WordBasedCompletionItemProvider implements languages.CompletionItemProvide
 
 		if (config.wordBasedSuggestions === 'offWithInlineSuggestions'
 			&& this.languageFeaturesService.inlineCompletionsProvider.has(model)
-			&& isCompletionsEnabledWithTextResourceConfig(this._configurationService, model.getLanguageId())) {
+			&& isCompletionsEnabledWithTextResourceConfig(this._configurationService, model.uri, model.getLanguageId())) {
 			return undefined;
 		}
 

--- a/src/vs/editor/common/services/completionsEnablement.ts
+++ b/src/vs/editor/common/services/completionsEnablement.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import product from '../../../platform/product/common/product.js';
+import { isObject } from '../../../base/common/types.js';
+import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
+import { ITextResourceConfigurationService } from './textResourceConfiguration.js';
+
+/**
+ * Get the completions enablement setting name from product configuration.
+ */
+function getCompletionsEnablementSettingName(): string | undefined {
+	return product.defaultChatAgent?.completionsEnablementSetting;
+}
+
+/**
+ * Checks if completions (e.g., Copilot) are enabled for a given language ID
+ * using `IConfigurationService`.
+ *
+ * @param configurationService The configuration service to read settings from.
+ * @param modeId The language ID to check. Defaults to '*' which checks the global setting.
+ * @returns `true` if completions are enabled for the language, `false` otherwise.
+ */
+export function isCompletionsEnabled(configurationService: IConfigurationService, modeId: string = '*'): boolean {
+	const settingName = getCompletionsEnablementSettingName();
+	if (!settingName) {
+		return false;
+	}
+
+	return isCompletionsEnabledFromObject(
+		configurationService.getValue<Record<string, boolean>>(settingName),
+		modeId
+	);
+}
+
+/**
+ * Checks if completions (e.g., Copilot) are enabled for a given language ID
+ * using `ITextResourceConfigurationService`.
+ *
+ * @param configurationService The text resource configuration service to read settings from.
+ * @param modeId The language ID to check. Defaults to '*' which checks the global setting.
+ * @returns `true` if completions are enabled for the language, `false` otherwise.
+ */
+export function isCompletionsEnabledWithTextResourceConfig(configurationService: ITextResourceConfigurationService, modeId: string = '*'): boolean {
+	const settingName = getCompletionsEnablementSettingName();
+	if (!settingName) {
+		return false;
+	}
+
+	// Pass undefined as resource to get the global setting
+	return isCompletionsEnabledFromObject(
+		configurationService.getValue<Record<string, boolean>>(undefined, settingName),
+		modeId
+	);
+}
+
+/**
+ * Checks if completions are enabled for a given language ID using a pre-fetched
+ * completions enablement object.
+ *
+ * @param completionsEnablementObject The object containing per-language enablement settings.
+ * @param modeId The language ID to check. Defaults to '*' which checks the global setting.
+ * @returns `true` if completions are enabled for the language, `false` otherwise.
+ */
+export function isCompletionsEnabledFromObject(completionsEnablementObject: Record<string, boolean> | undefined, modeId: string = '*'): boolean {
+	if (!isObject(completionsEnablementObject)) {
+		return false; // default to disabled if setting is not available
+	}
+
+	if (typeof completionsEnablementObject[modeId] !== 'undefined') {
+		return Boolean(completionsEnablementObject[modeId]); // go with setting if explicitly defined
+	}
+
+	return Boolean(completionsEnablementObject['*']); // fallback to global setting otherwise
+}

--- a/src/vs/editor/common/services/completionsEnablement.ts
+++ b/src/vs/editor/common/services/completionsEnablement.ts
@@ -7,6 +7,7 @@ import product from '../../../platform/product/common/product.js';
 import { isObject } from '../../../base/common/types.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { ITextResourceConfigurationService } from './textResourceConfiguration.js';
+import { URI } from '../../../base/common/uri.js';
 
 /**
  * Get the completions enablement setting name from product configuration.
@@ -43,7 +44,7 @@ export function isCompletionsEnabled(configurationService: IConfigurationService
  * @param modeId The language ID to check. Defaults to '*' which checks the global setting.
  * @returns `true` if completions are enabled for the language, `false` otherwise.
  */
-export function isCompletionsEnabledWithTextResourceConfig(configurationService: ITextResourceConfigurationService, modeId: string = '*'): boolean {
+export function isCompletionsEnabledWithTextResourceConfig(configurationService: ITextResourceConfigurationService, resource: URI, modeId: string = '*'): boolean {
 	const settingName = getCompletionsEnablementSettingName();
 	if (!settingName) {
 		return false;
@@ -51,7 +52,7 @@ export function isCompletionsEnabledWithTextResourceConfig(configurationService:
 
 	// Pass undefined as resource to get the global setting
 	return isCompletionsEnabledFromObject(
-		configurationService.getValue<Record<string, boolean>>(undefined, settingName),
+		configurationService.getValue<Record<string, boolean>>(resource, settingName),
 		modeId
 	);
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsSource.ts
@@ -28,6 +28,7 @@ import { Command, InlineCompletionEndOfLifeReasonKind, InlineCompletionTriggerKi
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../../common/model.js';
 import { offsetEditFromContentChanges } from '../../../../common/model/textModelStringEdit.js';
+import { isCompletionsEnabledFromObject } from '../../../../common/services/completionsEnablement.js';
 import { IFeatureDebounceInformation } from '../../../../common/services/languageFeatureDebounce.js';
 import { IModelContentChangedEvent } from '../../../../common/textModelEvents.js';
 import { formatRecordableLogEntry, IRecordableEditorLogEntry, IRecordableLogEntry, StructuredLogger } from '../structuredLogger.js';
@@ -445,7 +446,7 @@ export class InlineCompletionsSource extends Disposable {
 		}
 
 
-		if (!isCompletionsEnabled(this._completionsEnabled, this._textModel.getLanguageId())) {
+		if (!isCompletionsEnabledFromObject(this._completionsEnabled, this._textModel.getLanguageId())) {
 			return;
 		}
 
@@ -569,18 +570,6 @@ class RequestResponseData {
 
 function isSubset<T>(set1: Set<T>, set2: Set<T>): boolean {
 	return [...set1].every(item => set2.has(item));
-}
-
-function isCompletionsEnabled(completionsEnablementObject: Record<string, boolean> | undefined, modeId: string = '*'): boolean {
-	if (completionsEnablementObject === undefined) {
-		return false; // default to disabled if setting is not available
-	}
-
-	if (typeof completionsEnablementObject[modeId] !== 'undefined') {
-		return Boolean(completionsEnablementObject[modeId]); // go with setting if explicitly defined
-	}
-
-	return Boolean(completionsEnablementObject['*']); // fallback to global setting otherwise
 }
 
 class UpdateOperation implements IDisposable {

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatus.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatus.ts
@@ -4,24 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
-import product from '../../../../../platform/product/common/product.js';
-import { isObject } from '../../../../../base/common/types.js';
 
 export function isNewUser(chatEntitlementService: IChatEntitlementService): boolean {
 	return !chatEntitlementService.sentiment.installed ||					// chat not installed
 		chatEntitlementService.entitlement === ChatEntitlement.Available;	// not yet signed up to chat
-}
-
-export function isCompletionsEnabled(configurationService: IConfigurationService, modeId: string = '*'): boolean {
-	const result = configurationService.getValue<Record<string, boolean>>(product.defaultChatAgent.completionsEnablementSetting);
-	if (!isObject(result)) {
-		return false;
-	}
-
-	if (typeof result[modeId] !== 'undefined') {
-		return Boolean(result[modeId]); // go with setting if explicitly defined
-	}
-
-	return Boolean(result['*']); // fallback to global setting otherwise
 }

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -40,13 +40,14 @@ import { EditorResourceAccessor, SideBySideEditor } from '../../../../common/edi
 import { IChatEntitlementService, ChatEntitlementService, ChatEntitlement, IQuotaSnapshot, getChatPlanName } from '../../../../services/chat/common/chatEntitlementService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatSessionsService } from '../../common/chatSessionsService.js';
-import { isNewUser, isCompletionsEnabled } from './chatStatus.js';
+import { isNewUser } from './chatStatus.js';
 import { IChatStatusItemService, ChatStatusEntry } from './chatStatusItemService.js';
 import product from '../../../../../platform/product/common/product.js';
 import { contrastBorder, inputValidationErrorBorder, inputValidationInfoBorder, inputValidationWarningBorder, registerColor, transparent } from '../../../../../platform/theme/common/colorRegistry.js';
 import { Color } from '../../../../../base/common/color.js';
 import { IViewsService } from '../../../../services/views/common/viewsService.js';
 import { ChatViewId } from '../chat.js';
+import { isCompletionsEnabled } from '../../../../../editor/common/services/completionsEnablement.js';
 
 const defaultChat = product.defaultChatAgent;
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -19,8 +19,9 @@ import { IChatSessionsService } from '../../common/chatSessionsService.js';
 import { ChatStatusDashboard } from './chatStatusDashboard.js';
 import { mainWindow } from '../../../../../base/browser/window.js';
 import { disposableWindowInterval } from '../../../../../base/browser/dom.js';
-import { isNewUser, isCompletionsEnabled } from './chatStatus.js';
+import { isNewUser } from './chatStatus.js';
 import product from '../../../../../platform/product/common/product.js';
+import { isCompletionsEnabled } from '../../../../../editor/common/services/completionsEnablement.js';
 
 export class ChatStatusBarEntry extends Disposable implements IWorkbenchContribution {
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the logic to hide word suggestions only when inline completions are enabled for the specific language configuration. Introduce a new utility function to check completions enablement based on the text resource configuration. Remove the previous implementation of the completions enablement check.

closes https://github.com/microsoft/vscode/issues/290370