### PR TITLE
fix diagnostics not being repushed from problem matcher to markerServ…

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -448,7 +448,11 @@ export class WatchingProblemCollector extends AbstractProblemCollector implement
 				false,
 				true
 			)(async (markerEvent: readonly URI[]) => {
-				if (!markerEvent || !markerEvent.includes(modelEvent.uri) || (this.markerService.read({ resource: modelEvent.uri }).length !== 0)) {
+				if (markerEvent.length === 0) {
+					return;
+				}
+				const modelEventUriStr = modelEvent.uri.toString();
+				if ((!markerEvent.some(uri => uri.toString() === modelEventUriStr)) || (this.markerService.read({ resource: modelEvent.uri }).length !== 0)) {
 					return;
 				}
 				const oldLines = Array.from(this.lines);


### PR DESCRIPTION
When a file is opened from EH by `vscode.workspace.openTextDocument`, and closed after, the diagnostics originated from task problem matcher are not repushed to markerService on document auto-disposal after auto-dispose delay time has passed, due to incorrect uri comparison in WatchingProblemCollector

Investigation history https://github.com/microsoft/vscode/issues/291739#issuecomment-3830210992