### PR TITLE
fix: always remove the old context menu entries on win11

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1605,7 +1605,7 @@ begin
   begin
 #ifdef AppxPackageName
     // Remove the old context menu registry keys
-    if IsWindows11OrLater() and WizardIsTaskSelected('addcontextmenufiles') then begin
+    if IsWindows11OrLater() then begin
       RegDeleteKeyIncludingSubkeys({#EnvironmentRootKey}, 'Software\Classes\*\shell\{#RegValueName}');
       RegDeleteKeyIncludingSubkeys({#EnvironmentRootKey}, 'Software\Classes\directory\shell\{#RegValueName}');
       RegDeleteKeyIncludingSubkeys({#EnvironmentRootKey}, 'Software\Classes\directory\background\shell\{#RegValueName}');


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/291065