### PR TITLE
Replace hardcoded inlay hints limit with config option (#265980)

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3203,6 +3203,7 @@ export interface IEditorInlayHintsOptions {
 
 	/**
 	 * Maximum number of inlay hints per editor.
+	 * Set to 0 to have an unlimited number of inlay hints.
 	 */
 	maxHintsCount?: number;
 }

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3200,6 +3200,11 @@ export interface IEditorInlayHintsOptions {
 	 * Set to 0 to have an unlimited length.
 	 */
 	maximumLength?: number;
+
+	/**
+	 * Maximum number of inlay hints per editor.
+	 */
+	maxHintsCount?: number;
 }
 
 /**
@@ -3210,7 +3215,7 @@ export type EditorInlayHintsOptions = Readonly<Required<IEditorInlayHintsOptions
 class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditorInlayHintsOptions, EditorInlayHintsOptions> {
 
 	constructor() {
-		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', padding: false, maximumLength: 43 };
+		const defaults: EditorInlayHintsOptions = { enabled: 'on', fontSize: 0, fontFamily: '', padding: false, maximumLength: 43, maxHintsCount: 1500 };
 		super(
 			EditorOption.inlayHints, 'inlayHints', defaults,
 			{
@@ -3245,6 +3250,11 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 					type: 'number',
 					default: defaults.maximumLength,
 					markdownDescription: nls.localize('inlayHints.maximumLength', "Maximum overall length of inlay hints, for a single line, before they get truncated by the editor. Set to `0` to never truncate")
+				},
+				'editor.inlayHints.maxHintsCount': {
+					type: 'number',
+					default: defaults.maxHintsCount,
+					markdownDescription: nls.localize('inlayHints.maxHintsCount', "Maximum number of inlay hints per editor. Set to `0` to have an unlimited number of inlay hints.")
 				}
 			}
 		);
@@ -3264,6 +3274,7 @@ class EditorInlayHints extends BaseEditorOption<EditorOption.inlayHints, IEditor
 			fontFamily: EditorStringOption.string(input.fontFamily, this.defaultValue.fontFamily),
 			padding: boolean(input.padding, this.defaultValue.padding),
 			maximumLength: EditorIntOption.clampedInt(input.maximumLength, this.defaultValue.maximumLength, 0, Number.MAX_SAFE_INTEGER),
+			maxHintsCount: EditorIntOption.clampedInt(input.maxHintsCount, this.defaultValue.maxHintsCount, 0, Number.MAX_SAFE_INTEGER)
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -130,7 +130,6 @@ export class InlayHintsController implements IEditorContribution {
 
 	static readonly ID: string = 'editor.contrib.InlayHints';
 
-	private static readonly _MAX_DECORATORS = 1500;
 	private static readonly _whitespaceData = {};
 
 	static get(editor: ICodeEditor): InlayHintsController | undefined {
@@ -570,6 +569,7 @@ export class InlayHintsController implements IEditorContribution {
 		//
 		const { fontSize, fontFamily, padding, isUniform } = this._getLayoutInfo();
 		const maxLength = this._editor.getOption(EditorOption.inlayHints).maximumLength;
+		const maxHintsCount = this._editor.getOption(EditorOption.inlayHints).maxHintsCount;
 		const fontFamilyVar = '--code-editorInlayHintsFontFamily';
 		this._editor.getContainerDomNode().style.setProperty(fontFamilyVar, fontFamily);
 
@@ -696,8 +696,7 @@ export class InlayHintsController implements IEditorContribution {
 			if (item.hint.paddingRight) {
 				addInjectedWhitespace(item, true);
 			}
-
-			if (newDecorationsData.length > InlayHintsController._MAX_DECORATORS) {
+			if (maxHintsCount !== 0 && newDecorationsData.length > maxHintsCount) {
 				break;
 			}
 		}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4484,6 +4484,10 @@ declare namespace monaco.editor {
 		 * Set to 0 to have an unlimited length.
 		 */
 		maximumLength?: number;
+		/**
+		 * Maximum number of inlay hints per editor.
+		 */
+		maxHintsCount?: number;
 	}
 
 	/**


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode/issues/265980

The change allows to configure max inlay hints limit. 
It is not typical for regular languages to set that many inlay hints but Rainbow CSV extension can generate so many inlay hints in "virtual align" mode.

In order to test the change, the following can be done:
1. Install "Rainbow CSV" extension: https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv. If needed, the VSIX file for the last release can be downloaded here: https://github.com/mechatroner/vscode_rainbow_csv/releases/tag/3.24.1
2. Open a test csv file with multiple columns [random_wide.csv](https://github.com/user-attachments/files/24955283/random_wide.csv)
3. Make sure it is highlighted by the Rainbow CSV extension.
4. Set `editor.inlayHints.maxHintsCount` to 500 in settings.
5. Right Click -> "Rainbow CSV" -> "Virtual Align CSV Columns"
6. Observe that only the top few lines are aligned
7. Change  `editor.inlayHints.maxHintsCount` to 0 or a very large value
8. Observe that all lines on the screen are now aligned. 

Here are some demo screenshots:
* Default: 1500 inlay hints max 
<img width="1633" height="1026" alt="max_hints_1500" src="https://github.com/user-attachments/assets/7a787c0b-95c1-4b36-bc5d-478303b4ff20" />
* 500 inlay hints max:
<img width="1631" height="1038" alt="max_hints_500" src="https://github.com/user-attachments/assets/f59fd29b-7afb-4e55-9949-2cd74da6df38" />
* unlimited inlay hints (set to 0):
<img width="1636" height="1041" alt="max_hints_0" src="https://github.com/user-attachments/assets/c6913b9e-8c8a-42f5-82af-c860c2081447" />

