### PR TITLE
fix terminal output in thinking container

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -371,7 +371,9 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			this.domNode = progressPart.domNode;
 		}
 
-		if (expandedStateByInvocation.get(toolInvocation) || (this._isInThinkingContainer && IChatToolInvocation.isComplete(toolInvocation))) {
+		// Only auto-expand in thinking containers if there's actual output to show
+		const hasStoredOutput = !!terminalData.terminalCommandOutput;
+		if (expandedStateByInvocation.get(toolInvocation) || (this._isInThinkingContainer && IChatToolInvocation.isComplete(toolInvocation) && hasStoredOutput)) {
 			void this._toggleOutput(true);
 		}
 		this._register(this._terminalChatService.registerProgressPart(this));


### PR DESCRIPTION
When a terminal tool runs in a thinking container:

Old behavior: As soon as the tool invocation completes, the output section expands, even if no output snapshot has been captured yet. This caused "Command output is no longer available" or empty output to show prematurely.

New behavior: Only expand if the tool invocation is complete AND there's actual stored output If no snapshot yet, `TerminalToolAutoExpand` will handle expanding later when real output arrives via terminal events.

This ensures thinking containers only show the output section when there's actually something to display.

Fixes https://github.com/microsoft/vscode/issues/288963