### PR TITLE
Fix secondary button hover background color calculation

### DIFF
--- a/src/vs/platform/theme/common/colors/inputColors.ts
+++ b/src/vs/platform/theme/common/colors/inputColors.ts
@@ -143,7 +143,7 @@ export const buttonSecondaryBorder = registerColor('button.secondaryBorder',
 	nls.localize('buttonSecondaryBorder', "Secondary button border color."));
 
 export const buttonSecondaryHoverBackground = registerColor('button.secondaryHoverBackground',
-	{ dark: lighten(buttonSecondaryBorder, 0.2), light: lighten(buttonSecondaryBorder, 0.2), hcDark: null, hcLight: null },
+	{ dark: lighten(buttonSecondaryBackground, 0.2), light: lighten(buttonSecondaryBackground, 0.2), hcDark: null, hcLight: null },
 	nls.localize('buttonSecondaryHoverBackground', "Secondary button background color when hovering."));
 
 // ------ radio


### PR DESCRIPTION
Update the calculation for the secondary button hover background color to use the correct base color. This change ensures that the hover effect appears as intended across different themes. Testing can be done by checking the hover state of the secondary button in both light and dark themes.

Addresses: https://github.com/microsoft/vscode/issues/292546

