### PR TITLE
Browser: clean up command visibility

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -66,14 +66,14 @@ class NewTabAction extends Action2 {
 			title: localize2('browser.newTabAction', "New Tab"),
 			category: BrowserCategory,
 			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
 				group: ActionGroupTabs,
 				order: 1,
 			},
+			// When already in a browser, Ctrl/Cmd + T opens a new tab
 			keybinding: {
-				// When already in a browser, Ctrl/Cmd + T opens a new tab
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over search actions
 				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
 			}
@@ -100,15 +100,14 @@ class GoBackAction extends Action2 {
 			title: localize2('browser.goBackAction', 'Go Back'),
 			category: BrowserCategory,
 			icon: Codicon.arrowLeft,
-			f1: false,
+			f1: true,
+			precondition: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_CAN_GO_BACK),
 			menu: {
 				id: MenuId.BrowserNavigationToolbar,
 				group: 'navigation',
 				order: 1,
 			},
-			precondition: CONTEXT_BROWSER_CAN_GO_BACK,
 			keybinding: {
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over editor navigation
 				primary: KeyMod.Alt | KeyCode.LeftArrow,
 				secondary: [KeyCode.BrowserBack],
@@ -133,16 +132,15 @@ class GoForwardAction extends Action2 {
 			title: localize2('browser.goForwardAction', 'Go Forward'),
 			category: BrowserCategory,
 			icon: Codicon.arrowRight,
-			f1: false,
+			f1: true,
+			precondition: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_CAN_GO_FORWARD),
 			menu: {
 				id: MenuId.BrowserNavigationToolbar,
 				group: 'navigation',
 				order: 2,
 				when: CONTEXT_BROWSER_CAN_GO_FORWARD
 			},
-			precondition: CONTEXT_BROWSER_CAN_GO_FORWARD,
 			keybinding: {
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over editor navigation
 				primary: KeyMod.Alt | KeyCode.RightArrow,
 				secondary: [KeyCode.BrowserForward],
@@ -167,7 +165,8 @@ class ReloadAction extends Action2 {
 			title: localize2('browser.reloadAction', 'Reload'),
 			category: BrowserCategory,
 			icon: Codicon.refresh,
-			f1: false,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			menu: {
 				id: MenuId.BrowserNavigationToolbar,
 				group: 'navigation',
@@ -198,9 +197,9 @@ class FocusUrlInputAction extends Action2 {
 			id: FocusUrlInputAction.ID,
 			title: localize2('browser.focusUrlInputAction', 'Focus URL Input'),
 			category: BrowserCategory,
-			f1: false,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			keybinding: {
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyL,
 			}
@@ -222,9 +221,10 @@ class AddElementToChatAction extends Action2 {
 		super({
 			id: AddElementToChatAction.ID,
 			title: localize2('browser.addElementToChatAction', 'Add Element to Chat'),
+			category: BrowserCategory,
 			icon: Codicon.inspect,
-			f1: false,
-			precondition: enabled,
+			f1: true,
+			precondition: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, enabled),
 			toggled: CONTEXT_BROWSER_ELEMENT_SELECTION_ACTIVE,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
@@ -233,11 +233,10 @@ class AddElementToChatAction extends Action2 {
 				when: enabled
 			},
 			keybinding: [{
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over terminal
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC,
 			}, {
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_ELEMENT_SELECTION_ACTIVE),
+				when: CONTEXT_BROWSER_ELEMENT_SELECTION_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyCode.Escape
 			}]
@@ -260,7 +259,8 @@ class ToggleDevToolsAction extends Action2 {
 			title: localize2('browser.toggleDevToolsAction', 'Toggle Developer Tools'),
 			category: BrowserCategory,
 			icon: Codicon.console,
-			f1: false,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			toggled: ContextKeyExpr.equals(CONTEXT_BROWSER_DEVTOOLS_OPEN.key, true),
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
@@ -268,7 +268,6 @@ class ToggleDevToolsAction extends Action2 {
 				order: 5,
 			},
 			keybinding: {
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyCode.F12
 			}
@@ -291,7 +290,8 @@ class OpenInExternalBrowserAction extends Action2 {
 			title: localize2('browser.openExternalAction', 'Open in External Browser'),
 			category: BrowserCategory,
 			icon: Codicon.linkExternal,
-			f1: false,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
 				group: ActionGroupPage,
@@ -371,7 +371,7 @@ class ClearEphemeralBrowserStorageAction extends Action2 {
 			category: BrowserCategory,
 			icon: Codicon.clearAll,
 			f1: true,
-			precondition: BROWSER_EDITOR_ACTIVE,
+			precondition: ContextKeyExpr.equals(CONTEXT_BROWSER_STORAGE_SCOPE.key, BrowserViewStorageScope.Ephemeral),
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
 				group: '3_settings',
@@ -422,14 +422,14 @@ class ShowBrowserFindAction extends Action2 {
 			id: ShowBrowserFindAction.ID,
 			title: localize2('browser.showFindAction', 'Find in Page'),
 			category: BrowserCategory,
-			f1: false,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			menu: {
 				id: MenuId.BrowserActionsToolbar,
 				group: ActionGroupPage,
 				order: 1,
 			},
 			keybinding: {
-				when: BROWSER_EDITOR_ACTIVE,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyF
 			}
@@ -452,8 +452,8 @@ class HideBrowserFindAction extends Action2 {
 			title: localize2('browser.hideFindAction', 'Close Find Widget'),
 			category: BrowserCategory,
 			f1: false,
+			precondition: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE),
 			keybinding: {
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE),
 				weight: KeybindingWeight.EditorContrib + 5,
 				primary: KeyCode.Escape
 			}
@@ -477,12 +477,13 @@ class BrowserFindNextAction extends Action2 {
 			title: localize2('browser.findNextAction', 'Find Next'),
 			category: BrowserCategory,
 			f1: false,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			keybinding: [{
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_FOCUSED),
+				when: CONTEXT_BROWSER_FIND_WIDGET_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyCode.Enter
 			}, {
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE),
+				when: CONTEXT_BROWSER_FIND_WIDGET_VISIBLE,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyCode.F3,
 				mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG }
@@ -507,12 +508,13 @@ class BrowserFindPreviousAction extends Action2 {
 			title: localize2('browser.findPreviousAction', 'Find Previous'),
 			category: BrowserCategory,
 			f1: false,
+			precondition: BROWSER_EDITOR_ACTIVE,
 			keybinding: [{
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_FOCUSED),
+				when: CONTEXT_BROWSER_FIND_WIDGET_FOCUSED,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Shift | KeyCode.Enter
 			}, {
-				when: ContextKeyExpr.and(BROWSER_EDITOR_ACTIVE, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE),
+				when: CONTEXT_BROWSER_FIND_WIDGET_VISIBLE,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Shift | KeyCode.F3,
 				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG }


### PR DESCRIPTION
Action Name | Command Palette? | Menu? | Keybinding?
-- | -- | -- | --
Open Integrated Browser | Always | - | -
New Tab | Browser active | Always | Browser active
Go Back | Browser active & can go back | Always (disabled when can't go back) | Browser active & can go back
Go Forward | Browser active & can go forward | Can go forward | Browser active & can go forward
Reload | Browser active | Always | Browser focused
Focus URL Input | Browser active | - | Browser active
Add Element to Chat | Browser active & chat enabled | Chat enabled | Browser active & chat enabled
Toggle Developer Tools | Browser active | Always | Browser active
Open in External Browser | Browser active | Always | -
Clear Storage (Global) | Always | `scope == global` | -
Clear Storage (Workspace) | Always | `scope == workspace` | -
Clear Storage (Ephemeral) | `scope == ephemeral` | `scope == ephemeral` | -
Open Browser Settings | - | Always | -
Find in Page | Browser active | Always | Browser active
Close Find Widget | - | - | Widget visible
Find Next | - | - | Widget visible
Find Previous | - | - | Widget visible
