### PR TITLE
chat: enhance compare block diff actions and accessibility

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -59,7 +59,7 @@ export function isCodeBlockActionContext(thing: unknown): thing is ICodeBlockAct
 }
 
 export function isCodeCompareBlockActionContext(thing: unknown): thing is ICodeCompareBlockActionContext {
-	return typeof thing === 'object' && thing !== null && 'element' in thing;
+	return typeof thing === 'object' && thing !== null && 'element' in thing && 'diffEditor' in thing && 'toggleDiffViewMode' in thing;
 }
 
 function isResponseFiltered(context: ICodeBlockActionContext) {
@@ -635,11 +635,12 @@ export function registerChatCodeCompareBlockActions() {
 				f1: false,
 				category: CHAT_CATEGORY,
 				icon: Codicon.gitPullRequestGoToChanges,
-				precondition: ContextKeyExpr.and(EditorContextKeys.hasChanges, ChatContextKeys.editApplied.negate()),
+				precondition: ContextKeyExpr.and(EditorContextKeys.hasChanges, ChatContextKeys.editApplied.negate(), EditorContextKeys.readOnly.negate()),
 				menu: {
 					id: MenuId.ChatCompareBlock,
 					group: 'navigation',
-					order: 1,
+					order: 10,
+					when: EditorContextKeys.readOnly.negate(),
 				}
 			});
 		}
@@ -688,11 +689,12 @@ export function registerChatCodeCompareBlockActions() {
 				f1: false,
 				category: CHAT_CATEGORY,
 				icon: Codicon.trash,
-				precondition: ContextKeyExpr.and(EditorContextKeys.hasChanges, ChatContextKeys.editApplied.negate()),
+				precondition: ContextKeyExpr.and(EditorContextKeys.hasChanges, ChatContextKeys.editApplied.negate(), EditorContextKeys.readOnly.negate()),
 				menu: {
 					id: MenuId.ChatCompareBlock,
 					group: 'navigation',
-					order: 2,
+					order: 11,
+					when: EditorContextKeys.readOnly.negate(),
 				}
 			});
 		}
@@ -702,6 +704,61 @@ export function registerChatCodeCompareBlockActions() {
 			const instaService = accessor.get(IInstantiationService);
 			const editor = instaService.createInstance(DefaultChatTextEditor);
 			editor.discard(context.element, context.edit);
+		}
+	});
+
+	registerAction2(class ToggleDiffViewModeAction extends ChatCompareCodeBlockAction {
+		constructor() {
+			super({
+				id: 'workbench.action.chat.toggleCompareBlockDiffViewMode',
+				title: localize2('interactive.compare.toggleDiffViewMode', "Toggle Inline/Side-by-Side Diff"),
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.diffSingle,
+				toggled: {
+					condition: EditorContextKeys.diffEditorInlineMode,
+					icon: Codicon.diff,
+				},
+				menu: {
+					id: MenuId.ChatCompareBlock,
+					group: 'navigation',
+					order: 1,
+				}
+			});
+		}
+
+		runWithContext(_accessor: ServicesAccessor, context: ICodeCompareBlockActionContext): void {
+			context.toggleDiffViewMode();
+		}
+	});
+
+	registerAction2(class OpenCompareBlockInDiffEditor extends ChatCompareCodeBlockAction {
+		constructor() {
+			super({
+				id: 'workbench.action.chat.openCompareBlockInDiffEditor',
+				title: localize2('interactive.compare.openInDiffEditor', "Open in Diff Editor"),
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.goToFile,
+				menu: {
+					id: MenuId.ChatCompareBlock,
+					group: 'navigation',
+					order: 2,
+				}
+			});
+		}
+
+		async runWithContext(accessor: ServicesAccessor, context: ICodeCompareBlockActionContext): Promise<void> {
+			const editorService = accessor.get(IEditorService);
+			const model = context.diffEditor.getModel();
+			if (!model) {
+				return;
+			}
+
+			await editorService.openEditor({
+				original: { resource: model.original.uri },
+				modified: { resource: model.modified.uri },
+			});
 		}
 	});
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/codeBlockPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/codeBlockPart.css
@@ -156,16 +156,50 @@
 	color: var(--vscode-textLink-foreground);
 }
 
-.interactive-result-code-block.compare .interactive-result-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 0 3px;
-	box-sizing: border-box;
-	border-bottom: solid 1px var(--vscode-chat-requestBorder);
-}
+.interactive-result-code-block.compare {
+	& .interactive-result-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0 3px;
+		box-sizing: border-box;
+		border-bottom: solid 1px var(--vscode-chat-requestBorder);
 
-.interactive-result-code-block.compare.no-diff .interactive-result-header,
-.interactive-result-code-block.compare.no-diff .interactive-result-editor {
-	display: none;
+		& .monaco-icon-label {
+			flex: 1;
+			min-width: 0;
+
+			& > .monaco-icon-label-container {
+				display: flex;
+				align-items: baseline;
+
+				& > .monaco-icon-name-container {
+					flex-shrink: 0;
+
+					& > .label-name {
+						white-space: nowrap;
+					}
+				}
+
+				& > .monaco-icon-description-container {
+					min-width: 0;
+					flex: 1;
+
+					& > .label-description {
+						white-space: nowrap;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						display: block;
+					}
+				}
+			}
+		}
+	}
+
+	&.no-diff {
+		& .interactive-result-header,
+		& .interactive-result-editor {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
Adds improved diff editing workflow and accessibility features to chat
compare blocks:

- Add toggle inline/side-by-side diff view mode action with icon
- Add open in diff editor action for full editor view
- Fix isCodeCompareBlockActionContext to properly check diffEditor property
- Add readOnly context key checks to prevent editing read-only diffs
- Adjust menu order for accept/discard actions (10, 11) and diff toggle (1)
- Add toggleDiffViewMode callback to action context
- Improve screen reader accessibility for compare block toolbar
- Add width tracking to layout method for proper initialization
- Refactor CSS for compare block header with nested selectors for better
  label truncation and styling

Fixes https://github.com/microsoft/vscode/issues/287816

(Commit message generated by Copilot)