### PR TITLE
Remove inline action buttons from update status bar entry tooltip.

### DIFF
--- a/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
@@ -135,14 +135,3 @@
 	color: var(--vscode-descriptionForeground);
 	font-size: var(--vscode-bodyFontSize-small);
 }
-
-/* Action button */
-.update-status-tooltip .action-button-container {
-	display: flex;
-	justify-content: flex-end;
-	margin-top: 8px;
-}
-
-.update-status-tooltip .action-button-container .monaco-button {
-	padding: 4px 14px;
-}

--- a/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
-import { Button } from '../../../../base/browser/ui/button/button.js';
 import { toAction } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
@@ -17,7 +16,6 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IHoverService, nativeHoverDelegate } from '../../../../platform/hover/browser/hover.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
-import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { Downloading, IUpdate, IUpdateService, Overwriting, StateType, State as UpdateState } from '../../../../platform/update/common/update.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, ShowTooltipCommand, StatusbarAlignment, TooltipContent } from '../../../services/statusbar/browser/statusbar.js';
@@ -198,10 +196,6 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 				this.appendProductInfo(container, update);
 				this.appendWhatsIncluded(container);
 
-				this.appendActionButton(container, nls.localize('updateStatus.downloadButton', "Download"), store, () => {
-					this.runCommandAndClose('update.downloadNow');
-				});
-
 				return container;
 			}
 		};
@@ -274,10 +268,6 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 				this.appendProductInfo(container, update);
 				this.appendWhatsIncluded(container);
 
-				this.appendActionButton(container, nls.localize('updateStatus.installButton', "Install"), store, () => {
-					this.runCommandAndClose('update.install');
-				});
-
 				return container;
 			}
 		};
@@ -292,10 +282,6 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 				this.appendHeader(container, nls.localize('updateStatus.updateInstalledTitle', "Update Installed"), store);
 				this.appendProductInfo(container, update);
 				this.appendWhatsIncluded(container);
-
-				this.appendActionButton(container, nls.localize('updateStatus.restartButton', "Restart"), store, () => {
-					this.runCommandAndClose('update.restart');
-				});
 
 				return container;
 			}
@@ -403,7 +389,8 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 		}
 	}
 
-	private appendWhatsIncluded(container: HTMLElement): void {
+	private appendWhatsIncluded(container: HTMLElement) {
+		/*
 		const whatsIncluded = dom.append(container, dom.$('.whats-included'));
 
 		const sectionTitle = dom.append(whatsIncluded, dom.$('.section-title'));
@@ -421,13 +408,7 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 			const li = dom.append(list, dom.$('li'));
 			li.textContent = item;
 		}
-	}
-
-	private appendActionButton(container: HTMLElement, label: string, store: DisposableStore, onClick: () => void): void {
-		const buttonContainer = dom.append(container, dom.$('.action-button-container'));
-		const button = store.add(new Button(buttonContainer, { ...defaultButtonStyles, secondary: true, hoverDelegate: nativeHoverDelegate }));
-		button.label = label;
-		store.add(button.onDidClick(onClick));
+		*/
 	}
 }
 


### PR DESCRIPTION
Removing inline action buttons per UX feedback.
Hiding changes summary until it is populated from real content.
