### PR TITLE
Fix typo: accomodate -> accommodate

### DIFF
--- a/src/vs/editor/common/viewLayout/viewLayout.ts
+++ b/src/vs/editor/common/viewLayout/viewLayout.ts
@@ -324,7 +324,7 @@ export class ViewLayout extends Disposable implements IViewLayout {
 			if (maxLineWidth > layoutInfo.contentWidth + fontInfo.typicalHalfwidthCharacterWidth) {
 				// This is a case where viewport wrapping is on, but the line extends above the viewport
 				if (minimap.enabled && minimap.side === 'right') {
-					// We need to accomodate the scrollbar width
+					// We need to accommodate the scrollbar width
 					return maxLineWidth + layoutInfo.verticalScrollbarWidth;
 				}
 			}

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -618,7 +618,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 
 	protected restartWatching(watcher: ParcelWatcherInstance, delay = 800): void {
 
-		// Restart watcher delayed to accomodate for
+		// Restart watcher delayed to accommodate for
 		// changes on disk that have triggered the
 		// need for a restart in the first place.
 		const scheduler = new RunOnceScheduler(async () => {

--- a/src/vs/workbench/common/editor/editorGroupModel.ts
+++ b/src/vs/workbench/common/editor/editorGroupModel.ts
@@ -373,7 +373,7 @@ export class EditorGroupModel extends Disposable implements IEditorGroupModel {
 				if (this.preview) {
 					const indexOfPreview = this.indexOf(this.preview);
 					if (targetIndex > indexOfPreview) {
-						targetIndex--; // accomodate for the fact that the preview editor closes
+						targetIndex--; // accommodate for the fact that the preview editor closes
 					}
 
 					this.replaceEditor(this.preview, newEditor, targetIndex, !makeActive);


### PR DESCRIPTION
Fix spelling of "accommodate" in comments across multiple files:
- src/vs/editor/common/viewLayout/viewLayout.ts
- src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
- src/vs/workbench/common/editor/editorGroupModel.ts

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
