### PR TITLE
feat: move core chat settings to top-level ToC entry

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -593,6 +593,7 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			description: nls.localize('chat.agent.enabled.description', "When enabled, agent mode can be activated from chat and tools in agentic contexts with side effects can be used."),
 			default: true,
+			order: 1,
 			policy: {
 				name: 'ChatAgentMode',
 				category: PolicyCategory.InteractiveSession,
@@ -1182,6 +1183,7 @@ class ChatAgentSettingContribution extends Disposable implements IWorkbenchContr
 							type: 'number',
 							markdownDescription: nls.localize('chat.agent.maxRequests', "The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue."),
 							default: defaultValue,
+							order: 2,
 						},
 					}
 				};

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel.ts
@@ -115,6 +115,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('inlineChatDefaultModelDescription', "Select the default language model to use for inline chat from the available providers. Model names may include the provider in parentheses, for example 'Claude Haiku 4.5 (copilot)'."),
 			type: 'string',
 			default: '',
+			order: 1,
 			enum: InlineChatDefaultModel.modelIds,
 			enumItemLabels: InlineChatDefaultModel.modelLabels,
 			markdownEnumDescriptions: InlineChatDefaultModel.modelDescriptions

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -172,6 +172,112 @@ export const tocData: ITOCEntry<string> = {
 			]
 		},
 		{
+			id: 'chat',
+			label: localize('chat', "Chat"),
+			settings: ['chat.*'],
+			children: [
+				{
+					id: 'chat/agent',
+					label: localize('chatAgent', "Agent"),
+					settings: [
+						'chat.agent.*',
+						'chat.checkpoints.*',
+						'chat.editRequests',
+						'chat.requestQueuing.*',
+						'chat.undoRequests.*',
+						'chat.customAgentInSubagent.*',
+						'chat.editing.autoAcceptDelay',
+						'chat.editing.confirmEditRequest*'
+					]
+				},
+				{
+					id: 'chat/appearance',
+					label: localize('chatAppearance', "Appearance"),
+					settings: [
+						'chat.editor.*',
+						'chat.fontFamily',
+						'chat.fontSize',
+						'chat.math.*',
+						'chat.agentsControl.*',
+						'chat.alternativeToolAction.*',
+						'chat.codeBlock.*',
+						'chat.editing.explainChanges.enabled',
+						'chat.editMode.hidden',
+						'chat.editorAssociations',
+						'chat.extensionUnification.*',
+						'chat.inlineReferences.*',
+						'chat.notifyWindow*',
+						'chat.statusWidget.*',
+						'chat.tips.*',
+						'chat.unifiedAgentsBar.*',
+					]
+				},
+				{
+					id: 'chat/sessions',
+					label: localize('chatSessions', "Sessions"),
+					settings: [
+						'chat.agentSessionProjection.*',
+						'chat.sessions.*',
+						'chat.viewProgressBadge.*',
+						'chat.viewSessions.*',
+						'chat.restoreLastPanelSession',
+						'chat.exitAfterDelegation',
+						'chat.repoInfo.*'
+					]
+				},
+				{
+					id: 'chat/tools',
+					label: localize('chatTools', "Tools"),
+					settings: [
+						'chat.tools.*',
+						'chat.extensionTools.*',
+						'chat.edits2.enabled'
+					]
+				},
+				{
+					id: 'chat/mcp',
+					label: localize('chatMcp', "MCP"),
+					settings: ['mcp', 'chat.mcp.*', 'mcp.*']
+				},
+				{
+					id: 'chat/context',
+					label: localize('chatContext', "Context"),
+					settings: [
+						'chat.detectParticipant.*',
+						'chat.implicitContext.*',
+						'chat.promptFilesLocations',
+						'chat.instructionsFilesLocations',
+						'chat.modeFilesLocations',
+						'chat.agentFilesLocations',
+						'chat.agentSkillsLocations',
+						'chat.hookFilesLocations',
+						'chat.promptFilesRecommendations',
+						'chat.useAgentsMdFile',
+						'chat.useNestedAgentsMdFiles',
+						'chat.useAgentSkills',
+						'chat.experimental.useSkillAdherencePrompt',
+						'chat.useChatHooks',
+						'chat.includeApplyingInstructions',
+						'chat.includeReferencedInstructions',
+						'chat.sendElementsToChat.*'
+					]
+				},
+				{
+					id: 'chat/inlineChat',
+					label: localize('chatInlineChat', "Inline Chat"),
+					settings: ['inlineChat.*']
+				},
+				{
+					id: 'chat/miscellaneous',
+					label: localize('chatMiscellaneous', "Miscellaneous"),
+					settings: [
+						'chat.disableAIFeatures',
+						'chat.allowAnonymousAccess'
+					]
+				},
+			]
+		},
+		{
 			id: 'features',
 			label: localize('features', "Features"),
 			children: [
@@ -259,11 +365,6 @@ export const tocData: ITOCEntry<string> = {
 					id: 'features/mergeEditor',
 					label: localize('mergeEditor', 'Merge Editor'),
 					settings: ['mergeEditor.*']
-				},
-				{
-					id: 'features/chat',
-					label: localize('chat', 'Chat'),
-					settings: ['chat.*', 'inlineChat.*', 'mcp']
 				},
 				{
 					id: 'features/issueReporter',

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -209,7 +209,7 @@ export const tocData: ITOCEntry<string> = {
 						'chat.notifyWindow*',
 						'chat.statusWidget.*',
 						'chat.tips.*',
-						'chat.unifiedAgentsBar.*',
+						'chat.unifiedAgentsBar.*'
 					]
 				},
 				{

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -512,14 +512,6 @@ export async function createTocTreeForExtensionSettings(extensionService: IExten
 	return Promise.all(processPromises).then(() => {
 		const extGroups: ITOCEntry<ISetting>[] = [];
 		for (const extensionRootEntry of extGroupTree.values()) {
-			for (const child of extensionRootEntry.children!) {
-				// Sort the individual settings of the child by order.
-				// Leave the undefined order settings untouched.
-				child.settings?.sort((a, b) => {
-					return compareTwoNullableNumbers(a.order, b.order);
-				});
-			}
-
 			if (extensionRootEntry.children!.length === 1) {
 				// There is a single category for this extension.
 				// Push a flattened setting.
@@ -645,7 +637,11 @@ function getMatchingSettings(allSettings: Set<ISetting>, filter: ITOCFilter): IS
 		}
 	});
 
-	return result.sort((a, b) => a.key.localeCompare(b.key));
+	// Sort settings by order, then alphabetically
+	return result.sort((a, b) => {
+		const orderComparison = compareTwoNullableNumbers(a.order, b.order);
+		return orderComparison !== 0 ? orderComparison : a.key.localeCompare(b.key);
+	});
 }
 
 const settingPatternCache = new Map<string, RegExp>();

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -650,17 +650,15 @@ function getMatchingSettings(allSettings: Set<ISetting>, filter: ITOCFilter): IS
 		return SETTING_STATUS_NORMAL;
 	};
 
-	// Sort settings by order, then alphabetically, deprioritizing experimental and preview settings
+	// Sort settings so that preview and experimental settings are deprioritized.
+	// Within each tier, sort the settings by order, then alphabetically.
 	return result.sort((a, b) => {
 		const experimentalStatusA = getExperimentalStatus(a);
 		const experimentalStatusB = getExperimentalStatus(b);
-
-		// If priorities differ, sort by priority (lower first)
 		if (experimentalStatusA !== experimentalStatusB) {
 			return experimentalStatusA - experimentalStatusB;
 		}
 
-		// Within same priority tier, sort by order then alphabetically
 		const orderComparison = compareTwoNullableNumbers(a.order, b.order);
 		return orderComparison !== 0 ? orderComparison : a.key.localeCompare(b.key);
 	});

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -637,8 +637,30 @@ function getMatchingSettings(allSettings: Set<ISetting>, filter: ITOCFilter): IS
 		}
 	});
 
-	// Sort settings by order, then alphabetically
+	const SETTING_STATUS_NORMAL = 0;
+	const SETTING_STATUS_PREVIEW = 1;
+	const SETTING_STATUS_EXPERIMENTAL = 2;
+
+	const getExperimentalStatus = (setting: ISetting) => {
+		if (setting.tags?.includes('experimental')) {
+			return SETTING_STATUS_EXPERIMENTAL;
+		} else if (setting.tags?.includes('preview')) {
+			return SETTING_STATUS_PREVIEW;
+		}
+		return SETTING_STATUS_NORMAL;
+	};
+
+	// Sort settings by order, then alphabetically, deprioritizing experimental and preview settings
 	return result.sort((a, b) => {
+		const experimentalStatusA = getExperimentalStatus(a);
+		const experimentalStatusB = getExperimentalStatus(b);
+
+		// If priorities differ, sort by priority (lower first)
+		if (experimentalStatusA !== experimentalStatusB) {
+			return experimentalStatusA - experimentalStatusB;
+		}
+
+		// Within same priority tier, sort by order then alphabetically
 		const orderComparison = compareTwoNullableNumbers(a.order, b.order);
 		return orderComparison !== 0 ? orderComparison : a.key.localeCompare(b.key);
 	});


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/271367

This PR moves core chat settings to their own top-level table of contents (ToC) entry in the Settings editor. It also adds to the settings sorting algorithm so that certain chat settings are sorted to the top, while preview and experimental settings are sorted to the bottom.

This PR does not alter the extensions ToC. As a result, GitHub Copilot extension settings will still render under the Extensions tab rather than right next to the core chat settings.

<img width="2560" height="1392" alt="Core chat settings under their own table of contents entry" src="https://github.com/user-attachments/assets/607107bf-2515-4418-9ade-22596b560d21" />
