### PR TITLE
ensure entire width of terminal output is scrollable

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -190,9 +190,6 @@ div.chat-terminal-content-part.progress-step > div.chat-terminal-output-containe
 .chat-terminal-output-terminal.chat-terminal-output-terminal-no-output {
 	display: none;
 }
-.chat-terminal-output-terminal.chat-terminal-output-terminal-clipped {
-	overflow: hidden;
-}
 .chat-terminal-output {
 	margin: 0;
 	white-space: pre;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -870,7 +870,6 @@ class ChatTerminalToolOutputSection extends Disposable {
 	private readonly _terminalContainer: HTMLElement;
 	private readonly _emptyElement: HTMLElement;
 	private _lastRenderedLineCount: number | undefined;
-	private _lastRenderedMaxColumnWidth: number | undefined;
 
 	private readonly _onDidFocusEmitter = this._register(new Emitter<void>());
 	public get onDidFocus() { return this._onDidFocusEmitter.event; }
@@ -1082,7 +1081,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 			if (result.lineCount && result.lineCount > 0) {
 				this._hideEmptyMessage();
 			}
-			this._layoutOutput(result.lineCount, result.maxColumnWidth);
+			this._layoutOutput(result.lineCount);
 			if (this._isAtBottom) {
 				this._scrollOutputToBottom();
 			}
@@ -1131,13 +1130,13 @@ class ChatTerminalToolOutputSection extends Disposable {
 		} else {
 			this._hideEmptyMessage();
 		}
-		this._layoutOutput(result?.lineCount ?? 0, result?.maxColumnWidth);
+		this._layoutOutput(result?.lineCount ?? 0);
 		return true;
 	}
 
 	private async _renderSnapshotOutput(snapshot: NonNullable<IChatTerminalToolInvocationData['terminalCommandOutput']>): Promise<void> {
 		if (this._snapshotMirror) {
-			this._layoutOutput(snapshot.lineCount ?? 0, this._lastRenderedMaxColumnWidth);
+			this._layoutOutput(snapshot.lineCount ?? 0);
 			return;
 		}
 		if (this._store.isDisposed) {
@@ -1155,7 +1154,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 			this._showEmptyMessage(localize('chat.terminalOutputEmpty', 'No output was produced by the command.'));
 		}
 		const lineCount = result?.lineCount ?? snapshot.lineCount ?? 0;
-		this._layoutOutput(lineCount, result?.maxColumnWidth);
+		this._layoutOutput(lineCount);
 	}
 
 	private _renderUnavailableMessage(liveTerminalInstance: ITerminalInstance | undefined): void {
@@ -1211,7 +1210,7 @@ class ChatTerminalToolOutputSection extends Disposable {
 		}
 	}
 
-	private _layoutOutput(lineCount?: number, maxColumnWidth?: number): void {
+	private _layoutOutput(lineCount?: number): void {
 		if (!this._scrollableContainer) {
 			return;
 		}
@@ -1222,22 +1221,12 @@ class ChatTerminalToolOutputSection extends Disposable {
 			lineCount = this._lastRenderedLineCount;
 		}
 
-		if (maxColumnWidth !== undefined) {
-			this._lastRenderedMaxColumnWidth = maxColumnWidth;
-		} else {
-			maxColumnWidth = this._lastRenderedMaxColumnWidth;
-		}
-
 		this._scrollableContainer.scanDomNode();
 		if (!this.isExpanded || lineCount === undefined) {
 			return;
 		}
 
 		const scrollableDomNode = this._scrollableContainer.getDomNode();
-
-		// Calculate and apply width based on content
-		this._applyContentWidth(maxColumnWidth);
-
 		const rowHeight = this._computeRowHeightPx();
 		const padding = this._getOutputPadding();
 		const minHeight = rowHeight * MIN_OUTPUT_ROWS + padding;
@@ -1283,53 +1272,6 @@ class ChatTerminalToolOutputSection extends Disposable {
 		const paddingTop = Number.parseFloat(style.paddingTop || '0');
 		const paddingBottom = Number.parseFloat(style.paddingBottom || '0');
 		return paddingTop + paddingBottom;
-	}
-
-	private _applyContentWidth(maxColumnWidth?: number): void {
-		if (!this._scrollableContainer) {
-			return;
-		}
-
-		const window = dom.getActiveWindow();
-		const font = this._terminalConfigurationService.getFont(window);
-		const charWidth = font.charWidth;
-
-		if (!charWidth || !maxColumnWidth || maxColumnWidth <= 0) {
-			// No content width info, leave existing width unchanged
-			return;
-		}
-
-		// Calculate the pixel width needed for the content
-		// Add some padding for scrollbar and visual comfort
-		// Account for container padding
-		// Add one extra character width (cursorWidth) to account for the cursor position
-		// which may be one character beyond the last content character during streaming
-		const horizontalPadding = 24;
-		const cursorWidth = charWidth;
-		const contentWidth = Math.ceil(maxColumnWidth * charWidth) + horizontalPadding + cursorWidth;
-
-		// Get the max available width (container's parent width)
-		const parentWidth = this.domNode.parentElement?.clientWidth ?? 0;
-
-		const scrollableDomNode = this._scrollableContainer.getDomNode();
-
-		if (parentWidth > 0 && contentWidth < parentWidth) {
-			// Content is smaller than available space - shrink to fit
-			// Apply width to both the scrollable container and the content body
-			// The xterm element renders at full column width, so we need to clip it
-			scrollableDomNode.style.width = `${contentWidth}px`;
-			this._outputBody.style.width = `${contentWidth}px`;
-			this._terminalContainer.style.width = `${contentWidth}px`;
-			this._terminalContainer.classList.add('chat-terminal-output-terminal-clipped');
-		} else {
-			// Content needs full width or more (scrollbar will show)
-			scrollableDomNode.style.width = '';
-			this._outputBody.style.width = '';
-			this._terminalContainer.style.width = '';
-			this._terminalContainer.classList.remove('chat-terminal-output-terminal-clipped');
-		}
-
-		this._scrollableContainer.scanDomNode();
 	}
 
 	private _computeRowHeightPx(): number {


### PR DESCRIPTION
fixes #291007

The width calculation wasn't working anyway, so removing it is fine/better