### PR TITLE
feat(testing): show running badge on Activity Bar while tests are running

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -636,19 +636,19 @@ class ResultSummaryView extends Disposable {
 
 	private renderActivityBadge(countSummary: CountSummary, isRunning: boolean) {
 		if (isRunning) {
-			if (this.lastBadge instanceof IconBadge && this.lastBadge.icon === spinningLoading) {
+			if (this.badgeDisposable.value && this.lastBadge instanceof IconBadge && this.lastBadge.icon === spinningLoading) {
 				return;
 			}
 
 			this.lastBadge = new IconBadge(spinningLoading, () => localize('testingRunningBadge', 'Tests are running'));
 		} else if (countSummary && this.badgeType !== TestingCountBadge.Off && countSummary[this.badgeType] !== 0) {
-			if (this.lastBadge instanceof NumberBadge && this.lastBadge.number === countSummary[this.badgeType]) {
+			if (this.badgeDisposable.value && this.lastBadge instanceof NumberBadge && this.lastBadge.number === countSummary[this.badgeType]) {
 				return;
 			}
 
 			this.lastBadge = new NumberBadge(countSummary[this.badgeType], num => this.getLocalizedBadgeString(this.badgeType, num));
 		} else if (this.crService.isEnabled()) {
-			if (this.lastBadge instanceof IconBadge && this.lastBadge.icon === icons.testingContinuousIsOn) {
+			if (this.badgeDisposable.value && this.lastBadge instanceof IconBadge && this.lastBadge.icon === icons.testingContinuousIsOn) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -625,7 +625,7 @@ class ResultSummaryView extends Disposable {
 
 		count.textContent = `${counts.passed}/${counts.totalWillBeRun}`;
 		this.countHover.update(getTestProgressText(counts));
-		this.renderActivityBadge(counts);
+		this.renderActivityBadge(counts, live.length > 0);
 
 		if (!this.elementsWereAttached) {
 			dom.clearNode(this.container);
@@ -634,8 +634,14 @@ class ResultSummaryView extends Disposable {
 		}
 	}
 
-	private renderActivityBadge(countSummary: CountSummary) {
-		if (countSummary && this.badgeType !== TestingCountBadge.Off && countSummary[this.badgeType] !== 0) {
+	private renderActivityBadge(countSummary: CountSummary, isRunning: boolean) {
+		if (isRunning) {
+			if (this.lastBadge instanceof IconBadge && this.lastBadge.icon === spinningLoading) {
+				return;
+			}
+
+			this.lastBadge = new IconBadge(spinningLoading, () => localize('testingRunningBadge', 'Tests are running'));
+		} else if (countSummary && this.badgeType !== TestingCountBadge.Off && countSummary[this.badgeType] !== 0) {
 			if (this.lastBadge instanceof NumberBadge && this.lastBadge.number === countSummary[this.badgeType]) {
 				return;
 			}


### PR DESCRIPTION
## Summary
Shows a spinning loading indicator badge on the Testing icon in the Activity Bar when tests are actively running.

### Before
No visual indication on the Activity Bar icon when tests are running - you had to look at the Testing view to see if tests were in progress.

### After
A spinning loading badge appears on the Testing Activity Bar icon while tests are running, providing immediate visual feedback.

### Changes
- Added `isRunning` parameter to `renderActivityBadge` function
- Show `spinningLoading` icon badge when tests are running (highest priority)
- Badge priority: Running > Count (failed/passed/skipped) > Continuous testing

### Use Case
This is particularly useful when:
- Continuous testing is enabled and you want to know when triggered tests have completed
- Running tests after a Git pull
- Running long test suites in the background

Fixes #201982

Made with [Cursor](https://cursor.com)