### PR TITLE
Revert "Bump @isaacs/brace-expansion from 5.0.0 to 5.0.1 in /extensions/css-language-features"

### DIFF
--- a/extensions/css-language-features/package-lock.json
+++ b/extensions/css-language-features/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"


### PR DESCRIPTION
Reverts microsoft/vscode#292649 to unblock the build.