### PR TITLE
build: always repackage electron from oss entry scripts

### DIFF
--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -229,15 +229,9 @@ function getElectron(arch: string): () => NodeJS.ReadWriteStream {
 }
 
 async function main(arch: string = process.arch): Promise<void> {
-	const version = electronVersion;
 	const electronPath = path.join(root, '.build', 'electron');
-	const versionFile = path.join(electronPath, versionedResourcesFolder, 'version');
-	const isUpToDate = fs.existsSync(versionFile) && fs.readFileSync(versionFile, 'utf8') === `${version}`;
-
-	if (!isUpToDate) {
-		await util.rimraf(electronPath)();
-		await util.streamToPromise(getElectron(arch)());
-	}
+	await util.rimraf(electronPath)();
+	await util.streamToPromise(getElectron(arch)());
 }
 
 if (import.meta.main) {

--- a/extensions/vscode-test-resolver/src/extension.ts
+++ b/extensions/vscode-test-resolver/src/extension.ts
@@ -165,6 +165,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 				outputChannel.appendLine(`Launching server: "${serverCommandPath}" ${commandArgs.join(' ')}`);
 				const shell = (process.platform === 'win32');
+				// Skip prelaunch to avoid redownloading electron while it may be in use
+				env['VSCODE_SKIP_PRELAUNCH'] = '1';
 				extHostProcess = cp.spawn(serverCommandPath, commandArgs, { env, cwd: vscodePath, shell });
 			} else {
 				const extensionToInstall = process.env['TESTRESOLVER_INSTALL_BUILTIN_EXTENSION'];

--- a/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
+++ b/src/vs/workbench/contrib/policyExport/test/node/policyExport.integrationTest.ts
@@ -38,8 +38,10 @@ suite('PolicyExport Integration Tests', () => {
 				? join(rootPath, 'scripts', 'code.bat')
 				: join(rootPath, 'scripts', 'code.sh');
 
+			// Skip prelaunch to avoid redownloading electron while the parent VS Code is using it
 			await exec(`"${scriptPath}" --export-policy-data="${tempFile}"`, {
-				cwd: rootPath
+				cwd: rootPath,
+				env: { ...process.env, VSCODE_SKIP_PRELAUNCH: '1' }
 			});
 
 			// Read both files


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/291948

Users having cached version of `.build/electron` will fail to pick up the renamed executable. Also, the downloads for a version are already cached, it isn't required to cache the packaging.