### PR TITLE
Make the view models known to the text models to ensure all events are processed immediately

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -19,7 +19,7 @@ import { IWordAtPosition } from './core/wordHelper.js';
 import { FormattingOptions } from './languages.js';
 import { ILanguageSelection } from './languages/language.js';
 import { IBracketPairsTextModelPart } from './textModelBracketPairs.js';
-import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelLanguageChangedEvent, IModelLanguageConfigurationChangedEvent, IModelOptionsChangedEvent, IModelTokensChangedEvent, InternalModelContentChangeEvent, ModelFontChangedEvent, ModelInjectedTextChangedEvent, ModelLineHeightChangedEvent } from './textModelEvents.js';
+import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelLanguageChangedEvent, IModelLanguageConfigurationChangedEvent, IModelOptionsChangedEvent, IModelTokensChangedEvent, LineInjectedText, ModelFontChangedEvent, ModelLineHeightChangedEvent } from './textModelEvents.js';
 import { IModelContentChange } from './model/mirrorTextModel.js';
 import { IGuidesTextModelPart } from './textModelGuides.js';
 import { ITokenizationTextModelPart } from './tokenizationTextModelPart.js';
@@ -28,6 +28,7 @@ import { TokenArray } from './tokens/lineTokens.js';
 import { IEditorModel } from './editorCommon.js';
 import { TextModelEditSource } from './textModelEditSource.js';
 import { TextEdit } from './core/edits/textEdit.js';
+import { IViewModel } from './viewModel.js';
 
 /**
  * Vertical Lane in the overview ruler of the editor.
@@ -716,6 +717,18 @@ export interface ITextModel {
 	readonly isForSimpleWidget: boolean;
 
 	/**
+	 * Method to register a view model on a model
+	 * @internal
+	 */
+	registerViewModel(viewModel: IViewModel): void;
+
+	/**
+	 * Method which unregister a view model on a model
+	 * @internal
+	 */
+	unregisterViewModel(viewModel: IViewModel): void;
+
+	/**
 	 * If true, the text model might contain RTL.
 	 * If false, the text model **contains only** contain LTR.
 	 * @internal
@@ -842,6 +855,12 @@ export interface ITextModel {
 	 * Get the text for a certain line.
 	 */
 	getLineContent(lineNumber: number): string;
+
+	/**
+	 * Get the line injected text for a certain line.
+	 * @internal
+	 */
+	getLineInjectedText(lineNumber: number, ownerId?: number): LineInjectedText[];
 
 	/**
 	 * Get the text length for a certain line.
@@ -1285,13 +1304,6 @@ export interface ITextModel {
 	 */
 	canRedo(): boolean;
 
-	/**
-	 * @deprecated Please use `onDidChangeContent` instead.
-	 * An event emitted when the contents of the model have changed.
-	 * @internal
-	 * @event
-	 */
-	readonly onDidChangeContentOrInjectedText: Event<InternalModelContentChangeEvent | ModelInjectedTextChangedEvent>;
 	/**
 	 * An event emitted when the contents of the model have changed.
 	 * @event

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -19,7 +19,7 @@ import { IWordAtPosition } from './core/wordHelper.js';
 import { FormattingOptions } from './languages.js';
 import { ILanguageSelection } from './languages/language.js';
 import { IBracketPairsTextModelPart } from './textModelBracketPairs.js';
-import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelLanguageChangedEvent, IModelLanguageConfigurationChangedEvent, IModelOptionsChangedEvent, IModelTokensChangedEvent, LineInjectedText, ModelFontChangedEvent, ModelLineHeightChangedEvent } from './textModelEvents.js';
+import { IModelContentChangedEvent, IModelDecorationsChangedEvent, IModelLanguageChangedEvent, IModelLanguageConfigurationChangedEvent, IModelOptionsChangedEvent, IModelTokensChangedEvent, ModelFontChangedEvent, ModelLineHeightChangedEvent } from './textModelEvents.js';
 import { IModelContentChange } from './model/mirrorTextModel.js';
 import { IGuidesTextModelPart } from './textModelGuides.js';
 import { ITokenizationTextModelPart } from './tokenizationTextModelPart.js';
@@ -855,12 +855,6 @@ export interface ITextModel {
 	 * Get the text for a certain line.
 	 */
 	getLineContent(lineNumber: number): string;
-
-	/**
-	 * Get the line injected text for a certain line.
-	 * @internal
-	 */
-	getLineInjectedText(lineNumber: number, ownerId?: number): LineInjectedText[];
 
 	/**
 	 * Get the text length for a certain line.

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -16,6 +16,7 @@ import { INewScrollPosition, ScrollType } from './editorCommon.js';
 import { EditorTheme } from './editorTheme.js';
 import { EndOfLinePreference, IGlyphMarginLanesModel, IModelDecorationOptions, ITextModel, TextDirection } from './model.js';
 import { ILineBreaksComputer, InjectedText } from './modelLineProjectionData.js';
+import { InternalModelContentChangeEvent, ModelInjectedTextChangedEvent } from './textModelEvents.js';
 import { BracketGuideOptions, IActiveIndentGuideInfo, IndentGuide } from './textModelGuides.js';
 import { IViewLineTokens } from './tokens/lineTokens.js';
 import { ViewEventHandler } from './viewEventHandler.js';
@@ -84,6 +85,9 @@ export interface IViewModel extends ICursorSimpleModel, ISimpleModel {
 	deduceModelPositionRelativeToViewPosition(viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position;
 	getPlainTextToCopy(modelRanges: Range[], emptySelectionClipboard: boolean, forceCRLF: boolean): { sourceRanges: Range[]; sourceText: string | string[] };
 	getRichTextToCopy(modelRanges: Range[], emptySelectionClipboard: boolean): { html: string; mode: string } | null;
+
+	onDidChangeContentOrInjectedText(e: InternalModelContentChangeEvent | ModelInjectedTextChangedEvent): void;
+	emitContentChangeEvent(e: InternalModelContentChangeEvent | ModelInjectedTextChangedEvent): void;
 
 	createLineBreaksComputer(): ILineBreaksComputer;
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -166,6 +166,7 @@ export class ViewModel extends Disposable implements IViewModel {
 		}));
 
 		this._updateConfigurationViewLineCountNow();
+		this.model.registerViewModel(this);
 	}
 
 	public override dispose(): void {
@@ -176,6 +177,7 @@ export class ViewModel extends Disposable implements IViewModel {
 		this._lines.dispose();
 		this._viewportStart.dispose();
 		this._eventDispatcher.dispose();
+		this.model.unregisterViewModel(this);
 	}
 
 	public getEditorOption<T extends EditorOption>(id: T): FindComputedEditorOptionValueById<T> {
@@ -311,23 +313,22 @@ export class ViewModel extends Disposable implements IViewModel {
 		}
 	}
 
-	private _registerModelEvents(): void {
+	onDidChangeContentOrInjectedText(e: textModelEvents.InternalModelContentChangeEvent | textModelEvents.ModelInjectedTextChangedEvent): void {
 
-		this._register(this.model.onDidChangeContentOrInjectedText((e) => {
-			try {
-				const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
+		try {
+			const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
 
-				let hadOtherModelChange = false;
-				let hadModelLineChangeThatChangedLineMapping = false;
+			let hadOtherModelChange = false;
+			let hadModelLineChangeThatChangedLineMapping = false;
 
-				const changes = (e instanceof textModelEvents.InternalModelContentChangeEvent ? e.rawContentChangedEvent.changes : e.changes);
-				const versionId = (e instanceof textModelEvents.InternalModelContentChangeEvent ? e.rawContentChangedEvent.versionId : null);
+			const changes = (e instanceof textModelEvents.InternalModelContentChangeEvent ? e.rawContentChangedEvent.changes : e.changes);
+			const versionId = (e instanceof textModelEvents.InternalModelContentChangeEvent ? e.rawContentChangedEvent.versionId : null);
 
-				// Do a first pass to compute line mappings, and a second pass to actually interpret them
-				const lineBreaksComputer = this._lines.createLineBreaksComputer();
-				for (const change of changes) {
-					switch (change.changeType) {
-						case textModelEvents.RawContentChangedType.LinesInserted: {
+			// Do a first pass to compute line mappings, and a second pass to actually interpret them
+			const lineBreaksComputer = this._lines.createLineBreaksComputer();
+			for (const change of changes) {
+				switch (change.changeType) {
+					case textModelEvents.RawContentChangedType.LinesInserted: {
 							for (let lineIdx = 0; lineIdx < change.detail.length; lineIdx++) {
 								const line = change.detail[lineIdx];
 								let injectedText = change.injectedTexts[lineIdx];
@@ -335,119 +336,120 @@ export class ViewModel extends Disposable implements IViewModel {
 									injectedText = injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
 								}
 								lineBreaksComputer.addRequest(line, injectedText, null);
-							}
-							break;
 						}
-						case textModelEvents.RawContentChangedType.LineChanged: {
+						break;
+					}
+					case textModelEvents.RawContentChangedType.LineChanged: {
 							let injectedText: textModelEvents.LineInjectedText[] | null = null;
 							if (change.injectedText) {
 								injectedText = change.injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
 							}
 							lineBreaksComputer.addRequest(change.detail, injectedText, null);
-							break;
-						}
+						break;
 					}
 				}
-				const lineBreaks = lineBreaksComputer.finalize();
-				const lineBreakQueue = new ArrayQueue(lineBreaks);
+			}
+			const lineBreaks = lineBreaksComputer.finalize();
+			const lineBreakQueue = new ArrayQueue(lineBreaks);
 
-				for (const change of changes) {
-					switch (change.changeType) {
-						case textModelEvents.RawContentChangedType.Flush: {
-							this._lines.onModelFlushed();
-							eventsCollector.emitViewEvent(new viewEvents.ViewFlushedEvent());
-							this._decorations.reset();
-							this.viewLayout.onFlushed(this.getLineCount(), this._getCustomLineHeights());
-							hadOtherModelChange = true;
-							break;
+			for (const change of changes) {
+				switch (change.changeType) {
+					case textModelEvents.RawContentChangedType.Flush: {
+						this._lines.onModelFlushed();
+						eventsCollector.emitViewEvent(new viewEvents.ViewFlushedEvent());
+						this._decorations.reset();
+						this.viewLayout.onFlushed(this.getLineCount(), this._getCustomLineHeights());
+						hadOtherModelChange = true;
+						break;
+					}
+					case textModelEvents.RawContentChangedType.LinesDeleted: {
+						const linesDeletedEvent = this._lines.onModelLinesDeleted(versionId, change.fromLineNumber, change.toLineNumber);
+						if (linesDeletedEvent !== null) {
+							eventsCollector.emitViewEvent(linesDeletedEvent);
+							this.viewLayout.onLinesDeleted(linesDeletedEvent.fromLineNumber, linesDeletedEvent.toLineNumber);
 						}
-						case textModelEvents.RawContentChangedType.LinesDeleted: {
-							const linesDeletedEvent = this._lines.onModelLinesDeleted(versionId, change.fromLineNumber, change.toLineNumber);
-							if (linesDeletedEvent !== null) {
-								eventsCollector.emitViewEvent(linesDeletedEvent);
-								this.viewLayout.onLinesDeleted(linesDeletedEvent.fromLineNumber, linesDeletedEvent.toLineNumber);
-							}
-							hadOtherModelChange = true;
-							break;
-						}
-						case textModelEvents.RawContentChangedType.LinesInserted: {
+						hadOtherModelChange = true;
+						break;
+					}
+					case textModelEvents.RawContentChangedType.LinesInserted: {
 							const insertedLineBreaks = lineBreakQueue.takeCount(change.detail.length);
-							const linesInsertedEvent = this._lines.onModelLinesInserted(versionId, change.fromLineNumber, change.toLineNumber, insertedLineBreaks);
-							if (linesInsertedEvent !== null) {
-								eventsCollector.emitViewEvent(linesInsertedEvent);
-								this.viewLayout.onLinesInserted(linesInsertedEvent.fromLineNumber, linesInsertedEvent.toLineNumber);
-							}
-							hadOtherModelChange = true;
-							break;
+						const linesInsertedEvent = this._lines.onModelLinesInserted(versionId, change.fromLineNumber, change.toLineNumber, insertedLineBreaks);
+						if (linesInsertedEvent !== null) {
+							eventsCollector.emitViewEvent(linesInsertedEvent);
+							this.viewLayout.onLinesInserted(linesInsertedEvent.fromLineNumber, linesInsertedEvent.toLineNumber);
 						}
-						case textModelEvents.RawContentChangedType.LineChanged: {
-							const changedLineBreakData = lineBreakQueue.dequeue()!;
-							const [lineMappingChanged, linesChangedEvent, linesInsertedEvent, linesDeletedEvent] =
-								this._lines.onModelLineChanged(versionId, change.lineNumber, changedLineBreakData);
-							hadModelLineChangeThatChangedLineMapping = lineMappingChanged;
-							if (linesChangedEvent) {
-								eventsCollector.emitViewEvent(linesChangedEvent);
-							}
-							if (linesInsertedEvent) {
-								eventsCollector.emitViewEvent(linesInsertedEvent);
-								this.viewLayout.onLinesInserted(linesInsertedEvent.fromLineNumber, linesInsertedEvent.toLineNumber);
-							}
-							if (linesDeletedEvent) {
-								eventsCollector.emitViewEvent(linesDeletedEvent);
-								this.viewLayout.onLinesDeleted(linesDeletedEvent.fromLineNumber, linesDeletedEvent.toLineNumber);
-							}
-							break;
+						hadOtherModelChange = true;
+						break;
+					}
+					case textModelEvents.RawContentChangedType.LineChanged: {
+						const changedLineBreakData = lineBreakQueue.dequeue()!;
+						const [lineMappingChanged, linesChangedEvent, linesInsertedEvent, linesDeletedEvent] =
+							this._lines.onModelLineChanged(versionId, change.lineNumber, changedLineBreakData);
+						hadModelLineChangeThatChangedLineMapping = lineMappingChanged;
+						if (linesChangedEvent) {
+							eventsCollector.emitViewEvent(linesChangedEvent);
 						}
-						case textModelEvents.RawContentChangedType.EOLChanged: {
-							// Nothing to do. The new version will be accepted below
-							break;
+						if (linesInsertedEvent) {
+							eventsCollector.emitViewEvent(linesInsertedEvent);
+							this.viewLayout.onLinesInserted(linesInsertedEvent.fromLineNumber, linesInsertedEvent.toLineNumber);
 						}
+						if (linesDeletedEvent) {
+							eventsCollector.emitViewEvent(linesDeletedEvent);
+							this.viewLayout.onLinesDeleted(linesDeletedEvent.fromLineNumber, linesDeletedEvent.toLineNumber);
+						}
+						break;
+					}
+					case textModelEvents.RawContentChangedType.EOLChanged: {
+						// Nothing to do. The new version will be accepted below
+						break;
 					}
 				}
-
-				if (versionId !== null) {
-					this._lines.acceptVersionId(versionId);
-				}
-				this.viewLayout.onHeightMaybeChanged();
-
-				if (!hadOtherModelChange && hadModelLineChangeThatChangedLineMapping) {
-					eventsCollector.emitViewEvent(new viewEvents.ViewLineMappingChangedEvent());
-					eventsCollector.emitViewEvent(new viewEvents.ViewDecorationsChangedEvent(null));
-					this._cursor.onLineMappingChanged(eventsCollector);
-					this._decorations.onLineMappingChanged();
-				}
-			} finally {
-				this._eventDispatcher.endEmitViewEvents();
 			}
 
-			// Update the configuration and reset the centered view line
-			const viewportStartWasValid = this._viewportStart.isValid;
-			this._viewportStart.invalidate();
-			this._configuration.setModelLineCount(this.model.getLineCount());
-			this._updateConfigurationViewLineCountNow();
-
-			// Recover viewport
-			if (!this._hasFocus && this.model.getAttachedEditorCount() >= 2 && viewportStartWasValid) {
-				const modelRange = this.model._getTrackedRange(this._viewportStart.modelTrackedRange);
-				if (modelRange) {
-					const viewPosition = this.coordinatesConverter.convertModelPositionToViewPosition(modelRange.getStartPosition());
-					const viewPositionTop = this.viewLayout.getVerticalOffsetForLineNumber(viewPosition.lineNumber);
-					this.viewLayout.setScrollPosition({ scrollTop: viewPositionTop + this._viewportStart.startLineDelta }, ScrollType.Immediate);
-				}
+			if (versionId !== null) {
+				this._lines.acceptVersionId(versionId);
 			}
+			this.viewLayout.onHeightMaybeChanged();
 
-			try {
-				const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
-				if (e instanceof textModelEvents.InternalModelContentChangeEvent) {
-					eventsCollector.emitOutgoingEvent(new ModelContentChangedEvent(e.contentChangedEvent));
-				}
-				this._cursor.onModelContentChanged(eventsCollector, e);
-			} finally {
-				this._eventDispatcher.endEmitViewEvents();
+			if (!hadOtherModelChange && hadModelLineChangeThatChangedLineMapping) {
+				eventsCollector.emitViewEvent(new viewEvents.ViewLineMappingChangedEvent());
+				eventsCollector.emitViewEvent(new viewEvents.ViewDecorationsChangedEvent(null));
+				this._cursor.onLineMappingChanged(eventsCollector);
+				this._decorations.onLineMappingChanged();
 			}
+		} finally {
+			this._eventDispatcher.endEmitViewEvents();
+		}
 
-			this._handleVisibleLinesChanged();
-		}));
+		// Update the configuration and reset the centered view line
+		const viewportStartWasValid = this._viewportStart.isValid;
+		this._viewportStart.invalidate();
+		this._configuration.setModelLineCount(this.model.getLineCount());
+		this._updateConfigurationViewLineCountNow();
+
+		// Recover viewport
+		if (!this._hasFocus && this.model.getAttachedEditorCount() >= 2 && viewportStartWasValid) {
+			const modelRange = this.model._getTrackedRange(this._viewportStart.modelTrackedRange);
+			if (modelRange) {
+				const viewPosition = this.coordinatesConverter.convertModelPositionToViewPosition(modelRange.getStartPosition());
+				const viewPositionTop = this.viewLayout.getVerticalOffsetForLineNumber(viewPosition.lineNumber);
+				this.viewLayout.setScrollPosition({ scrollTop: viewPositionTop + this._viewportStart.startLineDelta }, ScrollType.Immediate);
+			}
+		}
+
+		this._handleVisibleLinesChanged();
+	}
+
+	emitContentChangeEvent(e: textModelEvents.InternalModelContentChangeEvent | textModelEvents.ModelInjectedTextChangedEvent): void {
+		this._emitViewEvent((eventsCollector) => {
+			if (e instanceof textModelEvents.InternalModelContentChangeEvent) {
+				eventsCollector.emitOutgoingEvent(new ModelContentChangedEvent(e.contentChangedEvent));
+			}
+			this._cursor.onModelContentChanged(eventsCollector, e);
+		});
+	}
+
+	private _registerModelEvents(): void {
 
 		const allowVariableLineHeights = this._configuration.options.get(EditorOption.allowVariableLineHeights);
 		if (allowVariableLineHeights) {
@@ -1246,13 +1248,17 @@ export class ViewModel extends Disposable implements IViewModel {
 
 	private _withViewEventsCollector<T>(callback: (eventsCollector: ViewModelEventsCollector) => T): T {
 		return this._transactionalTarget.batchChanges(() => {
-			try {
-				const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
-				return callback(eventsCollector);
-			} finally {
-				this._eventDispatcher.endEmitViewEvents();
-			}
+			return this._emitViewEvent(callback);
 		});
+	}
+
+	private _emitViewEvent<T>(callback: (eventsCollector: ViewModelEventsCollector) => T): T {
+		try {
+			const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
+			return callback(eventsCollector);
+		} finally {
+			this._eventDispatcher.endEmitViewEvents();
+		}
 	}
 
 	public batchEvents(callback: () => void): void {

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -313,6 +313,9 @@ export class ViewModel extends Disposable implements IViewModel {
 		}
 	}
 
+	/**
+	 * Gets called directly by the text model.
+	 */
 	onDidChangeContentOrInjectedText(e: textModelEvents.InternalModelContentChangeEvent | textModelEvents.ModelInjectedTextChangedEvent): void {
 
 		try {
@@ -440,6 +443,9 @@ export class ViewModel extends Disposable implements IViewModel {
 		this._handleVisibleLinesChanged();
 	}
 
+	/**
+	 * Gets called directly by the text model.
+	 */
 	emitContentChangeEvent(e: textModelEvents.InternalModelContentChangeEvent | textModelEvents.ModelInjectedTextChangedEvent): void {
 		this._emitViewEvent((eventsCollector) => {
 			if (e instanceof textModelEvents.InternalModelContentChangeEvent) {

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -332,22 +332,22 @@ export class ViewModel extends Disposable implements IViewModel {
 			for (const change of changes) {
 				switch (change.changeType) {
 					case textModelEvents.RawContentChangedType.LinesInserted: {
-							for (let lineIdx = 0; lineIdx < change.detail.length; lineIdx++) {
-								const line = change.detail[lineIdx];
-								let injectedText = change.injectedTexts[lineIdx];
-								if (injectedText) {
-									injectedText = injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
-								}
-								lineBreaksComputer.addRequest(line, injectedText, null);
+						for (let lineIdx = 0; lineIdx < change.detail.length; lineIdx++) {
+							const line = change.detail[lineIdx];
+							let injectedText = change.injectedTexts[lineIdx];
+							if (injectedText) {
+								injectedText = injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
+							}
+							lineBreaksComputer.addRequest(line, injectedText, null);
 						}
 						break;
 					}
 					case textModelEvents.RawContentChangedType.LineChanged: {
-							let injectedText: textModelEvents.LineInjectedText[] | null = null;
-							if (change.injectedText) {
-								injectedText = change.injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
-							}
-							lineBreaksComputer.addRequest(change.detail, injectedText, null);
+						let injectedText: textModelEvents.LineInjectedText[] | null = null;
+						if (change.injectedText) {
+							injectedText = change.injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
+						}
+						lineBreaksComputer.addRequest(change.detail, injectedText, null);
 						break;
 					}
 				}
@@ -375,7 +375,7 @@ export class ViewModel extends Disposable implements IViewModel {
 						break;
 					}
 					case textModelEvents.RawContentChangedType.LinesInserted: {
-							const insertedLineBreaks = lineBreakQueue.takeCount(change.detail.length);
+						const insertedLineBreaks = lineBreakQueue.takeCount(change.detail.length);
 						const linesInsertedEvent = this._lines.onModelLinesInserted(versionId, change.fromLineNumber, change.toLineNumber, insertedLineBreaks);
 						if (linesInsertedEvent !== null) {
 							eventsCollector.emitViewEvent(linesInsertedEvent);

--- a/src/vs/editor/test/browser/viewModel/viewModelImpl.test.ts
+++ b/src/vs/editor/test/browser/viewModel/viewModelImpl.test.ts
@@ -101,7 +101,7 @@ suite('ViewModel', () => {
 		const ed1 = disposables.add(instantiateTestCodeEditor(instantiationService, model));
 		disposables.add(instantiateTestCodeEditor(instantiationService, model));
 
-		// Add a nasy listener which modifies the model during the model change event
+		// Add a nasty listener which modifies the model during the model change event
 		let isFirst = true;
 		disposables.add(ed1.onDidChangeModelContent((e) => {
 			if (isFirst) {

--- a/src/vs/editor/test/common/model/model.test.ts
+++ b/src/vs/editor/test/common/model/model.test.ts
@@ -121,7 +121,7 @@ suite('Editor Model - Model', () => {
 		const e = withEventCapturing(() => {
 			thisModel.applyEdits([EditOperation.insert(new Position(1, 1), '')]);
 		});
-		assert.deepStrictEqual(e, null, 'wast no expecting event');
+		assert.deepStrictEqual(e, null, 'was not expecting event');
 	});
 
 	test('model insert text without newline eventing', () => {

--- a/src/vs/editor/test/common/model/model.test.ts
+++ b/src/vs/editor/test/common/model/model.test.ts
@@ -15,8 +15,10 @@ import { ILanguageService } from '../../../common/languages/language.js';
 import { ILanguageConfigurationService } from '../../../common/languages/languageConfigurationRegistry.js';
 import { NullState } from '../../../common/languages/nullTokenize.js';
 import { TextModel } from '../../../common/model/textModel.js';
-import { InternalModelContentChangeEvent, ModelRawContentChangedEvent, ModelRawFlush, ModelRawLineChanged, ModelRawLinesDeleted, ModelRawLinesInserted } from '../../../common/textModelEvents.js';
+import { InternalModelContentChangeEvent, ModelInjectedTextChangedEvent, ModelRawContentChangedEvent, ModelRawFlush, ModelRawLineChanged, ModelRawLinesDeleted, ModelRawLinesInserted } from '../../../common/textModelEvents.js';
 import { createModelServices, createTextModel, instantiateTextModel } from '../testTextModel.js';
+import { mock } from '../../../../base/test/common/mock.js';
+import { IViewModel } from '../../../common/viewModel.js';
 
 // --------- utils
 
@@ -98,23 +100,34 @@ suite('Editor Model - Model', () => {
 
 	// --------- insert text eventing
 
+	function withEventCapturing(callback: () => void): ModelRawContentChangedEvent | null {
+		let e: ModelRawContentChangedEvent | null = null;
+		const spyViewModel = new class extends mock<IViewModel>() {
+			override onDidChangeContentOrInjectedText(_e: InternalModelContentChangeEvent | ModelInjectedTextChangedEvent) {
+				if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
+					assert.fail('Unexpected assertion error');
+				}
+				e = _e.rawContentChangedEvent;
+			}
+			override emitContentChangeEvent(e: InternalModelContentChangeEvent | ModelInjectedTextChangedEvent): void { }
+		};
+		thisModel.registerViewModel(spyViewModel);
+		callback();
+		thisModel.unregisterViewModel(spyViewModel);
+		return e;
+	}
+
 	test('model insert empty text does not trigger eventing', () => {
-		const disposable = thisModel.onDidChangeContentOrInjectedText((e) => {
-			assert.ok(false, 'was not expecting event');
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.insert(new Position(1, 1), '')]);
 		});
-		thisModel.applyEdits([EditOperation.insert(new Position(1, 1), '')]);
-		disposable.dispose();
+		assert.deepStrictEqual(e, null, 'wast no expecting event');
 	});
 
 	test('model insert text without newline eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.insert(new Position(1, 1), 'foo ')]);
 		});
-		thisModel.applyEdits([EditOperation.insert(new Position(1, 1), 'foo ')]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, 'foo My First Line', null)
@@ -123,18 +136,12 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	test('model insert text with one newline eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.insert(new Position(1, 3), ' new line\nNo longer')]);
 		});
-		thisModel.applyEdits([EditOperation.insert(new Position(1, 3), ' new line\nNo longer')]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, 'My new line', null),
@@ -144,7 +151,6 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 
@@ -198,22 +204,16 @@ suite('Editor Model - Model', () => {
 	// --------- delete text eventing
 
 	test('model delete empty text does not trigger eventing', () => {
-		const disposable = thisModel.onDidChangeContentOrInjectedText((e) => {
-			assert.ok(false, 'was not expecting event');
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 1))]);
 		});
-		thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 1))]);
-		disposable.dispose();
+		assert.deepStrictEqual(e, null, 'was not expecting event');
 	});
 
 	test('model delete text from one line eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 2))]);
 		});
-		thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 2))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, 'y First Line', null),
@@ -222,18 +222,12 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	test('model delete all text from a line eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 14))]);
 		});
-		thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 14))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, '', null),
@@ -242,18 +236,12 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	test('model delete text from two lines eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 2, 6))]);
 		});
-		thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 2, 6))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, 'My Second Line', null),
@@ -263,18 +251,12 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	test('model delete text from many lines eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 3, 5))]);
 		});
-		thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 3, 5))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawLineChanged(1, 'My Third Line', null),
@@ -284,7 +266,6 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	// --------- getValueInRange
@@ -319,14 +300,9 @@ suite('Editor Model - Model', () => {
 
 	// --------- setValue
 	test('setValue eventing', () => {
-		let e: ModelRawContentChangedEvent | null = null;
-		const disposable = thisModel.onDidChangeContentOrInjectedText((_e) => {
-			if (e !== null || !(_e instanceof InternalModelContentChangeEvent)) {
-				assert.fail('Unexpected assertion error');
-			}
-			e = _e.rawContentChangedEvent;
+		const e = withEventCapturing(() => {
+			thisModel.setValue('new value');
 		});
-		thisModel.setValue('new value');
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
 				new ModelRawFlush()
@@ -335,7 +311,6 @@ suite('Editor Model - Model', () => {
 			false,
 			false
 		));
-		disposable.dispose();
 	});
 
 	test('issue #46342: Maintain edit operation order in applyEdits', () => {


### PR DESCRIPTION
Before, it would have been possible to have the following event delivery:

```
TextModel -> 1. ViewModel1 -> 2. (other code editor listeners)
          -> 3. ViewModel2 -> 4. (other code editor listeners)
```

After, the event delivery is enforced:
```
TextModel -> 1. ViewModel1 -> 3. (other code editor listeners)
          -> 2. ViewModel2 -> 4. (other code editor listeners)
```
