### PR TITLE
Provide completions when Copilot extension is not installed

### DIFF
--- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
+++ b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
@@ -153,7 +153,7 @@ export class InlineCompletionsUnificationImpl extends Disposable implements IInl
 		// Extension might be installed on remote and local
 		const completionExtensionInstalled = installedExtensions.filter(ext => ext.identifier.id.toLowerCase() === this._completionsExtensionId);
 		if (completionExtensionInstalled.length === 0) {
-			return false;
+			return true;
 		}
 
 		const completionsExtensionDisabledByUnification = completionExtensionInstalled.some(ext => this._extensionEnablementService.getEnablementState(ext) === EnablementState.DisabledByUnification);


### PR DESCRIPTION
```Copilot Generated Description:``` Enable completions to be provided even when the Copilot extension is not installed.

closes https://github.com/microsoft/vscode/issues/291837