### PR TITLE
prevent first 10 lines from being clipped in terminal output

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1273,7 +1273,8 @@ class ChatTerminalToolOutputSection extends Disposable {
 
 	private _getOutputContentHeight(lineCount: number, rowHeight: number, padding: number): number {
 		const contentRows = Math.max(lineCount, MIN_OUTPUT_ROWS);
-		const adjustedRows = contentRows + (lineCount > MAX_OUTPUT_ROWS ? 1 : 0);
+		// Always add an extra row for buffer space to prevent the last line from being cut off during streaming
+		const adjustedRows = contentRows + 1;
 		return (adjustedRows * rowHeight) + padding;
 	}
 


### PR DESCRIPTION
addresses #291935 in main

The fix addresses a bug where the bottom line of terminal output was cut off when streaming content within the first 10 lines.

Root cause: In `_getOutputContentHeight`, an extra row of buffer space was only added when `lineCount > MAX_OUTPUT_ROWS` (10), meaning content ≤10 lines had no buffer and the last line could be clipped.

Fix: Changed to always add one extra row for buffer space regardless of line count:

**Exact script to repro** the issue is included in the issue. Note that sometimes when streaming this means there'll be an extra line, but that seems worth it to prevent lines from being cutoff.

<img width="449" height="229" alt="Screenshot 2026-01-30 at 11 29 30 AM" src="https://github.com/user-attachments/assets/53dfd1e9-6e25-40bc-b71d-42dcb68a91d6" />

