### PR TITLE
Fix Monaco scroll offset buffer use after destroy

### DIFF
--- a/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/fullFileRenderStrategy.ts
@@ -172,6 +172,9 @@ export class FullFileRenderStrategy extends BaseRenderStrategy {
 	}
 
 	public override onScrollChanged(e?: ViewScrollChangedEvent): boolean {
+		if (this._store.isDisposed) {
+			return false;
+		}
 		const dpr = getActiveWindow().devicePixelRatio;
 		this._scrollOffsetValueBuffer[0] = (e?.scrollLeft ?? this._context.viewLayout.getCurrentScrollLeft()) * dpr;
 		this._scrollOffsetValueBuffer[1] = (e?.scrollTop ?? this._context.viewLayout.getCurrentScrollTop()) * dpr;

--- a/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/renderStrategy/viewportRenderStrategy.ts
@@ -157,6 +157,9 @@ export class ViewportRenderStrategy extends BaseRenderStrategy {
 	}
 
 	public override onScrollChanged(e?: ViewScrollChangedEvent): boolean {
+		if (this._store.isDisposed) {
+			return false;
+		}
 		const dpr = getActiveWindow().devicePixelRatio;
 		this._scrollOffsetValueBuffer[0] = (e?.scrollLeft ?? this._context.viewLayout.getCurrentScrollLeft()) * dpr;
 		this._scrollOffsetValueBuffer[1] = (e?.scrollTop ?? this._context.viewLayout.getCurrentScrollTop()) * dpr;


### PR DESCRIPTION
Fixes #291991

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
