### PR TITLE
Add engines property to root package.json (#252372)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "license": "MIT",
   "main": "./out/main.js",
   "type": "module",
+  "engines": {
+    "node": ">=22.21.1"
+  },
   "private": true,
   "scripts": {
     "test": "echo Please run any of the test scripts from the scripts folder.",


### PR DESCRIPTION
 Summary                                                                   
                                                                            
  - Adds engines field to root package.json specifying "node": ">=22.21.1", 
  matching the version enforced by .nvmrc and build/npm/preinstall.ts       
  - Gives contributors a clear signal of the required Node.js version at the
   package level                                                            
                                     
                                                                                    
                                                                 