### PR TITLE
Add scroll behavior setting for Settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1069,7 +1069,7 @@ export class SettingsEditor2 extends EditorPane {
 				}
 				if (element && (!e.browserEvent || !(<IFocusEventFromScroll>e.browserEvent).fromScroll)) {
 					let targetElement = element;
-					// Searches equvalent old Object currently living in the Tree nodes.
+					// Searches equivalent old Object currently living in the Tree nodes.
 					if (!this.settingsTree.hasElement(targetElement)) {
 						if (element instanceof SettingsTreeGroupElement) {
 							const targetId = element.id;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1705,11 +1705,14 @@ export class SettingsEditor2 extends EditorPane {
 				// In paginated mode, set initial category to the first one (Commonly Used)
 				const scrollBehavior = this.configurationService.getValue<'paginated' | 'continuous'>(SCROLL_BEHAVIOR_KEY);
 				if (scrollBehavior === 'paginated') {
-					const firstCategory = this.settingsTreeModel.value.root.children[0];
-					if (firstCategory instanceof SettingsTreeGroupElement) {
-						this.viewState.filterToCategory = firstCategory;
-						this.tocTree.setFocus([firstCategory]);
-						this.tocTree.setSelection([firstCategory]);
+					const rootChildren = this.settingsTreeModel.value.root.children;
+					if (Array.isArray(rootChildren) && rootChildren.length > 0) {
+						const firstCategory = rootChildren[0];
+						if (firstCategory instanceof SettingsTreeGroupElement) {
+							this.viewState.filterToCategory = firstCategory;
+							this.tocTree.setFocus([firstCategory]);
+							this.tocTree.setSelection([firstCategory]);
+						}
 					}
 				}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -99,6 +99,7 @@ interface IFocusEventFromScroll extends KeyboardEvent {
 
 const searchBoxLabel = localize('SearchSettings.AriaLabel', "Search settings");
 const SEARCH_TOC_BEHAVIOR_KEY = 'workbench.settings.settingsSearchTocBehavior';
+const SCROLL_BEHAVIOR_KEY = 'workbench.settings.scrollBehavior';
 
 const SHOW_AI_RESULTS_ENABLED_LABEL = localize('showAiResultsEnabled', "Show AI-recommended results");
 const SHOW_AI_RESULTS_DISABLED_LABEL = localize('showAiResultsDisabled', "No AI results available at this time...");
@@ -1050,7 +1051,9 @@ export class SettingsEditor2 extends EditorPane {
 
 			this.tocFocusedElement = element;
 			this.tocTree.setSelection(element ? [element] : []);
-			if (this.searchResultModel) {
+			const scrollBehavior = this.configurationService.getValue<'paginated' | 'continuous'>(SCROLL_BEHAVIOR_KEY);
+			if (this.searchResultModel || scrollBehavior === 'paginated') {
+				// In search mode or paginated mode, filter to show only the selected category
 				if (this.viewState.filterToCategory !== element) {
 					this.viewState.filterToCategory = element ?? undefined;
 					// Force render in this case, because
@@ -1058,46 +1061,53 @@ export class SettingsEditor2 extends EditorPane {
 					this.renderTree(undefined, true);
 					this.settingsTree.scrollTop = 0;
 				}
-			} else if (element && (!e.browserEvent || !(<IFocusEventFromScroll>e.browserEvent).fromScroll)) {
-				let targetElement = element;
-				// Searches equvalent old Object currently living in the Tree nodes.
-				if (!this.settingsTree.hasElement(targetElement)) {
-					if (element instanceof SettingsTreeGroupElement) {
-						const targetId = element.id;
+			} else {
+				// In continuous mode, clear any category filter that may have been set in paginated mode
+				if (this.viewState.filterToCategory) {
+					this.viewState.filterToCategory = undefined;
+					this.renderTree(undefined, true);
+				}
+				if (element && (!e.browserEvent || !(<IFocusEventFromScroll>e.browserEvent).fromScroll)) {
+					let targetElement = element;
+					// Searches equvalent old Object currently living in the Tree nodes.
+					if (!this.settingsTree.hasElement(targetElement)) {
+						if (element instanceof SettingsTreeGroupElement) {
+							const targetId = element.id;
 
-						const findInViewNodes = (nodes: any[]): SettingsTreeGroupElement | undefined => {
-							for (const node of nodes) {
-								if (node.element instanceof SettingsTreeGroupElement && node.element.id === targetId) {
-									return node.element;
-								}
-								if (node.children && node.children.length > 0) {
-									const found = findInViewNodes(node.children);
-									if (found) {
-										return found;
+							const findInViewNodes = (nodes: any[]): SettingsTreeGroupElement | undefined => {
+								for (const node of nodes) {
+									if (node.element instanceof SettingsTreeGroupElement && node.element.id === targetId) {
+										return node.element;
+									}
+									if (node.children && node.children.length > 0) {
+										const found = findInViewNodes(node.children);
+										if (found) {
+											return found;
+										}
 									}
 								}
-							}
-							return undefined;
-						};
+								return undefined;
+							};
 
-						try {
-							const rootNode = this.settingsTree.getNode(null);
-							if (rootNode && rootNode.children) {
-								const foundOldElement = findInViewNodes(rootNode.children);
-								if (foundOldElement) {
-									// Now we don't reveal the New Object, reveal the Old Object"
-									targetElement = foundOldElement;
+							try {
+								const rootNode = this.settingsTree.getNode(null);
+								if (rootNode && rootNode.children) {
+									const foundOldElement = findInViewNodes(rootNode.children);
+									if (foundOldElement) {
+										// Now we don't reveal the New Object, reveal the Old Object"
+										targetElement = foundOldElement;
+									}
 								}
+							} catch (err) {
+								// Tree might be in an invalid state, ignore
 							}
-						} catch (err) {
-							// Tree might be in an invalid state, ignore
 						}
 					}
-				}
 
-				if (this.settingsTree.hasElement(targetElement)) {
-					this.settingsTree.reveal(targetElement, 0);
-					this.settingsTree.setFocus([targetElement]);
+					if (this.settingsTree.hasElement(targetElement)) {
+						this.settingsTree.reveal(targetElement, 0);
+						this.settingsTree.setFocus([targetElement]);
+					}
 				}
 			}
 		}));
@@ -1246,6 +1256,12 @@ export class SettingsEditor2 extends EditorPane {
 	private updateTreeScrollSync(): void {
 		this.settingRenderers.cancelSuggesters();
 		if (this.searchResultModel) {
+			return;
+		}
+
+		// In paginated mode, we don't sync scroll position since categories are filtered
+		const scrollBehavior = this.configurationService.getValue<'paginated' | 'continuous'>(SCROLL_BEHAVIOR_KEY);
+		if (scrollBehavior === 'paginated') {
 			return;
 		}
 
@@ -1685,6 +1701,18 @@ export class SettingsEditor2 extends EditorPane {
 				await this.onSearchInputChanged(true);
 			} else {
 				this.refreshTOCTree();
+
+				// In paginated mode, set initial category to the first one (Commonly Used)
+				const scrollBehavior = this.configurationService.getValue<'paginated' | 'continuous'>(SCROLL_BEHAVIOR_KEY);
+				if (scrollBehavior === 'paginated') {
+					const firstCategory = this.settingsTreeModel.value.root.children[0];
+					if (firstCategory instanceof SettingsTreeGroupElement) {
+						this.viewState.filterToCategory = firstCategory;
+						this.tocTree.setFocus([firstCategory]);
+						this.tocTree.setSelection([firstCategory]);
+					}
+				}
+
 				this.refreshTree();
 				this.tocTree.collapseAll();
 			}

--- a/src/vs/workbench/contrib/preferences/browser/tocTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/tocTree.ts
@@ -216,7 +216,7 @@ export class TOCTree extends WorkbenchObjectTree<SettingsTreeGroupElement> {
 	) {
 		// test open mode
 
-		const filter = instantiationService.createInstance(SettingsTreeFilter, viewState);
+		const filter = instantiationService.createInstance(SettingsTreeFilter, viewState, false);
 		const options: IWorkbenchObjectTreeOptions<SettingsTreeGroupElement, void> = {
 			filter,
 			multipleSelectionSupport: false,

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -125,6 +125,17 @@ registry.registerConfiguration({
 			'description': nls.localize('settingsSearchTocBehavior', "Controls the behavior of the Settings editor Table of Contents while searching. If this setting is being changed in the Settings editor, the setting will take effect after the search query is modified."),
 			'default': 'filter',
 			'scope': ConfigurationScope.WINDOW
+		},
+		'workbench.settings.scrollBehavior': {
+			'type': 'string',
+			'enum': ['paginated', 'continuous'],
+			'enumDescriptions': [
+				nls.localize('settingsScrollBehavior.paginated', "Show only settings from the selected category. Clicking a category in the Table of Contents filters the view to that category."),
+				nls.localize('settingsScrollBehavior.continuous', "Show all settings in a continuous scrolling list. Clicking a category scrolls to that section."),
+			],
+			'description': nls.localize('settingsScrollBehavior', "Controls whether the Settings editor shows one category at a time (paginated) or allows continuous scrolling through all settings."),
+			'default': 'paginated',
+			'scope': ConfigurationScope.WINDOW
 		}
 	}
 });


### PR DESCRIPTION
Adds setting to control the scroll behavior in the settings editor, offering continuous or paginated. Paginated will restrict the settings shown to only those in that category. 
