### PR TITLE
Preserve VS Code extension paths in telemetry callstacks

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -311,10 +311,10 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 
 	const nodeModulesRegex = /^[\\\/]?(node_modules|node_modules\.asar)[\\\/]/;
 	// Match VS Code extension paths:
-	// 1. User extensions: .vscode/extensions/, .vscode-insiders/extensions/, .vscode-server/extensions/, etc.
+	// 1. User extensions: .vscode/extensions/, .vscode-insiders/extensions/, .vscode-server/extensions/, .vscode-server-insiders/extensions/, etc.
 	// 2. Built-in extensions: resources/app/extensions/
 	// Capture everything from the vscode folder or resources/app/extensions onwards
-	const vscodeExtensionsPathRegex = /^(.*?)((?:\.vscode(?:-[a-z]+)?|resources[\\\/]app)[\\\/]extensions[\\\/].*)$/i;
+	const vscodeExtensionsPathRegex = /^(.*?)((?:\.vscode(?:-[a-z]+)*|resources[\\\/]app)[\\\/]extensions[\\\/].*)$/i;
 	const fileRegex = /(file:\/\/)?([a-zA-Z]:(\\\\|\\|\/)|(\\\\|\\|\/))?([\w-\._]+(\\\\|\\|\/))+[\w-\._]*/g;
 	let lastIndex = 0;
 	updatedStack = '';

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -310,6 +310,11 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 	}
 
 	const nodeModulesRegex = /^[\\\/]?(node_modules|node_modules\.asar)[\\\/]/;
+	// Match VS Code extension paths:
+	// 1. User extensions: .vscode/extensions/, .vscode-insiders/extensions/, .vscode-server/extensions/, etc.
+	// 2. Built-in extensions: resources/app/extensions/
+	// Capture everything from the vscode folder or resources/app/extensions onwards
+	const vscodeExtensionsPathRegex = /^(.*?)((?:\.vscode(?:-[a-z]+)?|resources[\\\/]app)[\\\/]extensions[\\\/].*)$/i;
 	const fileRegex = /(file:\/\/)?([a-zA-Z]:(\\\\|\\|\/)|(\\\\|\\|\/))?([\w-\._]+(\\\\|\\|\/))+[\w-\._]*/g;
 	let lastIndex = 0;
 	updatedStack = '';
@@ -325,7 +330,14 @@ function anonymizeFilePaths(stack: string, cleanupPatterns: RegExp[]): string {
 
 		// anoynimize user file paths that do not need to be retained or cleaned up.
 		if (!nodeModulesRegex.test(result[0]) && !overlappingRange) {
-			updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
+			// Check if this is a VS Code extension path - if so, preserve the .vscode*/extensions/... portion
+			const vscodeExtMatch = vscodeExtensionsPathRegex.exec(result[0]);
+			if (vscodeExtMatch) {
+				// Keep ".vscode[-variant]/extensions/extension-name/..." but redact the parent folder
+				updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>/' + vscodeExtMatch[2];
+			} else {
+				updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
+			}
 			lastIndex = fileRegex.lastIndex;
 		}
 	}

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -61,9 +61,9 @@ class ErrorTestingSettings {
 	public extensionPathToRetain: string = '.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
 	public fullExtensionPath: string = '/Users/username/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
 	public anonymizedExtensionPath: string = '<REDACTED: user-file-path>/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
-	public builtinExtensionPathToRetain: string = 'resources/app/extensions/git/out/git.js:42:1234';
+	public builtinExtensionPathToRetain: string = 'Resources/app/extensions/git/out/git.js:42:1234';
 	public fullBuiltinExtensionPath: string = '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/out/git.js:42:1234';
-	public anonymizedBuiltinExtensionPath: string = '<REDACTED: user-file-path>/resources/app/extensions/git/out/git.js:42:1234';
+	public anonymizedBuiltinExtensionPath: string = '<REDACTED: user-file-path>/Resources/app/extensions/git/out/git.js:42:1234';
 
 	constructor() {
 		this.personalInfo = 'DANGEROUS/PATH';

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -58,6 +58,12 @@ class ErrorTestingSettings {
 	public anonymizedRandomUserFile: string = '<REDACTED: user-file-path>';
 	public nodeModulePathToRetain: string = 'node_modules/path/that/shouldbe/retained/names.js:14:15854';
 	public nodeModuleAsarPathToRetain: string = 'node_modules.asar/path/that/shouldbe/retained/names.js:14:12354';
+	public extensionPathToRetain: string = '.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
+	public fullExtensionPath: string = '/Users/username/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
+	public anonymizedExtensionPath: string = '<REDACTED: user-file-path>/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
+	public builtinExtensionPathToRetain: string = 'resources/app/extensions/git/out/git.js:42:1234';
+	public fullBuiltinExtensionPath: string = '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/out/git.js:42:1234';
+	public anonymizedBuiltinExtensionPath: string = '<REDACTED: user-file-path>/resources/app/extensions/git/out/git.js:42:1234';
 
 	constructor() {
 		this.personalInfo = 'DANGEROUS/PATH';
@@ -81,6 +87,8 @@ class ErrorTestingSettings {
 		`    at t._handleMessage (${this.nodeModuleAsarPathToRetain})`,
 		`    at t._onmessage (/${this.nodeModulePathToRetain})`,
 		`    at t.onmessage (${this.nodeModulePathToRetain})`,
+		`    at uv.provideCodeActions (${this.fullExtensionPath})`,
+		`    at git.getRepositoryState (${this.fullBuiltinExtensionPath})`,
 			`    at DedicatedWorkerGlobalScope.self.onmessage`,
 		this.dangerousPathWithImportantInfo,
 		this.dangerousPathWithoutImportantInfo,
@@ -496,6 +504,43 @@ suite('TelemetryService', () => {
 			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf('(' + settings.nodeModulePathToRetain), -1);
 			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModuleAsarPathToRetain), -1);
 			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf('(/' + settings.nodeModulePathToRetain), -1);
+
+			errorTelemetry.dispose();
+			service.dispose();
+		}
+		finally {
+			Errors.setUnexpectedErrorHandler(origErrorHandler);
+		}
+	}));
+
+	test('Unexpected Error Telemetry removes PII but preserves extension path', sinonTestFn(function (this: any) {
+
+		const origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+		Errors.setUnexpectedErrorHandler(() => { });
+
+		try {
+			const settings = new ErrorTestingSettings();
+			const testAppender = new TestTelemetryAppender();
+			const service = new TestErrorTelemetryService({ appenders: [testAppender] });
+			const errorTelemetry = new ErrorTelemetry(service);
+
+			const dangerousPathWithImportantInfoError: any = new Error(settings.dangerousPathWithImportantInfo);
+			dangerousPathWithImportantInfoError.stack = settings.stack;
+
+			Errors.onUnexpectedError(dangerousPathWithImportantInfoError);
+			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+			// Verify user extension path is preserved but parent folder is redacted
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.extensionPathToRetain), -1, 'User extension path should be retained');
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.anonymizedExtensionPath), -1, 'User extension path should be anonymized with preserved extension name');
+			// Verify the username is removed
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf('/Users/username/'), -1, 'Username should be redacted from extension path');
+
+			// Verify built-in extension path is preserved but app folder is redacted
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.builtinExtensionPathToRetain), -1, 'Built-in extension path should be retained');
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.anonymizedBuiltinExtensionPath), -1, 'Built-in extension path should be anonymized with preserved extension name');
+			// Verify the app path is removed
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf('/Applications/Visual Studio Code.app'), -1, 'App path should be redacted from built-in extension path');
 
 			errorTelemetry.dispose();
 			service.dispose();

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -61,6 +61,9 @@ class ErrorTestingSettings {
 	public extensionPathToRetain: string = '.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
 	public fullExtensionPath: string = '/Users/username/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
 	public anonymizedExtensionPath: string = '<REDACTED: user-file-path>/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516';
+	public serverInsidersExtensionPathToRetain: string = '.vscode-server-insiders/extensions/ms-vscode.remote-server-2024.1.0/out/server.js:99:8888';
+	public fullServerInsidersExtensionPath: string = '/home/user/.vscode-server-insiders/extensions/ms-vscode.remote-server-2024.1.0/out/server.js:99:8888';
+	public anonymizedServerInsidersExtensionPath: string = '<REDACTED: user-file-path>/.vscode-server-insiders/extensions/ms-vscode.remote-server-2024.1.0/out/server.js:99:8888';
 	public builtinExtensionPathToRetain: string = 'Resources/app/extensions/git/out/git.js:42:1234';
 	public fullBuiltinExtensionPath: string = '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/out/git.js:42:1234';
 	public anonymizedBuiltinExtensionPath: string = '<REDACTED: user-file-path>/Resources/app/extensions/git/out/git.js:42:1234';
@@ -88,6 +91,7 @@ class ErrorTestingSettings {
 		`    at t._onmessage (/${this.nodeModulePathToRetain})`,
 		`    at t.onmessage (${this.nodeModulePathToRetain})`,
 		`    at uv.provideCodeActions (${this.fullExtensionPath})`,
+		`    at remote.handleConnection (${this.fullServerInsidersExtensionPath})`,
 		`    at git.getRepositoryState (${this.fullBuiltinExtensionPath})`,
 			`    at DedicatedWorkerGlobalScope.self.onmessage`,
 		this.dangerousPathWithImportantInfo,
@@ -535,6 +539,12 @@ suite('TelemetryService', () => {
 			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.anonymizedExtensionPath), -1, 'User extension path should be anonymized with preserved extension name');
 			// Verify the username is removed
 			assert.strictEqual(testAppender.events[0].data.callstack.indexOf('/Users/username/'), -1, 'Username should be redacted from extension path');
+
+			// Verify server-insiders extension path is preserved (multi-segment suffix like .vscode-server-insiders)
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.serverInsidersExtensionPathToRetain), -1, 'Server-insiders extension path should be retained');
+			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.anonymizedServerInsidersExtensionPath), -1, 'Server-insiders extension path should be anonymized with preserved extension name');
+			// Verify the home directory is removed
+			assert.strictEqual(testAppender.events[0].data.callstack.indexOf('/home/user/'), -1, 'Home directory should be redacted from server-insiders extension path');
 
 			// Verify built-in extension path is preserved but app folder is redacted
 			assert.notStrictEqual(testAppender.events[0].data.callstack.indexOf(settings.builtinExtensionPathToRetain), -1, 'Built-in extension path should be retained');


### PR DESCRIPTION
## Summary

When anonymizing file paths in telemetry data, preserve the extension name and path within VS Code extension directories while redacting the parent folder containing user information.

## Problem

Extension host error callstacks in telemetry were being fully redacted:
```
at uv.provideCodeActions (<REDACTED: user-file-path>:144:145516)
```

This made it impossible to identify which extension was causing errors.

## Solution

The `anonymizeFilePaths` function now recognizes VS Code extension paths and preserves them:

**Matches:**
- User extensions: `.vscode/extensions/`, `.vscode-insiders/extensions/`, `.vscode-server/extensions/`, etc.
- Built-in extensions: `resources/app/extensions/`

**After:**
```
at uv.provideCodeActions (<REDACTED: user-file-path>/.vscode/extensions/ms-python.python-2024.0.1/out/extension.js:144:145516)
```

The user's home directory is redacted, but the extension name and file path within it are preserved for debugging.

## Testing

- Added test case for extension path preservation
- All 31 telemetry tests pass