### PR TITLE
Lower data event threshold for showing output

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -611,9 +611,9 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				}
 				// If we've received many data events, treat it as real output even if cursor
 				// hasn't moved past the marker (e.g., progress bars updating on same line)
-				// Shell integration sequences fire multiple times per command (PromptStart, CommandStart,
-				// CommandExecuted, CommandFinished, etc.), so we need a higher threshold
-				return receivedDataCount > 4;
+				// Shell integration sequences fire a couple times per command (PromptStart, CommandStart,
+				// CommandExecuted), so we need a small threshold to filter those out
+				return receivedDataCount > 2;
 			};
 
 			// Use the extracted auto-expand logic


### PR DESCRIPTION
address #291927 in main

We had a threshold of > 4 data events to prevent commands like sleep from showing output. However, that threshold is too high and caused commands like `npm i` to fail to auto-expand. The issue is that `npm i` outputs progress bars on the same line, so the cursor doesn't advance past the executed marker. By the time the 500ms timeout checks `hasRealOutput`, npm has only fired ~3 data events, which didn't pass the > 4 threshold.

Lowering to > 2 allows npm and similar commands to auto-expand. The tradeoff is that `sleep` (which fires ~3 shell integration sequence data events: PromptStart, CommandStart, CommandExecuted) briefly shows an empty output box, but it auto-collapses when the command finishes with exit code 0.

https://github.com/user-attachments/assets/f24a0fd8-75fc-4957-9d24-e3653b9abfea

https://github.com/user-attachments/assets/dda1324c-9af6-4861-ba08-e8dc2c4be4e6
