### PR TITLE
Add "Copy Stash Name" option to Stashes view

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1101,7 +1101,6 @@
       {
         "command": "git.repositories.stashCopyName",
         "title": "%command.stashCopyName%",
-        "icon": "$(diff-multiple)",
         "category": "Git",
         "enablement": "!operationInProgress"
       },
@@ -2086,7 +2085,7 @@
         },
         {
           "command": "git.repositories.stashCopyName",
-          "group": "1_view@2",
+          "group": "9_copy@1",
           "when": "scmProvider == git && scmArtifactGroupId == stashes"
         },
         {

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1102,7 +1102,6 @@
         "command": "git.repositories.stashCopyName",
         "title": "%command.stashCopyName%",
         "category": "Git",
-        "enablement": "!operationInProgress"
       },
       {
         "command": "git.repositories.stashApply",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1101,7 +1101,7 @@
       {
         "command": "git.repositories.stashCopyName",
         "title": "%command.stashCopyName%",
-        "category": "Git",
+        "category": "Git"
       },
       {
         "command": "git.repositories.stashApply",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1099,6 +1099,13 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.repositories.stashCopyName",
+        "title": "%command.stashCopyName%",
+        "icon": "$(diff-multiple)",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.repositories.stashApply",
         "title": "%command.stashApplyEditor%",
         "icon": "$(git-stash-apply)",
@@ -1818,6 +1825,10 @@
           "when": "false"
         },
         {
+          "command": "git.repositories.stashCopyName",
+          "when": "false"
+        },
+        {
           "command": "git.repositories.stashApply",
           "when": "false"
         },
@@ -2071,6 +2082,11 @@
         {
           "command": "git.repositories.stashView",
           "group": "1_view@1",
+          "when": "scmProvider == git && scmArtifactGroupId == stashes"
+        },
+        {
+          "command": "git.repositories.stashCopyName",
+          "group": "1_view@2",
           "when": "scmProvider == git && scmArtifactGroupId == stashes"
         },
         {

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -128,6 +128,7 @@
 	"command.stashDropEditor": "Drop Stash",
 	"command.stashView": "View Stash...",
 	"command.stashView2": "View Stash",
+	"command.stashCopyName": "Copy Stash Name",
 	"command.timelineOpenDiff": "Open Changes",
 	"command.timelineCopyCommitId": "Copy Commit ID",
 	"command.timelineCopyCommitMessage": "Copy Commit Message",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5315,6 +5315,15 @@ export class CommandCenter {
 		await this._viewStash(repository, stash);
 	}
 
+	@command('git.repositories.stashCopyName', { repository: true })
+	async artifactStashCopyName(repository: Repository, artifact: SourceControlArtifact): Promise<void> {
+		if (!repository || !artifact) {
+			return;
+		}
+
+		env.clipboard.writeText(artifact.name);
+	}
+
 	@command('git.repositories.stashApply', { repository: true })
 	async artifactStashApply(repository: Repository, artifact: SourceControlArtifact): Promise<void> {
 		if (!repository || !artifact) {


### PR DESCRIPTION
Changes:
Added _git.repositories.stashCopyName_ command to copy the selected stash name to clipboard.

Fixes: #289824

<img width="367" height="277" alt="image" src="https://github.com/user-attachments/assets/f54c5180-40d4-4970-9c4e-547766a49610" />
