### PR TITLE
chat: add post-approval feedback message

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1030,6 +1030,9 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 						const title = state.confirmationMessages?.title;
 						return title ? (isMarkdownString(title) ? title.value : title) : undefined;
 					}
+					if (state.type === IChatToolInvocation.StateKind.WaitingForPostApproval) {
+						return localize('waitingForPostApproval', "Approve tool result?");
+					}
 				}
 				if (part.kind === 'confirmation' && !part.isUsed) {
 					return part.title;


### PR DESCRIPTION
Adds display of a localized 'Approve tool result?' message when a chat
response is waiting for post-approval confirmation on a tool invocation.

- Updates ChatResponseModel to detect WaitingForPostApproval state
- Displays appropriate confirmation message to user during tool approval
- Improves UX by providing clear feedback on what action is needed

(Commit message generated by Copilot)