### PR TITLE
ensure stop button comes back

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -746,27 +746,35 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 				acceptLabel,
 				rejectLabel,
 				async (value: IAction | true) => {
-					thePart.hide();
-					this._promptPart = undefined;
 					try {
 						const r = await (onAccept ? onAccept(value) : undefined);
 						resolve(r as T | undefined);
+						// Don't hide if return value is a Symbol (e.g., focusTerminalSelection)
+						// This keeps the elicitation visible while user focuses terminal to provide input
+						if (typeof r === 'symbol') {
+							return ElicitationState.Pending;
+						}
 					} catch {
 						resolve(undefined);
 					}
-
+					thePart.hide();
+					this._promptPart = undefined;
 					return ElicitationState.Accepted;
 				},
 				async () => {
-					thePart.hide();
-					this._promptPart = undefined;
 					try {
 						const r = await (onReject ? onReject() : undefined);
 						resolve(r as T | undefined);
+						// Don't hide if return value is a Symbol (e.g., focusTerminalSelection)
+						// This keeps the elicitation visible while user focuses terminal to provide input
+						if (typeof r === 'symbol') {
+							return ElicitationState.Pending;
+						}
 					} catch {
 						resolve(undefined);
 					}
-
+					thePart.hide();
+					this._promptPart = undefined;
 					return ElicitationState.Rejected;
 				},
 				undefined, // source


### PR DESCRIPTION
fixes #283328

https://github.com/user-attachments/assets/502dc929-6c56-4098-a3aa-f083a5ac1013

When clicking "Focus Terminal", the elicitation was immediately hidden and its state set to `Accepted`. This caused `requestInProgress`  to become false and never recover, so the stop button disappeared permanently.

Now, when the callback returns a Symbol (like `focusTerminalSelection`, we return `ElicitationState.Pending` instead of hiding the elicitation immediately. The elicitation gets properly hidden later when the user provides input in the terminal, at which point `requestInProgress` correctly returns to true and the stop button reappears.

cc @tyriar