### PR TITLE
chore: add engines field to package.json (fixes #252372)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "main": "./out/main.js",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=22.21.1",
+    "npm": ">=10.8.0"
+  },
   "scripts": {
     "test": "echo Please run any of the test scripts from the scripts folder.",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",


### PR DESCRIPTION
# PR Title
chore: add engines field to package.json (fixes #252372)

# Description
This PR adds the `engines` field to the root `package.json`, as requested in issue #252372. This change enforces the Node.js and npm versions to be consistent with `.nvmrc` and the project's requirements, reducing environment setup errors for contributors.

**Changes:**
- Added `engines` field to `package.json`:
    - `node`: `>=22.21.1` (Matches `.nvmrc` in main)
    - `npm`: `>=10.8.0`

# Related Issue
Fixes #252372
