### PR TITLE
Update @vscode/codicons to version 0.0.45-2 and add 'openai' icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-0",
+        "@vscode/codicons": "^0.0.45-2",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -2947,9 +2947,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-0",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-0.tgz",
-      "integrity": "sha512-ixvw4auQobMOnMX9cOk8/3GfEgkTKCchsab2O6QvyL6+x4FJegOrK3Wgn4Y+Qua51LqnAsgpB5n74q8HEPh1pA==",
+      "version": "0.0.45-2",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-2.tgz",
+      "integrity": "sha512-Z5uZd8E2f84Jf4jv6ozSjIU/cnHn7F1REBGUtzdqJufWoLYauH/nwpVn8fWtvXNtR1QwEyh6x3WAeR2l5rnnyg==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/deviceid": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-0",
+    "@vscode/codicons": "^0.0.45-2",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-0",
+        "@vscode/codicons": "^0.0.45-2",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-0",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-0.tgz",
-      "integrity": "sha512-ixvw4auQobMOnMX9cOk8/3GfEgkTKCchsab2O6QvyL6+x4FJegOrK3Wgn4Y+Qua51LqnAsgpB5n74q8HEPh1pA==",
+      "version": "0.0.45-2",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-2.tgz",
+      "integrity": "sha512-Z5uZd8E2f84Jf4jv6ozSjIU/cnHn7F1REBGUtzdqJufWoLYauH/nwpVn8fWtvXNtR1QwEyh6x3WAeR2l5rnnyg==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-0",
+    "@vscode/codicons": "^0.0.45-2",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -652,4 +652,5 @@ export const codiconsLibrary = {
 	worktree: register('worktree', 0xec7e),
 	screenCut: register('screen-cut', 0xec7f),
 	ask: register('ask', 0xec80),
+	openai: register('openai', 0xec81),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.45-2 and introduce a new 'openai' icon in the codicons library. This enhances the icon set available for use.

