### PR TITLE
chat: allow extensions to control tool invocation collapse behavior

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1336,6 +1336,16 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return true;
 		}
 
+		// Check for explicit expanded display style - don't pin tools that should be expanded
+		// Runtime presentation overrides static displayStyle
+		if (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') {
+			const presentation = part.presentation;
+			const displayStyle = part.displayStyle;
+			if (presentation === 'expanded' || (!presentation && displayStyle === 'expanded')) {
+				return false;
+			}
+		}
+
 		// Don't pin MCP tools
 		const isMcpTool = (part.kind === 'toolInvocation' || part.kind === 'toolInvocationSerialized') && part.source?.type === 'mcp';
 		if (isMcpTool) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -540,6 +540,7 @@ export interface IChatToolInvocation {
 	readonly invocationMessage: string | IMarkdownString;
 	readonly pastTenseMessage: string | IMarkdownString | undefined;
 	readonly source: ToolDataSource;
+	readonly displayStyle?: 'expanded' | 'default';
 	readonly toolId: string;
 	readonly toolCallId: string;
 	readonly subAgentInvocationId?: string;
@@ -804,6 +805,7 @@ export interface IChatToolInvocationSerialized {
 	toolCallId: string;
 	toolId: string;
 	source: ToolDataSource | undefined; // undefined on pre-1.104 versions
+	displayStyle?: 'expanded' | 'default';
 	readonly subAgentInvocationId?: string;
 	generatedTitle?: string;
 	kind: 'toolInvocationSerialized';

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -28,6 +28,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public presentation: IPreparedToolInvocation['presentation'];
 	public readonly toolId: string;
 	public source: ToolDataSource;
+	public readonly displayStyle?: 'expanded' | 'default';
 	public readonly subAgentInvocationId: string | undefined;
 	public parameters: unknown;
 	public generatedTitle?: string;
@@ -73,6 +74,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this.toolSpecificData = preparedInvocation?.toolSpecificData;
 		this.toolId = toolData.id;
 		this.source = toolData.source;
+		this.displayStyle = toolData.displayStyle;
 		this.subAgentInvocationId = subAgentInvocationId;
 		this.parameters = parameters;
 		this.chatRequestId = chatRequestId;
@@ -281,6 +283,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 			isConfirmed: waitingForPostApproval ? { type: ToolConfirmKind.Skipped } : IChatToolInvocation.executionConfirmedOrDenied(this),
 			isComplete: true,
 			source: this.source,
+			displayStyle: this.displayStyle,
 			resultDetails: isToolResultOutputDetails(details)
 				? { output: { type: 'data', mimeType: details.output.mimeType, base64Data: encodeBase64(details.output.value) } }
 				: details,

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsContribution.ts
@@ -36,6 +36,7 @@ export interface IRawToolContribution {
 	userDescription?: string;
 	inputSchema?: IJSONSchema;
 	canBeReferencedInPrompt?: boolean;
+	displayStyle?: 'expanded' | 'default';
 }
 
 const languageModelToolsExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawToolContribution[]>({
@@ -130,6 +131,15 @@ const languageModelToolsExtensionPoint = extensionsRegistry.ExtensionsRegistry.r
 						type: 'string',
 						pattern: '^(?!copilot_|vscode_)'
 					}
+				},
+				displayStyle: {
+					markdownDescription: localize('displayStyle', "Controls how this tool's invocations are displayed during chat responses. Use `expanded` to keep the tool invocation always visible (not collapsed into the 'thinking' section). By default, VS Code decides based on tool type and context."),
+					type: 'string',
+					enum: ['expanded', 'default'],
+					enumDescriptions: [
+						localize('displayStyle.expanded', "Always show the tool invocation expanded, never collapse into the 'thinking' section."),
+						localize('displayStyle.default', "Let VS Code decide whether to collapse based on tool type and context (default behavior).")
+					]
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -68,6 +68,11 @@ export interface IToolData {
 	 * If defined, the tool is only available when the selected model matches one of the selectors.
 	 */
 	readonly models?: readonly ILanguageModelChatSelector[];
+	/**
+	 * Controls how this tool's invocations are displayed. When 'expanded', the tool invocation
+	 * is always shown expanded and never collapsed into the 'thinking' section.
+	 */
+	readonly displayStyle?: 'expanded' | 'default';
 }
 
 /**
@@ -326,7 +331,8 @@ export type ToolConfirmationAction = IToolConfirmationAction | Separator;
 
 export enum ToolInvocationPresentation {
 	Hidden = 'hidden',
-	HiddenAfterComplete = 'hiddenAfterComplete'
+	HiddenAfterComplete = 'hiddenAfterComplete',
+	Expanded = 'expanded'
 }
 
 export interface IToolInvocationStreamContext {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -3720,4 +3720,94 @@ suite('LanguageModelToolsService', () => {
 			assert.ok(!toolIds.includes('childToolWithWhen'), 'Child tool with when=true should NOT be in tool set when context key is false');
 		});
 	});
+
+	suite('displayStyle property', () => {
+		test('displayStyle is propagated to ChatToolInvocation', async () => {
+			const toolData: IToolData = {
+				id: 'testToolWithDisplayStyle',
+				modelDescription: 'Test Tool with display style',
+				displayName: 'Test Tool Display',
+				source: ToolDataSource.Internal,
+				displayStyle: 'expanded',
+			};
+
+			const invocation = new ChatToolInvocation(
+				undefined,
+				toolData,
+				'toolCallId',
+				undefined,
+				{},
+				false
+			);
+
+			assert.strictEqual(invocation.displayStyle, 'expanded', 'displayStyle should be propagated from toolData');
+		});
+
+		test('displayStyle is serialized in toJSON', async () => {
+			const toolData: IToolData = {
+				id: 'testToolWithDisplayStyleSerialized',
+				modelDescription: 'Test Tool with display style serialized',
+				displayName: 'Test Tool Display',
+				source: ToolDataSource.Internal,
+				displayStyle: 'expanded',
+			};
+
+			const invocation = new ChatToolInvocation(
+				undefined,
+				toolData,
+				'toolCallId2',
+				undefined,
+				{},
+				false
+			);
+
+			const serialized = invocation.toJSON();
+
+			assert.strictEqual(serialized.displayStyle, 'expanded', 'displayStyle should be serialized to JSON');
+		});
+
+		test('displayStyle default is undefined when not specified', async () => {
+			const toolData: IToolData = {
+				id: 'testToolWithoutDisplayStyle',
+				modelDescription: 'Test Tool without display style',
+				displayName: 'Test Tool Display',
+				source: ToolDataSource.Internal,
+			};
+
+			const invocation = new ChatToolInvocation(
+				undefined,
+				toolData,
+				'toolCallId3',
+				undefined,
+				{},
+				false
+			);
+
+			assert.strictEqual(invocation.displayStyle, undefined, 'displayStyle should be undefined when not set');
+
+			const serialized = invocation.toJSON();
+			assert.strictEqual(serialized.displayStyle, undefined, 'displayStyle should be undefined in serialized form when not set');
+		});
+
+		test('displayStyle can be set to default', async () => {
+			const toolData: IToolData = {
+				id: 'testToolWithDefaultDisplayStyle',
+				modelDescription: 'Test Tool with default display style',
+				displayName: 'Test Tool Display',
+				source: ToolDataSource.Internal,
+				displayStyle: 'default',
+			};
+
+			const invocation = new ChatToolInvocation(
+				undefined,
+				toolData,
+				'toolCallId4',
+				undefined,
+				{},
+				false
+			);
+
+			assert.strictEqual(invocation.displayStyle, 'default', 'displayStyle should be default when explicitly set');
+		});
+	});
 });

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -275,7 +275,7 @@ declare module 'vscode' {
 		isComplete?: boolean;
 		toolSpecificData?: ChatTerminalToolInvocationData | ChatMcpToolInvocationData;
 		subAgentInvocationId?: string;
-		presentation?: 'hidden' | 'hiddenAfterComplete' | undefined;
+		presentation?: 'hidden' | 'hiddenAfterComplete' | 'expanded' | undefined;
 
 		constructor(toolName: string, toolCallId: string, isError?: boolean);
 	}

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -271,7 +271,7 @@ declare module 'vscode' {
 
 	export interface PreparedToolInvocation {
 		pastTenseMessage?: string | MarkdownString;
-		presentation?: 'hidden' | 'hiddenAfterComplete' | undefined;
+		presentation?: 'hidden' | 'hiddenAfterComplete' | 'expanded' | undefined;
 	}
 
 	export class ExtendedLanguageModelToolResult extends LanguageModelToolResult {


### PR DESCRIPTION
Extensions should be able to opt-out of having their tool invocations collapsed into the 'thinking' section, while VS Code retains the default decision logic for tools that don't specify a preference.

### Technical Details
- Added `displayStyle: 'expanded' | 'default'` to the `languageModelTools` contribution point in `package.json`.
- Added a new `Expanded` value to the `ToolInvocationPresentation` enum and exposed it in the proposed API (`vscode.proposed.chatParticipantAdditions.d.ts` and `vscode.proposed.chatParticipantPrivate.d.ts`).
- Updated `shouldPinPart` in `chatListRenderer.ts` to respect the `expanded` preference. It checks both the runtime `presentation` and the static `displayStyle` from the contribution.
- Propagated the `displayStyle` property through the internally used `IChatToolInvocation` and `IChatToolInvocationSerialized` interfaces and the `ChatToolInvocation` model class.
- Added unit tests in `languageModelToolsService.test.ts` to verify propagation and serialization.

Fixes https://github.com/microsoft/vscode/issues/292142