### PR TITLE
Browser: Fix searchbox length

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -203,6 +203,10 @@
 			.codicon-regex {
 				display: none;
 			}
+			/* Adjust input width to account for fewer toggles */
+			.input {
+				width: calc(100% - 16px) !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/291789

Search box length was too short in Integrated Browsers's Find in Page feature