### PR TITLE
ButtonBar - add support to set the context for the widget

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -574,6 +574,16 @@ export class ButtonBar {
 	private readonly _buttons: IButton[] = [];
 	private readonly _buttonStore = new DisposableStore();
 
+	private _context: unknown;
+
+	get context(): unknown {
+		return this._context;
+	}
+
+	set context(context: unknown) {
+		this._context = context;
+	}
+
 	constructor(private readonly container: HTMLElement, private readonly options?: { alignment?: ButtonBarAlignment }) { }
 
 	dispose(): void {

--- a/src/vs/platform/actions/browser/buttonbar.ts
+++ b/src/vs/platform/actions/browser/buttonbar.ts
@@ -141,12 +141,12 @@ export class WorkbenchButtonBar extends ButtonBar {
 				if (this._options?.disableWhileRunning) {
 					btn.enabled = false;
 					try {
-						await this._actionRunner.run(action);
+						await this._actionRunner.run(action, this.context);
 					} finally {
 						btn.enabled = action.enabled;
 					}
 				} else {
-					this._actionRunner.run(action);
+					this._actionRunner.run(action, this.context);
 				}
 			}));
 		}
@@ -168,6 +168,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 				this._contextMenuService.showContextMenu({
 					getAnchor: () => btn.element,
 					getActions: () => secondary,
+					getActionsContext: () => this.context,
 					actionRunner: this._actionRunner,
 					onHide: () => btn.element.setAttribute('aria-expanded', 'false')
 				});

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -324,7 +324,6 @@ export class MenuId {
 
 export interface IMenuActionOptions {
 	arg?: unknown;
-	args?: unknown[];
 	shouldForwardArgs?: boolean;
 	renderShortTitle?: boolean;
 }
@@ -614,9 +613,7 @@ export class MenuItemAction implements IAction {
 	run(...args: unknown[]): Promise<void> {
 		let runArgs: unknown[] = [];
 
-		if (this._options?.args) {
-			runArgs = [...runArgs, ...this._options.args];
-		} else if (this._options?.arg) {
+		if (this._options?.arg) {
 			runArgs = [...runArgs, this._options.arg];
 		}
 


### PR DESCRIPTION
* This pull request reverts the changes to `action.ts` made in https://github.com/microsoft/vscode/pull/291554 as those did not feel right
* Added support to set the `context` for the ButtonBar widget matching the implementation of the ActionBar
* Adopted the context for the working set ButtonBar so that we can pass session metadata to the actions