### PR TITLE
Remove 'Add Element to Chat' tip

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -36,7 +36,6 @@ import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js'
 import { MenuWorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
 import { IBrowserElementsService } from '../../../services/browserElements/browser/browserElementsService.js';
 import { IChatWidgetService } from '../../chat/browser/chat.js';
-import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { BrowserFindWidget, CONTEXT_BROWSER_FIND_WIDGET_FOCUSED, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE } from './browserFindWidget.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -770,13 +769,6 @@ export class BrowserEditor extends EditorPane {
 		const subtitle = $('.browser-welcome-subtitle');
 		subtitle.textContent = localize('browser.welcomeSubtitle', "Enter a URL above to get started.");
 		content.appendChild(subtitle);
-
-		const chatEnabled = this.contextKeyService.getContextKeyValue<boolean>(ChatContextKeys.enabled.key);
-		if (chatEnabled) {
-			const tip = $('.browser-welcome-tip');
-			tip.textContent = localize('browser.welcomeTip', "Tip: Use Add Element to Chat to reference UI elements in chat prompts.");
-			content.appendChild(tip);
-		}
 
 		container.appendChild(content);
 		return container;


### PR DESCRIPTION
Before:
<img width="887" height="595" alt="image" src="https://github.com/user-attachments/assets/a35abb3e-3144-45d8-bcb9-419106e8201a" />

After:
<img width="888" height="592" alt="image" src="https://github.com/user-attachments/assets/ef2942f1-f715-471f-a696-742f40a7077c" />