### PR TITLE
Add back in iframe z-index adjustments

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -38,12 +38,11 @@
 .monaco-workbench .part.auxiliarybar { box-shadow: var(--shadow-md); z-index: 40; position: relative; }
 
 /* Ensure iframe containers in pane-body render above sidebar z-index */
-/* Commented out - may cause content to be hidden by z-index issues
 .monaco-workbench > div[data-keybinding-context],
 .monaco-workbench > div[data-keybinding-context] {
 	z-index: 50 !important;
 }
-*/
+
 
 /* Ensure webview containers render above sidebar z-index */
 .monaco-workbench .part.sidebar .webview,


### PR DESCRIPTION
Clean up the styles by removing commented-out z-index adjustments for iframe containers.

Addresses: https://github.com/microsoft/vscode/issues/292488
