### PR TITLE
chat: clean up some debt around session timings

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -380,20 +380,10 @@ export class ChatService extends Disposable implements IChatService {
 			.filter(entry => !this._sessionModels.has(LocalChatSessionUri.forSession(entry.sessionId)) && entry.initialLocation === ChatAgentLocation.Chat && !entry.isEmpty)
 			.map((entry): IChatDetail => {
 				const sessionResource = LocalChatSessionUri.forSession(entry.sessionId);
-				const lastResponseState = entry.lastResponseState ?? ResponseModelState.Complete;
 				return ({
 					...entry,
 					sessionResource,
-					// TODO@roblourens- missing for old data- normalize inside the store
-					timing: entry.timing ?? {
-						created: entry.lastMessageDate,
-						lastRequestStarted: undefined,
-						lastRequestEnded: entry.lastMessageDate,
-					},
 					isActive: this._sessionModels.has(sessionResource),
-					// TODO@roblourens- missing for old data- normalize inside the store
-					// TODO@connor4312: the check here guards old sessions from Insiders pre PR #288161 and it can be safely removed after a transition period.
-					lastResponseState: lastResponseState === ResponseModelState.Pending || lastResponseState === ResponseModelState.NeedsInput ? ResponseModelState.Complete : lastResponseState,
 				});
 			});
 	}
@@ -405,15 +395,7 @@ export class ChatService extends Disposable implements IChatService {
 			return {
 				...metadata,
 				sessionResource,
-				// TODO@roblourens- missing for old data- normalize inside the store
-				timing: metadata.timing ?? {
-					created: metadata.lastMessageDate,
-					lastRequestStarted: undefined,
-					lastRequestEnded: metadata.lastMessageDate,
-				},
 				isActive: this._sessionModels.has(sessionResource),
-				// TODO@roblourens- missing for old data- normalize inside the store
-				lastResponseState: metadata.lastResponseState ?? ResponseModelState.Complete,
 			};
 		}
 


### PR DESCRIPTION
Moves session timing normalization into ChatSessionStore during load rather
than in ChatServiceImpl at query time. This consolidates the backward
compatibility logic and makes timing/lastResponseState non-optional in the
metadata types.

- Move timing backfill logic from ChatServiceImpl to ChatSessionStore
- Make timing and lastResponseState required in IChatSessionEntryMetadata
- Remove inline TODO debt from ChatServiceImpl query methods
- Normalize data once at load time instead of repeatedly at query time

Refs https://github.com/microsoft/vscode/issues/291553

(Commit message generated by Copilot)