### PR TITLE
Fix issue #264340: diff view not updated when unstaging new files

### DIFF
--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -144,6 +144,23 @@ export class GitFileSystemProvider implements FileSystemProvider {
 			this.logger.warn(`[GitFileSystemProvider][stat] Repository not found - ${uri.toString()}`);
 			throw FileSystemError.FileNotFound();
 		}
+		if (ref === '~') {
+			// Try index first
+			try {
+				const details = await repository.getObjectDetails('', path);
+				return { type: FileType.File, size: details.size, mtime: this.mtime, ctime: 0 };
+			} catch {
+				// File not in index, try HEAD
+				try {
+					const details = await repository.getObjectDetails('HEAD', path);
+					return { type: FileType.File, size: details.size, mtime: this.mtime, ctime: 0 };
+				} catch {
+					// File not in HEAD either (new file), return empty
+					this.logger.warn(`[GitFileSystemProvider][stat] File not found for diff original, returning empty - ${uri.toString()}`);
+					return { type: FileType.File, size: 0, mtime: this.mtime, ctime: 0 };
+				}
+			}
+		}
 
 		try {
 			const details = await repository.getObjectDetails(sanitizeRef(ref, path, submoduleOf, repository), path);
@@ -201,6 +218,25 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		const cacheValue: CacheRow = { uri, timestamp };
 
 		this.cache.set(uri.toString(), cacheValue);
+
+		// For '~' ref (diff original), we need to try index first, then HEAD.
+		// We can't rely on repository.indexGroup.resourceStates because it might be stale
+		// (e.g., after unstaging, the state might not have been updated yet).
+		if (ref === '~') {
+			// Try index first
+			try {
+				return await repository.buffer('', path);
+			} catch {
+				// File not in index, try HEAD
+				try {
+					return await repository.buffer('HEAD', path);
+				} catch {
+					// File not in HEAD either (new file), return empty
+					this.logger.warn(`[GitFileSystemProvider][readFile] File not found for diff original, returning empty - ${uri.toString()}`);
+					return new Uint8Array(0);
+				}
+			}
+		}
 
 		try {
 			return await repository.buffer(sanitizeRef(ref, path, submoduleOf, repository), path);

--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -219,19 +219,14 @@ export class GitFileSystemProvider implements FileSystemProvider {
 
 		this.cache.set(uri.toString(), cacheValue);
 
-		// For '~' ref (diff original), we need to try index first, then HEAD.
-		// We can't rely on repository.indexGroup.resourceStates because it might be stale
-		// (e.g., after unstaging, the state might not have been updated yet).
+		// For '~' ref (diff original), try index first, then HEAD, otherwise return empty.
 		if (ref === '~') {
-			// Try index first
 			try {
 				return await repository.buffer('', path);
 			} catch {
-				// File not in index, try HEAD
 				try {
 					return await repository.buffer('HEAD', path);
 				} catch {
-					// File not in HEAD either (new file), return empty
 					this.logger.warn(`[GitFileSystemProvider][readFile] File not found for diff original, returning empty - ${uri.toString()}`);
 					return new Uint8Array(0);
 				}

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -674,14 +674,14 @@ suite('git', () => {
 				if (result !== null) {
 					return result;
 				}
-				throw new Error('Not in index');
+				throw new Error();
 			} catch {
 				try {
 					const result = await headBuffer();
 					if (result !== null) {
 						return result;
 					}
-					throw new Error('Not in HEAD');
+					throw new Error();
 				} catch {
 					return new Uint8Array(0);
 				}

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -663,4 +663,72 @@ suite('git', () => {
 			);
 		});
 	});
+
+	suite('Diff original resource fallback (ref=~)', () => {
+		async function simulateReadFileWithTildeRef(
+			indexBuffer: () => Promise<Uint8Array | null>,
+			headBuffer: () => Promise<Uint8Array | null>
+		): Promise<Uint8Array> {
+			try {
+				const result = await indexBuffer();
+				if (result !== null) {
+					return result;
+				}
+				throw new Error('Not in index');
+			} catch {
+				try {
+					const result = await headBuffer();
+					if (result !== null) {
+						return result;
+					}
+					throw new Error('Not in HEAD');
+				} catch {
+					return new Uint8Array(0);
+				}
+			}
+		}
+
+		test('returns index content when file is staged', async () => {
+			const indexContent = new TextEncoder().encode('staged content');
+			const result = await simulateReadFileWithTildeRef(
+				async () => indexContent,
+				async () => null
+			);
+			assert.deepStrictEqual(result, indexContent);
+		});
+
+		test('returns HEAD content when file is unstaged but exists in HEAD', async () => {
+			const headContent = new TextEncoder().encode('committed content');
+			const result = await simulateReadFileWithTildeRef(
+				async () => null,
+				async () => headContent
+			);
+			assert.deepStrictEqual(result, headContent);
+		});
+
+		test('returns empty content for new file after unstage (not in index, not in HEAD)', async () => {
+			const result = await simulateReadFileWithTildeRef(
+				async () => null,
+				async () => null
+			);
+			assert.deepStrictEqual(result, new Uint8Array(0));
+		});
+
+		test('handles index error and falls back to HEAD', async () => {
+			const headContent = new TextEncoder().encode('head content');
+			const result = await simulateReadFileWithTildeRef(
+				async () => { throw new Error('git show : failed'); },
+				async () => headContent
+			);
+			assert.deepStrictEqual(result, headContent);
+		});
+
+		test('handles both index and HEAD errors and returns empty', async () => {
+			const result = await simulateReadFileWithTildeRef(
+				async () => { throw new Error('git show : failed'); },
+				async () => { throw new Error('git show HEAD: failed'); }
+			);
+			assert.deepStrictEqual(result, new Uint8Array(0));
+		});
+	});
 });


### PR DESCRIPTION
Fixes #264340

## Problem
When unstaging changes for a new file (a file that doesn't exist in the repository yet), the diff view doesn't update correctly. The left side of the diff still shows the previously staged content instead of being empty.

## Cause
`sanitizeRef('~')` in `GitFileSystemProvider` relies on `repository.indexGroup.resourceStates` to determine whether to read from index or HEAD. However, this state can be stale due to a race condition - the `_onDidChangeOriginalResource` event fires before the repository state is updated.

## Solution
For `ref='~'`, bypass `sanitizeRef` and directly query git:
1. Try index first (`git show :path`)
2. If not in index, try HEAD (`git show HEAD:path`)
3. If not in HEAD either (new file), return empty content

This ensures the diff view always gets the correct content regardless of repository state timing.

## How to test
1. Create a new file in a git repository
2. Stage the file (`git add`)
3. Modify the file content
4. Open the diff view (Working Tree)
5. Unstage the file
6. **Expected**: Diff view updates to show empty on the left (all content appears as added)
7. **Before fix**: Diff view still showed staged content on the left

## Screen recording showing the fix works
https://github.com/user-attachments/assets/fef89ea1-75b9-4201-94bb-f680a723c3a2

## Test coverage
Added unit tests in `extensions/git/src/test/git.test.ts` - suite `'Diff original resource fallback (ref=~)'`