### PR TITLE
fix: use Ctrl+Alt+T for Go to Symbol in Workspace when in browser/Codespaces

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -10,6 +10,7 @@ import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/c
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 //#region Actions
 registerAction2(class ShowAllSymbolsAction extends Action2 {
@@ -29,7 +30,8 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT
+				// In browser/Codespaces, Ctrl+T opens a new tab; use Ctrl+Alt+T to avoid conflict
+				primary: isWeb ? KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyT : KeyMod.CtrlCmd | KeyCode.KeyT
 			},
 			menu: {
 				id: MenuId.MenubarGoMenu,


### PR DESCRIPTION
## Summary
In Codespaces (browser), the keyboard shortcut for "Go to Symbol in Workspace" is Ctrl+T, which opens a new browser tab instead of triggering the command. This change uses **Ctrl+Alt+T** as the default keybinding when running in web context (Codespaces, vscode.dev) to avoid the conflict.

### Changes
- Import `isWeb` from platform
- When `isWeb` is true: use `Ctrl+Alt+T` (does not conflict with browser "new tab")
- When `isWeb` is false (desktop): keep `Ctrl+T` unchanged

### Before
- In Codespaces: Ctrl+T → new browser tab (command never triggered)

### After
- In Codespaces: Ctrl+Alt+T → Go to Symbol in Workspace
- On desktop: Ctrl+T → Go to Symbol in Workspace (unchanged)

Fixes #232381

Made with [Cursor](https://cursor.com)