### PR TITLE
version-control: respect push remotes with 'sync changes'

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -20,6 +20,8 @@ function isActionButtonStateEqual(state1: ActionButtonState, state2: ActionButto
 		state1.HEAD?.upstream?.name === state2.HEAD?.upstream?.name &&
 		state1.HEAD?.upstream?.remote === state2.HEAD?.upstream?.remote &&
 		state1.HEAD?.upstream?.commit === state2.HEAD?.upstream?.commit &&
+		state1.HEAD?.pushBranch?.name === state2.HEAD?.pushBranch?.name &&
+		state1.HEAD?.pushBranch?.remote === state2.HEAD?.pushBranch?.remote &&
 		state1.isCheckoutInProgress === state2.isCheckoutInProgress &&
 		state1.isCommitInProgress === state2.isCommitInProgress &&
 		state1.isMergeInProgress === state2.isMergeInProgress &&

--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -21,6 +21,8 @@ function isActionButtonStateEqual(state1: ActionButtonState, state2: ActionButto
 		state1.HEAD?.upstream?.name === state2.HEAD?.upstream?.name &&
 		state1.HEAD?.upstream?.remote === state2.HEAD?.upstream?.remote &&
 		state1.HEAD?.upstream?.commit === state2.HEAD?.upstream?.commit &&
+		state1.HEAD?.pushBranch?.name === state2.HEAD?.pushBranch?.name &&
+		state1.HEAD?.pushBranch?.remote === state2.HEAD?.pushBranch?.remote &&
 		state1.isCheckoutInProgress === state2.isCheckoutInProgress &&
 		state1.isCommitInProgress === state2.isCommitInProgress &&
 		state1.isMergeInProgress === state2.isMergeInProgress &&

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -34,14 +34,15 @@ export interface Ref {
 	readonly remote?: string;
 }
 
-export interface UpstreamRef {
+export interface RemoteRef {
 	readonly remote: string;
 	readonly name: string;
 	readonly commit?: string;
 }
 
 export interface Branch extends Ref {
-	readonly upstream?: UpstreamRef;
+	readonly upstream?: RemoteRef;
+	readonly pushBranch?: RemoteRef;
 	readonly ahead?: number;
 	readonly behind?: number;
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4248,15 +4248,18 @@ export class CommandCenter {
 			return;
 		}
 
-		const remoteName = HEAD.remote || HEAD.upstream.remote;
-		const remote = repository.remotes.find(r => r.name === remoteName);
-		const isReadonly = remote && remote.isReadOnly;
+		const pushBranch = HEAD.pushBranch ?? HEAD.upstream;
+		const pushRemote = repository.remotes.find(r => r.name === pushBranch.remote);
+		const isReadonly = pushRemote && pushRemote.isReadOnly;
 
 		const config = workspace.getConfiguration('git');
 		const shouldPrompt = !isReadonly && config.get<boolean>('confirmSync') === true;
 
 		if (shouldPrompt) {
-			const message = l10n.t('This action will pull and push commits from and to "{0}/{1}".', HEAD.upstream.remote, HEAD.upstream.name);
+			const triangular = HEAD.pushBranch && (HEAD.pushBranch.remote !== HEAD.upstream.remote || HEAD.pushBranch.name !== HEAD.upstream.name);
+			const message = triangular
+				? l10n.t('This action will pull commits from "{0}/{1}" and push commits to "{2}/{3}".', HEAD.upstream.remote, HEAD.upstream.name, pushBranch.remote, pushBranch.name)
+				: l10n.t('This action will pull and push commits from and to "{0}/{1}".', HEAD.upstream.remote, HEAD.upstream.name);
 			const yes = l10n.t('OK');
 			const neverAgain = l10n.t('OK, Don\'t Show Again');
 			const pick = await window.showWarningMessage(message, { modal: true }, yes, neverAgain);

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4248,17 +4248,16 @@ export class CommandCenter {
 			return;
 		}
 
-		const pushBranch = HEAD.pushBranch ?? HEAD.upstream;
-		const pushRemote = repository.remotes.find(r => r.name === pushBranch.remote);
+		const pushRemoteName = HEAD.pushBranch?.remote || HEAD.remote || HEAD.upstream.remote;
+		const pushRemote = repository.remotes.find(r => r.name === pushRemoteName);
 		const isReadonly = pushRemote && pushRemote.isReadOnly;
 
 		const config = workspace.getConfiguration('git');
 		const shouldPrompt = !isReadonly && config.get<boolean>('confirmSync') === true;
 
 		if (shouldPrompt) {
-			const triangular = HEAD.pushBranch && (HEAD.pushBranch.remote !== HEAD.upstream.remote || HEAD.pushBranch.name !== HEAD.upstream.name);
-			const message = triangular
-				? l10n.t('This action will pull commits from "{0}/{1}" and push commits to "{2}/{3}".', HEAD.upstream.remote, HEAD.upstream.name, pushBranch.remote, pushBranch.name)
+			const message = HEAD.pushBranch
+				? l10n.t('This action will pull commits from "{0}/{1}" and push commits to "{2}/{3}".', HEAD.upstream.remote, HEAD.upstream.name, HEAD.pushBranch.remote, HEAD.pushBranch.name)
 				: l10n.t('This action will pull and push commits from and to "{0}/{1}".', HEAD.upstream.remote, HEAD.upstream.name);
 			const yes = l10n.t('OK');
 			const neverAgain = l10n.t('OK, Don\'t Show Again');

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4277,15 +4277,17 @@ export class CommandCenter {
 			return;
 		}
 
-		const remoteName = HEAD.remote || HEAD.upstream.remote;
-		const remote = repository.remotes.find(r => r.name === remoteName);
-		const isReadonly = remote && remote.isReadOnly;
+		const pushRemoteName = HEAD.pushBranch?.remote || HEAD.remote || HEAD.upstream.remote;
+		const pushRemote = repository.remotes.find(r => r.name === pushRemoteName);
+		const isReadonly = pushRemote && pushRemote.isReadOnly;
 
 		const config = workspace.getConfiguration('git');
 		const shouldPrompt = !isReadonly && config.get<boolean>('confirmSync') === true;
 
 		if (shouldPrompt) {
-			const message = l10n.t('This action will pull and push commits from and to "{0}/{1}".', HEAD.upstream.remote, HEAD.upstream.name);
+			const message = HEAD.pushBranch
+				? l10n.t('This action will pull commits from "{0}/{1}" and push commits to "{2}/{3}".', HEAD.upstream.remote, HEAD.upstream.name, HEAD.pushBranch.remote, HEAD.pushBranch.name)
+				: l10n.t('This action will pull and push commits from and to "{0}/{1}".', HEAD.upstream.remote, HEAD.upstream.name);
 			const yes = l10n.t('OK');
 			const neverAgain = l10n.t('OK, Don\'t Show Again');
 			const pick = await window.showWarningMessage(message, { modal: true }, yes, neverAgain);

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3181,7 +3181,7 @@ export class Repository {
 				} catch { }
 			}
 
-			if (branch.type === RefType.Head && branch.name && branch.upstream && !branch.pushBranch) {
+			if (branch.type === RefType.Head && branch.name && branch.upstream) {
 				try {
 					const pushResult = await this.exec(['rev-parse', '--abbrev-ref', `${branch.name}@{push}`]);
 					const pushRef = pushResult.stdout.trim();
@@ -3191,8 +3191,8 @@ export class Repository {
 							remote: pushRef.substring(0, firstSlash),
 							name: pushRef.substring(firstSlash + 1)
 						};
-						(branch as Mutable<Branch>).pushBranch = pushBranch;
 						if (pushBranch.remote !== branch.upstream.remote || pushBranch.name !== branch.upstream.name) {
+							(branch as Mutable<Branch>).pushBranch = pushBranch;
 							const result = await this.exec(['rev-list', '--count', `${pushBranch.remote}/${pushBranch.name}..${branch.name}`]);
 							(branch as Mutable<Branch>).ahead = Number(result.stdout.trim()) || 0;
 						}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1002,51 +1002,6 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
-export function parseBranchForEachRefLine(line: string): Branch | undefined {
-	let [branchName, upstream, ref, status, remoteName, upstreamRef] = line.trim().split('\0');
-
-	if (branchName.startsWith('refs/heads/')) {
-		branchName = branchName.substring(11);
-		const index = upstream.indexOf('/');
-
-		let ahead;
-		let behind;
-		const match = /\[(?:ahead ([0-9]+))?[,\s]*(?:behind ([0-9]+))?]|\[gone]/.exec(status);
-		if (match) {
-			[, ahead, behind] = match;
-		}
-
-		return {
-			type: RefType.Head,
-			name: branchName,
-			upstream: upstream !== '' && status !== '[gone]' ? {
-				name: upstreamRef ? upstreamRef.substring(11) : upstream.substring(index + 1),
-				remote: remoteName ? remoteName : upstream.substring(0, index)
-			} : undefined,
-			pushBranch: undefined,
-			commit: ref || undefined,
-			ahead: Number(ahead) || 0,
-			behind: Number(behind) || 0,
-		};
-	} else if (branchName.startsWith('refs/remotes/')) {
-		branchName = branchName.substring(13);
-		const index = branchName.indexOf('/');
-
-		return {
-			type: RefType.RemoteHead,
-			name: branchName.substring(index + 1),
-			remote: branchName.substring(0, index),
-			commit: ref,
-		};
-	}
-
-	return undefined;
-}
-
-export function getPushAhead(branch: Branch): number | undefined {
-	return branch.ahead;
-}
-
 const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
 
 function parseGitStashes(raw: string): Stash[] {
@@ -3173,9 +3128,45 @@ export class Repository {
 		}
 
 		const result = await this.exec(args);
-		const branches: Branch[] = result.stdout.trim().split('\n')
-			.map(line => parseBranchForEachRefLine(line))
-			.filter((b?: Branch): b is Branch => !!b);
+		const branches: Branch[] = result.stdout.trim().split('\n').map<Branch | undefined>(line => {
+			let [branchName, upstream, ref, status, remoteName, upstreamRef] = line.trim().split('\0');
+
+			if (branchName.startsWith('refs/heads/')) {
+				branchName = branchName.substring(11);
+				const index = upstream.indexOf('/');
+
+				let ahead;
+				let behind;
+				const match = /\[(?:ahead ([0-9]+))?[,\s]*(?:behind ([0-9]+))?]|\[gone]/.exec(status);
+				if (match) {
+					[, ahead, behind] = match;
+				}
+
+				return {
+					type: RefType.Head,
+					name: branchName,
+					upstream: upstream !== '' && status !== '[gone]' ? {
+						name: upstreamRef ? upstreamRef.substring(11) : upstream.substring(index + 1),
+						remote: remoteName ? remoteName : upstream.substring(0, index)
+					} : undefined,
+					commit: ref || undefined,
+					ahead: Number(ahead) || 0,
+					behind: Number(behind) || 0,
+				};
+			} else if (branchName.startsWith('refs/remotes/')) {
+				branchName = branchName.substring(13);
+				const index = branchName.indexOf('/');
+
+				return {
+					type: RefType.RemoteHead,
+					name: branchName.substring(index + 1),
+					remote: branchName.substring(0, index),
+					commit: ref,
+				};
+			} else {
+				return undefined;
+			}
+		}).filter((b?: Branch): b is Branch => !!b);
 
 		if (branches.length) {
 			const [branch] = branches;

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1002,6 +1002,51 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
+export function parseBranchForEachRefLine(line: string): Branch | undefined {
+	let [branchName, upstream, ref, status, remoteName, upstreamRef] = line.trim().split('\0');
+
+	if (branchName.startsWith('refs/heads/')) {
+		branchName = branchName.substring(11);
+		const index = upstream.indexOf('/');
+
+		let ahead;
+		let behind;
+		const match = /\[(?:ahead ([0-9]+))?[,\s]*(?:behind ([0-9]+))?]|\[gone]/.exec(status);
+		if (match) {
+			[, ahead, behind] = match;
+		}
+
+		return {
+			type: RefType.Head,
+			name: branchName,
+			upstream: upstream !== '' && status !== '[gone]' ? {
+				name: upstreamRef ? upstreamRef.substring(11) : upstream.substring(index + 1),
+				remote: remoteName ? remoteName : upstream.substring(0, index)
+			} : undefined,
+			pushBranch: undefined,
+			commit: ref || undefined,
+			ahead: Number(ahead) || 0,
+			behind: Number(behind) || 0,
+		};
+	} else if (branchName.startsWith('refs/remotes/')) {
+		branchName = branchName.substring(13);
+		const index = branchName.indexOf('/');
+
+		return {
+			type: RefType.RemoteHead,
+			name: branchName.substring(index + 1),
+			remote: branchName.substring(0, index),
+			commit: ref,
+		};
+	}
+
+	return undefined;
+}
+
+export function getPushAhead(branch: Branch): number | undefined {
+	return branch.ahead;
+}
+
 const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
 
 function parseGitStashes(raw: string): Stash[] {
@@ -3128,45 +3173,9 @@ export class Repository {
 		}
 
 		const result = await this.exec(args);
-		const branches: Branch[] = result.stdout.trim().split('\n').map<Branch | undefined>(line => {
-			let [branchName, upstream, ref, status, remoteName, upstreamRef] = line.trim().split('\0');
-
-			if (branchName.startsWith('refs/heads/')) {
-				branchName = branchName.substring(11);
-				const index = upstream.indexOf('/');
-
-				let ahead;
-				let behind;
-				const match = /\[(?:ahead ([0-9]+))?[,\s]*(?:behind ([0-9]+))?]|\[gone]/.exec(status);
-				if (match) {
-					[, ahead, behind] = match;
-				}
-
-				return {
-					type: RefType.Head,
-					name: branchName,
-					upstream: upstream !== '' && status !== '[gone]' ? {
-						name: upstreamRef ? upstreamRef.substring(11) : upstream.substring(index + 1),
-						remote: remoteName ? remoteName : upstream.substring(0, index)
-					} : undefined,
-					commit: ref || undefined,
-					ahead: Number(ahead) || 0,
-					behind: Number(behind) || 0,
-				};
-			} else if (branchName.startsWith('refs/remotes/')) {
-				branchName = branchName.substring(13);
-				const index = branchName.indexOf('/');
-
-				return {
-					type: RefType.RemoteHead,
-					name: branchName.substring(index + 1),
-					remote: branchName.substring(0, index),
-					commit: ref,
-				};
-			} else {
-				return undefined;
-			}
-		}).filter((b?: Branch): b is Branch => !!b);
+		const branches: Branch[] = result.stdout.trim().split('\n')
+			.map(line => parseBranchForEachRefLine(line))
+			.filter((b?: Branch): b is Branch => !!b);
 
 		if (branches.length) {
 			const [branch] = branches;
@@ -3178,6 +3187,25 @@ export class Repository {
 
 					(branch as Mutable<Branch>).ahead = Number(ahead) || 0;
 					(branch as Mutable<Branch>).behind = Number(behind) || 0;
+				} catch { }
+			}
+
+			if (branch.type === RefType.Head && branch.name && branch.upstream && !branch.pushBranch) {
+				try {
+					const pushResult = await this.exec(['rev-parse', '--abbrev-ref', `${branch.name}@{push}`]);
+					const pushRef = pushResult.stdout.trim();
+					if (pushRef && pushRef.includes('/')) {
+						const firstSlash = pushRef.indexOf('/');
+						const pushBranch = {
+							remote: pushRef.substring(0, firstSlash),
+							name: pushRef.substring(firstSlash + 1)
+						};
+						(branch as Mutable<Branch>).pushBranch = pushBranch;
+						if (pushBranch.remote !== branch.upstream.remote || pushBranch.name !== branch.upstream.name) {
+							const result = await this.exec(['rev-list', '--count', `${pushBranch.remote}/${pushBranch.name}..${branch.name}`]);
+							(branch as Mutable<Branch>).ahead = Number(result.stdout.trim()) || 0;
+						}
+					}
 				} catch { }
 			}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3235,6 +3235,25 @@ export class Repository {
 				} catch { }
 			}
 
+			if (branch.type === RefType.Head && branch.name && branch.upstream) {
+				try {
+					const pushResult = await this.exec(['rev-parse', '--abbrev-ref', `${branch.name}@{push}`]);
+					const pushRef = pushResult.stdout.trim();
+					if (pushRef && pushRef.includes('/')) {
+						const firstSlash = pushRef.indexOf('/');
+						const pushBranch = {
+							remote: pushRef.substring(0, firstSlash),
+							name: pushRef.substring(firstSlash + 1)
+						};
+						if (pushBranch.remote !== branch.upstream.remote || pushBranch.name !== branch.upstream.name) {
+							(branch as Mutable<Branch>).pushBranch = pushBranch;
+							const result = await this.exec(['rev-list', '--count', `${pushBranch.remote}/${pushBranch.name}..${branch.name}`]);
+							(branch as Mutable<Branch>).ahead = Number(result.stdout.trim()) || 0;
+						}
+					}
+				} catch { }
+			}
+
 			return branch;
 		}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2258,16 +2258,14 @@ export class Repository implements Disposable {
 		let pushBranch: string | undefined;
 
 		if (head.name && head.upstream) {
-			pullRemoteName = head.upstream.remote;
+			pullRemoteName = pushRemoteName = head.upstream.remote;
 			pullBranch = `${head.upstream.name}`;
+			pushBranch = `${head.name}:${head.upstream.name}`;
 		}
 
 		if (head.name && head.pushBranch) {
 			pushRemoteName = head.pushBranch.remote;
 			pushBranch = `${head.name}:${head.pushBranch.name}`;
-		} else if (head.name && head.upstream) {
-			pushRemoteName = head.upstream.remote;
-			pushBranch = `${head.name}:${head.upstream.name}`;
 		}
 
 		await this.run(Operation.Sync, async () => {
@@ -2302,14 +2300,13 @@ export class Repository implements Disposable {
 					await fn();
 				}
 
-				const remote = this.remotes.find(r => r.name === pushRemoteName);
+				const pushRemote = this.remotes.find(r => r.name === pushRemoteName);
 
-				if (remote && remote.isReadOnly) {
+				if (pushRemote && pushRemote.isReadOnly) {
 					return;
 				}
 
-				const pushAhead = this.HEAD?.ahead;
-				const shouldPush = this.HEAD && (typeof pushAhead === 'number' ? pushAhead > 0 : true);
+				const shouldPush = this.HEAD && (typeof this.HEAD.ahead === 'number' ? this.HEAD.ahead > 0 : true);
 
 				if (shouldPush) {
 					await this._push(pushRemoteName, pushBranch, false, followTags);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3131,17 +3131,17 @@ export class Repository implements Disposable {
 			return l10n.t('Synchronize Changes');
 		}
 
-		const pushBranch = this.HEAD.pushBranch ?? this.HEAD.upstream;
-		const pushRemote = this.remotes.find(r => r.name === pushBranch.remote);
+		const pushRemoteName = this.HEAD?.pushBranch?.remote;
+		const pushRemote = this.remotes.find(r => r.name === pushRemoteName);
 
 		if ((pushRemote && pushRemote.isReadOnly) || !this.HEAD.ahead) {
 			return l10n.t('Pull {0} commits from {1}/{2}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		} else if (!this.HEAD.behind) {
-			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead, pushBranch.remote, pushBranch.name);
+		} else if (pushRemote && pushRemoteName && !this.HEAD.behind) {
+			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead!, pushRemoteName, this.HEAD.pushBranch!.name);
 		} else if (this.HEAD.pushBranch && (this.HEAD.pushBranch.remote !== this.HEAD.upstream.remote || this.HEAD.pushBranch.name !== this.HEAD.upstream.name)) {
-			return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', this.HEAD.behind, this.HEAD.upstream.remote, this.HEAD.upstream.name, this.HEAD.ahead, pushBranch.remote, pushBranch.name);
+			return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name, this.HEAD.ahead!, this.HEAD.pushBranch.remote, this.HEAD.pushBranch.name);
 		} else {
-			return l10n.t('Pull {0} and push {1} commits between {2}/{3}', this.HEAD.behind, this.HEAD.ahead, this.HEAD.upstream.remote, this.HEAD.upstream.name);
+			return l10n.t('Pull {0} and push {1} commits between {2}/{3}', this.HEAD.behind!, this.HEAD.ahead!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
 		}
 	}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -696,6 +696,30 @@ export interface IRepositoryResolver {
 	getRepository(hint: SourceControl | SourceControlResourceGroup | Uri | string): Repository | undefined;
 }
 
+export function getSyncTooltip(HEAD: Branch | undefined, remotes: Remote[]): string {
+	if (!HEAD
+		|| !HEAD.name
+		|| !HEAD.commit
+		|| !HEAD.upstream
+		|| !(HEAD.ahead || HEAD.behind)
+	) {
+		return l10n.t('Synchronize Changes');
+	}
+
+	const pushRemoteName = HEAD.pushBranch?.remote;
+	const pushRemote = remotes.find(r => r.name === pushRemoteName);
+
+	if ((pushRemote && pushRemote.isReadOnly) || !HEAD.ahead) {
+		return l10n.t('Pull {0} commits from {1}/{2}', HEAD.behind!, HEAD.upstream.remote, HEAD.upstream.name);
+	} else if (pushRemote && pushRemoteName && !HEAD.behind) {
+		return l10n.t('Push {0} commits to {1}/{2}', HEAD.ahead!, pushRemoteName, HEAD.pushBranch!.name);
+	} else if (HEAD.pushBranch && (HEAD.pushBranch.remote !== HEAD.upstream.remote || HEAD.pushBranch.name !== HEAD.upstream.name)) {
+		return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', HEAD.behind!, HEAD.upstream.remote, HEAD.upstream.name, HEAD.ahead!, HEAD.pushBranch.remote, HEAD.pushBranch.name);
+	} else {
+		return l10n.t('Pull {0} and push {1} commits between {2}/{3}', HEAD.behind!, HEAD.ahead!, HEAD.upstream.remote, HEAD.upstream.name);
+	}
+}
+
 export class Repository implements Disposable {
 	static readonly WORKTREE_ROOT_STORAGE_KEY = 'worktreeRoot';
 
@@ -3122,27 +3146,7 @@ export class Repository implements Disposable {
 	}
 
 	get syncTooltip(): string {
-		if (!this.HEAD
-			|| !this.HEAD.name
-			|| !this.HEAD.commit
-			|| !this.HEAD.upstream
-			|| !(this.HEAD.ahead || this.HEAD.behind)
-		) {
-			return l10n.t('Synchronize Changes');
-		}
-
-		const pushRemoteName = this.HEAD?.pushBranch?.remote;
-		const pushRemote = this.remotes.find(r => r.name === pushRemoteName);
-
-		if ((pushRemote && pushRemote.isReadOnly) || !this.HEAD.ahead) {
-			return l10n.t('Pull {0} commits from {1}/{2}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		} else if (pushRemote && pushRemoteName && !this.HEAD.behind) {
-			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead!, pushRemoteName, this.HEAD.pushBranch!.name);
-		} else if (this.HEAD.pushBranch && (this.HEAD.pushBranch.remote !== this.HEAD.upstream.remote || this.HEAD.pushBranch.name !== this.HEAD.upstream.name)) {
-			return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name, this.HEAD.ahead!, this.HEAD.pushBranch.remote, this.HEAD.pushBranch.name);
-		} else {
-			return l10n.t('Pull {0} and push {1} commits between {2}/{3}', this.HEAD.behind!, this.HEAD.ahead!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		}
+		return getSyncTooltip(this.HEAD, this.remotes);
 	}
 
 	private updateInputBoxPlaceholder(): void {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -706,15 +706,17 @@ export function getSyncTooltip(HEAD: Branch | undefined, remotes: Remote[]): str
 		return l10n.t('Synchronize Changes');
 	}
 
+	const remoteName = HEAD && HEAD.remote || HEAD.upstream.remote;
+	const remote = remotes.find(r => r.name === remoteName);
 	const pushRemoteName = HEAD.pushBranch?.remote;
 	const pushRemote = remotes.find(r => r.name === pushRemoteName);
 
-	if ((pushRemote && pushRemote.isReadOnly) || !HEAD.ahead) {
+	if (remote && pushRemote && !pushRemote.isReadOnly && pushRemoteName && HEAD.ahead && HEAD.behind) {
+		return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', HEAD.behind, HEAD.upstream.remote, HEAD.upstream.name, HEAD.ahead, HEAD.pushBranch.remote, HEAD.pushBranch.name);
+	} else if ((pushRemote && pushRemote.isReadOnly) || !HEAD.ahead) {
 		return l10n.t('Pull {0} commits from {1}/{2}', HEAD.behind!, HEAD.upstream.remote, HEAD.upstream.name);
-	} else if (pushRemote && pushRemoteName && !HEAD.behind) {
-		return l10n.t('Push {0} commits to {1}/{2}', HEAD.ahead!, pushRemoteName, HEAD.pushBranch!.name);
-	} else if (HEAD.pushBranch && (HEAD.pushBranch.remote !== HEAD.upstream.remote || HEAD.pushBranch.name !== HEAD.upstream.name)) {
-		return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', HEAD.behind!, HEAD.upstream.remote, HEAD.upstream.name, HEAD.ahead!, HEAD.pushBranch.remote, HEAD.pushBranch.name);
+	} else if (!HEAD.behind) {
+		return l10n.t('Push {0} commits to {1}/{2}', HEAD.ahead!, pushRemoteName ?? HEAD.upstream.name, HEAD.pushBranch?.name ?? HEAD.upstream.name);
 	} else {
 		return l10n.t('Pull {0} and push {1} commits between {2}/{3}', HEAD.behind!, HEAD.ahead!, HEAD.upstream.remote, HEAD.upstream.name);
 	}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2252,13 +2252,21 @@ export class Repository implements Disposable {
 	}
 
 	private async _sync(head: Branch, rebase: boolean): Promise<void> {
-		let remoteName: string | undefined;
+		let pullRemoteName: string | undefined;
 		let pullBranch: string | undefined;
+		let pushRemoteName: string | undefined;
 		let pushBranch: string | undefined;
 
 		if (head.name && head.upstream) {
-			remoteName = head.upstream.remote;
+			pullRemoteName = head.upstream.remote;
 			pullBranch = `${head.upstream.name}`;
+		}
+
+		if (head.name && head.pushBranch) {
+			pushRemoteName = head.pushBranch.remote;
+			pushBranch = `${head.name}:${head.pushBranch.name}`;
+		} else if (head.name && head.upstream) {
+			pushRemoteName = head.upstream.remote;
 			pushBranch = `${head.name}:${head.upstream.name}`;
 		}
 
@@ -2278,7 +2286,7 @@ export class Repository implements Disposable {
 					}
 
 					if (await this.checkIfMaybeRebased(this.HEAD?.name)) {
-						await this._pullAndHandleTagConflict(rebase, remoteName, pullBranch, { tags, cancellationToken, autoStash });
+						await this._pullAndHandleTagConflict(rebase, pullRemoteName, pullBranch, { tags, cancellationToken, autoStash });
 					}
 				};
 
@@ -2294,16 +2302,17 @@ export class Repository implements Disposable {
 					await fn();
 				}
 
-				const remote = this.remotes.find(r => r.name === remoteName);
+				const remote = this.remotes.find(r => r.name === pushRemoteName);
 
 				if (remote && remote.isReadOnly) {
 					return;
 				}
 
-				const shouldPush = this.HEAD && (typeof this.HEAD.ahead === 'number' ? this.HEAD.ahead > 0 : true);
+				const pushAhead = this.HEAD?.ahead;
+				const shouldPush = this.HEAD && (typeof pushAhead === 'number' ? pushAhead > 0 : true);
 
 				if (shouldPush) {
-					await this._push(remoteName, pushBranch, false, followTags);
+					await this._push(pushRemoteName, pushBranch, false, followTags);
 				}
 			});
 		});
@@ -3125,13 +3134,15 @@ export class Repository implements Disposable {
 			return l10n.t('Synchronize Changes');
 		}
 
-		const remoteName = this.HEAD && this.HEAD.remote || this.HEAD.upstream.remote;
-		const remote = this.remotes.find(r => r.name === remoteName);
+		const pushBranch = this.HEAD.pushBranch ?? this.HEAD.upstream;
+		const pushRemote = this.remotes.find(r => r.name === pushBranch.remote);
 
-		if ((remote && remote.isReadOnly) || !this.HEAD.ahead) {
+		if ((pushRemote && pushRemote.isReadOnly) || !this.HEAD.ahead) {
 			return l10n.t('Pull {0} commits from {1}/{2}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
 		} else if (!this.HEAD.behind) {
-			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead, this.HEAD.upstream.remote, this.HEAD.upstream.name);
+			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead, pushBranch.remote, pushBranch.name);
+		} else if (this.HEAD.pushBranch && (this.HEAD.pushBranch.remote !== this.HEAD.upstream.remote || this.HEAD.pushBranch.name !== this.HEAD.upstream.name)) {
+			return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', this.HEAD.behind, this.HEAD.upstream.remote, this.HEAD.upstream.name, this.HEAD.ahead, pushBranch.remote, pushBranch.name);
 		} else {
 			return l10n.t('Pull {0} and push {1} commits between {2}/{3}', this.HEAD.behind, this.HEAD.ahead, this.HEAD.upstream.remote, this.HEAD.upstream.name);
 		}
@@ -3262,7 +3273,8 @@ export class Repository implements Disposable {
 			if (this.HEAD.ahead === 0) {
 				this.unpublishedCommits = new Set<string>();
 			} else {
-				const ref1 = `${this.HEAD.upstream.remote}/${this.HEAD.upstream.name}`;
+				const pushRef = this.HEAD.pushBranch ?? this.HEAD.upstream;
+				const ref1 = `${pushRef.remote}/${pushRef.name}`;
 				const ref2 = this.HEAD.name;
 
 				const revList = await this.repository.revList(ref1, ref2);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -700,6 +700,38 @@ export interface IRepositoryResolver {
 	getRepository(hint: SourceControl | SourceControlResourceGroup | Uri | string): Repository | undefined;
 }
 
+export function getSyncTooltip(HEAD: Branch | undefined, remotes: Remote[]): string {
+	if (!HEAD
+		|| !HEAD.name
+		|| !HEAD.commit
+		|| !HEAD.upstream
+		|| !(HEAD.ahead || HEAD.behind)
+	) {
+		return l10n.t('Synchronize Changes');
+	}
+
+	const remoteName = HEAD && HEAD.remote || HEAD.upstream.remote;
+	const remote = remotes.find(r => r.name === remoteName);
+	const pushRemoteName = HEAD.pushBranch?.remote;
+	const pushRemote = remotes.find(r => r.name === pushRemoteName);
+
+	const pushReadOnly = !!pushRemote && pushRemote.isReadOnly;
+	const pushTargetRemote = pushRemoteName ?? HEAD.upstream.remote;
+	const pushTargetBranch = HEAD.pushBranch?.name ?? HEAD.upstream.name;
+
+	if (remote && pushRemote && !pushReadOnly && pushRemoteName && HEAD.ahead && HEAD.behind) {
+		return l10n.t('Pull {0} commits from {1}/{2} and push {3} commits to {4}/{5}', HEAD.behind, HEAD.upstream.remote, HEAD.upstream.name, HEAD.ahead, HEAD.pushBranch!.remote, HEAD.pushBranch!.name);
+	} else if (HEAD.behind && (pushReadOnly || !HEAD.ahead)) {
+		return l10n.t('Pull {0} commits from {1}/{2}', HEAD.behind, HEAD.upstream.remote, HEAD.upstream.name);
+	} else if (HEAD.ahead && !HEAD.behind && !pushReadOnly) {
+		return l10n.t('Push {0} commits to {1}/{2}', HEAD.ahead, pushTargetRemote, pushTargetBranch);
+	} else if (HEAD.ahead && HEAD.behind) {
+		return l10n.t('Pull {0} and push {1} commits between {2}/{3}', HEAD.behind, HEAD.ahead, HEAD.upstream.remote, HEAD.upstream.name);
+	}
+
+	return l10n.t('Synchronize Changes');
+}
+
 export class Repository implements Disposable {
 	static readonly WORKTREE_ROOT_STORAGE_KEY = 'worktreeRoot';
 
@@ -2388,14 +2420,20 @@ export class Repository implements Disposable {
 	}
 
 	private async _sync(head: Branch, rebase: boolean): Promise<void> {
-		let remoteName: string | undefined;
+		let pullRemoteName: string | undefined;
 		let pullBranch: string | undefined;
+		let pushRemoteName: string | undefined;
 		let pushBranch: string | undefined;
 
 		if (head.name && head.upstream) {
-			remoteName = head.upstream.remote;
+			pullRemoteName = pushRemoteName = head.upstream.remote;
 			pullBranch = `${head.upstream.name}`;
 			pushBranch = `${head.name}:${head.upstream.name}`;
+		}
+
+		if (head.name && head.pushBranch) {
+			pushRemoteName = head.pushBranch.remote;
+			pushBranch = `${head.name}:${head.pushBranch.name}`;
 		}
 
 		await this.run(Operation.Sync, async () => {
@@ -2414,7 +2452,7 @@ export class Repository implements Disposable {
 					}
 
 					if (await this.checkIfMaybeRebased(this.HEAD?.name)) {
-						await this._pullAndHandleTagConflict(rebase, remoteName, pullBranch, { tags, cancellationToken, autoStash });
+						await this._pullAndHandleTagConflict(rebase, pullRemoteName, pullBranch, { tags, cancellationToken, autoStash });
 					}
 				};
 
@@ -2430,16 +2468,16 @@ export class Repository implements Disposable {
 					await fn();
 				}
 
-				const remote = this.remotes.find(r => r.name === remoteName);
+				const pushRemote = this.remotes.find(r => r.name === pushRemoteName);
 
-				if (remote && remote.isReadOnly) {
+				if (pushRemote && pushRemote.isReadOnly) {
 					return;
 				}
 
 				const shouldPush = this.HEAD && (typeof this.HEAD.ahead === 'number' ? this.HEAD.ahead > 0 : true);
 
 				if (shouldPush) {
-					await this._push(remoteName, pushBranch, false, followTags);
+					await this._push(pushRemoteName, pushBranch, false, followTags);
 				}
 			});
 		});
@@ -3253,25 +3291,7 @@ export class Repository implements Disposable {
 	}
 
 	get syncTooltip(): string {
-		if (!this.HEAD
-			|| !this.HEAD.name
-			|| !this.HEAD.commit
-			|| !this.HEAD.upstream
-			|| !(this.HEAD.ahead || this.HEAD.behind)
-		) {
-			return l10n.t('Synchronize Changes');
-		}
-
-		const remoteName = this.HEAD && this.HEAD.remote || this.HEAD.upstream.remote;
-		const remote = this.remotes.find(r => r.name === remoteName);
-
-		if ((remote && remote.isReadOnly) || !this.HEAD.ahead) {
-			return l10n.t('Pull {0} commits from {1}/{2}', this.HEAD.behind!, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		} else if (!this.HEAD.behind) {
-			return l10n.t('Push {0} commits to {1}/{2}', this.HEAD.ahead, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		} else {
-			return l10n.t('Pull {0} and push {1} commits between {2}/{3}', this.HEAD.behind, this.HEAD.ahead, this.HEAD.upstream.remote, this.HEAD.upstream.name);
-		}
+		return getSyncTooltip(this.HEAD, this.remotes);
 	}
 
 	private updateInputBoxPlaceholder(): void {
@@ -3399,7 +3419,8 @@ export class Repository implements Disposable {
 			if (this.HEAD.ahead === 0) {
 				this.unpublishedCommits = new Set<string>();
 			} else {
-				const ref1 = `${this.HEAD.upstream.remote}/${this.HEAD.upstream.name}`;
+				const pushRef = this.HEAD.pushBranch ?? this.HEAD.upstream;
+				const ref1 = `${pushRef.remote}/${pushRef.name}`;
 				const ref2 = this.HEAD.name;
 
 				const revList = await this.repository.revList(ref1, ref2);

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseBranchForEachRefLine } from '../git';
-import { RefType } from '../api/git';
+import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -662,65 +661,6 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
-		});
-	});
-
-	suite('parseBranchForEachRefLine', () => {
-		test('local branch with upstream', () => {
-			const line = 'refs/heads/main\0origin/main\0abc123\0[ahead 2, behind 1]';
-			const result = parseBranchForEachRefLine(line);
-
-			assert.deepStrictEqual(result, {
-				type: RefType.Head,
-				name: 'main',
-				upstream: { name: 'main', remote: 'origin' },
-				pushBranch: undefined,
-				commit: 'abc123',
-				ahead: 2,
-				behind: 1
-			});
-		});
-
-		test('local branch with different push remote (triangular workflow)', () => {
-			const line = 'refs/heads/feature\0upstream/main\0abc123\0[ahead 2, behind 1]\0upstream\0refs/heads/main';
-			const result = parseBranchForEachRefLine(line);
-
-			assert.deepStrictEqual(result, {
-				type: RefType.Head,
-				name: 'feature',
-				upstream: { name: 'main', remote: 'upstream' },
-				pushBranch: undefined,
-				commit: 'abc123',
-				ahead: 2,
-				behind: 1
-			});
-		});
-
-		test('local branch without push remote configured', () => {
-			const line = 'refs/heads/feature\0upstream/main\0def456\0[ahead 3]\0upstream\0refs/heads/main';
-			const result = parseBranchForEachRefLine(line);
-
-			assert.deepStrictEqual(result, {
-				type: RefType.Head,
-				name: 'feature',
-				upstream: { name: 'main', remote: 'upstream' },
-				pushBranch: undefined,
-				commit: 'def456',
-				ahead: 3,
-				behind: 0
-			});
-		});
-
-		test('remote branch', () => {
-			const line = 'refs/remotes/origin/main\0\0abc123\0';
-			const result = parseBranchForEachRefLine(line);
-
-			assert.deepStrictEqual(result, {
-				type: RefType.RemoteHead,
-				name: 'main',
-				remote: 'origin',
-				commit: 'abc123'
-			});
 		});
 	});
 });

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -10,15 +10,11 @@ import { splitInChunks } from '../util';
 import { getSyncTooltip } from '../repository';
 import { Branch, Remote, RefType } from '../api/git';
 
-function branch(overrides: Partial<Branch> & { name: string; commit?: string; upstream: { remote: string; name: string } }): Branch {
+function branch(fields: Partial<Branch>): Branch {
 	return {
 		type: RefType.Head,
-		name: overrides.name,
-		commit: overrides.commit ?? 'abc123',
-		upstream: overrides.upstream,
-		pushBranch: overrides.pushBranch,
-		ahead: overrides.ahead,
-		behind: overrides.behind
+		commit: 'abc123',
+		...fields
 	};
 }
 

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -7,6 +7,24 @@ import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
+import { getSyncTooltip } from '../repository';
+import { Branch, Remote, RefType } from '../api/git';
+
+function branch(overrides: Partial<Branch> & { name: string; commit?: string; upstream: { remote: string; name: string } }): Branch {
+	return {
+		type: RefType.Head,
+		name: overrides.name,
+		commit: overrides.commit ?? 'abc123',
+		upstream: overrides.upstream,
+		pushBranch: overrides.pushBranch,
+		ahead: overrides.ahead,
+		behind: overrides.behind
+	};
+}
+
+function remote(props: { name: string; isReadOnly?: boolean }): Remote {
+	return { name: props.name, isReadOnly: props.isReadOnly ?? false };
+}
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -661,6 +679,121 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('getSyncTooltip', () => {
+		test('returns default when HEAD is undefined', () => {
+			assert.strictEqual(getSyncTooltip(undefined, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no upstream', () => {
+			const HEAD: Branch = {
+				type: RefType.Head,
+				name: 'main',
+				commit: 'abc123',
+				upstream: undefined,
+				ahead: 1,
+				behind: 0
+			};
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no name', () => {
+			const HEAD = branch({ name: '', upstream: { remote: 'origin', name: 'main' } });
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no commit', () => {
+			const HEAD: Branch = {
+				type: RefType.Head,
+				name: 'main',
+				commit: undefined,
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 1,
+				behind: 0
+			};
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when neither ahead nor behind', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 0,
+				behind: 0
+			});
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('pull only when push remote is read-only', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'main' },
+				ahead: 2,
+				behind: 1
+			});
+			const remotes = [remote({ name: 'origin', isReadOnly: true })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 1 commits from origin/main');
+		});
+
+		test('pull only when no commits to push', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 0,
+				behind: 3
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 3 commits from origin/main');
+		});
+
+		test('push only when no commits to pull', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'main' },
+				ahead: 2,
+				behind: 0
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Push 2 commits to origin/main');
+		});
+
+		test('pull and push to different remotes', () => {
+			const HEAD = branch({
+				name: 'feature',
+				upstream: { remote: 'upstream', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'feature' },
+				ahead: 1,
+				behind: 2
+			});
+			const remotes = [remote({ name: 'upstream' }), remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 2 commits from upstream/main and push 1 commits to origin/feature');
+		});
+
+		test('pull and push between same remote/branch', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 1,
+				behind: 1
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 1 and push 1 commits between origin/main');
+		});
+
+		test('push only when push remote differs but behind is zero', () => {
+			const HEAD = branch({
+				name: 'feature',
+				upstream: { remote: 'upstream', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'feature' },
+				ahead: 1,
+				behind: 0
+			});
+			const remotes = [remote({ name: 'upstream' }), remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Push 1 commits to origin/feature');
 		});
 	});
 });

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes } from '../git';
+import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseBranchForEachRefLine } from '../git';
+import { RefType } from '../api/git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -661,6 +662,65 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('parseBranchForEachRefLine', () => {
+		test('local branch with upstream', () => {
+			const line = 'refs/heads/main\0origin/main\0abc123\0[ahead 2, behind 1]';
+			const result = parseBranchForEachRefLine(line);
+
+			assert.deepStrictEqual(result, {
+				type: RefType.Head,
+				name: 'main',
+				upstream: { name: 'main', remote: 'origin' },
+				pushBranch: undefined,
+				commit: 'abc123',
+				ahead: 2,
+				behind: 1
+			});
+		});
+
+		test('local branch with different push remote (triangular workflow)', () => {
+			const line = 'refs/heads/feature\0upstream/main\0abc123\0[ahead 2, behind 1]\0upstream\0refs/heads/main';
+			const result = parseBranchForEachRefLine(line);
+
+			assert.deepStrictEqual(result, {
+				type: RefType.Head,
+				name: 'feature',
+				upstream: { name: 'main', remote: 'upstream' },
+				pushBranch: undefined,
+				commit: 'abc123',
+				ahead: 2,
+				behind: 1
+			});
+		});
+
+		test('local branch without push remote configured', () => {
+			const line = 'refs/heads/feature\0upstream/main\0def456\0[ahead 3]\0upstream\0refs/heads/main';
+			const result = parseBranchForEachRefLine(line);
+
+			assert.deepStrictEqual(result, {
+				type: RefType.Head,
+				name: 'feature',
+				upstream: { name: 'main', remote: 'upstream' },
+				pushBranch: undefined,
+				commit: 'def456',
+				ahead: 3,
+				behind: 0
+			});
+		});
+
+		test('remote branch', () => {
+			const line = 'refs/remotes/origin/main\0\0abc123\0';
+			const result = parseBranchForEachRefLine(line);
+
+			assert.deepStrictEqual(result, {
+				type: RefType.RemoteHead,
+				name: 'main',
+				remote: 'origin',
+				commit: 'abc123'
+			});
 		});
 	});
 });

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -7,6 +7,20 @@ import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
+import { getSyncTooltip } from '../repository';
+import { Branch, Remote, RefType } from '../api/git';
+
+function branch(fields: Partial<Branch>): Branch {
+	return {
+		type: RefType.Head,
+		commit: 'abc123',
+		...fields
+	};
+}
+
+function remote(props: { name: string; isReadOnly?: boolean }): Remote {
+	return { name: props.name, isReadOnly: props.isReadOnly ?? false };
+}
 
 suite('git', () => {
 	suite('GitStatusParser', () => {
@@ -715,6 +729,133 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('getSyncTooltip', () => {
+		test('returns default when HEAD is undefined', () => {
+			assert.strictEqual(getSyncTooltip(undefined, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no upstream', () => {
+			const HEAD: Branch = {
+				type: RefType.Head,
+				name: 'main',
+				commit: 'abc123',
+				upstream: undefined,
+				ahead: 1,
+				behind: 0
+			};
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no name', () => {
+			const HEAD = branch({ name: '', upstream: { remote: 'origin', name: 'main' } });
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when HEAD has no commit', () => {
+			const HEAD: Branch = {
+				type: RefType.Head,
+				name: 'main',
+				commit: undefined,
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 1,
+				behind: 0
+			};
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('returns default when neither ahead nor behind', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 0,
+				behind: 0
+			});
+			assert.strictEqual(getSyncTooltip(HEAD, []), 'Synchronize Changes');
+		});
+
+		test('pull only when push remote is read-only', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'main' },
+				ahead: 2,
+				behind: 1
+			});
+			const remotes = [remote({ name: 'origin', isReadOnly: true })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 1 commits from origin/main');
+		});
+
+		test('pull only when no commits to push', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 0,
+				behind: 3
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 3 commits from origin/main');
+		});
+
+		test('push only when no commits to pull', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'main' },
+				ahead: 2,
+				behind: 0
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Push 2 commits to origin/main');
+		});
+
+		test('pull and push to different remotes', () => {
+			const HEAD = branch({
+				name: 'feature',
+				upstream: { remote: 'upstream', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'feature' },
+				ahead: 1,
+				behind: 2
+			});
+			const remotes = [remote({ name: 'upstream' }), remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 2 commits from upstream/main and push 1 commits to origin/feature');
+		});
+
+		test('pull and push between same remote/branch', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				ahead: 1,
+				behind: 1
+			});
+			const remotes = [remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Pull 1 and push 1 commits between origin/main');
+		});
+
+		test('push only when push remote differs but behind is zero', () => {
+			const HEAD = branch({
+				name: 'feature',
+				upstream: { remote: 'upstream', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'feature' },
+				ahead: 1,
+				behind: 0
+			});
+			const remotes = [remote({ name: 'upstream' }), remote({ name: 'origin' })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Push 1 commits to origin/feature');
+		});
+
+		test('default when push remote is read-only and nothing to pull', () => {
+			const HEAD = branch({
+				name: 'main',
+				upstream: { remote: 'origin', name: 'main' },
+				pushBranch: { remote: 'origin', name: 'main' },
+				ahead: 2,
+				behind: 0
+			});
+			const remotes = [remote({ name: 'origin', isReadOnly: true })];
+			assert.strictEqual(getSyncTooltip(HEAD, remotes), 'Synchronize Changes');
 		});
 	});
 });

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -9,6 +9,7 @@ import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, e
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { GitExtension, API, Repository, Status } from '../api/git';
 import { eventToPromise } from '../util';
 
@@ -34,6 +35,12 @@ suite('git smoke test', function () {
 		const end = doc.lineAt(doc.lineCount - 1).range.end;
 		edit.replace(doc.uri, new Range(end, end), text);
 		await workspace.applyEdit(edit);
+	}
+
+	function commitFile(relativePath: string) {
+		fs.writeFileSync(file(relativePath), relativePath, 'utf8');
+		cp.execSync('git add ' + relativePath, { cwd });
+		cp.execSync('git commit -m ' + JSON.stringify(relativePath), { cwd });
 	}
 
 	let git: API;
@@ -152,26 +159,79 @@ suite('git smoke test', function () {
 		const appjs = file('app.js');
 		const renamejs = file('rename.js');
 
-		await repository.createBranch('test', true);
+		try {
+			await repository.createBranch('test', true);
 
-		// Delete file (test branch)
-		fs.unlinkSync(appjs);
-		await repository.commit('commit on test', { all: true });
+			fs.unlinkSync(appjs);
+			await repository.commit('commit on test', { all: true });
 
-		await repository.checkout('main');
+			await repository.checkout('main');
 
-		// Rename file (main branch)
-		fs.renameSync(appjs, renamejs);
-		await repository.commit('commit on main', { all: true });
+			fs.renameSync(appjs, renamejs);
+			await repository.commit('commit on main', { all: true });
+
+			try {
+				await repository.merge('test');
+			} catch (e) { }
+
+			assert.strictEqual(repository.state.mergeChanges.length, 1);
+			assert.strictEqual(repository.state.mergeChanges[0].status, Status.DELETED_BY_THEM);
+
+			assert.strictEqual(repository.state.workingTreeChanges.length, 0);
+			assert.strictEqual(repository.state.indexChanges.length, 0);
+		} finally {
+			try { cp.execSync('git merge --abort', { cwd, stdio: 'pipe' }); } catch { }
+		}
+	});
+
+	test('sync respects triangular workflow (pull from upstream, push to origin)', async function () {
+		const testId = Date.now();
+		const upstreamBare = path.join(os.tmpdir(), `vscode-git-sync-upstream-${testId}`);
+		const originBare = path.join(os.tmpdir(), `vscode-git-sync-origin-${testId}`);
+		cp.execSync(`git -c advice.defaultBranchName=false init "${upstreamBare}"`);
+		cp.execSync(`git -c advice.defaultBranchName=false init "${originBare}"`);
 
 		try {
-			await repository.merge('test');
-		} catch (e) { }
+			cp.execSync(`git remote add origin "${originBare}"`, { cwd });
+			cp.execSync(`git remote add upstream "${upstreamBare}"`, { cwd });
 
-		assert.strictEqual(repository.state.mergeChanges.length, 1);
-		assert.strictEqual(repository.state.mergeChanges[0].status, Status.DELETED_BY_THEM);
+			cp.execSync(`git push upstream main:main`, { cwd });
+			cp.execSync('git checkout upstream/main -b feature', { cwd });
+			cp.execSync('git config branch.feature.pushRemote origin', { cwd });
+			cp.execSync('git push origin feature', { cwd });
 
-		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
-		assert.strictEqual(repository.state.indexChanges.length, 0);
+			cp.execSync('git checkout main', { cwd });
+			commitFile('main-first.txt');
+			commitFile('main-second.txt');
+			cp.execSync('git push upstream main', { cwd });
+
+			cp.execSync('git checkout feature', { cwd });
+			cp.execSync('git push', { cwd });
+			commitFile('feature-first.txt');
+
+			await workspace.getConfiguration('git', Uri.file(cwd)).update('confirmSync', false, true);
+			await repository.status();
+
+			assert.strictEqual(repository.state.HEAD?.name, 'feature');
+			assert.strictEqual(repository.state.HEAD?.ahead, 1, 'sync should show 1 commits to push to origin');
+			assert.strictEqual(repository.state.HEAD?.behind, 2, 'sync should show 2 commit to pull from upstream');
+
+			await commands.executeCommand('git.sync');
+			await repository.status();
+			assert.strictEqual(repository.state.HEAD?.ahead, 0);
+			assert.strictEqual(repository.state.HEAD?.behind, 0);
+
+			const originFeatureCommit = cp.execSync('git rev-parse origin/feature', { cwd, encoding: 'utf8' }).trim();
+			assert.strictEqual(repository.state.HEAD?.commit, originFeatureCommit, 'HEAD should be synced with origin/feature');
+			cp.execSync('git merge-base --is-ancestor upstream/main HEAD', { cwd });
+		} finally {
+			try { cp.execSync('git checkout main', { cwd }); } catch { }
+			try { cp.execSync('git branch -D feature', { cwd }); } catch { }
+			try { cp.execSync('git remote remove upstream', { cwd }); } catch { }
+			try { cp.execSync('git remote remove origin', { cwd }); } catch { }
+			try { cp.execSync('git config --unset branch.feature.pushRemote', { cwd }); } catch { }
+			try { fs.rmSync(upstreamBare, { recursive: true, force: true }); } catch { }
+			try { fs.rmSync(originBare, { recursive: true, force: true }); } catch { }
+		}
 	});
 });

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -162,11 +162,13 @@ suite('git smoke test', function () {
 		try {
 			await repository.createBranch('test', true);
 
+			// Delete file (test branch)
 			fs.unlinkSync(appjs);
 			await repository.commit('commit on test', { all: true });
 
 			await repository.checkout('main');
 
+			// Rename file (main branch)
 			fs.renameSync(appjs, renamejs);
 			await repository.commit('commit on main', { all: true });
 

--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -9,6 +9,7 @@ import { workspace, commands, window, Uri, WorkspaceEdit, Range, TextDocument, e
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import type { GitExtension, API, Repository } from '../api/git';
 import { Status } from '../api/git.constants';
 import { eventToPromise } from '../util';
@@ -35,6 +36,12 @@ suite('git smoke test', function () {
 		const end = doc.lineAt(doc.lineCount - 1).range.end;
 		edit.replace(doc.uri, new Range(end, end), text);
 		await workspace.applyEdit(edit);
+	}
+
+	function commitFile(relativePath: string) {
+		fs.writeFileSync(file(relativePath), relativePath, 'utf8');
+		cp.execFileSync('git', ['add', '--', relativePath], { cwd });
+		cp.execFileSync('git', ['commit', '-m', relativePath], { cwd });
 	}
 
 	let git: API;
@@ -153,26 +160,81 @@ suite('git smoke test', function () {
 		const appjs = file('app.js');
 		const renamejs = file('rename.js');
 
-		await repository.createBranch('test', true);
+		try {
+			await repository.createBranch('test', true);
 
-		// Delete file (test branch)
-		fs.unlinkSync(appjs);
-		await repository.commit('commit on test', { all: true });
+			// Delete file (test branch)
+			fs.unlinkSync(appjs);
+			await repository.commit('commit on test', { all: true });
 
-		await repository.checkout('main');
+			await repository.checkout('main');
 
-		// Rename file (main branch)
-		fs.renameSync(appjs, renamejs);
-		await repository.commit('commit on main', { all: true });
+			// Rename file (main branch)
+			fs.renameSync(appjs, renamejs);
+			await repository.commit('commit on main', { all: true });
+
+			try {
+				await repository.merge('test');
+			} catch (e) { }
+
+			assert.strictEqual(repository.state.mergeChanges.length, 1);
+			assert.strictEqual(repository.state.mergeChanges[0].status, Status.DELETED_BY_THEM);
+
+			assert.strictEqual(repository.state.workingTreeChanges.length, 0);
+			assert.strictEqual(repository.state.indexChanges.length, 0);
+		} finally {
+			try { cp.execSync('git merge --abort', { cwd, stdio: 'pipe' }); } catch { }
+		}
+	});
+
+	test('sync respects triangular workflow (pull from upstream, push to origin)', async function () {
+		const testId = Date.now();
+		const upstreamBare = path.join(os.tmpdir(), `vscode-git-sync-upstream-${testId}`);
+		const originBare = path.join(os.tmpdir(), `vscode-git-sync-origin-${testId}`);
+		cp.execSync(`git -c advice.defaultBranchName=false init --bare "${upstreamBare}"`);
+		cp.execSync(`git -c advice.defaultBranchName=false init --bare "${originBare}"`);
 
 		try {
-			await repository.merge('test');
-		} catch (e) { }
+			cp.execSync(`git remote add origin "${originBare}"`, { cwd });
+			cp.execSync(`git remote add upstream "${upstreamBare}"`, { cwd });
 
-		assert.strictEqual(repository.state.mergeChanges.length, 1);
-		assert.strictEqual(repository.state.mergeChanges[0].status, Status.DELETED_BY_THEM);
+			cp.execSync(`git push upstream main:main`, { cwd });
+			cp.execSync('git checkout upstream/main -b feature', { cwd });
+			cp.execSync('git config branch.feature.pushRemote origin', { cwd });
+			cp.execSync('git push origin feature', { cwd });
 
-		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
-		assert.strictEqual(repository.state.indexChanges.length, 0);
+			cp.execSync('git checkout main', { cwd });
+			commitFile('main-first.txt');
+			commitFile('main-second.txt');
+			cp.execSync('git push upstream main', { cwd });
+
+			cp.execSync('git checkout feature', { cwd });
+			cp.execSync('git push', { cwd });
+			commitFile('feature-first.txt');
+
+			await workspace.getConfiguration('git', Uri.file(cwd)).update('confirmSync', false, true);
+			await repository.status();
+
+			assert.strictEqual(repository.state.HEAD?.name, 'feature');
+			assert.strictEqual(repository.state.HEAD?.ahead, 1, 'sync should show 1 commits to push to origin');
+			assert.strictEqual(repository.state.HEAD?.behind, 2, 'sync should show 2 commit to pull from upstream');
+
+			await commands.executeCommand('git.sync');
+			await repository.status();
+			assert.strictEqual(repository.state.HEAD?.ahead, 0);
+			assert.strictEqual(repository.state.HEAD?.behind, 0);
+
+			const originFeatureCommit = cp.execSync('git rev-parse origin/feature', { cwd, encoding: 'utf8' }).trim();
+			assert.strictEqual(repository.state.HEAD?.commit, originFeatureCommit, 'HEAD should be synced with origin/feature');
+			cp.execSync('git merge-base --is-ancestor upstream/main HEAD', { cwd });
+		} finally {
+			try { cp.execSync('git checkout main', { cwd }); } catch { }
+			try { cp.execSync('git branch -D feature', { cwd }); } catch { }
+			try { cp.execSync('git remote remove upstream', { cwd }); } catch { }
+			try { cp.execSync('git remote remove origin', { cwd }); } catch { }
+			try { cp.execSync('git config --unset branch.feature.pushRemote', { cwd }); } catch { }
+			try { fs.rmSync(upstreamBare, { recursive: true, force: true }); } catch { }
+			try { fs.rmSync(originBare, { recursive: true, force: true }); } catch { }
+		}
 	});
 });

--- a/extensions/github/src/typings/git.d.ts
+++ b/extensions/github/src/typings/git.d.ts
@@ -32,13 +32,13 @@ export interface Ref {
 	readonly remote?: string;
 }
 
-export interface UpstreamRef {
+export interface RemoteRef {
 	readonly remote: string;
 	readonly name: string;
 }
 
 export interface Branch extends Ref {
-	readonly upstream?: UpstreamRef;
+	readonly upstream?: RemoteRef;
 	readonly ahead?: number;
 	readonly behind?: number;
 }


### PR DESCRIPTION
I use these for my branches:

```bash
git config remote.pushDefault origin
git branch --set-upstream-to upstream
```

This made VSCode push directly to origin/main when I ran "Sync changes". That is very dangerous, it should respect push branches which is a feature built into Git itself! From my terminal I can simply run 'git push' to push to `my_branch` but it's not good that VSCode pushes directly to upstream.

For reference, I have been working on Git core lately, so though I would take the opportunity to do a related fix here while my knowledge is still fresh: https://github.com/pulls/authored?q=author%3A%40me+repo%3Agit%2Fgit+label%3Amaster
