### PR TITLE
Quick access: ignore leading "<" shortcut for Sessions filter and "Send to agent"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
@@ -398,10 +398,6 @@ export class UnifiedQuickAccess extends Disposable {
 			return value.substring(1);
 		}
 
-		if (this._arrivedViaShortcut && value.startsWith(this._arrivedViaShortcut)) {
-			return value.substring(1);
-		}
-
 		return value;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
@@ -201,14 +201,7 @@ export class UnifiedQuickAccess extends Disposable {
 			);
 
 			// Get the filter text (without prefix or shortcut character)
-			let filterText: string;
-			if (this._arrivedViaShortcut && picker.value.startsWith(this._arrivedViaShortcut)) {
-				filterText = picker.value.substring(1).trim();
-			} else if (this._currentTab) {
-				filterText = picker.value.substring(this._currentTab.prefix.length).trim();
-			} else {
-				filterText = picker.value.trim();
-			}
+			const filterText = this._getFilterText(picker.value, this._currentTab);
 
 			// Send to agent if:
 			// 1. Send-to-agent item is explicitly selected, OR
@@ -396,6 +389,31 @@ export class UnifiedQuickAccess extends Disposable {
 		}
 	}
 
+	private _stripLeadingShortcut(value: string, tab: IUnifiedQuickAccessTab | undefined): string {
+		if (tab?.id === 'agentSessions' && value.startsWith('<')) {
+			return value.substring(1);
+		}
+
+		if (tab?.id === 'commands' && value.startsWith('>')) {
+			return value.substring(1);
+		}
+
+		if (this._arrivedViaShortcut && value.startsWith(this._arrivedViaShortcut)) {
+			return value.substring(1);
+		}
+
+		return value;
+	}
+
+	private _getFilterText(value: string, tab: IUnifiedQuickAccessTab | undefined): string {
+		let filterText = this._stripLeadingShortcut(value, tab);
+		if (tab && filterText.startsWith(tab.prefix)) {
+			filterText = filterText.substring(tab.prefix.length);
+		}
+
+		return filterText.trim();
+	}
+
 	/**
 	 * Open chat without sending a message.
 	 */
@@ -408,7 +426,7 @@ export class UnifiedQuickAccess extends Disposable {
 	 * Send the exact message to a new agent session (no prefix stripping).
 	 */
 	private async _sendMessageRaw(value: string): Promise<void> {
-		const message = value.trim();
+		const message = this._stripLeadingShortcut(value, this._currentTab).trim();
 		if (!message) {
 			return;
 		}
@@ -432,16 +450,12 @@ export class UnifiedQuickAccess extends Disposable {
 	 */
 	private async _sendMessage(value: string): Promise<void> {
 		// Strip any prefix or shortcut character from the value
-		let message = value;
+		let message = this._stripLeadingShortcut(value, this._currentTab);
 
-		// First, strip shortcut character if we arrived via shortcut
-		if (this._arrivedViaShortcut && message.startsWith(this._arrivedViaShortcut)) {
-			message = message.substring(1).trim();
-		} else if (this._currentTab) {
-			// Otherwise strip the normal prefix
-			if (value.startsWith(this._currentTab.prefix)) {
-				message = value.substring(this._currentTab.prefix.length).trim();
-			}
+		if (this._currentTab && message.startsWith(this._currentTab.prefix)) {
+			message = message.substring(this._currentTab.prefix.length).trim();
+		} else {
+			message = message.trim();
 		}
 
 		if (!message) {
@@ -473,18 +487,10 @@ export class UnifiedQuickAccess extends Disposable {
 		}
 
 		// Get the filter text (without prefix or shortcut character)
-		let filterText: string;
-		if (this._arrivedViaShortcut && picker.value.startsWith(this._arrivedViaShortcut)) {
-			// Strip shortcut character
-			filterText = picker.value.substring(1).trim();
-		} else if (this._currentTab) {
-			filterText = picker.value.substring(this._currentTab.prefix.length).trim();
-		} else {
-			filterText = picker.value.trim();
-		}
+		const filterText = this._getFilterText(picker.value, this._currentTab);
 
 		// Use full input if filter text is empty but there's input (user typed without prefix)
-		const fullInput = picker.value.trim();
+		const fullInput = this._stripLeadingShortcut(picker.value, this._currentTab).trim();
 		const messageToSend = filterText || fullInput;
 
 		// Only show if user has typed something
@@ -499,7 +505,7 @@ export class UnifiedQuickAccess extends Disposable {
 
 		// Check if send-to-agent is already the first item with same description
 		const firstItem = picker.items[0] as IQuickPickItem & { id?: string };
-		if (firstItem?.id === SEND_TO_AGENT_ID && firstItem.description === fullInput) {
+		if (firstItem?.id === SEND_TO_AGENT_ID && firstItem.description === messageToSend) {
 			return; // Already showing correct send-to-agent item
 		}
 
@@ -507,9 +513,9 @@ export class UnifiedQuickAccess extends Disposable {
 		const sendItem: IQuickPickItem & { id: string } = {
 			id: SEND_TO_AGENT_ID,
 			label: `$(send) ${localize('sendToAgentLabel', "Send to agent")}`,
-			description: fullInput,
+			description: messageToSend,
 			alwaysShow: true,
-			ariaLabel: localize('sendToAgentAria', "Send message to agent: {0}", fullInput),
+			ariaLabel: localize('sendToAgentAria', "Send message to agent: {0}", messageToSend),
 		};
 
 		// Get current items, excluding any existing send-to-agent item
@@ -673,13 +679,10 @@ export class UnifiedQuickAccess extends Disposable {
 		if (provider) {
 			// Configure filtering - strip the tab's prefix or shortcut character from the filter value
 			const tabPrefix = tab.prefix;
-			const arrivedViaShortcut = this._arrivedViaShortcut;
 			picker.filterValue = (value: string) => {
-				// If arrived via shortcut, strip the shortcut character
-				if (arrivedViaShortcut && value.startsWith(arrivedViaShortcut)) {
-					return value.substring(1);
-				}
-				// Otherwise strip the normal prefix
+				// Strip shortcut character when it matches the active tab
+				value = this._stripLeadingShortcut(value, tab);
+				// Strip the normal prefix
 				if (value.startsWith(tabPrefix)) {
 					return value.substring(tabPrefix.length);
 				}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/experiments/unifiedQuickAccess.ts
@@ -419,7 +419,7 @@ export class UnifiedQuickAccess extends Disposable {
 	}
 
 	/**
-	 * Send the exact message to a new agent session (no prefix stripping).
+	 * Send the exact message to a new agent session (strips leading shortcut character but not prefix).
 	 */
 	private async _sendMessageRaw(value: string): Promise<void> {
 		const message = this._stripLeadingShortcut(value, this._currentTab).trim();


### PR DESCRIPTION
Summary:
When using the Unified Quick Access Sessions shortcut (typing "<"), the leading "<" was being included in the quick pick filter, the "Send to agent" preview/description, and the message actually sent to a new agent session. This change strips the leading shortcut character so filtering, the preview text, and the sent message do not include "<".

What I changed:

Normalizes input by stripping the leading shortcut character for Sessions/Commands in [unifiedQuickAccess.ts](vscode-file://vscode-app/Users/ek844y/projects/vscode/out/vs/code/electron-browser/workbench/workbench-dev.html).
Uses the normalized text for:
picker filtering
"Send to agent" item description and aria label
sent message (both via Enter and the Send button)
Why:
Users expect typing "< Refactor this code" to switch to Sessions but not include the "<" in the filter or message; this restores that expected behavior.

Manual test steps:

Open Unified Quick Access.
Type "< Refactor this code".
Verify:
Sessions tab is selected.
Results are filtered for "Refactor this code" (no leading "<").
The "Send to agent" item shows "Refactor this code" (no leading "<").
Accepting Send or clicking Send creates a new chat with the message "Refactor this code".

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #292999