### PR TITLE
Enable VSCode To Run `CoreAudio Tap API` Apps [MacOS]

### DIFF
--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -117,6 +117,13 @@ async function main(buildDir?: string): Promise<void> {
 			'An application in Visual Studio Code wants to use the Camera.',
 			`${infoPlistPath}`
 		]);
+		await spawn('plutil', [
+			'-replace',
+			'NSAudioCaptureUsageDescription',
+			'-string',
+			'An application in Visual Studio Code wants to use Audio Capture.',
+			`${infoPlistPath}`
+		]);
 	}
 
 	await retrySignOnKeychainError(() => sign(appOpts));


### PR DESCRIPTION
Apple kinda quietly released a new API for doing native audio-capture and then didn't communicate well down-stream that a new `info.plist` permission `NSAudioCaptureUsageDescription` is required to use the new API:
###  🍎 : [CoreAudio Tap API Reference](https://github.com/insidegui/AudioCap) 
This is especially pertinent to apps like IDEs and Terminals which have users running their own code underneath. This is a simple PR to add the correct `info.plist` permission so VSCode developers will not experience issues when using the newer macOS audio capture API.

Similar to how we add `NSMicrophoneUsageDescription`, `NSCameraUsageDescription` so people's apps running from VSCode's terminal can request camera/microphone. The added `NSAudioCaptureUsageDescription` does the same thing but for audio capture with the new API introduced by apple.

Should be easy to confirm by:
1. Build the app
2. Right click the final `.App` artifact > Show Package Contents
3. Examine the info.plist file and confirm `NSAudioCaptureUsageDescription` is present.

---

Big apps like google are using this new CoreAudio Tap API (sometimes referred to as `catap` in chromium repos) [turned on as the default](https://source.chromium.org/chromium/chromium/src/+/ad17e8f8b93d5f34891b06085d373a668918255e) .  Developers using VSCode to run their apps are probably soon to follow.

I actually discovered this new system when my audio-capture [broke](https://github.com/electron/electron/issues/49607) in electron from a tangential issue. I guess as a music visualizer dev, this is my moment to contribute something to the FOSS community ;-)

[Relevant Issue](https://github.com/microsoft/vscode/issues/293039)

Cheers and let me know if you have questions!


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
