### PR TITLE
fix: flaky chat accessibility smoke tests

### DIFF
--- a/test/smoke/src/areas/accessibility/accessibility.test.ts
+++ b/test/smoke/src/areas/accessibility/accessibility.test.ts
@@ -107,7 +107,7 @@ export function setup(logger: Logger, opts: { web?: boolean }, quality: Quality)
 					await app.workbench.chat.waitForChatView();
 
 					// Send a simple message
-					await app.workbench.chat.sendMessage('Create a simple hello.txt file with the text "Hello World"');
+					await app.workbench.chat.sendMessage('Create a file called hello.txt in the current workspace with the text "Hello World"');
 
 					// Wait for the response to complete (1500 retries ~= 150 seconds at 100ms per retry)
 					await app.workbench.chat.waitForResponse(1500);
@@ -135,6 +135,8 @@ export function setup(logger: Logger, opts: { web?: boolean }, quality: Quality)
 					// Extend timeout for this test since AI responses can take a while
 					this.timeout(3 * 60 * 1000);
 
+					// Enable anonymous chat access
+					await app.workbench.settingsEditor.addUserSetting('chat.allowAnonymousAccess', 'true');
 					// Enable auto-approve for tools so terminal commands run automatically
 					await app.workbench.settingsEditor.addUserSetting('chat.tools.global.autoApprove', 'true');
 


### PR DESCRIPTION
The following two tests are failing on windows https://monacotools.visualstudio.com/Monaco/_build?definitionId=111&branchFilter=4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874%2C4874

```
1) VSCode Smoke Tests (Electron)
       Accessibility
         Chat
           chat response has no accessibility violations:
     Error: Timeout: get element 'div[id="workbench.panel.chat"] .interactive-item-container.interactive-response:not(.chat-response-loading)' after 150 seconds.
      at Code.poll (D:\a\_work\1\s\test\automation\out\code.js:286:23)
      at async Code.waitForElement (D:\a\_work\1\s\test\automation\out\code.js:242:16)
      at async Chat.waitForResponse (D:\a\_work\1\s\test\automation\out\chat.js:44:9)
      at async Context.<anonymous> (out\areas\accessibility\accessibility.test.js:89:21)

  2) VSCode Smoke Tests (Electron)
       Accessibility
         Chat
           chat terminal tool response has no accessibility violations:
     Error: Timeout: get element 'div[id="workbench.panel.chat"] .interactive-item-container.interactive-response:not(.chat-response-loading)' after 150 seconds.
      at Code.poll (D:\a\_work\1\s\test\automation\out\code.js:286:23)
      at runNextTicks (node:internal/process/task_queues:65:5)
      at process.processTimers (node:internal/timers:520:9)
      at async Code.waitForElement (D:\a\_work\1\s\test\automation\out\code.js:242:16)
      at async Chat.waitForResponse (D:\a\_work\1\s\test\automation\out\chat.js:44:9)
      at async Context.<anonymous> (out\areas\accessibility\accessibility.test.js:120:21)
```

Screenshots show they are blocked on tool confirmation, PR has a naive fix. Feel free to amend it.


<img width="1024" height="768" alt="playwright-screenshot-1-chat_response_has_no_accessibility_violations" src="https://github.com/user-attachments/assets/ad912da0-3ac1-42b3-9d4f-11292dea0f94" />

