### PR TITLE
Remove default formatter workspace setting for js/ts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,11 +24,9 @@
 		"files.insertFinalNewline": false
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[javascript]": {
-		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[rust]": {


### PR DESCRIPTION
Fixes #272750

This is needed so that we can switch between the ts6 and ts-go without having to change any settings. Longer term the plan is to make ts-go reuse the same formatter id. We will make that change once we ship tsgo builtin
