### PR TITLE
Remove `notifySessionItemsChanged`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -1009,10 +1009,6 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		return !!session?.setOption(optionId, value);
 	}
 
-	public notifySessionItemsChanged(chatSessionType: string): void {
-		this._onDidChangeSessionItems.fire({ chatSessionType });
-	}
-
 	/**
 	 * Store option groups for a session type
 	 */

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -227,13 +227,11 @@ export interface IChatSessionsService {
 	 * Get the list of chat session items grouped by session type.
 	 * @param providerTypeFilter If specified, only returns items from the given providers. If undefined, returns items from all providers.
 	 */
-	getChatSessionItems(providerTypeFilter: readonly string[] | undefined, token: CancellationToken): Promise<Array<{ readonly chatSessionType: string; readonly items: IChatSessionItem[] }>>;
+	getChatSessionItems(providerTypeFilter: readonly string[] | undefined, token: CancellationToken): Promise<Array<{ readonly chatSessionType: string; readonly items: readonly IChatSessionItem[] }>>;
 
 	reportInProgress(chatSessionType: string, count: number): void;
 	getInProgress(): { displayName: string; count: number }[];
 
-	// Notify providers about session items changes
-	notifySessionItemsChanged(chatSessionType: string): void;
 	// #endregion
 
 	// #region Content provider support

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsProvider.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsProvider.test.ts
@@ -801,35 +801,5 @@ suite('LocalAgentsSessionsProvider', () => {
 				assert.strictEqual(changeEventCount, 0, 'onDidChangeChatSessionItems should NOT fire after model is removed');
 			});
 		});
-
-		test('should fire onDidChange when session items change for local type', async () => {
-			return runWithFakedTimers({}, async () => {
-				const provider = createProvider();
-
-				let changeEventFired = false;
-				disposables.add(provider.onDidChange(() => {
-					changeEventFired = true;
-				}));
-
-				mockChatSessionsService.notifySessionItemsChanged(localChatSessionType);
-
-				assert.strictEqual(changeEventFired, true);
-			});
-		});
-
-		test('should not fire onDidChange when session items change for other types', async () => {
-			return runWithFakedTimers({}, async () => {
-				const provider = createProvider();
-
-				let changeEventFired = false;
-				disposables.add(provider.onDidChange(() => {
-					changeEventFired = true;
-				}));
-
-				mockChatSessionsService.notifySessionItemsChanged('other-type');
-
-				assert.strictEqual(changeEventFired, false);
-			});
-		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -167,10 +167,6 @@ export class MockChatSessionsService implements IChatSessionsService {
 		await this._onRequestNotifyExtension.fireAsync({ sessionResource, updates }, CancellationToken.None);
 	}
 
-	notifySessionItemsChanged(chatSessionType: string): void {
-		this._onDidChangeSessionItems.fire({ chatSessionType });
-	}
-
 	getSessionOption(sessionResource: URI, optionId: string): string | undefined {
 		return this.sessionOptions.get(sessionResource)?.get(optionId);
 	}


### PR DESCRIPTION
afaik `notifySessionItemsChanged` is only used in tests and the tests it is used in seem to be testing `notifySessionItemsChanged` 🙃

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
