### PR TITLE
tools: clean up auto-approved post-approval state

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWindowNotifier.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWindowNotifier.ts
@@ -72,18 +72,6 @@ export class ChatWindowNotifier extends Disposable implements IWorkbenchContribu
 			return;
 		}
 
-		// Wait a microtask to allow any synchronous auto-confirmations to complete.
-		// This prevents notifications for tools that briefly enter WaitingForConfirmation
-		// state before being auto-confirmed through various mechanisms (per-session rules,
-		// per-workspace rules, etc.)
-		await Promise.resolve();
-
-		// Re-check that the model still needs input after the microtask delay
-		const model = this._chatService.getSession(sessionResource);
-		if (!model?.requestNeedsInput.get()) {
-			return;
-		}
-
 		// Find the widget to determine the target window
 		const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);
 		const targetWindow = widget ? dom.getWindow(widget.domNode) : mainWindow;


### PR DESCRIPTION
Iterates the fix for https://github.com/microsoft/vscode/issues/288508

No assurance post-approval checks happen in a microtask. Tools results that will be auto-approved should never transition through the approval-needed state

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
