### PR TITLE
Browser: make paused state less jarring

### DIFF
--- a/src/vs/platform/browserView/common/browserView.ts
+++ b/src/vs/platform/browserView/common/browserView.ts
@@ -27,6 +27,7 @@ export interface IBrowserViewState {
 	canGoForward: boolean;
 	loading: boolean;
 	focused: boolean;
+	visible: boolean;
 	isDevToolsOpen: boolean;
 	lastScreenshot: VSBuffer | undefined;
 	lastFavicon: string | undefined;
@@ -53,6 +54,10 @@ export interface IBrowserViewLoadError {
 
 export interface IBrowserViewFocusEvent {
 	focused: boolean;
+}
+
+export interface IBrowserViewVisibilityEvent {
+	visible: boolean;
 }
 
 export interface IBrowserViewDevToolsStateEvent {
@@ -112,6 +117,7 @@ export interface IBrowserViewService {
 	onDynamicDidNavigate(id: string): Event<IBrowserViewNavigationEvent>;
 	onDynamicDidChangeLoadingState(id: string): Event<IBrowserViewLoadingEvent>;
 	onDynamicDidChangeFocus(id: string): Event<IBrowserViewFocusEvent>;
+	onDynamicDidChangeVisibility(id: string): Event<IBrowserViewVisibilityEvent>;
 	onDynamicDidChangeDevToolsState(id: string): Event<IBrowserViewDevToolsStateEvent>;
 	onDynamicDidKeyCommand(id: string): Event<IBrowserViewKeyDownEvent>;
 	onDynamicDidChangeTitle(id: string): Event<IBrowserViewTitleChangeEvent>;

--- a/src/vs/platform/browserView/electron-main/browserViewMainService.ts
+++ b/src/vs/platform/browserView/electron-main/browserViewMainService.ts
@@ -123,6 +123,10 @@ export class BrowserViewMainService extends Disposable implements IBrowserViewMa
 		return this._getBrowserView(id).onDidChangeFocus;
 	}
 
+	onDynamicDidChangeVisibility(id: string) {
+		return this._getBrowserView(id).onDidChangeVisibility;
+	}
+
 	onDynamicDidChangeDevToolsState(id: string) {
 		return this._getBrowserView(id).onDidChangeDevToolsState;
 	}

--- a/src/vs/workbench/contrib/browserView/common/browserView.ts
+++ b/src/vs/workbench/contrib/browserView/common/browserView.ts
@@ -22,7 +22,8 @@ import {
 	BrowserViewStorageScope,
 	IBrowserViewCaptureScreenshotOptions,
 	IBrowserViewFindInPageOptions,
-	IBrowserViewFindInPageResult
+	IBrowserViewFindInPageResult,
+	IBrowserViewVisibilityEvent
 } from '../../../../platform/browserView/common/browserView.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -82,6 +83,7 @@ export interface IBrowserViewModel extends IDisposable {
 	readonly screenshot: VSBuffer | undefined;
 	readonly loading: boolean;
 	readonly focused: boolean;
+	readonly visible: boolean;
 	readonly canGoBack: boolean;
 	readonly isDevToolsOpen: boolean;
 	readonly canGoForward: boolean;
@@ -98,6 +100,7 @@ export interface IBrowserViewModel extends IDisposable {
 	readonly onDidChangeFavicon: Event<IBrowserViewFaviconChangeEvent>;
 	readonly onDidRequestNewPage: Event<IBrowserViewNewPageRequest>;
 	readonly onDidFindInPage: Event<IBrowserViewFindInPageResult>;
+	readonly onDidChangeVisibility: Event<IBrowserViewVisibilityEvent>;
 	readonly onDidClose: Event<void>;
 	readonly onWillDispose: Event<void>;
 
@@ -125,6 +128,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 	private _screenshot: VSBuffer | undefined = undefined;
 	private _loading: boolean = false;
 	private _focused: boolean = false;
+	private _visible: boolean = false;
 	private _isDevToolsOpen: boolean = false;
 	private _canGoBack: boolean = false;
 	private _canGoForward: boolean = false;
@@ -150,6 +154,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 	get favicon(): string | undefined { return this._favicon; }
 	get loading(): boolean { return this._loading; }
 	get focused(): boolean { return this._focused; }
+	get visible(): boolean { return this._visible; }
 	get isDevToolsOpen(): boolean { return this._isDevToolsOpen; }
 	get canGoBack(): boolean { return this._canGoBack; }
 	get canGoForward(): boolean { return this._canGoForward; }
@@ -193,6 +198,10 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 		return this.browserViewService.onDynamicDidFindInPage(this.id);
 	}
 
+	get onDidChangeVisibility(): Event<IBrowserViewVisibilityEvent> {
+		return this.browserViewService.onDynamicDidChangeVisibility(this.id);
+	}
+
 	get onDidClose(): Event<void> {
 		return this.browserViewService.onDynamicDidClose(this.id);
 	}
@@ -221,6 +230,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 		this._title = state.title;
 		this._loading = state.loading;
 		this._focused = state.focused;
+		this._visible = state.visible;
 		this._isDevToolsOpen = state.isDevToolsOpen;
 		this._canGoBack = state.canGoBack;
 		this._canGoForward = state.canGoForward;
@@ -262,6 +272,10 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 		this._register(this.onDidChangeFocus(({ focused }) => {
 			this._focused = focused;
 		}));
+
+		this._register(this.onDidChangeVisibility(({ visible }) => {
+			this._visible = visible;
+		}));
 	}
 
 	async layout(bounds: IBrowserViewBounds): Promise<void> {
@@ -269,6 +283,7 @@ export class BrowserViewModel extends Disposable implements IBrowserViewModel {
 	}
 
 	async setVisible(visible: boolean): Promise<void> {
+		this._visible = visible; // Set optimistically so model is in sync immediately
 		return this.browserViewService.setVisible(this.id, visible);
 	}
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -5,7 +5,7 @@
 
 import './media/browser.css';
 import { localize } from '../../../../nls.js';
-import { $, addDisposableListener, Dimension, disposableWindowInterval, EventType, IDomPosition, registerExternalFocusChecker } from '../../../../base/browser/dom.js';
+import { $, addDisposableListener, Dimension, EventType, IDomPosition, registerExternalFocusChecker } from '../../../../base/browser/dom.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { RawContextKey, IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -192,6 +192,7 @@ export class BrowserEditor extends EditorPane {
 	private readonly _inputDisposables = this._register(new DisposableStore());
 	private overlayManager: BrowserOverlayManager | undefined;
 	private _elementSelectionCts: CancellationTokenSource | undefined;
+	private _screenshotTimeout: ReturnType<typeof setTimeout> | undefined;
 
 	constructor(
 		group: IEditorGroup,
@@ -344,6 +345,9 @@ export class BrowserEditor extends EditorPane {
 			this.focusUrlInput();
 		}
 
+		// Start / stop screenshots when the model visibility changes
+		this._inputDisposables.add(this._model.onDidChangeVisibility(() => this.doScreenshot()));
+
 		// Listen to model events for UI updates
 		this._inputDisposables.add(this._model.onDidKeyCommand(keyEvent => {
 			// Handle like webview does - convert to webview KeyEvent format
@@ -398,16 +402,10 @@ export class BrowserEditor extends EditorPane {
 				this.layoutBrowserContainer();
 			}
 		}));
-		// Capture screenshot periodically (once per second) to keep background updated
-		this._inputDisposables.add(disposableWindowInterval(
-			this.window,
-			() => this.capturePlaceholderSnapshot(),
-			1000
-		));
 
 		this.updateErrorDisplay();
 		this.layoutBrowserContainer();
-		await this._model.setVisible(this.shouldShowView);
+		this.updateVisibility();
 	}
 
 	protected override setEditorVisible(visible: boolean): void {
@@ -442,14 +440,26 @@ export class BrowserEditor extends EditorPane {
 
 		if (this._model) {
 			const show = this.shouldShowView;
-			void this._model.setVisible(show);
-			if (
-				show &&
-				this._browserContainer.ownerDocument.hasFocus() &&
-				this._browserContainer.ownerDocument.activeElement === this._browserContainer
-			) {
-				// If the editor is focused, ensure the browser view also gets focus
-				void this._model.focus();
+			if (show === this._model.visible) {
+				return;
+			}
+
+			if (show) {
+				this._model.setVisible(true);
+				if (
+					this._browserContainer.ownerDocument.hasFocus() &&
+					this._browserContainer.ownerDocument.activeElement === this._browserContainer
+				) {
+					// If the editor is focused, ensure the browser view also gets focus
+					void this._model.focus();
+				}
+			} else {
+				this.doScreenshot();
+
+				// Hide the browser view just before the next render.
+				// This attempts to give the screenshot some time to be captured and displayed.
+				// Tf we hide immediately it is more likely to flicker while the old screenshot is still visible.
+				this.window.requestAnimationFrame(() => this._model?.setVisible(false));
 			}
 		}
 	}
@@ -780,17 +790,31 @@ export class BrowserEditor extends EditorPane {
 		}
 	}
 
-	/**
-	 * Capture a screenshot of the current browser view to use as placeholder background
-	 */
-	private async capturePlaceholderSnapshot(): Promise<void> {
-		if (this._model && !this._overlayVisible) {
-			try {
-				const buffer = await this._model.captureScreenshot({ quality: 80 });
-				this.setBackgroundImage(buffer);
-			} catch (error) {
-				this.logService.error('BrowserEditor.capturePlaceholderSnapshot: Failed to capture screenshot', error);
-			}
+	private async doScreenshot(): Promise<void> {
+		if (!this._model) {
+			return;
+		}
+
+		// Cancel any existing timeout
+		this.cancelScheduledScreenshot();
+
+		// Only take screenshots if the model is visible
+		if (!this._model.visible) {
+			return;
+		}
+
+		// Capture screenshot and set as background image
+		const screenshot = await this._model.captureScreenshot({ quality: 80 });
+		this.setBackgroundImage(screenshot);
+
+		// Schedule next screenshot in 1 second
+		this._screenshotTimeout = setTimeout(() => this.doScreenshot(), 1000);
+	}
+
+	private cancelScheduledScreenshot(): void {
+		if (this._screenshotTimeout) {
+			clearTimeout(this._screenshotTimeout);
+			this._screenshotTimeout = undefined;
 		}
 	}
 
@@ -858,6 +882,9 @@ export class BrowserEditor extends EditorPane {
 			this._elementSelectionCts.dispose(true);
 			this._elementSelectionCts = undefined;
 		}
+
+		// Cancel any scheduled screenshots
+		this.cancelScheduledScreenshot();
 
 		// Clear find widget model
 		this._findWidget.rawValue?.setModel(undefined);

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -406,6 +406,7 @@ export class BrowserEditor extends EditorPane {
 		this.updateErrorDisplay();
 		this.layoutBrowserContainer();
 		this.updateVisibility();
+		this.doScreenshot();
 	}
 
 	protected override setEditorVisible(visible: boolean): void {
@@ -808,7 +809,7 @@ export class BrowserEditor extends EditorPane {
 			const screenshot = await this._model.captureScreenshot({ quality: 80 });
 			this.setBackgroundImage(screenshot);
 		} catch (error) {
-			this._logService.error('Failed to capture browser view screenshot', error);
+			this.logService.error('Failed to capture browser view screenshot', error);
 		}
 
 		// Schedule next screenshot in 1 second

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -458,7 +458,7 @@ export class BrowserEditor extends EditorPane {
 
 				// Hide the browser view just before the next render.
 				// This attempts to give the screenshot some time to be captured and displayed.
-				// Tf we hide immediately it is more likely to flicker while the old screenshot is still visible.
+				// If we hide immediately it is more likely to flicker while the old screenshot is still visible.
 				this.window.requestAnimationFrame(() => this._model?.setVisible(false));
 			}
 		}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -803,9 +803,13 @@ export class BrowserEditor extends EditorPane {
 			return;
 		}
 
-		// Capture screenshot and set as background image
-		const screenshot = await this._model.captureScreenshot({ quality: 80 });
-		this.setBackgroundImage(screenshot);
+		try {
+			// Capture screenshot and set as background image
+			const screenshot = await this._model.captureScreenshot({ quality: 80 });
+			this.setBackgroundImage(screenshot);
+		} catch (error) {
+			this._logService.error('Failed to capture browser view screenshot', error);
+		}
 
 		// Schedule next screenshot in 1 second
 		this._screenshotTimeout = setTimeout(() => this.doScreenshot(), 1000);

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -72,14 +72,18 @@
 		justify-content: center;
 		pointer-events: none;
 		color: var(--vscode-foreground);
-		background-color: color-mix(in srgb, var(--vscode-editor-background) 60%, transparent);
+		background-color: color-mix(in srgb, var(--vscode-editor-background) 20%, transparent);
 		opacity: 0;
 		visibility: hidden;
-		transition: opacity 200ms ease-out;
+		transition: opacity 200ms ease-in;
 
 		&.visible {
 			opacity: 1;
 			visibility: visible;
+		}
+
+		&.show-message {
+			background-color: color-mix(in srgb, var(--vscode-editor-background) 60%, transparent);
 		}
 	}
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -72,7 +72,7 @@
 		justify-content: center;
 		pointer-events: none;
 		color: var(--vscode-foreground);
-		background-color: color-mix(in srgb, var(--vscode-editor-background) 20%, transparent);
+		background-color: color-mix(in srgb, var(--vscode-editor-background) 15%, transparent);
 		opacity: 0;
 		visibility: hidden;
 		transition: opacity 200ms ease-in;


### PR DESCRIPTION
* Reduce darkening effect from 60% to 15% for simple hover overlays (i.e. non-notifications)
* Improve screenshotting logic to better keep the screenshot up-to-date and reduce flicker

<details>
<summary>Before</summary>

![6a3bae68-0873-4457-bfdf-bc91a014e4c4](https://github.com/user-attachments/assets/696ad085-276e-448b-9147-f250b310e01f)

</details>

<details>
<summary>After</summary>

![446dcf02-70da-4daa-8ce3-61f94f2ca9a8](https://github.com/user-attachments/assets/3dc3645c-9c9e-49b1-ab84-c8edb316f5e6)

</details>