### PR TITLE
moves share button to the left of command palette

### DIFF
--- a/src/vs/workbench/contrib/share/browser/share.contribution.ts
+++ b/src/vs/workbench/contrib/share/browser/share.contribution.ts
@@ -98,7 +98,7 @@ class ShareWorkbenchContribution extends Disposable {
 							primary: KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.KeyS,
 						},
 						menu: [
-							{ id: MenuId.CommandCenter, order: 1000 }
+							{ id: MenuId.CommandCenter, order: 3 }
 						]
 					});
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

today when agent status and share are enabled, the share button is between both. this pr moves share button to left of command palette.

---

<img width="540" height="39" alt="Screenshot 2026-02-05 at 1 31 54 PM" src="https://github.com/user-attachments/assets/40cc7de5-0f54-48fd-9528-aa855deec4ed" />
<img width="612" height="38" alt="Screenshot 2026-02-05 at 1 31 45 PM" src="https://github.com/user-attachments/assets/d5c61d34-c12d-4f3b-9229-48d70dda57fc" />
✅


<img width="660" height="41" alt="Screenshot 2026-02-05 at 1 51 16 PM" src="https://github.com/user-attachments/assets/64408fe6-0338-4327-860e-345601ff52c1" />
❌