### PR TITLE
improve specificity for chat selector to fix smoketest

### DIFF
--- a/test/automation/src/chat.ts
+++ b/test/automation/src/chat.ts
@@ -6,8 +6,8 @@
 import { Code } from './code';
 
 const CHAT_VIEW = 'div[id="workbench.panel.chat"]';
-const CHAT_EDITOR = `${CHAT_VIEW} .monaco-editor[role="code"]`;
-const CHAT_EDITOR_FOCUSED = `${CHAT_VIEW} .monaco-editor.focused[role="code"]`;
+const CHAT_INPUT_EDITOR = `${CHAT_VIEW} .interactive-input-part .monaco-editor[role="code"]`;
+const CHAT_INPUT_EDITOR_FOCUSED = `${CHAT_VIEW} .interactive-input-part .monaco-editor.focused[role="code"]`;
 const CHAT_RESPONSE = `${CHAT_VIEW} .interactive-item-container.interactive-response`;
 const CHAT_RESPONSE_COMPLETE = `${CHAT_RESPONSE}:not(.chat-response-loading)`;
 const CHAT_FOOTER_DETAILS = `${CHAT_VIEW} .chat-footer-details`;
@@ -17,7 +17,7 @@ export class Chat {
 	constructor(private code: Code) { }
 
 	private get chatInputSelector(): string {
-		return `${CHAT_EDITOR} ${!this.code.editContextEnabled ? 'textarea' : '.native-edit-context'}`;
+		return `${CHAT_INPUT_EDITOR} ${!this.code.editContextEnabled ? 'textarea' : '.native-edit-context'}`;
 	}
 
 	async waitForChatView(): Promise<void> {
@@ -25,12 +25,12 @@ export class Chat {
 	}
 
 	async waitForInputFocus(): Promise<void> {
-		await this.code.waitForElement(CHAT_EDITOR_FOCUSED);
+		await this.code.waitForElement(CHAT_INPUT_EDITOR_FOCUSED);
 	}
 
 	async sendMessage(message: string): Promise<void> {
 		// Click on the chat input to focus it
-		await this.code.waitAndClick(CHAT_EDITOR);
+		await this.code.waitAndClick(CHAT_INPUT_EDITOR);
 
 		// Wait for the editor to be focused
 		await this.waitForInputFocus();


### PR DESCRIPTION
The smoketest was failing because Playwright found 2 Monaco editors with `role="code"` in the chat panel:

- The chat input editor
- A code block in the terminal tool response

The fix narrows the selector, ensuring only the chat input editor is targeted.