### PR TITLE
fix terminal output position

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -310,7 +310,7 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 			if (!canAppend) {
 				// Reset the terminal if we had previous content (can't append, need full rewrite)
 				if (this._lastVT) {
-					detached.xterm.clearBuffer();
+					detached.xterm.reset();
 				}
 				if (vt.text) {
 					detached.xterm.write(vt.text, resolve);
@@ -544,7 +544,7 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 			if (!canAppend) {
 				// Reset the terminal if we had previous content (can't append, need full rewrite)
 				if (this._lastVT) {
-					detachedRaw.clearBuffer();
+					detachedRaw.reset();
 				}
 				if (vt.text) {
 					detachedRaw.write(vt.text, resolve);

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1502,6 +1502,12 @@ export interface IDetachedXtermTerminal extends IXtermTerminal {
 	resize(columns: number, rows: number): void;
 
 	/**
+	 * Performs a full reset (RIS) of the terminal, clearing all content
+	 * and resetting cursor position to the origin.
+	 */
+	reset(): void;
+
+	/**
 	 * Access to the terminal buffer for reading cursor position and content.
 	 */
 	readonly buffer: IBufferSet;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -721,6 +721,10 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 		this._accessibilitySignalService.playSignal(AccessibilitySignal.clear);
 	}
 
+	reset(): void {
+		this.raw.reset();
+	}
+
 	hasSelection(): boolean {
 		return this.raw.hasSelection();
 	}


### PR DESCRIPTION
fix #289138

`clearBuffer` clears the scrollback but leaves the cursor where it is, so new content was written at the wrong position. `reset` clears everything and moves the cursor back to the top-left, so content writes correctly from the start.

<img width="501" height="448" alt="Screenshot 2026-01-30 at 3 34 25 PM" src="https://github.com/user-attachments/assets/5d2245ca-0bd8-4c86-b578-54ee57fd0b15" />
