### PR TITLE
Add ARIA role and label to welcome view content

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -161,7 +161,7 @@ class ViewWelcomeController {
 
 		this.container.classList.add('welcome');
 		const viewWelcomeContainer = append(this.container, $('.welcome-view'));
-		this.element = $('.welcome-view-content', { tabIndex: 0 });
+		this.element = $('.welcome-view-content', { tabIndex: 0, role: 'region', 'aria-label': nls.localize('welcomeViewAriaLabel', "Welcome") });
 		if (this._wide) {
 			this.element.classList.add('wide');
 		}


### PR DESCRIPTION
```Copilot Generated Description:``` Add an ARIA role of 'region' and an 'aria-label' to the welcome view content element to improve accessibility compliance.

Fixes microsoft/vscode#250108

