### PR TITLE
fix: improve QuickInput accessibility for screen readers

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
@@ -7,6 +7,7 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { createSingleCallFunction } from '../../../../base/common/functional.js';
 import { DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
 import { getCodeEditor, isDiffEditor } from '../../../browser/editorBrowser.js';
 import { IRange } from '../../../common/core/range.js';
 import { IDiffEditor, IEditor, ScrollType } from '../../../common/editorCommon.js';
@@ -150,7 +151,8 @@ export abstract class AbstractEditorNavigationQuickAccessProvider implements IQu
 
 		const model = this.getModel(editor);
 		if (model) {
-			status(`${model.getLineContent(options.range.startLineNumber)}`);
+			const lineContent = model.getLineContent(options.range.startLineNumber);
+			status(localize('gotoLocation.status', "Line {0}, column {1}: {2}", options.range.startLineNumber, options.range.startColumn, lineContent));
 		}
 	}
 

--- a/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
@@ -60,6 +60,9 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 		const editor = context.editor;
 		const disposables = new DisposableStore();
 
+		// Set initial ariaLabel for screen readers
+		picker.ariaLabel = localize('gotoLine.ariaLabel', "Go to line. Type a line number, optionally followed by colon and column number.");
+
 		// Goto line once picked
 		disposables.add(picker.onDidAccept(event => {
 			const [item] = picker.selectedItems;
@@ -97,6 +100,9 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 				lineNumber,
 				column,
 				label,
+				ariaLabel: lineNumber
+					? localize('gotoLine.itemAriaLabel', "Go to line {0}, column {1}. Press Enter to navigate.", lineNumber, column || 1)
+					: label,
 			}];
 
 			// Clear decorations for invalid range

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -236,8 +236,10 @@ export class QuickInputController extends Disposable {
 				const activeDescendant = list.getActiveDescendant();
 				if (activeDescendant) {
 					inputBox.setAttribute('aria-activedescendant', activeDescendant);
+					inputBox.setListFocusMode(true);
 				} else {
 					inputBox.removeAttribute('aria-activedescendant');
+					inputBox.setListFocusMode(false);
 				}
 			}
 		}));
@@ -280,8 +282,10 @@ export class QuickInputController extends Disposable {
 				const activeDescendant = tree.getActiveDescendant();
 				if (activeDescendant) {
 					inputBox.setAttribute('aria-activedescendant', activeDescendant);
+					inputBox.setListFocusMode(true);
 				} else {
 					inputBox.removeAttribute('aria-activedescendant');
+					inputBox.setListFocusMode(false);
 				}
 			}
 		}));
@@ -341,6 +345,8 @@ export class QuickInputController extends Disposable {
 			// See: https://github.com/microsoft/vscode/issues/271032
 			if (!isModifierKey(e.keyCode)) {
 				inputBox.removeAttribute('aria-activedescendant');
+				// Reset ARIA popup mode to allow normal text editing with arrow keys
+				inputBox.setListFocusMode(false);
 			}
 		}));
 		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS, (e: FocusEvent) => {


### PR DESCRIPTION
Cherry-picked focused QuickInput accessibility fix (4 files):\n- src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts\n- src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts\n- src/vs/platform/quickinput/browser/quickInputBox.ts\n- src/vs/platform/quickinput/browser/quickInputController.ts\n\nThis PR contains only the small, targeted accessibility changes to QuickInput and Go to Line dialog. Please review the four modified files; the branch was cleaned to remove unrelated changes.

fixes https://github.com/microsoft/vscode/issues/292353