### PR TITLE
Remove region diagnostics setting

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -452,12 +452,6 @@
             "markdownDescription": "%typescript.workspaceSymbols.excludeLibrarySymbols%",
             "scope": "window"
           },
-          "typescript.tsserver.enableRegionDiagnostics": {
-            "type": "boolean",
-            "default": true,
-            "description": "%typescript.tsserver.enableRegionDiagnostics%",
-            "scope": "window"
-          },
           "javascript.updateImportsOnPaste.enabled": {
             "scope": "window",
             "type": "boolean",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -22,7 +22,6 @@
 	"typescript.tsserver.pluginPaths": "Additional paths to discover TypeScript Language Service plugins.",
 	"typescript.tsserver.pluginPaths.item": "Either an absolute or relative path. Relative path will be resolved against workspace folder(s).",
 	"typescript.tsserver.trace": "Enables tracing of messages sent to the TS server. This trace can be used to diagnose TS Server issues. The trace may contain file paths, source code, and other potentially sensitive information from your project.",
-	"typescript.tsserver.enableRegionDiagnostics": "Enables region-based diagnostics in TypeScript. Requires using TypeScript 5.6+ in the workspace.",
 	"typescript.validate.enable": "Enable/disable TypeScript validation.",
 	"typescript.format.enable": "Enable/disable default TypeScript formatter.",
 	"javascript.format.enable": "Enable/disable default JavaScript formatter.",

--- a/extensions/typescript-language-features/src/configuration/configuration.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.ts
@@ -133,7 +133,6 @@ export interface TypeScriptServiceConfiguration {
 	readonly localNodePath: string | null;
 	readonly globalNodePath: string | null;
 	readonly workspaceSymbolsExcludeLibrarySymbols: boolean;
-	readonly enableRegionDiagnostics: boolean;
 }
 
 export function areServiceConfigurationsEqual(a: TypeScriptServiceConfiguration, b: TypeScriptServiceConfiguration): boolean {
@@ -176,7 +175,6 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 			localNodePath: this.readLocalNodePath(configuration),
 			globalNodePath: this.readGlobalNodePath(configuration),
 			workspaceSymbolsExcludeLibrarySymbols: this.readWorkspaceSymbolsExcludeLibrarySymbols(configuration),
-			enableRegionDiagnostics: this.readEnableRegionDiagnostics(configuration),
 		};
 	}
 
@@ -306,9 +304,5 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 
 	private readWebTypeAcquisition(configuration: vscode.WorkspaceConfiguration): boolean {
 		return configuration.get<boolean>('typescript.tsserver.web.typeAcquisition.enabled', true);
-	}
-
-	private readEnableRegionDiagnostics(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('typescript.tsserver.enableRegionDiagnostics', true);
 	}
 }

--- a/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
@@ -354,7 +354,7 @@ class GetErrRequest {
 	}
 
 	private areRegionDiagnosticsEnabled(): boolean {
-		return this.client.configuration.enableRegionDiagnostics && this.client.apiVersion.gte(API.v560);
+		return this.client.apiVersion.gte(API.v560);
 	}
 
 	public cancel(): void {


### PR DESCRIPTION
Part of #292934

This setting was added in 5.6 in case the new behavior caused issues. Should be safe to remove now since it's more of an implementation detail and has almost zero real usage 
