### PR TITLE
Fix opening chat editors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -38,7 +38,7 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
-import { AUX_WINDOW_GROUP } from '../../../../services/editor/common/editorService.js';
+import { ACTIVE_GROUP, AUX_WINDOW_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IHostService } from '../../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../../services/layout/browser/layoutService.js';
 import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
@@ -64,6 +64,7 @@ import { ChatViewId, IChatWidget, IChatWidgetService } from '../chat.js';
 import { IChatEditorOptions } from '../widgetHosts/editor/chatEditor.js';
 import { ChatEditorInput, showClearEditingSessionConfirmation } from '../widgetHosts/editor/chatEditorInput.js';
 import { convertBufferToScreenshotVariable } from '../attachments/chatScreenshotContext.js';
+import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 
 export const CHAT_CATEGORY = localize2('chat.category', 'Chat');
 
@@ -601,7 +602,7 @@ export function registerChatActions() {
 
 		async run(accessor: ServicesAccessor) {
 			const widgetService = accessor.get(IChatWidgetService);
-			await widgetService.openSession(ChatEditorInput.getNewEditorUri(), undefined, { pinned: true } satisfies IChatEditorOptions);
+			await widgetService.openSession(LocalChatSessionUri.getNewSessionUri(), ACTIVE_GROUP, { pinned: true } satisfies IChatEditorOptions);
 		}
 	});
 
@@ -627,7 +628,7 @@ export function registerChatActions() {
 
 		async run(accessor: ServicesAccessor) {
 			const widgetService = accessor.get(IChatWidgetService);
-			await widgetService.openSession(ChatEditorInput.getNewEditorUri(), AUX_WINDOW_GROUP, { pinned: true, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } } satisfies IChatEditorOptions);
+			await widgetService.openSession(LocalChatSessionUri.getNewSessionUri(), AUX_WINDOW_GROUP, { pinned: true, auxiliary: { compact: true, bounds: { width: 640, height: 640 } } } satisfies IChatEditorOptions);
 		}
 	});
 

--- a/src/vs/workbench/contrib/chat/common/model/chatUri.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatUri.ts
@@ -23,6 +23,11 @@ export namespace LocalChatSessionUri {
 		return URI.from({ scheme, authority: localChatSessionType, path: '/' + encodedId });
 	}
 
+	export function getNewSessionUri(): URI {
+		const handle = Math.floor(Math.random() * 1e9);
+		return forSession(`chat-${handle}`);
+	}
+
 	export function parseLocalSessionId(resource: URI): string | undefined {
 		const parsed = parse(resource);
 		return parsed?.chatSessionType === localChatSessionType ? parsed.sessionId : undefined;


### PR DESCRIPTION
Looks like multiple changes are using the chat editor input uri type to instead of the session uri. This fixes `new chat editor` but I think a few other callers are doing the same thing. Will follow up with separate PRs

Not 100% sure why this only recently started happening since the changes have been in multiple weeks but this fix is the correct modern way to do this