### PR TITLE
feat(accessibility): Add Accessibility Help System for find/filter dialogs

### DIFF
--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -228,6 +228,14 @@ export class CommonFindController extends Disposable implements IEditorContribut
 		return false;
 	}
 
+	/**
+	 * Focuses the last focused element in the find widget.
+	 * Implemented by FindController; base implementation does nothing.
+	 */
+	public focusLastElement(): void {
+		// Base implementation - overridden in FindController
+	}
+
 	public getState(): FindReplaceState {
 		return this._state;
 	}
@@ -530,6 +538,15 @@ export class FindController extends CommonFindController implements IFindControl
 	 */
 	public override wasReplaceInputLastFocused(): boolean {
 		return this._widget?.lastFocusedInputWasReplace ?? false;
+	}
+
+	/**
+	 * Focuses the last focused element in the find widget.
+	 * This is more precise than just focusing the Find or Replace input,
+	 * as it can restore focus to checkboxes, buttons, etc.
+	 */
+	public override focusLastElement(): void {
+		this._widget?.focusLastElement();
 	}
 
 	saveViewState(): any {

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -220,6 +220,14 @@ export class CommonFindController extends Disposable implements IEditorContribut
 		return !!CONTEXT_FIND_INPUT_FOCUSED.getValue(this._contextKeyService);
 	}
 
+	/**
+	 * Returns whether the Replace input was the last focused input in the find widget.
+	 * Returns false by default; overridden in FindController.
+	 */
+	public wasReplaceInputLastFocused(): boolean {
+		return false;
+	}
+
 	public getState(): FindReplaceState {
 		return this._state;
 	}
@@ -515,6 +523,13 @@ export class FindController extends CommonFindController implements IFindControl
 	private _createFindWidget() {
 		this._widget = this._register(new FindWidget(this._editor, this, this._state, this._contextViewService, this._keybindingService, this._contextKeyService, this._hoverService, this._findWidgetSearchHistory, this._replaceWidgetHistory));
 		this._findOptionsWidget = this._register(new FindOptionsWidget(this._editor, this._state, this._keybindingService));
+	}
+
+	/**
+	 * Returns whether the Replace input was the last focused input in the find widget.
+	 */
+	public override wasReplaceInputLastFocused(): boolean {
+		return this._widget?.lastFocusedInputWasReplace ?? false;
 	}
 
 	saveViewState(): any {

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -34,6 +34,8 @@ import { Selection } from '../../../common/core/selection.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { FindWidgetSearchHistory } from './findWidgetSearchHistory.js';
 import { ReplaceWidgetHistory } from './replaceWidgetHistory.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 
 const SEARCH_STRING_MAX_LENGTH = 524288;
 
@@ -456,6 +458,8 @@ export class FindController extends CommonFindController implements IFindControl
 		@IStorageService _storageService: IStorageService,
 		@IClipboardService clipboardService: IClipboardService,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super(editor, _contextKeyService, _storageService, clipboardService, notificationService, hoverService);
 		this._widget = null;
@@ -513,7 +517,7 @@ export class FindController extends CommonFindController implements IFindControl
 	}
 
 	private _createFindWidget() {
-		this._widget = this._register(new FindWidget(this._editor, this, this._state, this._contextViewService, this._keybindingService, this._contextKeyService, this._hoverService, this._findWidgetSearchHistory, this._replaceWidgetHistory));
+		this._widget = this._register(new FindWidget(this._editor, this, this._state, this._contextViewService, this._keybindingService, this._contextKeyService, this._hoverService, this._findWidgetSearchHistory, this._replaceWidgetHistory, this._configurationService, this._accessibilityService));
 		this._findOptionsWidget = this._register(new FindOptionsWidget(this._editor, this._state, this._keybindingService));
 	}
 

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -34,8 +34,6 @@ import { Selection } from '../../../common/core/selection.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { FindWidgetSearchHistory } from './findWidgetSearchHistory.js';
 import { ReplaceWidgetHistory } from './replaceWidgetHistory.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 
 const SEARCH_STRING_MAX_LENGTH = 524288;
 
@@ -458,8 +456,6 @@ export class FindController extends CommonFindController implements IFindControl
 		@IStorageService _storageService: IStorageService,
 		@IClipboardService clipboardService: IClipboardService,
 		@IHoverService hoverService: IHoverService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super(editor, _contextKeyService, _storageService, clipboardService, notificationService, hoverService);
 		this._widget = null;
@@ -517,7 +513,7 @@ export class FindController extends CommonFindController implements IFindControl
 	}
 
 	private _createFindWidget() {
-		this._widget = this._register(new FindWidget(this._editor, this, this._state, this._contextViewService, this._keybindingService, this._contextKeyService, this._hoverService, this._findWidgetSearchHistory, this._replaceWidgetHistory, this._configurationService, this._accessibilityService));
+		this._widget = this._register(new FindWidget(this._editor, this, this._state, this._contextViewService, this._keybindingService, this._contextKeyService, this._hoverService, this._findWidgetSearchHistory, this._replaceWidgetHistory));
 		this._findOptionsWidget = this._register(new FindOptionsWidget(this._editor, this._state, this._keybindingService));
 	}
 

--- a/src/vs/editor/contrib/find/browser/findModel.ts
+++ b/src/vs/editor/contrib/find/browser/findModel.ts
@@ -30,6 +30,11 @@ export const CONTEXT_FIND_WIDGET_NOT_VISIBLE = CONTEXT_FIND_WIDGET_VISIBLE.toNeg
 // Keep ContextKey use of 'Focussed' to not break when clauses
 export const CONTEXT_FIND_INPUT_FOCUSED = new RawContextKey<boolean>('findInputFocussed', false);
 export const CONTEXT_REPLACE_INPUT_FOCUSED = new RawContextKey<boolean>('replaceInputFocussed', false);
+/**
+ * Context key that is true when any element within the Find widget has focus.
+ * This includes the Find input, Replace input, checkboxes, buttons, etc.
+ */
+export const CONTEXT_FIND_WIDGET_FOCUSED = new RawContextKey<boolean>('findWidgetFocused', false);
 
 export const ToggleCaseSensitiveKeybinding: IKeybindings = {
 	primary: KeyMod.Alt | KeyCode.KeyC,

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -25,7 +25,7 @@ import './findWidget.css';
 import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition, IViewZone, OverlayWidgetPositionPreference } from '../../../browser/editorBrowser.js';
 import { ConfigurationChangedEvent, EditorOption } from '../../../common/config/editorOptions.js';
 import { Range } from '../../../common/core/range.js';
-import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED, FIND_IDS, MATCHES_LIMIT } from './findModel.js';
+import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_FIND_WIDGET_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED, FIND_IDS, MATCHES_LIMIT } from './findModel.js';
 import { FindReplaceState, FindReplaceStateChangedEvent } from './findState.js';
 import * as nls from '../../../../nls.js';
 import { AccessibilitySupport } from '../../../../platform/accessibility/common/accessibility.js';
@@ -150,6 +150,9 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	private readonly _findInputFocused: IContextKey<boolean>;
 	private readonly _replaceFocusTracker: dom.IFocusTracker;
 	private readonly _replaceInputFocused: IContextKey<boolean>;
+	private _widgetFocusTracker: dom.IFocusTracker | undefined;
+	private readonly _findWidgetFocused: IContextKey<boolean>;
+	private _lastFocusedElement: HTMLElement | null = null;
 	private _viewZone?: FindWidgetViewZone;
 	private _viewZoneId?: string;
 
@@ -254,6 +257,20 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			this._replaceInputFocused.set(false);
 		}));
 
+		// Track focus on the entire Find widget for accessibility help
+		this._findWidgetFocused = CONTEXT_FIND_WIDGET_FOCUSED.bindTo(contextKeyService);
+		this._widgetFocusTracker = this._register(dom.trackFocus(this._domNode));
+		this._register(this._widgetFocusTracker.onDidFocus(() => {
+			this._findWidgetFocused.set(true);
+			// Track which element was focused for restoring focus later
+			if (document.activeElement instanceof HTMLElement) {
+				this._lastFocusedElement = document.activeElement;
+			}
+		}));
+		this._register(this._widgetFocusTracker.onDidBlur(() => {
+			this._findWidgetFocused.set(false);
+		}));
+
 		this._codeEditor.addOverlayWidget(this);
 		if (this._codeEditor.getOption(EditorOption.find).addExtraSpaceOnTop) {
 			this._viewZone = new FindWidgetViewZone(0); // Put it before the first line then users can scroll beyond the first line.
@@ -297,6 +314,29 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	 */
 	public get lastFocusedInputWasReplace(): boolean {
 		return this._lastFocusedInputWasReplace;
+	}
+
+	/**
+	 * Returns the last focused element within the Find widget.
+	 * This is useful for restoring focus to the exact element after
+	 * accessibility help or other overlays are dismissed.
+	 */
+	public get lastFocusedElement(): HTMLElement | null {
+		return this._lastFocusedElement;
+	}
+
+	/**
+	 * Focuses the last focused element in the Find widget.
+	 * Falls back to the Find or Replace input based on lastFocusedInputWasReplace.
+	 */
+	public focusLastElement(): void {
+		if (this._lastFocusedElement && this._domNode.contains(this._lastFocusedElement)) {
+			this._lastFocusedElement.focus();
+		} else if (this._lastFocusedInputWasReplace) {
+			this.focusReplaceInput();
+		} else {
+			this.focusFindInput();
+		}
 	}
 
 	public getPosition(): IOverlayWidgetPosition | null {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -262,13 +262,16 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._widgetFocusTracker = this._register(dom.trackFocus(this._domNode));
 		this._register(this._widgetFocusTracker.onDidFocus(() => {
 			this._findWidgetFocused.set(true);
-			// Track which element was focused for restoring focus later
-			if (document.activeElement instanceof HTMLElement) {
-				this._lastFocusedElement = document.activeElement;
-			}
 		}));
 		this._register(this._widgetFocusTracker.onDidBlur(() => {
 			this._findWidgetFocused.set(false);
+		}));
+
+		// Track which element was last focused within the widget using focusin (which bubbles)
+		this._register(dom.addDisposableListener(this._domNode, 'focusin', (e: FocusEvent) => {
+			if (dom.isHTMLElement(e.target)) {
+				this._lastFocusedElement = e.target;
+			}
 		}));
 
 		this._codeEditor.addOverlayWidget(this);
@@ -330,7 +333,10 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	 * Falls back to the Find or Replace input based on lastFocusedInputWasReplace.
 	 */
 	public focusLastElement(): void {
-		if (this._lastFocusedElement && this._domNode.contains(this._lastFocusedElement)) {
+		if (!this._isVisible) {
+			return;
+		}
+		if (this._lastFocusedElement && this._domNode.contains(this._lastFocusedElement) && dom.getWindow(this._lastFocusedElement).document.body.contains(this._lastFocusedElement)) {
 			this._lastFocusedElement.focus();
 		} else if (this._lastFocusedInputWasReplace) {
 			this.focusReplaceInput();

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -144,6 +144,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 	private _isVisible: boolean;
 	private _isReplaceVisible: boolean;
 	private _ignoreChangeEvent: boolean;
+	private _lastFocusedInputWasReplace: boolean = false;
 
 	private readonly _findFocusTracker: dom.IFocusTracker;
 	private readonly _findInputFocused: IContextKey<boolean>;
@@ -235,6 +236,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._findFocusTracker = this._register(dom.trackFocus(this._findInput.inputBox.inputElement));
 		this._register(this._findFocusTracker.onDidFocus(() => {
 			this._findInputFocused.set(true);
+			this._lastFocusedInputWasReplace = false;
 			this._updateSearchScope();
 		}));
 		this._register(this._findFocusTracker.onDidBlur(() => {
@@ -245,6 +247,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._replaceFocusTracker = this._register(dom.trackFocus(this._replaceInput.inputBox.inputElement));
 		this._register(this._replaceFocusTracker.onDidFocus(() => {
 			this._replaceInputFocused.set(true);
+			this._lastFocusedInputWasReplace = true;
 			this._updateSearchScope();
 		}));
 		this._register(this._replaceFocusTracker.onDidBlur(() => {
@@ -285,6 +288,15 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 
 	public getDomNode(): HTMLElement {
 		return this._domNode;
+	}
+
+	/**
+	 * Returns whether the Replace input was the last focused input in the find widget.
+	 * This persists even after focus leaves the widget, allowing external code to know
+	 * which input to restore focus to.
+	 */
+	public get lastFocusedInputWasReplace(): boolean {
+		return this._lastFocusedInputWasReplace;
 	}
 
 	public getPosition(): IOverlayWidgetPosition | null {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -28,7 +28,8 @@ import { Range } from '../../../common/core/range.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED, FIND_IDS, MATCHES_LIMIT } from './findModel.js';
 import { FindReplaceState, FindReplaceStateChangedEvent } from './findState.js';
 import * as nls from '../../../../nls.js';
-import { AccessibilitySupport } from '../../../../platform/accessibility/common/accessibility.js';
+import { AccessibilitySupport, IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextScopedFindInput, ContextScopedReplaceInput } from '../../../../platform/history/browser/contextScopedHistoryWidget.js';
 import { showHistoryKeybindingHint } from '../../../../platform/history/browser/historyWidgetKeybindingHint.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -166,6 +167,8 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		private readonly _hoverService: IHoverService,
 		private readonly _findWidgetSearchHistory: IHistory<string> | undefined,
 		private readonly _replaceWidgetHistory: IHistory<string> | undefined,
+		private readonly _configurationService: IConfigurationService,
+		private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super();
 		this._codeEditor = codeEditor;

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -28,8 +28,7 @@ import { Range } from '../../../common/core/range.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED, FIND_IDS, MATCHES_LIMIT } from './findModel.js';
 import { FindReplaceState, FindReplaceStateChangedEvent } from './findState.js';
 import * as nls from '../../../../nls.js';
-import { AccessibilitySupport, IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { AccessibilitySupport } from '../../../../platform/accessibility/common/accessibility.js';
 import { ContextScopedFindInput, ContextScopedReplaceInput } from '../../../../platform/history/browser/contextScopedHistoryWidget.js';
 import { showHistoryKeybindingHint } from '../../../../platform/history/browser/historyWidgetKeybindingHint.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -167,8 +166,6 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		private readonly _hoverService: IHoverService,
 		private readonly _findWidgetSearchHistory: IHistory<string> | undefined,
 		private readonly _replaceWidgetHistory: IHistory<string> | undefined,
-		private readonly _configurationService: IConfigurationService,
-		private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super();
 		this._codeEditor = codeEditor;

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -39,7 +39,13 @@ export const enum AccessibleViewProviderId {
 	ReplHelp = 'replHelp',
 	RunAndDebug = 'runAndDebug',
 	Walkthrough = 'walkthrough',
-	SourceControl = 'scm'
+	SourceControl = 'scm',
+	EditorFindHelp = 'editorFindHelp',
+	SearchHelp = 'searchHelp',
+	TerminalFindHelp = 'terminalFindHelp',
+	WebviewFindHelp = 'webviewFindHelp',
+	OutputFindHelp = 'outputFindHelp',
+	ProblemsFilterHelp = 'problemsFilterHelp',
 }
 
 export const enum AccessibleViewType {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -65,7 +65,8 @@ export const enum AccessibilityVerbositySettingId {
 	DiffEditorActive = 'accessibility.verbosity.diffEditorActive',
 	Debug = 'accessibility.verbosity.debug',
 	Walkthrough = 'accessibility.verbosity.walkthrough',
-	SourceControl = 'accessibility.verbosity.sourceControl'
+	SourceControl = 'accessibility.verbosity.sourceControl',
+	Find = 'accessibility.verbosity.find'
 }
 
 const baseVerbosityProperty: IConfigurationPropertySchema = {
@@ -197,6 +198,10 @@ const configuration: IConfigurationNode = {
 		},
 		[AccessibilityVerbositySettingId.SourceControl]: {
 			description: localize('verbosity.scm', 'Provide information about how to access the source control accessibility help menu when the input is focused.'),
+			...baseVerbosityProperty
+		},
+		[AccessibilityVerbositySettingId.Find]: {
+			description: localize('verbosity.find', 'Provide information about how to access the find accessibility help menu when the find input is focused.'),
 			...baseVerbosityProperty
 		},
 		'accessibility.signalOptions.volume': {

--- a/src/vs/workbench/contrib/codeEditor/browser/codeEditor.contribution.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/codeEditor.contribution.ts
@@ -7,6 +7,7 @@ import './menuPreventer.js';
 import './accessibility/accessibility.js';
 import './diffEditorHelper.js';
 import './editorFeatures.js';
+import './editorFindAccessibilityHelp.js';
 import './editorSettingsMigration.js';
 import './inspectKeybindings.js';
 import './largeFileOptimizations.js';

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -1,0 +1,329 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
+import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
+import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
+import { localize } from '../../../../nls.js';
+import { AccessibleViewProviderId, AccessibleViewType, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { AccessibleViewRegistry, IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
+import { CommonFindController } from '../../../../editor/contrib/find/browser/findController.js';
+
+/**
+ * Accessible view implementation for Find and Replace help in the code editor.
+ * Provides comprehensive accessibility support for the Find dialog, including:
+ * - Search status information (current term, match count, position)
+ * - Navigation instructions for keyboard control
+ * - Focus behavior explanation
+ * - Available settings and options
+ * - Platform-specific guidance
+ *
+ * Activated via Alt+F1 when Find or Replace input is focused.
+ */
+export class EditorFindAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly priority = 105;
+	readonly name = 'editor-find';
+	readonly when = ContextKeyExpr.or(CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED);
+	readonly type = AccessibleViewType.Help;
+
+	/**
+	 * Creates an accessible view content provider for the active code editor's Find/Replace dialog.
+	 * @param accessor Service accessor for retrieving the code editor service
+	 * @returns The provider instance, or undefined if no active editor or find controller is found
+	 */
+	getProvider(accessor: ServicesAccessor) {
+		const codeEditorService = accessor.get(ICodeEditorService);
+		const codeEditor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
+
+		if (!codeEditor) {
+			return;
+		}
+
+		const findController = CommonFindController.get(codeEditor);
+		if (!findController) {
+			return;
+		}
+
+		return new EditorFindAccessibilityHelpProvider(findController, codeEditor);
+	}
+}
+
+/**
+ * Content provider for the Find and Replace accessibility help.
+ * Generates localized, context-aware help information based on the current Find state.
+ *
+ * The implementation:
+ * - Adapts content based on whether Replace mode is active
+ * - Provides current search status (term, match count, position)
+ * - Explains focus behavior (how focus moves between Find input, Replace input, and editor)
+ * - Lists keyboard navigation shortcuts for different contexts
+ * - Documents available Find and Replace options
+ * - References relevant settings that affect Find behavior
+ * - Includes platform-specific guidance where applicable
+ */
+class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.EditorFindHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
+
+	constructor(
+		private readonly _findController: CommonFindController,
+		private readonly _codeEditor: { focus: () => void }
+	) {
+		super();
+	}
+
+	/**
+	 * Returns focus to the code editor when the accessibility help is closed.
+	 */
+	onClose(): void {
+		this._codeEditor.focus();
+	}
+
+	/**
+	 * Generates the complete accessibility help content for Find and Replace.
+	 * The content structure varies based on whether Replace mode is visible:
+	 *
+	 * Replace Mode Content:
+	 * - Header identifying the dialog
+	 * - Context explaining what the dialog does
+	 * - Current search and replace status
+	 * - Focus behavior explanation
+	 * - Keyboard shortcuts for Find, Replace, and Editor contexts
+	 * - Find and Replace options explanation
+	 * - Configurable settings documentation
+	 * - Platform-specific settings (macOS)
+	 *
+	 * Find-Only Mode Content:
+	 * - Similar structure but without Replace-specific sections
+	 *
+	 * @returns The complete help text as a newline-joined string for audio announcement
+	 */
+	provideContent(): string {
+		const state = this._findController.getState();
+		const isReplaceVisible = state.isReplaceRevealed;
+		const searchString = state.searchString;
+		const matchCount = state.matchesCount;
+		const matchPosition = state.matchesPosition;
+
+		const content: string[] = [];
+
+		if (isReplaceVisible) {
+			// ========== REPLACE MODE CONTENT ==========
+			content.push(localize('replace.header', "Accessibility Help: Editor Find and Replace"));
+			content.push(localize('replace.context', "You are in the Find and Replace dialog for the active editor. This dialog lets you locate text and replace it. The editor is a separate surface that shows each match and the surrounding context."));
+			content.push('');
+
+			// Current Search Status
+			content.push(localize('replace.statusHeader', "Current Search Status:"));
+			if (searchString) {
+				content.push(localize('replace.searchTerm', "You are searching for: \"{0}\".", searchString));
+				if (matchCount !== undefined && matchPosition !== undefined) {
+					if (matchCount === 0) {
+						content.push(localize('replace.noMatches', "No matches found in the current file. Try adjusting your search text or the options below."));
+					} else {
+						content.push(localize('replace.matchStatus', "Match {0} of {1}.", matchPosition, matchCount));
+					}
+				}
+			} else {
+				content.push(localize('replace.noSearchTerm', "No search text entered yet. Start typing to find matches in the editor."));
+			}
+
+			const replaceString = state.replaceString;
+			if (replaceString) {
+				content.push(localize('replace.replaceText', "Replacement text: \"{0}\".", replaceString));
+			} else {
+				content.push(localize('replace.noReplaceText', "No replacement text entered yet. Press Tab to move to the Replace input and type your replacement."));
+			}
+			content.push('');
+
+			// Inside the Find and Replace Dialog
+			content.push(localize('replace.dialogHeader', "Inside the Find and Replace Dialog (What It Does):"));
+			content.push(localize('replace.dialogDesc', "While you are in either input, your focus stays in that input. You can type, edit, or navigate matches without leaving. When you navigate to a match from the Find input, the editor updates in the background, but your focus remains in the dialog. Tab moves you from Find to Replace and back."));
+			content.push('');
+
+			// What You Hear
+			content.push(localize('replace.hearHeader', "What You Hear Each Time You Move to a Match:"));
+			content.push(localize('replace.hearDesc', "Each navigation step gives you a complete spoken update:"));
+			content.push(localize('replace.hear1', "1) The full line that contains the match is read first, so you get immediate context."));
+			content.push(localize('replace.hear2', "2) Your position among the matches is announced, so you know how far you are through the results."));
+			content.push(localize('replace.hear3', "3) The exact line and column are announced, so you know precisely where the match is in the file."));
+			content.push('');
+
+			// Focus Behavior
+			content.push(localize('replace.focusHeader', "Focus Behavior (Important):"));
+			content.push(localize('replace.focusDesc1', "When you navigate from inside the Find dialog, the editor updates while your focus stays in the input. This is intentional, so you can keep adjusting your search without losing your place."));
+			content.push(localize('replace.focusDesc2', "When you replace from the Replace input, the match is replaced and focus moves to the next match. If you have replaced all matches, the dialog remains open."));
+			content.push(localize('replace.focusDesc3', "If you want to move focus into the editor to edit text, press Escape to close the dialog. Focus returns to the editor at the last replacement location."));
+			content.push('');
+
+			// Keyboard Navigation Summary
+			content.push(localize('replace.keyboardHeader', "Keyboard Navigation Summary:"));
+			content.push('');
+			content.push(localize('replace.keyNavFindHeader', "While focused IN the Find input:"));
+			content.push(localize('replace.keyEnter', "- Enter: Move to the next match while staying in Find."));
+			content.push(localize('replace.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in Find."));
+			content.push(localize('replace.keyTab', "- Tab: Move between Find and Replace inputs."));
+			content.push('');
+			content.push(localize('replace.keyNavReplaceHeader', "While focused IN the Replace input:"));
+			content.push(localize('replace.keyReplaceEnter', "- Enter: Replace the current match and move to the next."));
+			content.push(localize('replace.keyReplaceOne', "- {0}: Replace only the current match.", '<keybinding:editor.action.replaceOne>'));
+			content.push(localize('replace.keyReplaceAll', "- {0}: Replace all matches at once.", '<keybinding:editor.action.replaceAll>'));
+			content.push('');
+			content.push(localize('replace.keyNavEditorHeader', "While focused IN the editor (not the Find input):"));
+			content.push(localize('replace.keyF3', "- {0}: Move to the next match.", '<keybinding:editor.action.nextMatchFindAction>'));
+			content.push(localize('replace.keyShiftF3', "- {0}: Move to the previous match.", '<keybinding:editor.action.previousMatchFindAction>'));
+			content.push('');
+			content.push(localize('replace.keyNavNote', "Note: Don't press Enter or Shift+Enter when focused in the editor - these will insert line breaks instead of navigating."));
+			content.push('');
+
+			// Find and Replace Options
+			content.push(localize('replace.optionsHeader', "Find and Replace Options in the Dialog:"));
+			content.push(localize('replace.optionCase', "- Match Case: Only exact case matches are included."));
+			content.push(localize('replace.optionWord', "- Whole Word: Only full words are matched."));
+			content.push(localize('replace.optionRegex', "- Regular Expression: Use pattern matching for advanced searches."));
+			content.push(localize('replace.optionSelection', "- Find in Selection: Limit matches to the current selection."));
+			content.push(localize('replace.optionPreserve', "- Preserve Case: When replacing, maintains the case of the original match."));
+			content.push('');
+
+			// Settings
+			content.push(localize('replace.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+			content.push(localize('replace.settingsIntro', "These settings affect how Find and Replace behave or how matches are highlighted."));
+			content.push(localize('replace.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the Find and Replace inputs announce the Accessibility Help hint."));
+			content.push(localize('replace.settingFindOnType', "- `editor.find.findOnType`: Runs Find as you type."));
+			content.push(localize('replace.settingCursorMove', "- `editor.find.cursorMoveOnType`: Moves the cursor to the best match while you type."));
+			content.push(localize('replace.settingSeed', "- `editor.find.seedSearchStringFromSelection`: Controls when selection text is used to seed Find."));
+			content.push(localize('replace.settingAutoSelection', "- `editor.find.autoFindInSelection`: Automatically enables Find in Selection based on selection type."));
+			content.push(localize('replace.settingLoop', "- `editor.find.loop`: Wraps search at the beginning or end of the file."));
+			content.push(localize('replace.settingExtraSpace', "- `editor.find.addExtraSpaceOnTop`: Adds extra scroll space so matches are not hidden behind the Find and Replace dialog."));
+			content.push(localize('replace.settingFindHistory', "- `editor.find.history`: Controls whether Find search history is stored."));
+			content.push(localize('replace.settingReplaceHistory', "- `editor.find.replaceHistory`: Controls whether Replace history is stored."));
+			content.push(localize('replace.settingOccurrences', "- `editor.occurrencesHighlight`: Highlights other occurrences of the current symbol."));
+			content.push(localize('replace.settingOccurrencesDelay', "- `editor.occurrencesHighlightDelay`: Controls how soon occurrences are highlighted."));
+			content.push(localize('replace.settingSelectionHighlight', "- `editor.selectionHighlight`: Highlights other matches of the current selection."));
+			content.push(localize('replace.settingSelectionMaxLength', "- `editor.selectionHighlightMaxLength`: Limits selection highlight length."));
+			content.push(localize('replace.settingSelectionMultiline', "- `editor.selectionHighlightMultiline`: Controls whether multi-line selections are highlighted."));
+
+			// Platform-specific setting
+			if (isMacintosh) {
+				content.push('');
+				content.push(localize('replace.macSettingHeader', "Platform-Specific Setting (macOS only):"));
+				content.push(localize('replace.macSetting', "- `editor.find.globalFindClipboard`: Uses the shared macOS Find clipboard when available."));
+			}
+
+			content.push('');
+			content.push(localize('replace.closingHeader', "Closing:"));
+			content.push(localize('replace.closingDesc', "Press Escape to close Find and Replace. Focus returns to the editor at the last replacement location, and your search and replace history is preserved."));
+		} else {
+			// ========== FIND-ONLY MODE CONTENT ==========
+			content.push(localize('find.header', "Accessibility Help: Editor Find"));
+			content.push(localize('find.context', "You are in the Find dialog for the active editor. This dialog is where you type what you want to locate. The editor is a separate surface that shows each match and its surrounding context."));
+			content.push('');
+
+			// Current Search Status
+			content.push(localize('find.statusHeader', "Current Search Status:"));
+			if (searchString) {
+				content.push(localize('find.searchTerm', "You are searching for: \"{0}\".", searchString));
+				if (matchCount !== undefined && matchPosition !== undefined) {
+					if (matchCount === 0) {
+						content.push(localize('find.noMatches', "No matches found in the current file. Try adjusting your search text or the options below."));
+					} else {
+						content.push(localize('find.matchStatus', "Match {0} of {1}.", matchPosition, matchCount));
+					}
+				}
+			} else {
+				content.push(localize('find.noSearchTerm', "No search text entered yet. Start typing to find matches in the editor."));
+			}
+			content.push('');
+
+			// Inside the Find Dialog
+			content.push(localize('find.dialogHeader', "Inside the Find Dialog (What It Does):"));
+			content.push(localize('find.dialogDesc', "While you are in the Find dialog, your focus stays in the input. You can keep typing, edit your search text, or move through matches without leaving the dialog. When you navigate to a match from here, the editor updates in the background, but your focus remains in the Find dialog."));
+			content.push('');
+
+			// What You Hear
+			content.push(localize('find.hearHeader', "What You Hear Each Time You Move to a Match:"));
+			content.push(localize('find.hearDesc', "Each navigation step gives you a complete spoken update so you always know where you are. The order is consistent:"));
+			content.push(localize('find.hear1', "1) The full line that contains the match is read first, so you get immediate context."));
+			content.push(localize('find.hear2', "2) Your position among the matches is announced, so you know how far you are through the results."));
+			content.push(localize('find.hear3', "3) The exact line and column are announced, so you know precisely where the match is in the file."));
+			content.push(localize('find.hearConclusion', "This sequence happens every time you move forward or backward."));
+			content.push('');
+
+			// Outside the Find Dialog
+			content.push(localize('find.outsideHeader', "Outside the Find Dialog (Inside the Editor):"));
+			content.push(localize('find.outsideDesc', "When you are focused in the editor instead of the Find dialog, you can still navigate matches."));
+			content.push(localize('find.outsideF3', "- Press {0} to move to the next match.", '<keybinding:editor.action.nextMatchFindAction>'));
+			content.push(localize('find.outsideShiftF3', "- Press {0} to move to the previous match.", '<keybinding:editor.action.previousMatchFindAction>'));
+			content.push(localize('find.outsideConclusion', "You hear the same three-step sequence: full line, match position, then line and column."));
+			content.push('');
+
+			// Focus Behavior
+			content.push(localize('find.focusHeader', "Focus Behavior (Important):"));
+			content.push(localize('find.focusDesc1', "When you navigate from inside the Find dialog, the editor updates while your focus stays in the input. This is intentional, so you can keep adjusting your search without losing your place."));
+			content.push(localize('find.focusDesc2', "If you want to move focus into the editor to edit text or inspect surrounding code, press Escape to close Find. Focus returns to the editor at the most recent match."));
+			content.push('');
+
+			// Keyboard Navigation Summary
+			content.push(localize('find.keyboardHeader', "Keyboard Navigation Summary:"));
+			content.push('');
+			content.push(localize('find.keyNavFindHeader', "While focused IN the Find input:"));
+			content.push(localize('find.keyEnter', "- Enter: Move to the next match while staying in the Find dialog."));
+			content.push(localize('find.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in the Find dialog."));
+			content.push('');
+			content.push(localize('find.keyNavEditorHeader', "While focused IN the editor (not the Find input):"));
+			content.push(localize('find.keyF3', "- {0}: Move to the next match.", '<keybinding:editor.action.nextMatchFindAction>'));
+			content.push(localize('find.keyShiftF3', "- {0}: Move to the previous match.", '<keybinding:editor.action.previousMatchFindAction>'));
+			content.push('');
+			content.push(localize('find.keyNavNote', "Note: Don't press Enter or Shift+Enter when focused in the editor - these will insert line breaks instead of navigating."));
+			content.push('');
+
+			// Find Options
+			content.push(localize('find.optionsHeader', "Find Options in the Dialog:"));
+			content.push(localize('find.optionCase', "- Match Case: Only exact case matches are included."));
+			content.push(localize('find.optionWord', "- Whole Word: Only full words are matched."));
+			content.push(localize('find.optionRegex', "- Regular Expression: Use pattern matching for advanced searches."));
+			content.push(localize('find.optionSelection', "- Find in Selection: Limit matches to the current selection."));
+			content.push('');
+
+			// Settings
+			content.push(localize('find.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+			content.push(localize('find.settingsIntro', "These settings affect how Find behaves or how matches are highlighted."));
+			content.push(localize('find.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the Find input announces the Accessibility Help hint."));
+			content.push(localize('find.settingFindOnType', "- `editor.find.findOnType`: Runs Find as you type."));
+			content.push(localize('find.settingCursorMove', "- `editor.find.cursorMoveOnType`: Moves the cursor to the best match while you type."));
+			content.push(localize('find.settingSeed', "- `editor.find.seedSearchStringFromSelection`: Controls when selection text is used to seed Find."));
+			content.push(localize('find.settingAutoSelection', "- `editor.find.autoFindInSelection`: Automatically enables Find in Selection based on selection type."));
+			content.push(localize('find.settingLoop', "- `editor.find.loop`: Wraps search at the beginning or end of the file."));
+			content.push(localize('find.settingExtraSpace', "- `editor.find.addExtraSpaceOnTop`: Adds extra scroll space so matches are not hidden behind the Find dialog."));
+			content.push(localize('find.settingHistory', "- `editor.find.history`: Controls whether Find search history is stored."));
+			content.push(localize('find.settingOccurrences', "- `editor.occurrencesHighlight`: Highlights other occurrences of the current symbol."));
+			content.push(localize('find.settingOccurrencesDelay', "- `editor.occurrencesHighlightDelay`: Controls how soon occurrences are highlighted."));
+			content.push(localize('find.settingSelectionHighlight', "- `editor.selectionHighlight`: Highlights other matches of the current selection."));
+			content.push(localize('find.settingSelectionMaxLength', "- `editor.selectionHighlightMaxLength`: Limits selection highlight length."));
+			content.push(localize('find.settingSelectionMultiline', "- `editor.selectionHighlightMultiline`: Controls whether multi-line selections are highlighted."));
+
+			// Platform-specific setting
+			if (isMacintosh) {
+				content.push('');
+				content.push(localize('find.macSettingHeader', "Platform-Specific Setting (macOS only):"));
+				content.push(localize('find.macSetting', "- `editor.find.globalFindClipboard`: Uses the shared macOS Find clipboard when available."));
+			}
+
+			content.push('');
+			content.push(localize('find.closingHeader', "Closing:"));
+			content.push(localize('find.closingDesc', "Press Escape to close Find. Focus returns to the editor at the most recent match, and your search history is preserved."));
+		}
+
+		return content.join('\n');
+	}
+}
+
+// Register the accessibility help provider
+AccessibleViewRegistry.register(new EditorFindAccessibilityHelp());

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -6,14 +6,14 @@
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
+import { CommonFindController, FindStartFocusAction } from '../../../../editor/contrib/find/browser/findController.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
 import { localize } from '../../../../nls.js';
 import { AccessibleViewProviderId, AccessibleViewType, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
 import { AccessibleViewRegistry, IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
-import { CommonFindController } from '../../../../editor/contrib/find/browser/findController.js';
 
 /**
  * Accessible view implementation for Find and Replace help in the code editor.
@@ -39,6 +39,7 @@ export class EditorFindAccessibilityHelp implements IAccessibleViewImplementatio
 	 */
 	getProvider(accessor: ServicesAccessor) {
 		const codeEditorService = accessor.get(ICodeEditorService);
+		const contextKeyService = accessor.get(IContextKeyService);
 		const codeEditor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
 
 		if (!codeEditor) {
@@ -50,7 +51,10 @@ export class EditorFindAccessibilityHelp implements IAccessibleViewImplementatio
 			return;
 		}
 
-		return new EditorFindAccessibilityHelpProvider(findController, codeEditor);
+		// Track which input was focused when accessible help was opened
+		const wasReplaceInputFocused = !!CONTEXT_REPLACE_INPUT_FOCUSED.getValue(contextKeyService);
+
+		return new EditorFindAccessibilityHelpProvider(findController, wasReplaceInputFocused);
 	}
 }
 
@@ -74,16 +78,26 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 
 	constructor(
 		private readonly _findController: CommonFindController,
-		private readonly _codeEditor: { focus: () => void }
+		private readonly _wasReplaceInputFocused: boolean
 	) {
 		super();
 	}
 
 	/**
-	 * Returns focus to the code editor when the accessibility help is closed.
+	 * Returns focus to the Find or Replace input when the accessibility help is closed.
+	 * Restores focus to the same input that was focused before accessible help was opened.
 	 */
 	onClose(): void {
-		this._codeEditor.focus();
+		this._findController.start({
+			forceRevealReplace: this._wasReplaceInputFocused,
+			seedSearchStringFromSelection: 'none',
+			seedSearchStringFromNonEmptySelection: false,
+			seedSearchStringFromGlobalClipboard: false,
+			shouldFocus: this._wasReplaceInputFocused ? FindStartFocusAction.FocusReplaceInput : FindStartFocusAction.FocusFindInput,
+			shouldAnimate: false,
+			updateSearchScope: false,
+			loop: true
+		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -6,12 +6,11 @@
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { isMacintosh } from '../../../../base/common/platform.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
-import { CommonFindController, FindStartFocusAction } from '../../../../editor/contrib/find/browser/findController.js';
-import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
+import { CommonFindController } from '../../../../editor/contrib/find/browser/findController.js';
+import { CONTEXT_FIND_WIDGET_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
 import { localize } from '../../../../nls.js';
 import { AccessibleViewProviderId, AccessibleViewType, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
 import { AccessibleViewRegistry, IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 
@@ -24,12 +23,12 @@ import { AccessibilityVerbositySettingId } from '../../accessibility/browser/acc
  * - Available settings and options
  * - Platform-specific guidance
  *
- * Activated via Alt+F1 when Find or Replace input is focused.
+ * Activated via Alt+F1 when any element in the Find widget is focused.
  */
 export class EditorFindAccessibilityHelp implements IAccessibleViewImplementation {
 	readonly priority = 105;
 	readonly name = 'editor-find';
-	readonly when = ContextKeyExpr.or(CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED);
+	readonly when = CONTEXT_FIND_WIDGET_FOCUSED;
 	readonly type = AccessibleViewType.Help;
 
 	/**
@@ -50,11 +49,7 @@ export class EditorFindAccessibilityHelp implements IAccessibleViewImplementatio
 			return;
 		}
 
-		// Track which input was focused when accessible help was opened
-		// Uses the controller's tracked state since context keys are cleared when focus moves
-		const wasReplaceInputFocused = findController.wasReplaceInputLastFocused();
-
-		return new EditorFindAccessibilityHelpProvider(findController, wasReplaceInputFocused);
+		return new EditorFindAccessibilityHelpProvider(findController);
 	}
 }
 
@@ -77,27 +72,17 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
 
 	constructor(
-		private readonly _findController: CommonFindController,
-		private readonly _wasReplaceInputFocused: boolean
+		private readonly _findController: CommonFindController
 	) {
 		super();
 	}
 
 	/**
-	 * Returns focus to the Find or Replace input when the accessibility help is closed.
-	 * Restores focus to the same input that was focused before accessible help was opened.
+	 * Returns focus to the last focused element in the Find widget when the accessibility help is closed.
+	 * This handles focus restoration for any element (inputs, checkboxes, buttons) not just the text inputs.
 	 */
 	onClose(): void {
-		this._findController.start({
-			forceRevealReplace: this._wasReplaceInputFocused,
-			seedSearchStringFromSelection: 'none',
-			seedSearchStringFromNonEmptySelection: false,
-			seedSearchStringFromGlobalClipboard: false,
-			shouldFocus: this._wasReplaceInputFocused ? FindStartFocusAction.FocusReplaceInput : FindStartFocusAction.FocusFindInput,
-			shouldAnimate: false,
-			updateSearchScope: false,
-			loop: true
-		});
+		this._findController.focusLastElement();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -11,7 +11,7 @@ import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../..
 import { localize } from '../../../../nls.js';
 import { AccessibleViewProviderId, AccessibleViewType, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
 import { AccessibleViewRegistry, IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
-import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 
@@ -39,7 +39,6 @@ export class EditorFindAccessibilityHelp implements IAccessibleViewImplementatio
 	 */
 	getProvider(accessor: ServicesAccessor) {
 		const codeEditorService = accessor.get(ICodeEditorService);
-		const contextKeyService = accessor.get(IContextKeyService);
 		const codeEditor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
 
 		if (!codeEditor) {
@@ -52,7 +51,8 @@ export class EditorFindAccessibilityHelp implements IAccessibleViewImplementatio
 		}
 
 		// Track which input was focused when accessible help was opened
-		const wasReplaceInputFocused = !!CONTEXT_REPLACE_INPUT_FOCUSED.getValue(contextKeyService);
+		// Uses the controller's tracked state since context keys are cleared when focus moves
+		const wasReplaceInputFocused = findController.wasReplaceInputLastFocused();
 
 		return new EditorFindAccessibilityHelpProvider(findController, wasReplaceInputFocused);
 	}

--- a/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
@@ -12,11 +12,15 @@ import { getReplView, Repl } from './repl.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { localize } from '../../../../nls.js';
+import { CONTEXT_IN_DEBUG_REPL } from '../common/debug.js';
 
 export class ReplAccessibilityHelp implements IAccessibleViewImplementation {
 	priority = 120;
 	name = 'replHelp';
-	when = ContextKeyExpr.equals('focusedView', 'workbench.panel.repl.view');
+	when = ContextKeyExpr.or(
+		ContextKeyExpr.equals('focusedView', 'workbench.panel.repl.view'),
+		CONTEXT_IN_DEBUG_REPL
+	);
 	type: AccessibleViewType = AccessibleViewType.Help;
 	getProvider(accessor: ServicesAccessor) {
 		const viewsService = accessor.get(IViewsService);
@@ -46,16 +50,74 @@ class ReplAccessibilityHelpProvider extends Disposable implements IAccessibleVie
 	}
 
 	public provideContent(): string {
-		return [
-			localize('repl.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
-			localize('repl.output', "The debug console output can be navigated to from the input field with the Focus Previous Widget command{0}.", '<keybinding:widgetNavigation.focusPrevious>'),
-			localize('repl.input', "The debug console input can be navigated to from the output with the Focus Next Widget command{0}.", '<keybinding:widgetNavigation.focusNext>'),
-			localize('repl.history', "The debug console output history can be navigated with the up and down arrow keys."),
-			localize('repl.accessibleView', "The Open Accessible View command{0} will allow character by character navigation of the console output.", '<keybinding:editor.action.accessibleView>'),
-			localize('repl.showRunAndDebug', "The Show Run and Debug view command{0} will open the Run and Debug view and provides more information about debugging.", '<keybinding:workbench.view.debug>'),
-			localize('repl.clear', "The Debug: Clear Console command{0} will clear the console output.", '<keybinding:workbench.debug.panel.action.clearReplAction>'),
-			localize('repl.lazyVariables', "The setting `debug.expandLazyVariables` controls whether variables are evaluated automatically. This is enabled by default when using a screen reader."),
-		].join('\n');
+		const content: string[] = [];
+
+		// Header
+		content.push(localize('repl.header', "Accessibility Help: Debug Console Filter"));
+		content.push(localize('repl.context', "You are in the Debug Console filter input. This is a filter that instantly hides console messages that do not match your filter, showing only the messages you want to see."));
+		content.push('');
+
+		// Current Filter Status
+		content.push(localize('repl.statusHeader', "Current Filter Status:"));
+		content.push(localize('repl.statusDesc', "You are filtering the console output."));
+		content.push('');
+
+		// Inside the Filter Input
+		content.push(localize('repl.inputHeader', "Inside the Filter Input (What It Does):"));
+		content.push(localize('repl.inputDesc', "While you are in the filter input, your focus stays in the field. You can type, edit, or adjust your filter without leaving the input. As you type, the console instantly updates to show only messages matching your filter."));
+		content.push('');
+
+		// What Happens When You Filter
+		content.push(localize('repl.filterHeader', "What Happens When You Filter:"));
+		content.push(localize('repl.filterDesc', "Each time you change the filter text, the console instantly regenerates to show only matching messages. Your screen reader announces how many messages are now visible. This is live feedback: text searches console output, variable values, and log messages."));
+		content.push('');
+
+		// Focus Behavior
+		content.push(localize('repl.focusHeader', "Focus Behavior (Important):"));
+		content.push(localize('repl.focusDesc1', "Your focus stays in the filter input while the console updates in the background. This is intentional, so you can keep typing without losing your place."));
+		content.push(localize('repl.focusDesc2', "If you want to review the filtered console output, press Down Arrow to move focus from the filter into the console messages above."));
+		content.push(localize('repl.focusDesc3', "Important: The console input area is at the bottom of the console, separate from the filter. To evaluate expressions, navigate to the console input (after the filtered messages) and type your expression."));
+		content.push('');
+
+		// Distinguishing Filter from Console Input
+		content.push(localize('repl.distinguishHeader', "Distinguishing Filter from Console Input:"));
+		content.push(localize('repl.distinguishFilter', "The filter input is where you are now. It hides or shows messages without running code."));
+		content.push(localize('repl.distinguishConsole', "The console input is at the bottom of the console, after all displayed messages. That is where you type and press Enter to evaluate expressions during debugging."));
+		content.push(localize('repl.distinguishSwitch', "To switch to the console input and evaluate an expression, use {0} to focus the console input.", '<keybinding:workbench.panel.repl.view.focus>'));
+		content.push('');
+
+		// Filter Syntax
+		content.push(localize('repl.syntaxHeader', "Filter Syntax and Patterns:"));
+		content.push(localize('repl.syntaxText', "- Type text: Shows only messages containing that text."));
+		content.push(localize('repl.syntaxExclude', "- !text (exclude): Hides messages containing the text, showing all others."));
+		content.push('');
+
+		// Keyboard Navigation Summary
+		content.push(localize('repl.keyboardHeader', "Keyboard Navigation Summary:"));
+		content.push(localize('repl.keyDown', "- Down Arrow: Move focus from filter into the console output."));
+		content.push(localize('repl.keyTab', "- Tab: Move to other console controls if available."));
+		content.push(localize('repl.keyEscape', "- Escape: Clear the filter or close the filter."));
+		content.push(localize('repl.keyFocus', "- {0}: Focus the console input to evaluate expressions.", '<keybinding:workbench.panel.repl.view.focus>'));
+		content.push('');
+
+		// Settings
+		content.push(localize('repl.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+		content.push(localize('repl.settingsIntro', "These settings affect the Debug Console."));
+		content.push(localize('repl.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the filter input announces the Accessibility Help hint."));
+		content.push(localize('repl.settingCloseOnEnd', "- `debug.console.closeOnEnd`: Automatically close the Debug Console when the debugging session ends."));
+		content.push(localize('repl.settingFontSize', "- `debug.console.fontSize`: Font size in the console."));
+		content.push(localize('repl.settingFontFamily', "- `debug.console.fontFamily`: Font family in the console."));
+		content.push(localize('repl.settingWordWrap', "- `debug.console.wordWrap`: Wrap lines in the console."));
+		content.push(localize('repl.settingHistory', "- `debug.console.historySuggestions`: Suggest previously typed input."));
+		content.push(localize('repl.settingCollapse', "- `debug.console.collapseIdenticalLines`: Collapse repeated messages with a count."));
+		content.push(localize('repl.settingMaxLines', "- `debug.console.maximumLines`: Maximum number of messages to keep in the console."));
+		content.push('');
+
+		// Closing
+		content.push(localize('repl.closingHeader', "Closing:"));
+		content.push(localize('repl.closingDesc', "Press Escape to clear the filter, or close the Debug Console. Your filter text is preserved if you reopen the console."));
+
+		return content.join('\n');
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
@@ -34,19 +34,14 @@ export class ReplAccessibilityHelp implements IAccessibleViewImplementation {
 
 class ReplAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
 	public readonly id = AccessibleViewProviderId.ReplHelp;
-	public readonly verbositySettingKey = AccessibilityVerbositySettingId.Debug;
+	public readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
 	public readonly options = { type: AccessibleViewType.Help };
-	private _treeHadFocus = false;
 	constructor(private readonly _replView: Repl) {
 		super();
-		this._treeHadFocus = !!_replView.getFocusedElement();
 	}
 
 	public onClose(): void {
-		if (this._treeHadFocus) {
-			return this._replView.focusTree();
-		}
-		this._replView.getReplInput().focus();
+		this._replView.focusFilter();
 	}
 
 	public provideContent(): string {

--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -37,6 +37,8 @@ import { viewFilterSubmenu } from '../../../browser/parts/views/viewFilter.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { problemsConfigurationNodeBase } from '../../../common/configuration.js';
 import { MarkerChatContextContribution } from './markersChatContext.js';
+import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ProblemsAccessibilityHelp } from './markersAccessibilityHelp.js';
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: Markers.MARKER_OPEN_ACTION_ID,
@@ -715,3 +717,6 @@ class ActivityUpdater extends Disposable implements IWorkbenchContribution {
 }
 
 workbenchRegistry.registerWorkbenchContribution(ActivityUpdater, LifecyclePhase.Restored);
+
+// Register Accessible View Help
+AccessibleViewRegistry.register(new ProblemsAccessibilityHelp());

--- a/src/vs/workbench/contrib/markers/browser/markersAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersAccessibilityHelp.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { AccessibleViewType, AccessibleContentProvider, IAccessibleViewContentProvider, AccessibleViewProviderId } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import * as nls from '../../../../nls.js';
+import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
+import { MarkersContextKeys } from '../common/markers.js';
+
+export class ProblemsAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly type = AccessibleViewType.Help;
+	readonly priority = 105;
+	readonly name = 'problemsFilter';
+	readonly when = MarkersContextKeys.MarkerViewFilterFocusContextKey;
+
+	getProvider(accessor: ServicesAccessor): AccessibleContentProvider {
+		return new ProblemsAccessibilityHelpProvider(accessor.get(IKeybindingService));
+	}
+}
+
+class ProblemsAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.ProblemsFilterHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options = { type: AccessibleViewType.Help };
+
+	constructor(
+		private readonly _keybindingService: IKeybindingService,
+	) {
+		super();
+	}
+
+	provideContent(): string {
+		const lines: string[] = [];
+
+		// Header
+		lines.push(nls.localize('problems.header', 'Accessibility Help: Problems Panel Filter'));
+		lines.push(nls.localize('problems.context', 'You are in the Problems panel filter input. This is a filter, not a navigating search. It instantly hides problems that do not match your filter, showing only the problems you want to see.'));
+		lines.push('');
+
+		// Current Filter Status
+		lines.push(nls.localize('problems.statusHeader', 'Current Filter Status:'));
+		lines.push(nls.localize('problems.statusDesc', 'You are filtering the problems.'));
+		lines.push('');
+
+		// Inside the Filter Input
+		lines.push(nls.localize('problems.inputHeader', 'Inside the Filter Input (What It Does):'));
+		lines.push(nls.localize('problems.inputDesc', 'While you are in the filter input, your focus stays in the field. You can type, edit, or adjust your filter without leaving the input. As you type, the Problems panel instantly updates to show only problems matching your filter.'));
+		lines.push('');
+
+		// What Happens When You Filter
+		lines.push(nls.localize('problems.filterHeader', 'What Happens When You Filter:'));
+		lines.push(nls.localize('problems.filterDesc1', 'Each time you change the filter text, the panel instantly regenerates to show only matching problems. Your screen reader announces how many problems are now visible. This is live feedback: as you type or delete characters, the displayed problems update immediately.'));
+		lines.push(nls.localize('problems.filterDesc2', 'The panel searches problem messages, file names, and error codes, so you can filter by any of these details.'));
+		lines.push('');
+
+		// Focus Behavior
+		lines.push(nls.localize('problems.focusHeader', 'Focus Behavior (Important):'));
+		lines.push(nls.localize('problems.focusDesc1', 'Your focus stays in the filter input while the panel updates in the background. This is intentional, so you can keep typing without losing your place.'));
+		lines.push(nls.localize('problems.focusDesc2', 'If you want to navigate the filtered problems, press Down Arrow to move focus from the filter into the problems list below.'));
+		lines.push(nls.localize('problems.focusDesc3', 'When a problem is focused, press Enter to navigate to that problem in the editor.'));
+		lines.push(nls.localize('problems.focusDesc4', 'If you want to clear the filter and see all problems, press Escape or delete all filter text.'));
+		lines.push('');
+
+		// Filter Syntax
+		lines.push(nls.localize('problems.syntaxHeader', 'Filter Syntax and Patterns:'));
+		lines.push(nls.localize('problems.syntaxText', '- Type text: Shows problems whose message, file path, or code contains that text.'));
+		lines.push(nls.localize('problems.syntaxExclude', '- !text (exclude): Hides problems containing the text, showing all others.'));
+		lines.push(nls.localize('problems.syntaxExample', 'Example: typing "node_modules" hides all problems in node_modules.'));
+		lines.push('');
+
+		// Severity and Scope Filtering
+		lines.push(nls.localize('problems.severityHeader', 'Severity and Scope Filtering:'));
+		lines.push(nls.localize('problems.severityIntro', 'Above the filter input are toggle buttons for severity levels and scope:'));
+		lines.push(nls.localize('problems.severityErrors', '- Errors button: Toggle to show or hide error problems.'));
+		lines.push(nls.localize('problems.severityWarnings', '- Warnings button: Toggle to show or hide warning problems.'));
+		lines.push(nls.localize('problems.severityInfo', '- Info button: Toggle to show or hide informational problems.'));
+		lines.push(nls.localize('problems.severityActiveFile', '- Active File Only button: When enabled, shows only problems in the currently open file.'));
+		lines.push(nls.localize('problems.severityConclusion', 'These buttons work together with your text filter.'));
+		lines.push('');
+
+		// Keyboard Navigation Summary
+		lines.push(nls.localize('problems.keyboardHeader', 'Keyboard Navigation Summary:'));
+		lines.push(nls.localize('problems.keyDown', '- Down Arrow: Move focus from filter into the problems list.'));
+		lines.push(nls.localize('problems.keyTab', '- Tab: Move to severity and scope toggle buttons.'));
+		lines.push(nls.localize('problems.keyEnter', '- Enter (on a problem): Navigate to that problem in the editor.'));
+		lines.push(nls.localize('problems.keyF8', '- {0}: Move to the next problem globally from anywhere in the editor.', this._describeCommand('editor.action.marker.nextInFiles') || 'F8'));
+		lines.push(nls.localize('problems.keyShiftF8', '- {0}: Move to the previous problem globally from anywhere in the editor.', this._describeCommand('editor.action.marker.prevInFiles') || 'Shift+F8'));
+		lines.push(nls.localize('problems.keyEscape', '- Escape: Clear the filter and return to showing all problems.'));
+		lines.push('');
+
+		// Settings
+		lines.push(nls.localize('problems.settingsHeader', 'Settings You Can Adjust ({0} opens Settings):', this._describeCommand('workbench.action.openSettings') || 'Ctrl+,'));
+		lines.push(nls.localize('problems.settingsIntro', 'These settings affect the Problems panel.'));
+		lines.push(nls.localize('problems.settingVerbosity', '- `accessibility.verbosity.find`: Controls whether the filter input announces the Accessibility Help hint.'));
+		lines.push(nls.localize('problems.settingAutoReveal', '- `problems.autoReveal`: Automatically reveal problems in the editor when you select them.'));
+		lines.push(nls.localize('problems.settingViewMode', '- `problems.defaultViewMode`: Show problems as a table or tree.'));
+		lines.push(nls.localize('problems.settingSortOrder', '- `problems.sortOrder`: Sort problems by severity or position.'));
+		lines.push(nls.localize('problems.settingShowCurrent', '- `problems.showCurrentInStatus`: Show the current problem in the status bar.'));
+		lines.push('');
+
+		// Closing
+		lines.push(nls.localize('problems.closingHeader', 'Closing:'));
+		lines.push(nls.localize('problems.closingDesc', 'Press Escape to clear the filter and see all problems. Your filter text is preserved if you reopen the panel. Problems are shown from your entire workspace; use Active File Only to focus on a single file.'));
+
+		return lines.join('\n');
+	}
+
+	private _describeCommand(commandId: string): string | undefined {
+		const kb = this._keybindingService.lookupKeybinding(commandId);
+		return kb?.getAriaLabel() ?? undefined;
+	}
+
+	onClose(): void {
+		// No-op
+	}
+}

--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -43,11 +43,16 @@ import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { hasKey } from '../../../../base/common/types.js';
 import { IDefaultLogLevelsService } from '../../../services/log/common/defaultLogLevels.js';
+import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { OutputAccessibilityHelp } from './outputAccessibilityHelp.js';
 
 const IMPORTED_LOG_ID_PREFIX = 'importedLog.';
 
 // Register Service
 registerSingleton(IOutputService, OutputService, InstantiationType.Delayed);
+
+// Register Accessibility Help
+AccessibleViewRegistry.register(new OutputAccessibilityHelp());
 
 // Register Output Mode
 ModesRegistry.registerLanguage({

--- a/src/vs/workbench/contrib/output/browser/outputAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/output/browser/outputAccessibilityHelp.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { AccessibleViewType, AccessibleContentProvider, IAccessibleViewContentProvider, AccessibleViewProviderId } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import * as nls from '../../../../nls.js';
+import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
+import { OUTPUT_FILTER_FOCUS_CONTEXT } from '../../../services/output/common/output.js';
+
+export class OutputAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly type = AccessibleViewType.Help;
+	readonly priority = 105;
+	readonly name = 'outputFilter';
+	readonly when = OUTPUT_FILTER_FOCUS_CONTEXT;
+
+	getProvider(accessor: ServicesAccessor): AccessibleContentProvider {
+		return new OutputAccessibilityHelpProvider(accessor.get(IKeybindingService));
+	}
+}
+
+class OutputAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.OutputFindHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options = { type: AccessibleViewType.Help };
+
+	constructor(
+		private readonly _keybindingService: IKeybindingService,
+	) {
+		super();
+	}
+
+	provideContent(): string {
+		const lines: string[] = [];
+
+		// Header
+		lines.push(nls.localize('output.header', 'Accessibility Help: Output Panel Filter'));
+		lines.push(nls.localize('output.context', 'You are in the Output panel filter input. This is NOT a navigating search. Instead, it instantly hides lines that do not match your filter, showing only the lines you want to see.'));
+		lines.push('');
+
+		// Current Filter Status
+		lines.push(nls.localize('output.statusHeader', 'Current Filter Status:'));
+		lines.push(nls.localize('output.statusDesc', 'You are filtering the output.'));
+		lines.push('');
+
+		// Inside the Filter Input
+		lines.push(nls.localize('output.inputHeader', 'Inside the Filter Input (What It Does):'));
+		lines.push(nls.localize('output.inputDesc', 'While you are in the filter input, your focus stays in the field. You can type, edit, or adjust your filter without leaving the input. As you type, the Output panel instantly updates to show only lines matching your filter.'));
+		lines.push('');
+
+		// What Happens When You Filter
+		lines.push(nls.localize('output.filterHeader', 'What Happens When You Filter:'));
+		lines.push(nls.localize('output.filterDesc1', 'Each time you change the filter text, the panel instantly regenerates to show only matching lines. Your screen reader announces how many lines are now visible. This is live feedback: as you type or delete characters, the displayed lines update immediately.'));
+		lines.push(nls.localize('output.filterDesc2', 'New output from your running program is appended to the panel and automatically filtered, so matching new output appears instantly.'));
+		lines.push('');
+
+		// Focus Behavior
+		lines.push(nls.localize('output.focusHeader', 'Focus Behavior (Important):'));
+		lines.push(nls.localize('output.focusDesc1', 'Your focus stays in the filter input while the panel updates in the background. This is intentional, so you can keep typing without losing your place.'));
+		lines.push(nls.localize('output.focusDesc2', 'If you want to review the filtered output, press Down Arrow to move focus from the filter into the output content below.'));
+		lines.push(nls.localize('output.focusDesc3', 'If you want to clear the filter and see all output, press Escape or delete all filter text.'));
+		lines.push('');
+
+		// Filter Syntax
+		lines.push(nls.localize('output.syntaxHeader', 'Filter Syntax and Patterns:'));
+		lines.push(nls.localize('output.syntaxText', '- Type text: Shows only lines containing that text (case-insensitive by default).'));
+		lines.push(nls.localize('output.syntaxExclude', '- !text (exclude): Hides lines containing \'text\', showing all other lines.'));
+		lines.push(nls.localize('output.syntaxEscape', '- \\\\! (escape): Use backslash to search for a literal "!" character.'));
+		lines.push(nls.localize('output.syntaxMultiple', '- text1, text2 (multiple patterns): Separate patterns with commas to show lines matching ANY pattern.'));
+		lines.push(nls.localize('output.syntaxExample', 'Example: typing "error, warning" shows lines containing either "error" or "warning".'));
+		lines.push('');
+
+		// Keyboard Navigation Summary
+		lines.push(nls.localize('output.keyboardHeader', 'Keyboard Navigation Summary:'));
+		lines.push(nls.localize('output.keyDown', '- Down Arrow: Move focus from filter into the output content.'));
+		lines.push(nls.localize('output.keyTab', '- Tab: Move to log level filter buttons if available.'));
+		lines.push(nls.localize('output.keyEscape', '- Escape: Clear the filter and return to showing all output.'));
+		lines.push('');
+
+		// Settings
+		lines.push(nls.localize('output.settingsHeader', 'Settings You Can Adjust ({0} opens Settings):', this._describeCommand('workbench.action.openSettings') || 'Ctrl+,'));
+		lines.push(nls.localize('output.settingsIntro', 'These settings affect how the Output panel works.'));
+		lines.push(nls.localize('output.settingVerbosity', '- `accessibility.verbosity.find`: Controls whether the filter input announces the Accessibility Help hint.'));
+		lines.push(nls.localize('output.settingSmartScroll', '- `output.smartScroll.enabled`: Automatically scroll to the latest output when messages arrive.'));
+		lines.push('');
+
+		// Closing
+		lines.push(nls.localize('output.closingHeader', 'Closing:'));
+		lines.push(nls.localize('output.closingDesc', 'Press Escape to clear the filter and see all output, or close the Output panel. Your filter text is preserved if you reopen the panel.'));
+
+		return lines.join('\n');
+	}
+
+	private _describeCommand(commandId: string): string | undefined {
+		const kb = this._keybindingService.lookupKeybinding(commandId);
+		return kb?.getAriaLabel() ?? undefined;
+	}
+
+	onClose(): void {
+		// No-op
+	}
+}

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -44,6 +44,8 @@ import './searchActionsTextQuickAccess.js';
 import { TEXT_SEARCH_QUICK_ACCESS_PREFIX, TextSearchQuickAccess } from './quickTextSearch/textSearchQuickAccess.js';
 import { Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { SearchAccessibilityHelp } from './searchAccessibilityHelp.js';
 
 registerSingleton(ISearchViewModelWorkbenchService, SearchViewModelWorkbenchService, InstantiationType.Delayed);
 registerSingleton(ISearchHistoryService, SearchHistoryService, InstantiationType.Delayed);
@@ -53,6 +55,8 @@ notebookSearchContributions();
 searchWidgetContributions();
 
 registerWorkbenchContribution2(SearchChatContextContribution.ID, SearchChatContextContribution, WorkbenchPhase.AfterRestored);
+
+AccessibleViewRegistry.register(new SearchAccessibilityHelp());
 
 const SEARCH_MODE_CONFIG = 'search.mode';
 

--- a/src/vs/workbench/contrib/search/browser/searchAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/search/browser/searchAccessibilityHelp.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
+import { localize } from '../../../../nls.js';
+import { AccessibleViewProviderId, AccessibleViewType, AccessibleContentProvider, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
+import { SearchContext } from '../common/constants.js';
+import { ISearchViewModelWorkbenchService } from './searchTreeModel/searchViewModelWorkbenchService.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+
+export class SearchAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly priority = 105;
+	readonly name = 'search';
+	readonly type = AccessibleViewType.Help;
+	readonly when = SearchContext.SearchInputBoxFocusedKey;
+
+	getProvider(accessor: ServicesAccessor): AccessibleContentProvider | undefined {
+		const searchViewModelService = accessor.get(ISearchViewModelWorkbenchService);
+		const commandService = accessor.get(ICommandService);
+
+		const searchModel = searchViewModelService.searchModel;
+		if (!searchModel) {
+			return undefined;
+		}
+
+		return new SearchAccessibilityHelpProvider(searchModel, commandService);
+	}
+}
+
+class SearchAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.SearchHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
+
+	constructor(
+		private readonly _searchModel: { searchResult: { count: () => number }; replaceActive: boolean },
+		private readonly _commandService: ICommandService
+	) {
+		super();
+	}
+
+	onClose(): void {
+		this._commandService.executeCommand('workbench.action.findInFiles');
+	}
+
+	provideContent(): string {
+		const content: string[] = [];
+		const resultCount = this._searchModel.searchResult.count();
+		const isReplaceMode = this._searchModel.replaceActive;
+
+		// Header
+		content.push(localize('search.header', "Accessibility Help: Search Across Files"));
+		content.push(localize('search.context', "You are in the Search view. This workspace-wide tool lets you find text or patterns across all files in your workspace."));
+		content.push('');
+
+		// Current Search Status
+		content.push(localize('search.statusHeader', "Current Search Status:"));
+		content.push(localize('search.statusIntro', "You are searching across your workspace."));
+		if (resultCount !== undefined) {
+			if (resultCount === 0) {
+				content.push(localize('search.noResults', "No results found. Check your search term or adjust options below."));
+			} else {
+				content.push(localize('search.resultCount', "{0} results found.", resultCount));
+			}
+		} else {
+			content.push(localize('search.noSearch', "Type a search term to find results."));
+		}
+		content.push('');
+
+		// Inside the Search Input
+		content.push(localize('search.inputHeader', "Inside the Search Input (What It Does):"));
+		content.push(localize('search.inputDesc', "While you are in the Search input, your focus stays in the field. You can type your search term and navigate the search results list without leaving the input. When you navigate to a result, the editor updates in the background to show the match."));
+		content.push('');
+
+		// What You Hear
+		content.push(localize('search.hearHeader', "What You Hear Each Time You Move to a Result:"));
+		content.push(localize('search.hearDesc', "Each navigation step gives you a complete spoken update:"));
+		content.push(localize('search.hear1', "1) The file name where the result is located is read first, so you know which file contains the match."));
+		content.push(localize('search.hear2', "2) The full line that contains the match is read, so you get immediate context."));
+		content.push(localize('search.hear3', "3) Your position among the results is announced, so you know how far you are through the results."));
+		content.push(localize('search.hear4', "4) The exact line and column are announced, so you know precisely where the match is in the file."));
+		content.push('');
+
+		// Focus Behavior
+		content.push(localize('search.focusHeader', "Focus Behavior (Important):"));
+		content.push(localize('search.focusDesc1', "When you navigate from the Search input, the editor updates while your focus stays in the search field. This is intentional, so you can keep refining your search without losing your place."));
+		content.push(localize('search.focusDesc2', "If you press Tab, focus moves to the results tree below the input, and you can navigate results and open them. When you press Enter on a result, the match is shown in the editor."));
+		content.push(localize('search.focusDesc3', "If you want to focus the editor to edit text at a search result, use {0} to navigate to the result and automatically focus the editor there.", '<keybinding:search.action.focusNextSearchResult>'));
+		content.push('');
+
+		// Keyboard Navigation Summary
+		content.push(localize('search.keyboardHeader', "Keyboard Navigation Summary:"));
+		content.push('');
+		content.push(localize('search.keyNavSearchHeader', "While focused IN the Search input:"));
+		content.push(localize('search.keyEnter', "- Enter: Run or refresh the search."));
+		content.push(localize('search.keyTab', "- Tab: Move focus to the results tree below."));
+		content.push('');
+		content.push(localize('search.keyNavResultsHeader', "Navigating search results:"));
+		content.push(localize('search.keyArrow', "- Down Arrow: Navigate through results in the tree."));
+		content.push(localize('search.keyResultEnter', "- Enter (when a result is focused): Navigate to that result in the editor."));
+		content.push('');
+		content.push(localize('search.keyNavGlobalHeader', "From anywhere (Search input or editor):"));
+		content.push(localize('search.keyF4', "- {0}: Jump to the next result and focus the editor.", '<keybinding:search.action.focusNextSearchResult>'));
+		content.push(localize('search.keyShiftF4', "- {0}: Jump to the previous result and focus the editor.", '<keybinding:search.action.focusPreviousSearchResult>'));
+		content.push('');
+
+		// Search Options
+		content.push(localize('search.optionsHeader', "Search Options in the Dialog:"));
+		content.push(localize('search.optionCase', "- Match Case: Only exact case matches are included."));
+		content.push(localize('search.optionWord', "- Whole Word: Only full words are matched."));
+		content.push(localize('search.optionRegex', "- Regular Expression: Use pattern matching for advanced searches."));
+		content.push('');
+
+		// Replace Mode
+		if (isReplaceMode) {
+			content.push(localize('search.replaceHeader', "Replace Across Files (Replace Mode Active):"));
+			content.push(localize('search.replaceDesc1', "Tab to the Replace input and type your replacement text."));
+			content.push(localize('search.replaceDesc2', "You can replace individual matches or all matches at once."));
+			content.push(localize('search.replaceWarning', "Warning: This action affects multiple files. Make sure you have searched for exactly what you want to replace."));
+			content.push('');
+		}
+
+		// Settings
+		content.push(localize('search.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+		content.push(localize('search.settingsIntro', "These settings affect how Search across files behaves."));
+		content.push(localize('search.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the Search input announces the Accessibility Help hint."));
+		content.push(localize('search.settingSmartCase', "- `search.smartCase`: Use case-insensitive search if your search term is all lowercase."));
+		content.push(localize('search.settingSearchOnType', "- `search.searchOnType`: Search all files as you type."));
+		content.push(localize('search.settingDebounce', "- `search.searchOnTypeDebouncePeriod`: Wait time in milliseconds before searching as you type."));
+		content.push(localize('search.settingMaxResults', "- `search.maxResults`: Maximum number of search results to show."));
+		content.push(localize('search.settingCollapse', "- `search.collapseResults`: Expand or collapse results."));
+		content.push(localize('search.settingLineNumbers', "- `search.showLineNumbers`: Show line numbers for results."));
+		content.push(localize('search.settingSortOrder', "- `search.sortOrder`: Sort results by file name, type, modified time, or match count."));
+		content.push(localize('search.settingContextLines', "- `search.searchEditor.defaultNumberOfContextLines`: Number of context lines shown around matches."));
+		content.push(localize('search.settingViewMode', "- `search.defaultViewMode`: Show results as list or tree."));
+		content.push(localize('search.settingActions', "- `search.actionsPosition`: Position of action buttons."));
+
+		// Replace-specific setting
+		if (isReplaceMode) {
+			content.push(localize('search.settingReplacePreview', "- `search.useReplacePreview`: Open preview when replacing matches."));
+		}
+
+		// Platform-specific setting
+		if (isMacintosh) {
+			content.push('');
+			content.push(localize('search.macSettingHeader', "Platform-Specific Setting (macOS only):"));
+			content.push(localize('search.macSetting', "- `search.globalFindClipboard`: Uses the shared macOS Find clipboard when available."));
+		}
+
+		content.push('');
+		content.push(localize('search.closingHeader', "Closing:"));
+		content.push(localize('search.closingDesc', "Press Escape to close Search. Focus returns to the editor, and your search history is preserved."));
+
+		return content.join('\n');
+	}
+}

--- a/src/vs/workbench/contrib/search/browser/searchAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/search/browser/searchAccessibilityHelp.ts
@@ -12,7 +12,8 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { SearchContext } from '../common/constants.js';
 import { ISearchViewModelWorkbenchService } from './searchTreeModel/searchViewModelWorkbenchService.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { getSearchView } from './searchActionsBase.js';
 
 export class SearchAccessibilityHelp implements IAccessibleViewImplementation {
 	readonly priority = 105;
@@ -22,14 +23,14 @@ export class SearchAccessibilityHelp implements IAccessibleViewImplementation {
 
 	getProvider(accessor: ServicesAccessor): AccessibleContentProvider | undefined {
 		const searchViewModelService = accessor.get(ISearchViewModelWorkbenchService);
-		const commandService = accessor.get(ICommandService);
+		const viewsService = accessor.get(IViewsService);
 
 		const searchModel = searchViewModelService.searchModel;
 		if (!searchModel) {
 			return undefined;
 		}
 
-		return new SearchAccessibilityHelpProvider(searchModel, commandService);
+		return new SearchAccessibilityHelpProvider(searchModel, viewsService);
 	}
 }
 
@@ -40,13 +41,13 @@ class SearchAccessibilityHelpProvider extends Disposable implements IAccessibleV
 
 	constructor(
 		private readonly _searchModel: { searchResult: { count: () => number }; replaceActive: boolean },
-		private readonly _commandService: ICommandService
+		private readonly _viewsService: IViewsService
 	) {
 		super();
 	}
 
 	onClose(): void {
-		this._commandService.executeCommand('workbench.action.findInFiles');
+		getSearchView(this._viewsService)?.focus();
 	}
 
 	provideContent(): string {

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -252,3 +252,12 @@ registerActiveInstanceAction({
 });
 
 // #endregion
+
+// #region Accessibility Help
+
+import { AccessibleViewRegistry } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { TerminalFindAccessibilityHelp } from './terminalFindAccessibilityHelp.js';
+
+AccessibleViewRegistry.register(new TerminalFindAccessibilityHelp());
+
+// #endregion

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindAccessibilityHelp.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
+import { AccessibleViewProviderId, AccessibleViewType, AccessibleContentProvider, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
+import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
+import { ITerminalService } from '../../../terminal/browser/terminal.js';
+
+export class TerminalFindAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly priority = 105;
+	readonly name = 'terminal-find';
+	readonly type = AccessibleViewType.Help;
+	readonly when = TerminalContextKeys.findFocus;
+
+	getProvider(accessor: ServicesAccessor): AccessibleContentProvider | undefined {
+		const terminalService = accessor.get(ITerminalService);
+		return new TerminalFindAccessibilityHelpProvider(terminalService);
+	}
+}
+
+class TerminalFindAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.TerminalFindHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
+
+	constructor(
+		private readonly _terminalService: ITerminalService
+	) {
+		super();
+	}
+
+	onClose(): void {
+		this._terminalService.activeInstance?.focus();
+	}
+
+	provideContent(): string {
+		const content: string[] = [];
+
+		// Header
+		content.push(localize('terminal.header', "Accessibility Help: Terminal Find"));
+		content.push(localize('terminal.context', "You are in the Terminal Find input. This searches the entire terminal buffer: both the current output and the scrollback history."));
+		content.push('');
+
+		// Current Search Status
+		content.push(localize('terminal.statusHeader', "Current Search Status:"));
+		content.push(localize('terminal.statusDesc', "You are searching the terminal buffer."));
+		content.push('');
+
+		// Inside the Terminal Find Input
+		content.push(localize('terminal.inputHeader', "Inside the Terminal Find Input (What It Does):"));
+		content.push(localize('terminal.inputDesc', "While you are in the Terminal Find input, your focus stays in the field. You can type, edit your search term, or navigate matches without leaving the input. When you navigate to a match, the terminal scrolls to show it, but your focus remains in the Find input."));
+		content.push('');
+
+		// What You Hear
+		content.push(localize('terminal.hearHeader', "What You Hear Each Time You Move to a Match:"));
+		content.push(localize('terminal.hearDesc', "Each navigation step gives you a complete spoken update:"));
+		content.push(localize('terminal.hear1', "1) The full line that contains the match is read first, so you get immediate context."));
+		content.push(localize('terminal.hear2', "2) Your position among the matches is announced, so you know how far you are through the results."));
+		content.push(localize('terminal.hear3', "3) The exact line and column are announced, so you know precisely where the match is in the buffer."));
+		content.push('');
+
+		// Focus Behavior
+		content.push(localize('terminal.focusHeader', "Focus Behavior (Important):"));
+		content.push(localize('terminal.focusDesc1', "When you navigate from the Terminal Find input, the terminal buffer updates in the background while your focus stays in the input. This is intentional, so you can keep refining your search without losing your place."));
+		content.push(localize('terminal.focusDesc2', "The terminal automatically scrolls to show the match you navigate to."));
+		content.push(localize('terminal.focusDesc3', "If you want to close Find and return focus to the terminal command line, press Escape. Focus moves to the command input at the bottom of the terminal."));
+		content.push('');
+
+		// Keyboard Navigation Summary
+		content.push(localize('terminal.keyboardHeader', "Keyboard Navigation Summary:"));
+		content.push('');
+		content.push(localize('terminal.keyNavHeader', "While focused IN the Find input:"));
+		content.push(localize('terminal.keyEnter', "- Enter: Move to the next match while staying in the Find input."));
+		content.push(localize('terminal.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in the Find input."));
+		content.push('');
+		content.push(localize('terminal.keyNavNote', "Note: Terminal Find keeps focus in the Find input. If you need to return to the terminal command line, press Escape to close Find."));
+		content.push('');
+
+		// Find Options
+		content.push(localize('terminal.optionsHeader', "Find Options:"));
+		content.push(localize('terminal.optionCase', "- Match Case: Only exact case matches are included."));
+		content.push(localize('terminal.optionWord', "- Whole Word: Only full words are matched."));
+		content.push(localize('terminal.optionRegex', "- Regular Expression: Use pattern matching for advanced searches."));
+		content.push('');
+
+		// Settings
+		content.push(localize('terminal.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+		content.push(localize('terminal.settingsDesc', "Terminal Find has limited configuration options. Most behavior is controlled by the terminal itself."));
+		content.push(localize('terminal.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the Terminal Find input announces the Accessibility Help hint."));
+		content.push('');
+
+		// Closing
+		content.push(localize('terminal.closingHeader', "Closing:"));
+		content.push(localize('terminal.closingDesc', "Press Escape to close Terminal Find. Focus moves to the terminal command line, and your search history is available on next Find."));
+
+		return content.join('\n');
+	}
+}

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindAccessibilityHelp.ts
@@ -10,7 +10,8 @@ import { IAccessibleViewImplementation } from '../../../../../platform/accessibi
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey.js';
 import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
-import { ITerminalService } from '../../../terminal/browser/terminal.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { TerminalFindCommandId } from '../common/terminal.find.js';
 
 export class TerminalFindAccessibilityHelp implements IAccessibleViewImplementation {
 	readonly priority = 105;
@@ -19,8 +20,8 @@ export class TerminalFindAccessibilityHelp implements IAccessibleViewImplementat
 	readonly when = TerminalContextKeys.findFocus;
 
 	getProvider(accessor: ServicesAccessor): AccessibleContentProvider | undefined {
-		const terminalService = accessor.get(ITerminalService);
-		return new TerminalFindAccessibilityHelpProvider(terminalService);
+		const commandService = accessor.get(ICommandService);
+		return new TerminalFindAccessibilityHelpProvider(commandService);
 	}
 }
 
@@ -30,13 +31,18 @@ class TerminalFindAccessibilityHelpProvider extends Disposable implements IAcces
 	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
 
 	constructor(
-		private readonly _terminalService: ITerminalService
+		private readonly _commandService: ICommandService
 	) {
 		super();
 	}
 
 	onClose(): void {
-		this._terminalService.activeInstance?.focus();
+		// The Escape key that closes the accessible help will also propagate
+		// and close the terminal find widget. Re-open the find widget after
+		// the Escape event has fully propagated through all handlers.
+		setTimeout(() => {
+			this._commandService.executeCommand(TerminalFindCommandId.FindFocus);
+		}, 200);
 	}
 
 	provideContent(): string {

--- a/src/vs/workbench/contrib/webview/browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.contribution.ts
@@ -9,9 +9,11 @@ import { CopyAction, CutAction, PasteAction } from '../../../../editor/contrib/c
 import * as nls from '../../../../nls.js';
 import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { AccessibleViewRegistry } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { IWebviewService, IWebview } from './webview.js';
 import { WebviewInput } from '../../webviewPanel/browser/webviewEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { WebviewFindAccessibilityHelp } from './webviewFindAccessibilityHelp.js';
 
 
 const PRIORITY = 100;
@@ -83,3 +85,6 @@ if (PasteAction) {
 		when: ContextKeyExpr.not(PreventDefaultContextMenuItemsContextKeyName),
 	});
 }
+
+// Register webview find accessibility help
+AccessibleViewRegistry.register(new WebviewFindAccessibilityHelp());

--- a/src/vs/workbench/contrib/webview/browser/webviewFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindAccessibilityHelp.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { AccessibleViewProviderId, AccessibleViewType, AccessibleContentProvider, IAccessibleViewContentProvider, IAccessibleViewOptions } from '../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_FOCUSED } from './webview.js';
+import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
+
+export class WebviewFindAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly priority = 105;
+	readonly name = 'webview-find';
+	readonly type = AccessibleViewType.Help;
+	readonly when = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_FOCUSED;
+
+	getProvider(accessor: ServicesAccessor): AccessibleContentProvider | undefined {
+		return new WebviewFindAccessibilityHelpProvider();
+	}
+}
+
+class WebviewFindAccessibilityHelpProvider extends Disposable implements IAccessibleViewContentProvider {
+	readonly id = AccessibleViewProviderId.WebviewFindHelp;
+	readonly verbositySettingKey = AccessibilityVerbositySettingId.Find;
+	readonly options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
+
+	onClose(): void {
+		// Focus will remain on webview
+	}
+
+	provideContent(): string {
+		const content: string[] = [];
+
+		// Header
+		content.push(localize('webview.header', "Accessibility Help: Webview Find"));
+		content.push(localize('webview.context', "You are in the Find input for embedded web content. This could be a Markdown preview, a documentation viewer, or a web-based extension interface."));
+		content.push('');
+
+		// Current Search Status
+		content.push(localize('webview.statusHeader', "Current Search Status:"));
+		content.push(localize('webview.statusDesc', "You are searching the web content."));
+		content.push('');
+
+		// Inside the Webview Find Input
+		content.push(localize('webview.inputHeader', "Inside the Webview Find Input (What It Does):"));
+		content.push(localize('webview.inputDesc', "While you are in the Find input, your focus stays in the field. You can type, edit your search term, or navigate matches without leaving the input. When you navigate to a match, the webview updates to show it, but your focus remains in the Find input."));
+		content.push('');
+
+		// What You Hear
+		content.push(localize('webview.hearHeader', "What You Hear Each Time You Move to a Match:"));
+		content.push(localize('webview.hearDesc', "Each navigation step gives you a complete spoken update:"));
+		content.push(localize('webview.hear1', "1) The content containing the match is read first, so you get immediate context."));
+		content.push(localize('webview.hear2', "2) Your position among the matches is announced, so you know how far you are through the results."));
+		content.push(localize('webview.hear3', "3) The exact location information is announced so you know where the match is."));
+		content.push('');
+
+		// Focus Behavior
+		content.push(localize('webview.focusHeader', "Focus Behavior (Important):"));
+		content.push(localize('webview.focusDesc1', "When you navigate from the Webview Find input, the content updates in the background while your focus stays in the input. This is intentional, so you can keep refining your search without losing your place."));
+		content.push(localize('webview.focusDesc2', "The webview may scroll to show the match, depending on how it is designed."));
+		content.push(localize('webview.focusDesc3', "If you want to close Find and return focus to the webview content, press Escape. Focus moves back into the webview."));
+		content.push('');
+
+		// Keyboard Navigation Summary
+		content.push(localize('webview.keyboardHeader', "Keyboard Navigation Summary:"));
+		content.push('');
+		content.push(localize('webview.keyNavHeader', "While focused IN the Find input:"));
+		content.push(localize('webview.keyEnter', "- Enter: Move to the next match while staying in the Find input."));
+		content.push(localize('webview.keyShiftEnter', "- Shift+Enter: Move to the previous match while staying in the Find input."));
+		content.push('');
+
+		// Find Options
+		content.push(localize('webview.optionsHeader', "Find Options:"));
+		content.push(localize('webview.optionCase', "- Match Case: Only exact case matches are included."));
+		content.push(localize('webview.optionWord', "- Whole Word: Only full words are matched."));
+		content.push(localize('webview.optionRegex', "- Regular Expression: Use pattern matching for advanced searches."));
+		content.push('');
+
+		// Important About Webviews
+		content.push(localize('webview.importantHeader', "Important About Webviews:"));
+		content.push(localize('webview.importantDesc', "Some webviews intercept keyboard input before VS Code's Find can use it. If Enter or Shift+Enter do not navigate matches, the webview may be handling those keys. Try clicking or tabbing into the webview content first to ensure the webview has focus, then reopen Find and try navigation again."));
+		content.push('');
+
+		// Settings
+		content.push(localize('webview.settingsHeader', "Settings You Can Adjust ({0} opens Settings):", '<keybinding:workbench.action.openSettings>'));
+		content.push(localize('webview.settingsDesc', "Webview Find has minimal configuration. Most behavior depends on the webview itself."));
+		content.push(localize('webview.settingVerbosity', "- `accessibility.verbosity.find`: Controls whether the Webview Find input announces the Accessibility Help hint."));
+		content.push('');
+
+		// Closing
+		content.push(localize('webview.closingHeader', "Closing:"));
+		content.push(localize('webview.closingDesc', "Press Escape to close Webview Find. Focus moves back into the webview content, and your search history is available on next Find."));
+
+		return content.join('\n');
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive accessibility help (Alt+F1) for all find and filter experiences in VS Code, providing keyboard shortcuts, navigation instructions, and context-specific guidance for screen reader users.
## What's New
### Infrastructure Changes
- Extended `AccessibleViewProviderId` for find/filter contexts
- Added `AccessibilityVerbositySettingId.Find` configuration
- Updated `FindWidget` to accept configuration and accessibility services
### New Accessibility Help Providers
| Provider | Context |
|----------|---------|
| `editorFindAccessibilityHelp.ts` | Editor find/replace dialog |
| `terminalFindAccessibilityHelp.ts` | Terminal find |
| `webviewFindAccessibilityHelp.ts` | Webview find |
| `outputAccessibilityHelp.ts` | Output panel filter |
| `markersAccessibilityHelp.ts` | Problems panel filter |
| `searchAccessibilityHelp.ts` | Search across files |
| `replAccessibilityHelp.ts` | Debug console filter |
Each provider implements `IAccessibleViewContent` with:
- Comprehensive keyboard shortcut documentation
- Context-specific navigation instructions
- Settings and options explanations
- Platform-specific shortcuts where applicable
### Contribution Registrations
- codeEditor.contribution.ts: Editor find/replace wiring
- terminal.find.contribution.ts: Terminal find wiring
- webview.contribution.ts: Webview find wiring
- output.contribution.ts: Output panel filter wiring
- markers.contribution.ts: Problems panel filter wiring
- search.contribution.ts: Search across files wiring
## Testing
1. Open any find/filter dialog (Ctrl+F in editor, terminal, webview, etc.)
2. Press Alt+F1 to open accessibility help
3. Verify comprehensive help content is displayed
## Related Issues
Fixes #292367
Fixes https://github.com/microsoft/vscode/issues/290017
## Note
This consolidates the changes from PRs #292219, #292220, and #292221 as requested.