### PR TITLE
fix cursor being clipped in embedded terminal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1301,8 +1301,11 @@ class ChatTerminalToolOutputSection extends Disposable {
 		// Calculate the pixel width needed for the content
 		// Add some padding for scrollbar and visual comfort
 		// Account for container padding
+		// Add one extra character width (cursorWidth) to account for the cursor position
+		// which may be one character beyond the last content character during streaming
 		const horizontalPadding = 24;
-		const contentWidth = Math.ceil(maxColumnWidth * charWidth) + horizontalPadding;
+		const cursorWidth = charWidth;
+		const contentWidth = Math.ceil(maxColumnWidth * charWidth) + horizontalPadding + cursorWidth;
 
 		// Get the max available width (container's parent width)
 		const parentWidth = this.domNode.parentElement?.clientWidth ?? 0;


### PR DESCRIPTION
addresses #291867 in main

<img width="380" height="99" alt="Screenshot 2026-01-30 at 11 42 06 AM" src="https://github.com/user-attachments/assets/507fb0c0-bb95-4a76-9013-003343d443e2" />
