### PR TITLE
Disable session type picker when editing input

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/theme.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/theme.ts
@@ -90,7 +90,12 @@ export const inlineEditIndicatorSecondaryForeground = registerColor(
 );
 export const inlineEditIndicatorSecondaryBorder = registerColor(
 	'inlineEdit.gutterIndicator.secondaryBorder',
-	buttonSecondaryBackground,
+	{
+		light: buttonSecondaryBackground,
+		dark: buttonSecondaryBackground,
+		hcDark: buttonSecondaryBackground,
+		hcLight: buttonSecondaryBackground,
+	},
 	localize('inlineEdit.gutterIndicator.secondaryBorder', 'Border color for the secondary inline edit gutter indicator.')
 );
 export const inlineEditIndicatorSecondaryBackground = registerColor(

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -491,7 +491,7 @@ export class OpenSessionTargetPickerAction extends Action2 {
 			tooltip: localize('setSessionTarget', "Set Session Target"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.or(ChatContextKeys.chatSessionIsEmpty, ChatContextKeys.inAgentSessionsWelcome)),
+			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.or(ChatContextKeys.chatSessionIsEmpty, ChatContextKeys.inAgentSessionsWelcome), ChatContextKeys.currentlyEditingInput.negate(), ChatContextKeys.currentlyEditing.negate()),
 			menu: [
 				{
 					id: MenuId.ChatInput,
@@ -526,7 +526,7 @@ export class OpenDelegationPickerAction extends Action2 {
 			tooltip: localize('delegateSession', "Delegate Session"),
 			category: CHAT_CATEGORY,
 			f1: false,
-			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatSessionIsEmpty.negate()),
+			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatSessionIsEmpty.negate(), ChatContextKeys.currentlyEditingInput.negate(), ChatContextKeys.currentlyEditing.negate()),
 			menu: [
 				{
 					id: MenuId.ChatInput,


### PR DESCRIPTION
```Copilot Generated Description:``` Disable the session type picker when the user is currently editing input. Update preconditions for related actions to reflect this change.

closes https://github.com/microsoft/vscode/issues/290876