### PR TITLE
Update 2026 theme names

### DIFF
--- a/extensions/theme-2026/package.json
+++ b/extensions/theme-2026/package.json
@@ -17,14 +17,14 @@
 	"contributes": {
 		"themes": [
 			{
-				"id": "2026-light-experimental",
-				"label": "2026 Light",
+				"id": "Experimental Light",
+				"label": "VS Code Light",
 				"uiTheme": "vs",
 				"path": "./themes/2026-light.json"
 			},
 			{
-				"id": "2026-dark-experimental",
-				"label": "2026 Dark",
+				"id": "Experimental Dark",
+				"label": "VS Code Dark",
 				"uiTheme": "vs-dark",
 				"path": "./themes/2026-dark.json"
 			}


### PR DESCRIPTION
Revise theme IDs and labels to ensure consistency across the application.

`2026 Light / Dark` -> `VS Code Light / Dark`

This change enhances clarity and aligns with standard naming conventions. Testing can be done by verifying the updated themes in the settings.

