### PR TITLE
Update @vscode/codicons version to 0.0.45-5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-4",
+        "@vscode/codicons": "^0.0.45-5",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -2947,9 +2947,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-4",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-4.tgz",
-      "integrity": "sha512-uuWqpry+FcHAw1JDkXwEW0YIuTtX3n6KqSshNlvLUjuP92PSrfq99jW52AWJ7qeunmPvgKCaZOeSSLUqHRHjmw==",
+      "version": "0.0.45-5",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-5.tgz",
+      "integrity": "sha512-tvRtMrVAe+CnlePF1Z3uhRfu0mLhAVgrSiY9zuEaGyXyBlN1/06bnpXno8XYb4O3ggOFx2phximqje4dhoLnkQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/deviceid": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-4",
+    "@vscode/codicons": "^0.0.45-5",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-4",
+        "@vscode/codicons": "^0.0.45-5",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-4",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-4.tgz",
-      "integrity": "sha512-uuWqpry+FcHAw1JDkXwEW0YIuTtX3n6KqSshNlvLUjuP92PSrfq99jW52AWJ7qeunmPvgKCaZOeSSLUqHRHjmw==",
+      "version": "0.0.45-5",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-5.tgz",
+      "integrity": "sha512-tvRtMrVAe+CnlePF1Z3uhRfu0mLhAVgrSiY9zuEaGyXyBlN1/06bnpXno8XYb4O3ggOFx2phximqje4dhoLnkQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-4",
+    "@vscode/codicons": "^0.0.45-5",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.45-5 to incorporate the latest updates and improvements. No additional testing is required beyond verifying the functionality of the codicons in the application.

