### PR TITLE
base: support multiple MIME types per file extension

### DIFF
--- a/src/vs/base/common/mime.ts
+++ b/src/vs/base/common/mime.ts
@@ -16,10 +16,10 @@ export const Mimes = Object.freeze({
 });
 
 interface MapExtToMediaMimes {
-	[index: string]: string;
+	[index: string]: string | string[];
 }
 
-const mapExtToTextMimes: MapExtToMediaMimes = {
+const mapExtToTextMimes: Record<string, string> = {
 	'.css': 'text/css',
 	'.csv': 'text/csv',
 	'.htm': 'text/html',
@@ -39,9 +39,9 @@ const mapExtToMediaMimes: MapExtToMediaMimes = {
 	'.flv': 'video/x-flv',
 	'.gif': 'image/gif',
 	'.ico': 'image/x-icon',
-	'.jpe': 'image/jpg',
-	'.jpeg': 'image/jpg',
-	'.jpg': 'image/jpg',
+	'.jpe': ['image/jpg', 'image/jpeg'],
+	'.jpeg': ['image/jpg', 'image/jpeg'],
+	'.jpg': ['image/jpg', 'image/jpeg'],
 	'.m1v': 'video/mpeg',
 	'.m2a': 'audio/mpeg',
 	'.m2v': 'video/mpeg',
@@ -96,12 +96,14 @@ export function getMediaOrTextMime(path: string): string | undefined {
 
 export function getMediaMime(path: string): string | undefined {
 	const ext = extname(path);
-	return mapExtToMediaMimes[ext.toLowerCase()];
+	const mimeType = mapExtToMediaMimes[ext.toLowerCase()];
+	return Array.isArray(mimeType) ? mimeType[0] : mimeType;
 }
 
 export function getExtensionForMimeType(mimeType: string): string | undefined {
 	for (const extension in mapExtToMediaMimes) {
-		if (mapExtToMediaMimes[extension] === mimeType) {
+		const value = mapExtToMediaMimes[extension];
+		if (Array.isArray(value) ? value.includes(mimeType) : value === mimeType) {
 			return extension;
 		}
 	}

--- a/src/vs/base/test/common/mime.test.ts
+++ b/src/vs/base/test/common/mime.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { normalizeMimeType } from '../../common/mime.js';
+import { getExtensionForMimeType, normalizeMimeType } from '../../common/mime.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 suite('Mime', () => {
@@ -16,6 +16,20 @@ suite('Mime', () => {
 		assert.strictEqual(normalizeMimeType('Text/pläin'), 'text/pläin');
 		assert.strictEqual(normalizeMimeType('Text/plain;UPPER'), 'text/plain;UPPER');
 		assert.strictEqual(normalizeMimeType('Text/plain;lower'), 'text/plain;lower');
+	});
+
+	test('getExtensionForMimeType', () => {
+		// Note: for MIME types with multiple extensions (e.g., image/jpg -> .jpe, .jpeg, .jpg),
+		// the function returns the first matching extension in iteration order
+		assert.ok(['.jpe', '.jpeg', '.jpg'].includes(getExtensionForMimeType('image/jpg')!));
+		// image/jpeg is an alias for image/jpg and should also return a valid extension
+		assert.ok(['.jpe', '.jpeg', '.jpg'].includes(getExtensionForMimeType('image/jpeg')!));
+		assert.strictEqual(getExtensionForMimeType('image/png'), '.png');
+		assert.strictEqual(getExtensionForMimeType('image/gif'), '.gif');
+		assert.strictEqual(getExtensionForMimeType('image/webp'), '.webp');
+		assert.ok(['.mp2', '.mp2a', '.mp3', '.mpga', '.m2a', '.m3a'].includes(getExtensionForMimeType('audio/mpeg')!));
+		assert.ok(['.mp4', '.mp4v', '.mpg4'].includes(getExtensionForMimeType('video/mp4')!));
+		assert.strictEqual(getExtensionForMimeType('unknown/type'), undefined);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
Adds support for multiple MIME types to map to the same file extension by
allowing mapExtToMediaMimes values to be string or string[]. This enables
image/jpeg and image/jpg to both map to .jpg extension, fixing MCP image
responses that provide RFC-compliant image/jpeg MIME type.

- Changed MapExtToMediaMimes interface to support string | string[] values
- Updated getMediaMime() to return first MIME type from array if present
- Updated getExtensionForMimeType() to check both singular and array values
- Added .jpe, .jpeg, and .jpg to support both image/jpg and image/jpeg
- Added tests for getExtensionForMimeType with multiple MIME types

Fixes https://github.com/microsoft/vscode/issues/291962

(Commit message generated by Copilot)