### PR TITLE
chat: fix screen cheese in sensitive file overflow

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDiffBlockPart.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { Emitter } from '../../../../../../base/common/event.js';
 import { hashAsync } from '../../../../../../base/common/hash.js';
 import { Disposable, IReference, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../../base/common/network.js';
@@ -95,9 +94,6 @@ export interface IMarkdownDiffBlockData {
  * This is a lightweight wrapper that uses CodeCompareBlockPart for the actual rendering.
  */
 export class MarkdownDiffBlockPart extends Disposable {
-	private readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
-	public readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
-
 	readonly element: HTMLElement;
 	private readonly comparePart: IDisposableReference<CodeCompareBlockPart>;
 	private readonly modelRef = this._register(new MutableDisposable<SimpleDiffEditorModel>());
@@ -113,10 +109,6 @@ export class MarkdownDiffBlockPart extends Disposable {
 		super();
 
 		this.comparePart = this._register(diffEditorPool.get());
-
-		this._register(this.comparePart.object.onDidChangeContentHeight(() => {
-			this._onDidChangeContentHeight.fire();
-		}));
 
 		// Create in-memory models for the diff
 		const originalUri = URI.from({

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -7,7 +7,6 @@ import * as dom from '../../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
 import { HoverStyle } from '../../../../../../base/browser/ui/hover/hover.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { Emitter } from '../../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
@@ -59,9 +58,6 @@ export interface IChatCollapsibleOutputData {
 }
 
 export class ChatCollapsibleInputOutputContentPart extends Disposable {
-	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
-	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
-
 	private readonly _editorReferences: IDisposableReference<CodeBlockPart>[] = [];
 	private readonly _titlePart: ChatQueryTitlePart;
 	private _outputSubPart: ChatToolOutputContentSubPart | undefined;
@@ -116,7 +112,6 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			title,
 			subtitle,
 		));
-		this._register(this._titlePart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		const spacer = document.createElement('span');
 		spacer.style.flexGrow = '1';
 
@@ -155,8 +150,6 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 				messageContainer.root.appendChild(this.createMessageContents());
 				elements.root.appendChild(messageContainer.root);
 			}
-
-			this._onDidChangeHeight.fire();
 		}));
 
 		const toggle = (e: Event) => {
@@ -238,7 +231,6 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		};
 		const editorReference = this._register(this.context.editorPool.get());
 		editorReference.object.render(data, this.context.currentWidth.get() || 300);
-		this._register(editorReference.object.onDidChangeContentHeight(() => this._onDidChangeHeight.fire()));
 		container.appendChild(editorReference.object.element);
 		this._editorReferences.push(editorReference);
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProgressBar } from '../../../../../../../base/browser/ui/progressbar/progressbar.js';
-import { Emitter } from '../../../../../../../base/common/event.js';
 import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Lazy } from '../../../../../../../base/common/lazy.js';
 import { toDisposable } from '../../../../../../../base/common/lifecycle.js';
@@ -31,8 +30,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 
 	public readonly domNode: HTMLElement;
 	private readonly collapsibleListPart: ChatCollapsibleInputOutputContentPart;
-
-	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
 
 	public get codeblocks(): IChatCodeBlockInfo[] {
 		return this.collapsibleListPart.codeblocks;
@@ -119,7 +116,6 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			(isError && configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures)) ||
 			(ChatInputOutputMarkdownProgressPart._expandedByDefault.get(toolInvocation) ?? false),
 		));
-		this._register(collapsibleListPart.onDidChangeHeight(() => this._onDidChangeHeight.fire()));
 		this._register(toDisposable(() => ChatInputOutputMarkdownProgressPart._expandedByDefault.set(toolInvocation, collapsibleListPart.expanded)));
 
 		const progressObservable = toolInvocation.kind === 'toolInvocation' ? toolInvocation.state.map((s, r) => s.type === IChatToolInvocation.StateKind.Executing ? s.progress.read(r) : undefined) : undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.ts
@@ -180,9 +180,6 @@ export class ChatTerminalToolConfirmationSubPart extends BaseChatToolInvocationS
 			uriPromise: Promise.resolve(model.uri),
 			chatSessionResource: this.context.element.sessionResource
 		});
-		this._register(editor.object.onDidChangeContentHeight(() => {
-			editor.object.layout(this.currentWidthDelegate());
-		}));
 		this._register(model.onDidChangeContent(e => {
 			const currentValue = model.getValue();
 			// Only set userEdited if the content actually differs from the initial value

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -248,9 +248,6 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 					uriPromise: Promise.resolve(model.uri),
 					chatSessionResource: this.context.element.sessionResource
 				});
-				this._register(editor.object.onDidChangeContentHeight(() => {
-					editor.object.layout(this.currentWidthDelegate());
-				}));
 				this._register(model.onDidChangeContent(e => {
 					try {
 						inputData.rawInput = JSON.parse(model.getValue());


### PR DESCRIPTION
chat: fix screen cheese in sensitive file overflow

also cleans up old height eventing that is unused since Rob's refactor.

Fixes https://github.com/microsoft/vscode/issues/277541

(Commit message generated by Copilot)