### PR TITLE
mcp: update draft typings and announce mcp apps support

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMcpAppModel.ts
@@ -723,7 +723,7 @@ export class ChatMcpAppModel extends Disposable {
 			jsonrpc: '2.0',
 			id,
 			error: { code, message },
-		} satisfies MCP.JSONRPCError);
+		} satisfies MCP.JSONRPCErrorResponse);
 	}
 
 	private async _sendNotification(message: McpApps.HostNotification): Promise<void> {

--- a/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerRequestHandler.ts
@@ -133,6 +133,11 @@ export class McpServerRequestHandler extends Disposable {
 									elicitation: opts.elicitationRequestHandler ? { create: {} } : undefined,
 								},
 							},
+							extensions: {
+								'io.modelcontextprotocol/ui': {
+									mimeTypes: ['text/html;profile=mcp-app']
+								}
+							}
 						},
 						clientInfo: {
 							name: productService.nameLong,
@@ -321,22 +326,26 @@ export class McpServerRequestHandler extends Disposable {
 	/**
 	 * Handle successful responses
 	 */
-	private handleResult(response: MCP.JSONRPCResponse): void {
-		const request = this._pendingRequests.get(response.id);
-		if (request) {
-			this._pendingRequests.delete(response.id);
-			request.promise.complete(response.result);
+	private handleResult(response: MCP.JSONRPCResultResponse): void {
+		if (response.id !== undefined) {
+			const request = this._pendingRequests.get(response.id);
+			if (request) {
+				this._pendingRequests.delete(response.id);
+				request.promise.complete(response.result);
+			}
 		}
 	}
 
 	/**
 	 * Handle error responses
 	 */
-	private handleError(response: MCP.JSONRPCError): void {
-		const request = this._pendingRequests.get(response.id);
-		if (request) {
-			this._pendingRequests.delete(response.id);
-			request.promise.error(new MpcResponseError(response.error.message, response.error.code, response.error.data));
+	private handleError(response: MCP.JSONRPCErrorResponse): void {
+		if (response.id !== undefined) {
+			const request = this._pendingRequests.get(response.id);
+			if (request) {
+				this._pendingRequests.delete(response.id);
+				request.promise.error(new MpcResponseError(response.error.message, response.error.code, response.error.data));
+			}
 		}
 	}
 
@@ -394,7 +403,7 @@ export class McpServerRequestHandler extends Disposable {
 				e = McpError.unknown(e);
 			}
 
-			const errorResponse: MCP.JSONRPCError = {
+			const errorResponse: MCP.JSONRPCErrorResponse = {
 				jsonrpc: MCP.JSONRPC_VERSION,
 				id: request.id,
 				error: {

--- a/src/vs/workbench/contrib/mcp/common/mcpTaskManager.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTaskManager.ts
@@ -89,6 +89,7 @@ export class McpTaskManager extends Disposable {
 			status: 'working',
 			createdAt,
 			ttl,
+			lastUpdatedAt: new Date().toISOString(),
 			pollInterval: 1000, // Suggest 1 second polling interval
 		};
 
@@ -171,6 +172,8 @@ export class McpTaskManager extends Disposable {
 		}
 
 		entry.task.status = status;
+		entry.task.lastUpdatedAt = new Date().toISOString();
+
 		if (statusMessage !== undefined) {
 			entry.task.statusMessage = statusMessage;
 		}

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerRequestHandler.test.ts
@@ -220,7 +220,7 @@ suite('Workbench - MCP - ServerRequestHandler', () => {
 		const sentMessages = transport.getSentMessages();
 		const pingResponse = sentMessages.find(m =>
 			'id' in m && m.id === pingRequest.id && 'result' in m
-		) as MCP.JSONRPCResponse;
+		) as MCP.JSONRPCResultResponse;
 
 		assert.ok(pingResponse, 'No ping response was sent');
 		assert.deepStrictEqual(pingResponse.result, {});
@@ -246,7 +246,7 @@ suite('Workbench - MCP - ServerRequestHandler', () => {
 		const sentMessages = transport.getSentMessages();
 		const rootsResponse = sentMessages.find(m =>
 			'id' in m && m.id === rootsRequest.id && 'result' in m
-		) as MCP.JSONRPCResponse;
+		) as MCP.JSONRPCResultResponse;
 
 		assert.ok(rootsResponse, 'No roots/list response was sent');
 		assert.strictEqual((rootsResponse.result as MCP.ListRootsResult).roots.length, 2);
@@ -400,6 +400,7 @@ suite.skip('Workbench - MCP - McpTask', () => { // TODO@connor4312 https://githu
 			taskId: 'task1',
 			status: 'working',
 			createdAt: new Date().toISOString(),
+			lastUpdatedAt: new Date().toISOString(),
 			ttl: null,
 			...overrides
 		};


### PR DESCRIPTION
Implements https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx#client-host-capabilities

Updates MCP typings to the latest draft to be able to specify that field.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
