### PR TITLE
Expose noRenames options in git diff api

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -7,7 +7,7 @@
 
 import { Model } from '../model';
 import { Repository as BaseRepository, Resource } from '../repository';
-import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider, RefQuery, BranchProtectionProvider, InitOptions, SourceControlHistoryItemDetailsProvider, GitErrorCodes, CloneOptions, CommitShortStat, DiffChange, Worktree, RepositoryKind, RepositoryAccessDetails } from './git';
+import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider, RefQuery, BranchProtectionProvider, InitOptions, SourceControlHistoryItemDetailsProvider, GitErrorCodes, CloneOptions, CommitShortStat, DiffChange, Worktree, RepositoryKind, RepositoryAccessDetails, DiffWithOptions } from './git';
 import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands, CancellationToken } from 'vscode';
 import { combinedDisposable, filterEvent, mapEvent } from '../util';
 import { toGitUri } from '../uri';
@@ -173,10 +173,14 @@ export class ApiRepository implements Repository {
 		return this.#repository.diffWithHEADShortStats(path);
 	}
 
-	diffWith(ref: string): Promise<Change[]>;
-	diffWith(ref: string, path: string): Promise<string>;
-	diffWith(ref: string, path?: string): Promise<string | Change[]> {
-		return this.#repository.diffWith(ref, path);
+	diffWith(ref: string, options?: DiffWithOptions): Promise<Change[]>;
+	diffWith(ref: string, path: string, options?: DiffWithOptions): Promise<string>;
+	diffWith(ref: string, pathOrOptions?: string | DiffWithOptions, options?: DiffWithOptions): Promise<string | Change[]> {
+		if (typeof pathOrOptions === 'string') {
+			return this.#repository.diffWith(ref, options ?? {}, pathOrOptions);
+		} else {
+			return this.#repository.diffWith(ref, pathOrOptions ?? {});
+		}
 	}
 
 	diffIndexWithHEAD(): Promise<Change[]>;

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -233,6 +233,10 @@ export interface BranchQuery extends RefQuery {
 	readonly remote?: boolean;
 }
 
+export interface DiffWithOptions {
+	readonly noRenames?: boolean;
+}
+
 export interface Repository {
 
 	readonly rootUri: Uri;
@@ -266,8 +270,8 @@ export interface Repository {
 	diffWithHEAD(): Promise<Change[]>;
 	diffWithHEAD(path: string): Promise<string>;
 	diffWithHEADShortStats(path?: string): Promise<CommitShortStat>;
-	diffWith(ref: string): Promise<Change[]>;
-	diffWith(ref: string, path: string): Promise<string>;
+	diffWith(ref: string, options?: DiffWithOptions): Promise<Change[]>;
+	diffWith(ref: string, path: string, options?: DiffWithOptions): Promise<string>;
 	diffIndexWithHEAD(): Promise<Change[]>;
 	diffIndexWithHEAD(path: string): Promise<string>;
 	diffIndexWithHEADShortStats(path?: string): Promise<CommitShortStat>;

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -13,7 +13,7 @@ import { EventEmitter } from 'events';
 import * as filetype from 'file-type';
 import { assign, groupBy, IDisposable, toDisposable, dispose, mkdirp, readBytes, detectUnicodeEncoding, Encoding, onceEvent, splitInChunks, Limiter, Versions, isWindows, pathEquals, isMacintosh, isDescendant, relativePathWithNoFallback, Mutable } from './util';
 import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace } from 'vscode';
-import { Commit as ApiCommit, Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, RefQuery as ApiRefQuery, InitOptions, DiffChange, Worktree as ApiWorktree } from './api/git';
+import { Commit as ApiCommit, Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, RefQuery as ApiRefQuery, InitOptions, DiffChange, Worktree as ApiWorktree, DiffWithOptions } from './api/git';
 import * as byline from 'byline';
 import { StringDecoder } from 'string_decoder';
 
@@ -1733,12 +1733,12 @@ export class Repository {
 		return this.diffFilesShortStat(undefined, { cached: false, path });
 	}
 
-	diffWith(ref: string): Promise<Change[]>;
-	diffWith(ref: string, path: string): Promise<string>;
-	diffWith(ref: string, path?: string | undefined): Promise<string | Change[]>;
-	async diffWith(ref: string, path?: string): Promise<string | Change[]> {
+	diffWith(ref: string, options: DiffWithOptions): Promise<Change[]>;
+	diffWith(ref: string, options: DiffWithOptions, path: string): Promise<string>;
+	diffWith(ref: string, options: DiffWithOptions, path?: string | undefined): Promise<string | Change[]>;
+	async diffWith(ref: string, options: DiffWithOptions, path?: string): Promise<string | Change[]> {
 		if (!path) {
-			return await this.diffFiles(ref, { cached: false });
+			return await this.diffFiles(ref, { cached: false, noRenames: options.noRenames });
 		}
 
 		const args = ['diff', ref, '--', this.sanitizeRelativePath(path)];
@@ -1828,15 +1828,19 @@ export class Repository {
 		return parseGitChangesRaw(this.repositoryRoot, gitResult.stdout);
 	}
 
-	private async diffFiles(ref: string | undefined, options: { cached: boolean; similarityThreshold?: number }): Promise<Change[]> {
+	private async diffFiles(ref: string | undefined, options: { cached: boolean; similarityThreshold?: number; noRenames?: boolean }): Promise<Change[]> {
 		const args = ['diff', '--name-status', '-z', '--diff-filter=ADMR'];
 
 		if (options.cached) {
 			args.push('--cached');
 		}
 
-		if (options.similarityThreshold) {
-			args.push(`--find-renames=${options.similarityThreshold}%`);
+		if (options.noRenames) {
+			args.push('--no-renames');
+		} else {
+			if (options.similarityThreshold) {
+				args.push(`--find-renames=${options.similarityThreshold}%`);
+			}
 		}
 
 		if (ref) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -11,7 +11,7 @@ import picomatch from 'picomatch';
 import { CancellationError, CancellationToken, CancellationTokenSource, Command, commands, Disposable, Event, EventEmitter, ExcludeSettingOptions, FileDecoration, FileType, l10n, LogLevel, LogOutputChannel, Memento, ProgressLocation, ProgressOptions, QuickDiffProvider, RelativePattern, scm, SourceControl, SourceControlInputBox, SourceControlInputBoxValidation, SourceControlInputBoxValidationType, SourceControlResourceDecorations, SourceControlResourceGroup, SourceControlResourceState, TabInputNotebookDiff, TabInputTextDiff, TabInputTextMultiDiff, ThemeColor, ThemeIcon, Uri, window, workspace, WorkspaceEdit } from 'vscode';
 import { ActionButton } from './actionButton';
 import { ApiRepository } from './api/api1';
-import { Branch, BranchQuery, Change, CommitOptions, DiffChange, FetchOptions, ForcePushMode, GitErrorCodes, LogOptions, Ref, RefType, Remote, RepositoryKind, Status } from './api/git';
+import { Branch, BranchQuery, Change, CommitOptions, DiffChange, DiffWithOptions, FetchOptions, ForcePushMode, GitErrorCodes, LogOptions, Ref, RefType, Remote, RepositoryKind, Status } from './api/git';
 import { AutoFetcher } from './autofetch';
 import { GitBranchProtectionProvider, IBranchProtectionProviderRegistry } from './branchProtection';
 import { debounce, memoize, sequentialize, throttle } from './decorators';
@@ -1230,11 +1230,11 @@ export class Repository implements Disposable {
 		return this.run(Operation.Diff, () => this.repository.diffWithHEADShortStats(path));
 	}
 
-	diffWith(ref: string): Promise<Change[]>;
-	diffWith(ref: string, path: string): Promise<string>;
-	diffWith(ref: string, path?: string | undefined): Promise<string | Change[]>;
-	diffWith(ref: string, path?: string): Promise<string | Change[]> {
-		return this.run(Operation.Diff, () => this.repository.diffWith(ref, path));
+	diffWith(ref: string, options: DiffWithOptions): Promise<Change[]>;
+	diffWith(ref: string, options: DiffWithOptions, path: string): Promise<string>;
+	diffWith(ref: string, options: DiffWithOptions, path?: string | undefined): Promise<string | Change[]>;
+	diffWith(ref: string, options: DiffWithOptions, path?: string): Promise<string | Change[]> {
+		return this.run(Operation.Diff, () => this.repository.diffWith(ref, options, path));
 	}
 
 	diffIndexWithHEAD(): Promise<Change[]>;


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/284299

Exposes a `noRenames` option when computing the git diff: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---no-renames
