### PR TITLE
Bump macOS test timeout to 90 minutes

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-ci.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-ci.yml
@@ -7,7 +7,7 @@ parameters:
 jobs:
   - job: macOS${{ parameters.VSCODE_TEST_SUITE }}
     displayName: ${{ parameters.VSCODE_TEST_SUITE }} Tests
-    timeoutInMinutes: 30
+    timeoutInMinutes: 90
     variables:
       VSCODE_ARCH: arm64
     templateContext:


### PR DESCRIPTION
The owners of this have asked us to try a longer timeout to help them determine if the issues we're seeing are perf degradation or a hang