### PR TITLE
Demo of how Code Provenance is propagated through vscode.TextEdit in Cider

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -503,7 +503,7 @@ export class MainThreadTextEditor {
 			this._codeEditor.pushUndoStop();
 		}
 		const source = EditSources.unknown({name: 'MainThreadTextEditor', providerId: ProviderId.fromExtensionId(opts.extensionId ?? undefined)});
-		this._codeEditor.executeEdits('MainThreadTextEditor', transformedEdits);
+		this._codeEditor.executeEdits(source, transformedEdits);
 		if (opts.undoStopAfter) {
 			this._codeEditor.pushUndoStop();
 		}

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -502,6 +502,7 @@ export class MainThreadTextEditor {
 		if (opts.undoStopBefore) {
 			this._codeEditor.pushUndoStop();
 		}
+		const source = EditSources.unknown({name: 'MainThreadTextEditor', providerId: ProviderId.fromExtensionId(opts.extensionId ?? undefined)});
 		this._codeEditor.executeEdits('MainThreadTextEditor', transformedEdits);
 		if (opts.undoStopAfter) {
 			this._codeEditor.pushUndoStop();

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -272,6 +272,27 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			};
 		}
 
+		// Wraps an event that returns an ExtHostTextEditor and return an event which returns the
+		// corresponding vscode.TextEditor event for a given extension id.
+		function _asExtensionEditorEvent<T extends ExtHostTextEditor|undefined|readonly ExtHostTextEditor[]|{textEditor: ExtHostTextEditor;}>(actual: vscode.Event<T>):
+				vscode.Event<T extends ExtHostTextEditor|undefined ? vscode.TextEditor|undefined :
+										 T extends readonly ExtHostTextEditor[] ? readonly vscode.TextEditor[] :
+										 T extends { textEditor: ExtHostTextEditor; } ? Omit<T, 'textEditor'>&{textEditor: vscode.TextEditor} : never> {
+			return (listener, thisArgs, disposables) => {
+				const handle = actual((e: T) => {
+					if (Array.isArray(e)) {
+						listener.call(thisArgs, e.map(e => e.value(extension.identifier)) as any);
+					} else if (e && 'textEditor' in e) {
+						listener.call(thisArgs, {...e, textEditor: e.textEditor.value(extension.identifier)} as any);
+					} else {
+						listener.call(thisArgs, e === undefined ? undefined : (e as ExtHostTextEditor).value(extension.identifier) as any);
+					}
+				});
+				disposables?.push(handle);
+				return handle;
+			};
+		}
+
 
 		// Check document selectors for being overly generic. Technically this isn't a problem but
 		// in practice many extensions say they support `fooLang` but need fs-access to do so. Those
@@ -345,7 +366,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			registerTextEditorCommand(id: string, callback: (textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => void, thisArg?: any): vscode.Disposable {
 				return extHostCommands.registerCommand(true, id, (...args: any[]): any => {
-					const activeTextEditor = extHostEditors.getActiveTextEditor();
+					const activeTextEditor = extHostEditors.getActiveTextEditor(extension.identifier);
 					if (!activeTextEditor) {
 						extHostLogService.warn('Cannot execute ' + id + ' because there is no active text editor.');
 						return undefined;
@@ -722,10 +743,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 		// namespace: window
 		const window: typeof vscode.window = {
 			get activeTextEditor() {
-				return extHostEditors.getActiveTextEditor();
+				return extHostEditors.getActiveTextEditor(extension.identifier);
 			},
 			get visibleTextEditors() {
-				return extHostEditors.getVisibleTextEditors();
+				return extHostEditors.getVisibleTextEditors(extension.identifier);
 			},
 			get activeTerminal() {
 				return extHostTerminalService.activeTerminal;
@@ -741,32 +762,32 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 					? Promise.resolve(workspace.openTextDocument(documentOrUri))
 					: Promise.resolve(<vscode.TextDocument>documentOrUri));
 
-				return extHostEditors.showTextDocument(document, columnOrOptions, preserveFocus);
+				return extHostEditors.showTextDocument(extension.identifier, document, columnOrOptions, preserveFocus);
 			},
 			createTextEditorDecorationType(options: vscode.DecorationRenderOptions): vscode.TextEditorDecorationType {
 				return extHostEditors.createTextEditorDecorationType(extension, options);
 			},
 			onDidChangeActiveTextEditor(listener, thisArg?, disposables?) {
-				return _asExtensionEvent(extHostEditors.onDidChangeActiveTextEditor)(listener, thisArg, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeActiveTextEditor))(listener, thisArg, disposables);
 			},
 			onDidChangeVisibleTextEditors(listener, thisArg, disposables) {
-				return _asExtensionEvent(extHostEditors.onDidChangeVisibleTextEditors)(listener, thisArg, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeVisibleTextEditors))(listener, thisArg, disposables);
 			},
 			onDidChangeTextEditorSelection(listener: (e: vscode.TextEditorSelectionChangeEvent) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {
-				return _asExtensionEvent(extHostEditors.onDidChangeTextEditorSelection)(listener, thisArgs, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeTextEditorSelection))(listener, thisArgs, disposables);
 			},
 			onDidChangeTextEditorOptions(listener: (e: vscode.TextEditorOptionsChangeEvent) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {
-				return _asExtensionEvent(extHostEditors.onDidChangeTextEditorOptions)(listener, thisArgs, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeTextEditorOptions))(listener, thisArgs, disposables);
 			},
 			onDidChangeTextEditorVisibleRanges(listener: (e: vscode.TextEditorVisibleRangesChangeEvent) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {
-				return _asExtensionEvent(extHostEditors.onDidChangeTextEditorVisibleRanges)(listener, thisArgs, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeTextEditorVisibleRanges))(listener, thisArgs, disposables);
 			},
 			onDidChangeTextEditorViewColumn(listener, thisArg?, disposables?) {
-				return _asExtensionEvent(extHostEditors.onDidChangeTextEditorViewColumn)(listener, thisArg, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeTextEditorViewColumn))(listener, thisArg, disposables);
 			},
 			onDidChangeTextEditorDiffInformation(listener, thisArg?, disposables?) {
 				checkProposedApiEnabled(extension, 'textEditorDiffInformation');
-				return _asExtensionEvent(extHostEditors.onDidChangeTextEditorDiffInformation)(listener, thisArg, disposables);
+				return _asExtensionEvent(_asExtensionEditorEvent(extHostEditors.onDidChangeTextEditorDiffInformation))(listener, thisArg, disposables);
 			},
 			onDidCloseTerminal(listener, thisArg?, disposables?) {
 				return _asExtensionEvent(extHostTerminalService.onDidCloseTerminal)(listener, thisArg, disposables);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -313,6 +313,7 @@ export interface IUndoStopOptions {
 
 export interface IApplyEditsOptions extends IUndoStopOptions {
 	setEndOfLine?: EndOfLineSequence;
+	extensionId: string|null;
 }
 
 export interface ISnippetOptions extends IUndoStopOptions {

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -626,7 +626,7 @@ export class ExtHostChatAgents2 extends Disposable implements ExtHostChatAgentsS
 			// editor data
 			const document = this._documents.getDocument(request.locationData.document);
 			const editor = this._editorsAndDocuments.getEditor(request.locationData.id)!;
-			location = new extHostTypes.ChatRequestEditorData(editor.value, document, typeConvert.Selection.to(request.locationData.selection), typeConvert.Range.to(request.locationData.wholeRange));
+			location = new extHostTypes.ChatRequestEditorData(editor.value(extension.identifier.value), document, typeConvert.Selection.to(request.locationData.selection), typeConvert.Range.to(request.locationData.wholeRange));
 
 		} else if (request.locationData?.type === ChatAgentLocation.Notebook) {
 			// notebook data

--- a/src/vs/workbench/api/common/extHostVariableResolverService.ts
+++ b/src/vs/workbench/api/common/extHostVariableResolverService.ts
@@ -43,7 +43,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 	) {
 		function getActiveUri(): URI | undefined {
 			if (editorService) {
-				const activeEditor = editorService.activeEditor();
+				const activeEditor = editorService.activeEditor(null);
 				if (activeEditor) {
 					return activeEditor.document.uri;
 				}
@@ -101,7 +101,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 			},
 			getSelectedText: (): string | undefined => {
 				if (editorService) {
-					const activeEditor = editorService.activeEditor();
+					const activeEditor = editorService.activeEditor(null);
 					if (activeEditor && !activeEditor.selection.isEmpty) {
 						return activeEditor.document.getText(activeEditor.selection);
 					}
@@ -110,7 +110,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 			},
 			getLineNumber: (): string | undefined => {
 				if (editorService) {
-					const activeEditor = editorService.activeEditor();
+					const activeEditor = editorService.activeEditor(null);
 					if (activeEditor) {
 						return String(activeEditor.selection.end.line + 1);
 					}
@@ -119,7 +119,7 @@ class ExtHostVariableResolverService extends AbstractVariableResolverService {
 			},
 			getColumnNumber: (): string | undefined => {
 				if (editorService) {
-					const activeEditor = editorService.activeEditor();
+					const activeEditor = editorService.activeEditor(null);
 					if (activeEditor) {
 						return String(activeEditor.selection.end.character + 1);
 					}


### PR DESCRIPTION
This is a partial solution, showing how we propagate the extension id through the vscode.TextEditor object.

This a demo implementation of what was discussed in #291001

Note: This PR is meant to be a demo of the solution we have been running since July 2024 - there are likley more tweaks needed before it could be submitted.