### PR TITLE
Fix/cli bugfixes

### DIFF
--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -304,6 +304,26 @@ macro_rules! get_next_entry {
 	};
 }
 
+impl KeyringStorage {
+	fn chunk_sealed_value(sealed: &str) -> Vec<String> {
+		let step_size = KEYCHAIN_ENTRY_LIMIT - CONTINUE_MARKER.len();
+		let mut out = Vec::new();
+
+		for i in (0..sealed.len()).step_by(step_size) {
+			let cutoff = i + step_size;
+			if cutoff < sealed.len() {
+				let mut part = sealed[i..cutoff].to_string();
+				part.push_str(CONTINUE_MARKER);
+				out.push(part);
+			} else {
+				out.push(sealed[i..].to_string());
+			}
+		}
+
+		out
+	}
+}
+
 impl StorageImplementation for KeyringStorage {
 	fn read(&mut self) -> Result<Option<StoredCredential>, AnyError> {
 		let mut str = String::new();
@@ -329,19 +349,10 @@ impl StorageImplementation for KeyringStorage {
 
 	fn store(&mut self, value: StoredCredential) -> Result<(), AnyError> {
 		let sealed = seal(&value);
-		let step_size = KEYCHAIN_ENTRY_LIMIT - CONTINUE_MARKER.len();
 
-		for i in (0..sealed.len()).step_by(step_size) {
-			let entry = get_next_entry!(self, i / step_size);
-
-			let cutoff = i + step_size;
-			let stored = if cutoff <= sealed.len() {
-				let mut part = sealed[i..cutoff].to_string();
-				part.push_str(CONTINUE_MARKER);
-				entry.set_password(&part)
-			} else {
-				entry.set_password(&sealed[i..])
-			};
+		for (i, part) in Self::chunk_sealed_value(&sealed).into_iter().enumerate() {
+			let entry = get_next_entry!(self, i);
+			let stored = entry.set_password(&part);
 
 			if let Err(e) = stored {
 				return Err(wrap(e, "error updating keyring").into());
@@ -361,6 +372,44 @@ impl StorageImplementation for KeyringStorage {
 		self.entries.clear();
 
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_keychain_chunking_does_not_end_with_continue_marker_at_exact_boundary() {
+		let step_size = KEYCHAIN_ENTRY_LIMIT - CONTINUE_MARKER.len();
+		let sealed = "a".repeat(step_size);
+
+		let parts = KeyringStorage::chunk_sealed_value(&sealed);
+		assert_eq!(parts.len(), 1);
+		assert_eq!(parts[0], sealed);
+	}
+
+	#[test]
+	fn test_keychain_chunking_marks_all_but_last_entry() {
+		let step_size = KEYCHAIN_ENTRY_LIMIT - CONTINUE_MARKER.len();
+		let sealed = "a".repeat(step_size + 1);
+
+		let parts = KeyringStorage::chunk_sealed_value(&sealed);
+		assert_eq!(parts.len(), 2);
+		assert!(parts[0].ends_with(CONTINUE_MARKER));
+		assert!(!parts[1].ends_with(CONTINUE_MARKER));
+		assert_eq!(parts[1].len(), 1);
+	}
+
+	#[test]
+	fn test_keychain_chunking_two_exact_chunks_has_no_trailing_marker() {
+		let step_size = KEYCHAIN_ENTRY_LIMIT - CONTINUE_MARKER.len();
+		let sealed = "a".repeat(step_size * 2);
+
+		let parts = KeyringStorage::chunk_sealed_value(&sealed);
+		assert_eq!(parts.len(), 2);
+		assert!(parts[0].ends_with(CONTINUE_MARKER));
+		assert!(!parts[1].ends_with(CONTINUE_MARKER));
 	}
 }
 

--- a/cli/src/bin/code/main.rs
+++ b/cli/src/bin/code/main.rs
@@ -142,8 +142,14 @@ fn make_logger(core: &args::CliCore) -> log::Logger {
 	let tracer = SdkTracerProvider::builder().build().tracer("codecli");
 	let mut log = log::Logger::new(tracer, log_level);
 	if let Some(f) = &core.global_options.log_to_file {
-		log = log
-			.with_sink(log::FileLogSink::new(log_level, f).expect("expected to make file logger"))
+		match log::FileLogSink::new(log_level, f) {
+			Ok(sink) => log = log.with_sink(sink),
+			Err(e) => log::emit(
+				log::Level::Warn,
+				"",
+				&format!("failed to create log file {}: {e}", f.display()),
+			),
+		}
 	}
 
 	log

--- a/cli/src/desktop/version_manager.rs
+++ b/cli/src/desktop/version_manager.rs
@@ -379,7 +379,7 @@ fn detect_installed_program(log: &log::Logger) -> io::Result<Vec<PathBuf>> {
 		}
 	};
 
-	let current_exe = std::env::current_exe().expect("expected to read current exe");
+	let current_exe = std::env::current_exe()?;
 	let mut output = vec![];
 	for dir in path.split(':') {
 		let target: PathBuf = [dir, APPLICATION_NAME].iter().collect();

--- a/cli/src/msgpack_rpc.rs
+++ b/cli/src/msgpack_rpc.rs
@@ -66,7 +66,13 @@ pub async fn start_msgpack_rpc<
 	loop {
 		tokio::select! {
 			r = read.read_buf(&mut decoder_buf) => {
-				r?;
+				let n = r?;
+				if n == 0 {
+					return Err(io::Error::new(
+						ErrorKind::UnexpectedEof,
+						"msgpack rpc stream ended",
+					));
+				}
 
 				while let Some(frame) = decoder.decode(&mut decoder_buf)? {
 					match dispatcher.dispatch_with_partial(&frame.vec, frame.obj) {

--- a/cli/src/tunnels/control_server.rs
+++ b/cli/src/tunnels/control_server.rs
@@ -1411,7 +1411,12 @@ async fn do_challenge_response_flow(
 	let challenge: ChallengeIssueResponse = caller
 		.call(METHOD_CHALLENGE_ISSUE, EmptyObject {})
 		.await
-		.unwrap()
+		.map_err(|e| {
+			CodeError::ProcessSpawnHandshakeFailed(std::io::Error::new(
+				std::io::ErrorKind::BrokenPipe,
+				e,
+			))
+		})?
 		.map_err(CodeError::TunnelRpcCallFailed)?;
 
 	let _: EmptyObject = caller
@@ -1422,7 +1427,12 @@ async fn do_challenge_response_flow(
 			},
 		)
 		.await
-		.unwrap()
+		.map_err(|e| {
+			CodeError::ProcessSpawnHandshakeFailed(std::io::Error::new(
+				std::io::ErrorKind::BrokenPipe,
+				e,
+			))
+		})?
 		.map_err(CodeError::TunnelRpcCallFailed)?;
 
 	shutdown.open(());

--- a/cli/src/util/tar.rs
+++ b/cli/src/util/tar.rs
@@ -26,16 +26,16 @@ fn should_skip_first_segment(file: &fs::File) -> Result<(bool, u64), WrappedErro
 		.map_err(|e| wrap(e, "error opening archive"))?;
 
 	let first_name = {
-		let file = entries
-			.next()
-			.expect("expected not to have an empty archive")
-			.map_err(|e| wrap(e, "error reading entry file"))?;
+		let file = match entries.next() {
+			Some(f) => f.map_err(|e| wrap(e, "error reading entry file"))?,
+			None => return Err(wrap("", "archive is empty")),
+		};
 
-		let path = file.path().expect("expected to have path");
+		let path = file.path().map_err(|e| wrap(e, "error reading entry path"))?;
 
 		path.iter()
 			.next()
-			.expect("expected to have non-empty name")
+			.ok_or_else(|| wrap("", "expected to have non-empty entry name"))?
 			.to_owned()
 	};
 

--- a/cli/src/util/zipper.rs
+++ b/cli/src/util/zipper.rs
@@ -16,17 +16,20 @@ use zip::{self, ZipArchive};
 /// Returns whether all files in the archive start with the same path segment.
 /// If so, it's an indication we should skip that segment when extracting.
 fn should_skip_first_segment(archive: &mut ZipArchive<File>) -> bool {
-	let first_name = {
-		let file = archive
-			.by_index_raw(0)
-			.expect("expected not to have an empty archive");
+	if archive.len() < 2 {
+		return false;
+	}
 
-		let path = file
-			.enclosed_name()
-			.expect("expected to have path")
-			.iter()
-			.next()
-			.expect("expected to have non-empty name");
+	let first_name = {
+		let file = match archive.by_index_raw(0) {
+			Ok(f) => f,
+			Err(_) => return false,
+		};
+
+		let path = match file.enclosed_name().and_then(|n| n.iter().next()) {
+			Some(p) => p,
+			None => return false,
+		};
 
 		path.to_owned()
 	};
@@ -52,7 +55,7 @@ where
 		zip::ZipArchive::new(file).map_err(|e| wrap(e, "failed to open zip archive"))?;
 
 	let skip_segments_no = usize::from(should_skip_first_segment(&mut archive));
-	let report_progress_every = archive.len() / 20;
+	let report_progress_every = (archive.len() / 20).max(1);
 
 	for i in 0..archive.len() {
 		if i % report_progress_every == 0 {


### PR DESCRIPTION
This PR fixes several real crash/edge-case bugs in the VS Code Rust CLI update + tunnel flows.
It prevents keychain credentials from becoming unreadable at exact chunk boundaries and stops msgpack RPC from spinning on EOF.
It removes a few panic paths in version detection, tunnel auth and log file setup by converting them into normal errors/warnings.
It also fixes update extraction crashes for small/empty zip/tar archives.
All changes are minimal, covered by added unit tests for the keychain boundary case and cargo clippy + cargo test pass.