### PR TITLE
Fix stickyScroll bottom padding

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/viewLines/viewLines.ts
@@ -724,10 +724,13 @@ export class ViewLines extends ViewPart implements IViewLines {
 
 		if (!shouldIgnoreScrollOff) {
 			const maxLinesInViewport = (viewportHeight / this._lineHeight);
-			const surroundingLines = Math.max(this._cursorSurroundingLines, this._stickyScrollEnabled ? this._maxNumberStickyLines : 0);
-			const context = Math.min(maxLinesInViewport / 2, surroundingLines);
-			paddingTop = context * this._lineHeight;
-			paddingBottom = Math.max(0, (context - 1)) * this._lineHeight;
+			const surroundingLinesTop = Math.max(this._cursorSurroundingLines, this._stickyScrollEnabled ? this._maxNumberStickyLines : 0);
+			const surroundingLinesBottom = Math.max(this._cursorSurroundingLines, 0);
+			const contextTop = Math.min(maxLinesInViewport / 2, surroundingLinesTop);
+			const contextBottom = Math.min(maxLinesInViewport / 2, surroundingLinesBottom);
+			paddingTop = contextTop * this._lineHeight;
+			paddingBottom = Math.max(0, (contextBottom - 1)) * this._lineHeight;
+
 		} else {
 			if (!minimalReveal) {
 				// Reveal one more line above (this case is hit when dragging)


### PR DESCRIPTION
Break out padding calculation into top and bottom so that stickyScroll doesn't add padding to the bottom.

This addresses part of issue #204193.

When stickyScroll was enabled, but surroundingLines was set to 0, the stickyScroll setting was use for both top and bottom padding.  Now it only applies the stickyScroll max line count to the top padding.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
