### PR TITLE
chat: polish queue/steering menu button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -178,7 +178,8 @@ abstract class SubmitAction extends Action2 {
 	}
 }
 
-const whenNotInProgress = ChatContextKeys.requestInProgress.negate();
+const requestInProgressOrPendingToolCall = ContextKeyExpr.or(ChatContextKeys.requestInProgress, ChatContextKeys.Editing.hasToolConfirmation);
+const whenNotInProgress = ContextKeyExpr.and(ChatContextKeys.requestInProgress.negate(), ChatContextKeys.Editing.hasToolConfirmation.negate());
 
 export class ChatSubmitAction extends SubmitAction {
 	static readonly ID = 'workbench.action.chat.submit';
@@ -667,7 +668,7 @@ export class ChatEditingSessionSubmitAction extends SubmitAction {
 					id: MenuId.ChatExecute,
 					order: 4,
 					when: ContextKeyExpr.and(
-						ChatContextKeys.requestInProgress.negate(),
+						whenNotInProgress,
 						menuCondition),
 					group: 'navigation',
 					alt: {
@@ -821,7 +822,7 @@ export class CancelAction extends Action2 {
 			menu: [{
 				id: MenuId.ChatExecute,
 				when: ContextKeyExpr.and(
-					ChatContextKeys.requestInProgress,
+					requestInProgressOrPendingToolCall,
 					ChatContextKeys.remoteJobCreating.negate(),
 					ChatContextKeys.currentlyEditing.negate(),
 				),
@@ -841,7 +842,7 @@ export class CancelAction extends Action2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.Escape,
 				when: ContextKeyExpr.and(
-					ChatContextKeys.requestInProgress,
+					requestInProgressOrPendingToolCall,
 					ChatContextKeys.remoteJobCreating.negate()
 				),
 				win: { primary: KeyMod.Alt | KeyCode.Backspace },

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -4,21 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../../nls.js';
-import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
+import { Action2, MenuId, MenuRegistry, registerAction2, SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatRequestQueueKind, IChatService } from '../../common/chatService/chatService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetService } from '../chat.js';
+import { ChatQueuePickerActionItem } from '../widget/input/chatQueuePickerActionItem.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 
 const queueingEnabledCondition = ContextKeyExpr.equals(`config.${ChatConfiguration.RequestQueueingEnabled}`, true);
+const requestInProgressOrPendingToolCall = ContextKeyExpr.or(ChatContextKeys.requestInProgress, ChatContextKeys.Editing.hasToolConfirmation);
 
 export interface IChatRemovePendingRequestContext {
 	sessionResource: URI;
@@ -47,23 +53,18 @@ export class ChatQueueMessageAction extends Action2 {
 			category: CHAT_CATEGORY,
 			precondition: ContextKeyExpr.and(
 				queueingEnabledCondition,
-				ChatContextKeys.requestInProgress,
+				requestInProgressOrPendingToolCall,
 				ChatContextKeys.inputHasText
 			),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
-					ChatContextKeys.requestInProgress,
+					requestInProgressOrPendingToolCall,
 					queueingEnabledCondition
 				),
 				primary: KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib + 1
 			},
-			menu: [{
-				id: MenuId.ChatExecuteQueue,
-				group: 'navigation',
-				order: 1,
-			}]
 		});
 	}
 
@@ -96,23 +97,18 @@ export class ChatSteerWithMessageAction extends Action2 {
 			category: CHAT_CATEGORY,
 			precondition: ContextKeyExpr.and(
 				queueingEnabledCondition,
-				ChatContextKeys.requestInProgress,
+				requestInProgressOrPendingToolCall,
 				ChatContextKeys.inputHasText
 			),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inChatInput,
-					ChatContextKeys.requestInProgress,
+					requestInProgressOrPendingToolCall,
 					queueingEnabledCondition
 				),
 				primary: KeyMod.Alt | KeyCode.Enter,
 				weight: KeybindingWeight.EditorContrib + 1
 			},
-			menu: [{
-				id: MenuId.ChatExecuteQueue,
-				group: 'navigation',
-				order: 2,
-			}]
 		});
 	}
 
@@ -270,6 +266,29 @@ export class ChatRemoveAllPendingRequestsAction extends Action2 {
 	}
 }
 
+/**
+ * Workbench contribution that registers a custom action view item for the
+ * queue/steer picker in the execute toolbar. This replaces the default split
+ * button with a custom dropdown similar to the model switcher.
+ */
+export class ChatQueuePickerRendering extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.queuePickerRendering';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._register(actionViewItemService.register(MenuId.ChatExecute, MenuId.ChatExecuteQueue, (action, options) => {
+			if (!(action instanceof SubmenuItemAction)) {
+				return undefined;
+			}
+			return instantiationService.createInstance(ChatQueuePickerActionItem, action, options);
+		}));
+	}
+}
+
 export function registerChatQueueActions(): void {
 	registerAction2(ChatQueueMessageAction);
 	registerAction2(ChatSteerWithMessageAction);
@@ -277,19 +296,31 @@ export function registerChatQueueActions(): void {
 	registerAction2(ChatSendPendingImmediatelyAction);
 	registerAction2(ChatRemoveAllPendingRequestsAction);
 
-	// Register the queue submenu as a split button dropdown in the execute toolbar
-	// This shows "Add to Queue" / "Steer with Message" when a request is in progress and input has text
+	// Register the queue submenu in the execute toolbar.
+	// The custom ChatQueuePickerActionItem (registered via IActionViewItemService)
+	// replaces the default rendering with a dropdown that shows hover descriptions.
+	// We still need items in ChatExecuteQueue so the menu system treats it as non-empty.
+	MenuRegistry.appendMenuItem(MenuId.ChatExecuteQueue, {
+		command: { id: ChatQueueMessageAction.ID, title: localize2('chat.queueMessage', "Add to Queue"), icon: Codicon.add },
+		group: 'navigation',
+		order: 1,
+	});
+	MenuRegistry.appendMenuItem(MenuId.ChatExecuteQueue, {
+		command: { id: ChatSteerWithMessageAction.ID, title: localize2('chat.steerWithMessage', "Steer with Message"), icon: Codicon.arrowRight },
+		group: 'navigation',
+		order: 2,
+	});
+
 	MenuRegistry.appendMenuItem(MenuId.ChatExecute, {
 		submenu: MenuId.ChatExecuteQueue,
 		title: localize2('chat.queueSubmenu', "Queue"),
 		icon: Codicon.listOrdered,
 		when: ContextKeyExpr.and(
 			queueingEnabledCondition,
-			ChatContextKeys.requestInProgress,
+			requestInProgressOrPendingToolCall,
 			ChatContextKeys.inputHasText
 		),
 		group: 'navigation',
 		order: 4,
-		isSplitButton: { togglePrimaryAction: true }
 	});
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -4,23 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { localize, localize2 } from '../../../../../nls.js';
-import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, MenuId, MenuRegistry, registerAction2, SubmenuItemAction } from '../../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
-import { IWorkbenchContribution } from '../../../../common/contributions.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatRequestQueueKind, IChatService } from '../../common/chatService/chatService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { isRequestVM } from '../../common/model/chatViewModel.js';
 import { IChatWidgetService } from '../chat.js';
-import { ChatQueuePickerActionItem } from '../widget/input/chatQueuePickerActionItem.js';
 import { CHAT_CATEGORY } from './chatActions.js';
 
 const queueingEnabledCondition = ContextKeyExpr.equals(`config.${ChatConfiguration.RequestQueueingEnabled}`, true);
@@ -263,29 +258,6 @@ export class ChatRemoveAllPendingRequestsAction extends Action2 {
 		for (const pendingRequest of [...model.getPendingRequests()]) {
 			chatService.removePendingRequest(model.sessionResource, pendingRequest.request.id);
 		}
-	}
-}
-
-/**
- * Workbench contribution that registers a custom action view item for the
- * queue/steer picker in the execute toolbar. This replaces the default split
- * button with a custom dropdown similar to the model switcher.
- */
-export class ChatQueuePickerRendering extends Disposable implements IWorkbenchContribution {
-
-	static readonly ID = 'chat.queuePickerRendering';
-
-	constructor(
-		@IActionViewItemService actionViewItemService: IActionViewItemService,
-		@IInstantiationService instantiationService: IInstantiationService,
-	) {
-		super();
-		this._register(actionViewItemService.register(MenuId.ChatExecute, MenuId.ChatExecuteQueue, (action, options) => {
-			if (!(action instanceof SubmenuItemAction)) {
-				return undefined;
-			}
-			return instantiationService.createInstance(ChatQueuePickerActionItem, action, options);
-		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -81,7 +81,7 @@ import { registerLanguageModelActions } from './actions/chatLanguageModelActions
 import { registerMoveActions } from './actions/chatMoveActions.js';
 import { registerNewChatActions } from './actions/chatNewActions.js';
 import { registerChatPromptNavigationActions } from './actions/chatPromptNavigationActions.js';
-import { registerChatQueueActions } from './actions/chatQueueActions.js';
+import { ChatQueuePickerRendering, registerChatQueueActions } from './actions/chatQueueActions.js';
 import { registerQuickChatActions } from './actions/chatQuickInputActions.js';
 import { ChatAgentRecommendation } from './actions/chatAgentRecommendationActions.js';
 import { registerChatTitleActions } from './actions/chatTitleActions.js';
@@ -612,6 +612,16 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.requestQueuing.enabled.description', "When enabled, allows queuing additional messages while a request is in progress and steering the current request with a new message."),
 			default: true,
 			tags: ['experimental'],
+		},
+		[ChatConfiguration.RequestQueueingDefaultAction]: {
+			type: 'string',
+			enum: ['queue', 'steer'],
+			enumDescriptions: [
+				nls.localize('chat.requestQueuing.defaultAction.queue', "Queue the message to send after the current request completes."),
+				nls.localize('chat.requestQueuing.defaultAction.steer', "Steer the current request by sending the message immediately, signaling the current request to yield."),
+			],
+			description: nls.localize('chat.requestQueuing.defaultAction.description', "Controls which action is the default for the queue button when a request is in progress."),
+			default: 'steer',
 		},
 		[ChatConfiguration.EditModeHidden]: {
 			type: 'boolean',
@@ -1438,6 +1448,7 @@ registerWorkbenchContribution2(ChatAgentActionsContribution.ID, ChatAgentActions
 registerWorkbenchContribution2(ToolReferenceNamesContribution.ID, ToolReferenceNamesContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatAgentRecommendation.ID, ChatAgentRecommendation, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatEditingEditorAccessibility.ID, ChatEditingEditorAccessibility, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(ChatQueuePickerRendering.ID, ChatQueuePickerRendering, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatEditingEditorOverlay.ID, ChatEditingEditorOverlay, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(SimpleBrowserOverlay.ID, SimpleBrowserOverlay, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEditorContextKeys, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -81,7 +81,7 @@ import { registerLanguageModelActions } from './actions/chatLanguageModelActions
 import { registerMoveActions } from './actions/chatMoveActions.js';
 import { registerNewChatActions } from './actions/chatNewActions.js';
 import { registerChatPromptNavigationActions } from './actions/chatPromptNavigationActions.js';
-import { ChatQueuePickerRendering, registerChatQueueActions } from './actions/chatQueueActions.js';
+import { registerChatQueueActions } from './actions/chatQueueActions.js';
 import { registerQuickChatActions } from './actions/chatQuickInputActions.js';
 import { ChatAgentRecommendation } from './actions/chatAgentRecommendationActions.js';
 import { registerChatTitleActions } from './actions/chatTitleActions.js';
@@ -141,6 +141,7 @@ import { ChatWindowNotifier } from './chatWindowNotifier.js';
 import { ChatRepoInfoContribution } from './chatRepoInfo.js';
 import { VALID_PROMPT_FOLDER_PATTERN } from '../common/promptSyntax/utils/promptFilesLocator.js';
 import { ChatTipService, IChatTipService } from './chatTipService.js';
+import { ChatQueuePickerRendering } from './widget/input/chatQueuePickerActionItem.js';
 
 const toolReferenceNameEnumValues: string[] = [];
 const toolReferenceNameEnumDescriptions: string[] = [];

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -1,0 +1,214 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, addDisposableListener, append, EventType } from '../../../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
+import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { Action } from '../../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { KeyCode } from '../../../../../../base/common/keyCodes.js';
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { localize } from '../../../../../../nls.js';
+import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
+import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
+import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+import { ChatSubmitAction } from '../../actions/chatExecuteActions.js';
+import { ChatQueueMessageAction, ChatSteerWithMessageAction } from '../../actions/chatQueueActions.js';
+
+/**
+ * Split-button action view item for the queue/steer picker in the chat execute toolbar.
+ * The primary button runs the current default action (queue or steer).
+ * The dropdown arrow opens a custom action widget with hover descriptions.
+ *
+ * Follows the same split-button pattern as {@link DropdownWithDefaultActionViewItem},
+ * but uses {@link ActionWidgetDropdownActionViewItem} for the dropdown to show
+ * an action widget with hover descriptions instead of a standard context menu.
+ */
+export class ChatQueuePickerActionItem extends BaseActionViewItem {
+
+	private readonly _primaryActionAction: Action;
+	private readonly _primaryAction: ActionViewItem;
+	private readonly _dropdown: ActionWidgetDropdownActionViewItem;
+
+	constructor(
+		action: IAction,
+		_options: IActionViewItemOptions,
+		@ICommandService private readonly commandService: ICommandService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IActionWidgetService actionWidgetService: IActionWidgetService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super(undefined, action);
+
+		const isSteerDefault = this._isSteerDefault();
+
+		// Primary action - runs the current default (queue or steer)
+		this._primaryActionAction = this._register(new Action(
+			'chat.queuePickerPrimary',
+			isSteerDefault ? localize('chat.steerWithMessage', "Steer with Message") : localize('chat.queueMessage', "Add to Queue"),
+			ThemeIcon.asClassName(isSteerDefault ? Codicon.arrowRight : Codicon.add),
+			true,
+			() => this._runDefaultAction()
+		));
+		this._primaryAction = this._register(new ActionViewItem(undefined, this._primaryActionAction, { icon: true, label: false }));
+
+		// Dropdown - action widget with hover descriptions and chevron-down icon
+		const dropdownAction = this._register(new Action('chat.queuePickerDropdown', localize('chat.queuePicker.moreActions', "More Actions...")));
+		this._dropdown = this._register(new ChevronActionWidgetDropdown(
+			dropdownAction,
+			{
+				actionProvider: { getActions: () => this._getDropdownActions() },
+				showItemKeybindings: true,
+			},
+			actionWidgetService,
+			keybindingService,
+			contextKeyService,
+			telemetryService,
+		));
+
+		// React to config changes
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.RequestQueueingDefaultAction)) {
+				this._updatePrimaryAction();
+			}
+		}));
+	}
+
+	private _isSteerDefault(): boolean {
+		return this.configurationService.getValue<string>(ChatConfiguration.RequestQueueingDefaultAction) === 'steer';
+	}
+
+	private _updatePrimaryAction(): void {
+		const isSteerDefault = this._isSteerDefault();
+		this._primaryActionAction.label = isSteerDefault
+			? localize('chat.steerWithMessage', "Steer with Message")
+			: localize('chat.queueMessage', "Add to Queue");
+		this._primaryActionAction.class = ThemeIcon.asClassName(isSteerDefault ? Codicon.arrowRight : Codicon.add);
+	}
+
+	private _runDefaultAction(): void {
+		const actionId = this._isSteerDefault()
+			? ChatSteerWithMessageAction.ID
+			: ChatQueueMessageAction.ID;
+		this.commandService.executeCommand(actionId);
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		container.classList.add('monaco-dropdown-with-default');
+
+		// Primary action button
+		const primaryContainer = $('.action-container');
+		this._primaryAction.render(append(container, primaryContainer));
+		this._register(addDisposableListener(primaryContainer, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.RightArrow)) {
+				this._primaryAction.blur();
+				this._dropdown.focus();
+				event.stopPropagation();
+			}
+		}));
+
+		// Dropdown arrow button
+		const dropdownContainer = $('.dropdown-action-container');
+		this._dropdown.render(append(container, dropdownContainer));
+		this._register(addDisposableListener(dropdownContainer, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.LeftArrow)) {
+				this._dropdown.setFocusable(false);
+				this._primaryAction.focus();
+				event.stopPropagation();
+			}
+		}));
+	}
+
+	override focus(fromRight?: boolean): void {
+		if (fromRight) {
+			this._dropdown.focus();
+		} else {
+			this._primaryAction.focus();
+		}
+	}
+
+	override blur(): void {
+		this._primaryAction.blur();
+		this._dropdown.blur();
+	}
+
+	override setFocusable(focusable: boolean): void {
+		this._primaryAction.setFocusable(focusable);
+		this._dropdown.setFocusable(focusable);
+	}
+
+	private _getDropdownActions(): IActionWidgetDropdownAction[] {
+		const queueAction: IActionWidgetDropdownAction = {
+			id: ChatQueueMessageAction.ID,
+			label: localize('chat.queueMessage', "Add to Queue"),
+			tooltip: '',
+			enabled: true,
+			icon: Codicon.add,
+			class: undefined,
+			hover: {
+				content: localize('chat.queueMessage.hover', "Queue this message to send after the current request completes. The current response will finish uninterrupted before the queued message is sent."),
+			},
+			run: () => {
+				this.commandService.executeCommand(ChatQueueMessageAction.ID);
+			}
+		};
+
+		const steerAction: IActionWidgetDropdownAction = {
+			id: ChatSteerWithMessageAction.ID,
+			label: localize('chat.steerWithMessage', "Steer with Message"),
+			tooltip: '',
+			enabled: true,
+			icon: Codicon.arrowRight,
+			class: undefined,
+			hover: {
+				content: localize('chat.steerWithMessage.hover', "Send this message at the next opportunity, signaling the current request to yield. The current response will stop and the new message will be sent immediately."),
+			},
+			run: () => {
+				this.commandService.executeCommand(ChatSteerWithMessageAction.ID);
+			}
+		};
+
+		const sendAction: IActionWidgetDropdownAction = {
+			id: '_' + ChatSubmitAction.ID, // _ to avoid showing a keybinding which is not valid in this context
+			label: localize('chat.sendImmediately', "Send Immediately"),
+			tooltip: '',
+			enabled: true,
+			checked: false,
+			icon: Codicon.send,
+			class: undefined,
+			hover: {
+				content: localize('chat.sendImmediately.hover', "Cancel the current request and send this message immediately."),
+			},
+			run: () => {
+				this.commandService.executeCommand(ChatSubmitAction.ID);
+			}
+		};
+
+		return [sendAction, queueAction, steerAction];
+	}
+}
+
+/**
+ * {@link ActionWidgetDropdownActionViewItem} that renders a chevron-down icon
+ * as its label, used as the dropdown arrow in the split button.
+ */
+class ChevronActionWidgetDropdown extends ActionWidgetDropdownActionViewItem {
+	protected override renderLabel(element: HTMLElement): IDisposable | null {
+		element.classList.add('codicon', 'codicon-chevron-down');
+		return null;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -6,7 +6,7 @@
 import { $, addDisposableListener, append, EventType } from '../../../../../../base/browser/dom.js';
 import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
-import { Action } from '../../../../../../base/common/actions.js';
+import { Action, IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
@@ -187,7 +187,6 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			label: localize('chat.sendImmediately', "Send Immediately"),
 			tooltip: '',
 			enabled: true,
-			checked: false,
 			icon: Codicon.send,
 			class: undefined,
 			hover: {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -9,17 +9,21 @@ import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../.
 import { Action, IAction } from '../../../../../../base/common/actions.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
-import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
+import { IActionViewItemService } from '../../../../../../platform/actions/browser/actionViewItemService.js';
 import { ActionWidgetDropdownActionViewItem } from '../../../../../../platform/actions/browser/actionWidgetDropdownActionViewItem.js';
+import { MenuId, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
+import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { ChatSubmitAction } from '../../actions/chatExecuteActions.js';
 import { ChatQueueMessageAction, ChatSteerWithMessageAction } from '../../actions/chatQueueActions.js';
@@ -209,5 +213,29 @@ class ChevronActionWidgetDropdown extends ActionWidgetDropdownActionViewItem {
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
 		element.classList.add('codicon', 'codicon-chevron-down');
 		return null;
+	}
+}
+
+
+/**
+ * Workbench contribution that registers a custom action view item for the
+ * queue/steer picker in the execute toolbar. This replaces the default split
+ * button with a custom dropdown similar to the model switcher.
+ */
+export class ChatQueuePickerRendering extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chat.queuePickerRendering';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._register(actionViewItemService.register(MenuId.ChatExecute, MenuId.ChatExecuteQueue, (action, options) => {
+			if (!(action instanceof SubmenuItemAction)) {
+				return undefined;
+			}
+			return instantiationService.createInstance(ChatQueuePickerActionItem, action, options);
+		}));
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -12,6 +12,7 @@ export enum ChatConfiguration {
 	AIDisabled = 'chat.disableAIFeatures',
 	AgentEnabled = 'chat.agent.enabled',
 	RequestQueueingEnabled = 'chat.requestQueuing.enabled',
+	RequestQueueingDefaultAction = 'chat.requestQueuing.defaultAction',
 	AgentStatusEnabled = 'chat.agentsControl.enabled',
 	EditorAssociations = 'chat.editorAssociations',
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',


### PR DESCRIPTION
- Dropdown action that uses custom dropdowns to queue, steer, or send
  immediately.
- Fix not being able to message with a pending tool call
- Config controls the default button action

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
