### PR TITLE
Enhance preToolUse hook and clean up code

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -290,8 +290,12 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			chatRequestId: context.chatRequestId,
 			chatSessionId: context.chatSessionId,
 			chatSessionResource: context.chatSessionResource,
-			chatInteractionId: context.chatInteractionId
+			chatInteractionId: context.chatInteractionId,
+			forceConfirmationReason: context.forceConfirmationReason
 		};
+		if (context.forceConfirmationReason) {
+			checkProposedApiEnabled(item.extension, 'chatParticipantPrivate');
+		}
 		if (item.tool.prepareInvocation) {
 			const result = await item.tool.prepareInvocation(options, token);
 			if (!result) {
@@ -309,7 +313,7 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 				} : undefined,
 				invocationMessage: typeConvert.MarkdownString.fromStrict(result.invocationMessage),
 				pastTenseMessage: typeConvert.MarkdownString.fromStrict(result.pastTenseMessage),
-				presentation: result.presentation as ToolInvocationPresentation | undefined
+				presentation: result.presentation as ToolInvocationPresentation | undefined,
 			};
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -530,7 +530,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				preparedInvocation = await this.prepareToolInvocationWithHookResult(tool, dto, preToolUseHookResult, token);
 				prepareTimeWatch.stop();
 
-				const autoConfirmed = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, dto.context?.sessionResource);
+				const { autoConfirmed, preparedInvocation: updatedPreparedInvocation } = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, dto.context?.sessionResource);
+				preparedInvocation = updatedPreparedInvocation;
 
 
 				// Important: a tool invocation that will be autoconfirmed should never
@@ -578,7 +579,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				preparedInvocation = await this.prepareToolInvocationWithHookResult(tool, dto, preToolUseHookResult, token);
 				prepareTimeWatch.stop();
 
-				const fallbackAutoConfirmed = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, undefined);
+				const { autoConfirmed: fallbackAutoConfirmed, preparedInvocation: updatedPreparedInvocation } = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, undefined);
+				preparedInvocation = updatedPreparedInvocation;
 				if (preparedInvocation?.confirmationMessages?.title && !fallbackAutoConfirmed) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
@@ -664,7 +666,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	private async prepareToolInvocationWithHookResult(tool: IToolEntry, dto: IToolInvocation, hookResult: IPreToolUseHookResult | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
-		const forceConfirmationReason = hookResult?.permissionDecision === 'ask' ? (hookResult.permissionDecisionReason ?? '') : undefined;
+		const forceConfirmationReason = hookResult?.permissionDecision === 'ask' ? (hookResult.permissionDecisionReason || 'Hook requested confirmation') : undefined;
 		return this.prepareToolInvocation(tool, dto, forceConfirmationReason, token);
 	}
 
@@ -673,6 +675,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	 * If the hook returned 'allow', auto-approves. If 'ask', forces confirmation
 	 * and ensures confirmation messages exist on `preparedInvocation`. Otherwise
 	 * falls back to normal auto-confirm logic.
+	 *
+	 * Returns the possibly-updated preparedInvocation along with the auto-confirm decision,
+	 * since when the hook returns 'ask' and preparedInvocation was undefined, we create one.
 	 */
 	private async resolveAutoConfirmFromHook(
 		hookResult: IPreToolUseHookResult | undefined,
@@ -680,10 +685,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		dto: IToolInvocation,
 		preparedInvocation: IPreparedToolInvocation | undefined,
 		sessionResource: URI | undefined,
-	): Promise<ConfirmedReason | undefined> {
+	): Promise<{ autoConfirmed: ConfirmedReason | undefined; preparedInvocation: IPreparedToolInvocation | undefined }> {
 		if (hookResult?.permissionDecision === 'allow') {
 			this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} auto-approved by preToolUse hook`);
-			return { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
+			return { autoConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") }, preparedInvocation };
 		}
 
 		if (hookResult?.permissionDecision === 'ask') {
@@ -707,11 +712,12 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 					rawInput: dto.parameters,
 				};
 			}
-			return undefined;
+			return { autoConfirmed: undefined, preparedInvocation };
 		}
 
 		// No hook decision - use normal auto-confirm logic
-		return this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, sessionResource);
+		const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, sessionResource);
+		return { autoConfirmed, preparedInvocation };
 	}
 
 	private async prepareToolInvocation(tool: IToolEntry, dto: IToolInvocation, forceConfirmationReason: string | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -666,7 +666,13 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 	}
 
 	private async prepareToolInvocationWithHookResult(tool: IToolEntry, dto: IToolInvocation, hookResult: IPreToolUseHookResult | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
-		const forceConfirmationReason = hookResult?.permissionDecision === 'ask' ? (hookResult.permissionDecisionReason || 'Hook requested confirmation') : undefined;
+		let forceConfirmationReason: string | undefined;
+		if (hookResult?.permissionDecision === 'ask') {
+			const hookMessage = localize('preToolUseHookRequiredConfirmation', "{0} required confirmation", HookType.PreToolUse);
+			forceConfirmationReason = hookResult.permissionDecisionReason
+				? `${hookMessage}: ${hookResult.permissionDecisionReason}`
+				: hookMessage;
+		}
 		return this.prepareToolInvocation(tool, dto, forceConfirmationReason, token);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -34,7 +34,7 @@ import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
-import { IPreToolUseCallerInput } from '../../common/hooks/hooksTypes.js';
+import { IPreToolUseCallerInput, IPreToolUseHookResult } from '../../common/hooks/hooksTypes.js';
 import { IHooksExecutionService } from '../../common/hooks/hooksExecutionService.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ChatRequestToolReferenceEntry, toToolSetVariableEntry, toToolVariableEntry } from '../../common/attachments/chatVariableEntries.js';
@@ -363,19 +363,21 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	/**
 	 * Execute the preToolUse hook and handle denial.
-	 * Returns a tool result if the hook denied execution, or undefined to continue.
+	 * Returns an object containing:
+	 * - denialResult: A tool result if the hook denied execution (caller should return early)
+	 * - hookResult: The full hook result for use in auto-approval logic (allow/ask decisions)
 	 * @param pendingInvocation If there's an existing streaming invocation from beginToolCall, pass it here to cancel it instead of creating a new one.
 	 */
-	private async _executePreToolUseHookAndHandleDenial(
+	private async _executePreToolUseHook(
 		dto: IToolInvocation,
 		toolData: IToolData | undefined,
 		request: IChatRequestModel | undefined,
 		pendingInvocation: ChatToolInvocation | undefined,
 		token: CancellationToken
-	): Promise<IToolResult | undefined> {
+	): Promise<{ denialResult?: IToolResult; hookResult?: IPreToolUseHookResult }> {
 		// Skip hook if no session context or tool doesn't exist
 		if (!dto.context?.sessionResource || !toolData) {
-			return undefined;
+			return {};
 		}
 
 		const hookInput: IPreToolUseCallerInput = {
@@ -409,12 +411,15 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 			const denialMessage = localize('toolExecutionDenied', "Tool execution denied: {0}", hookReason);
 			return {
-				content: [{ kind: 'text', value: denialMessage }],
-				toolResultError: hookReason,
+				denialResult: {
+					content: [{ kind: 'text', value: denialMessage }],
+					toolResultError: hookReason,
+				},
+				hookResult,
 			};
 		}
 
-		return undefined;
+		return { hookResult };
 	}
 
 	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
@@ -465,7 +470,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 
 		// Execute preToolUse hook - returns early if hook denies execution
-		const hookDenialResult = await this._executePreToolUseHookAndHandleDenial(dto, toolData, request, toolInvocation, token);
+		const { denialResult: hookDenialResult, hookResult: preToolUseHookResult } = await this._executePreToolUseHook(dto, toolData, request, toolInvocation, token);
 		if (hookDenialResult) {
 			// Clean up pending tool call if it exists
 			if (pendingToolCallKey) {
@@ -522,10 +527,47 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				dto.userSelectedTools = request.userSelectedTools && { ...request.userSelectedTools };
 
 				prepareTimeWatch = StopWatch.create(true);
-				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
+				const forceConfirmationReason = preToolUseHookResult?.permissionDecision === 'ask' ? (preToolUseHookResult.permissionDecisionReason || true) : undefined;
+				preparedInvocation = await this.prepareToolInvocation(tool, dto, forceConfirmationReason, token);
 				prepareTimeWatch.stop();
 
-				const autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, dto.context?.sessionResource);
+				// Determine auto-confirm based on hook result and normal settings
+				// Hook decisions have priority: 'allow' auto-approves, 'ask' forces confirmation
+				let autoConfirmed: ConfirmedReason | undefined;
+				if (preToolUseHookResult?.permissionDecision === 'allow') {
+					// Hook explicitly allows - auto-approve with reason
+					autoConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
+					this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} auto-approved by preToolUse hook`);
+				} else if (preToolUseHookResult?.permissionDecision === 'ask') {
+					// Hook explicitly requires confirmation - never auto-approve
+					autoConfirmed = undefined;
+					this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} requires confirmation (preToolUse hook returned 'ask')`);
+					// Ensure confirmation messages exist when hook requires confirmation
+					if (!preparedInvocation?.confirmationMessages?.title) {
+						if (!preparedInvocation) {
+							preparedInvocation = {};
+						}
+						const fullReferenceName = getToolFullReferenceName(tool.data);
+						const hookReason = preToolUseHookResult.permissionDecisionReason;
+						// Use MarkdownString for message so the input editor is shown
+						// (chatToolConfirmationSubPart only shows editor when typeof message !== 'string')
+						const baseMessage = localize('hookRequiresConfirmation.message', "{0} hook confirmation required", HookType.PreToolUse);
+						preparedInvocation.confirmationMessages = {
+							...preparedInvocation.confirmationMessages,
+							title: localize('hookRequiresConfirmation.title', "Use the '{0}' tool?", fullReferenceName),
+							message: new MarkdownString(hookReason ? `${baseMessage}\n\n${hookReason}` : baseMessage),
+							allowAutoConfirm: false,
+						};
+						// Show input editor for confirmation
+						preparedInvocation.toolSpecificData = {
+							kind: 'input',
+							rawInput: dto.parameters,
+						};
+					}
+				} else {
+					// No hook decision - use normal auto-confirm logic
+					autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, dto.context?.sessionResource);
+				}
 
 
 				// Important: a tool invocation that will be autoconfirmed should never
@@ -570,9 +612,43 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				}
 			} else {
 				prepareTimeWatch = StopWatch.create(true);
-				preparedInvocation = await this.prepareToolInvocation(tool, dto, token);
+				const forceConfirmationReasonFallback = preToolUseHookResult?.permissionDecision === 'ask' ? (preToolUseHookResult.permissionDecisionReason || true) : undefined;
+				preparedInvocation = await this.prepareToolInvocation(tool, dto, forceConfirmationReasonFallback, token);
 				prepareTimeWatch.stop();
-				if (preparedInvocation?.confirmationMessages?.title && !(await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, undefined))) {
+				// Determine auto-confirm based on hook result and normal settings
+				// Note: hooks only run with session context, but check anyway for consistency
+				let fallbackAutoConfirmed: ConfirmedReason | undefined;
+				if (preToolUseHookResult?.permissionDecision === 'allow') {
+					fallbackAutoConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
+				} else if (preToolUseHookResult?.permissionDecision === 'ask') {
+					fallbackAutoConfirmed = undefined;
+
+					// Ensure confirmation messages exist when hook requires confirmation
+					if (!preparedInvocation?.confirmationMessages?.title) {
+						if (!preparedInvocation) {
+							preparedInvocation = {};
+						}
+						const fullReferenceName = getToolFullReferenceName(tool.data);
+						const hookReason = preToolUseHookResult.permissionDecisionReason;
+						// Use MarkdownString for message so the input editor is shown
+						// (chatToolConfirmationSubPart only shows editor when typeof message !== 'string')
+						const baseMessage = localize('hookRequiresConfirmation.message', "{0} hook confirmation required", HookType.PreToolUse);
+						preparedInvocation.confirmationMessages = {
+							...preparedInvocation.confirmationMessages,
+							title: localize('hookRequiresConfirmation.title', "Use the '{0}' tool?", fullReferenceName),
+							message: new MarkdownString(hookReason ? `${baseMessage}\n\n${hookReason}` : baseMessage),
+							allowAutoConfirm: false,
+						};
+						// Show input editor for confirmation
+						preparedInvocation.toolSpecificData = {
+							kind: 'input',
+							rawInput: dto.parameters,
+						};
+					}
+				} else {
+					fallbackAutoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, undefined);
+				}
+				if (preparedInvocation?.confirmationMessages?.title && !fallbackAutoConfirmed) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
 						throw new CancellationError();
@@ -656,7 +732,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 	}
 
-	private async prepareToolInvocation(tool: IToolEntry, dto: IToolInvocation, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	private async prepareToolInvocation(tool: IToolEntry, dto: IToolInvocation, forceConfirmationReason: string | true | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		let prepared: IPreparedToolInvocation | undefined;
 		if (tool.impl!.prepareToolInvocation) {
 			const preparePromise = tool.impl!.prepareToolInvocation({
@@ -664,7 +740,8 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				chatRequestId: dto.chatRequestId,
 				chatSessionId: dto.context?.sessionId,
 				chatSessionResource: dto.context?.sessionResource,
-				chatInteractionId: dto.chatInteractionId
+				chatInteractionId: dto.chatInteractionId,
+				forceConfirmationReason: typeof forceConfirmationReason === 'string' ? forceConfirmationReason : (forceConfirmationReason ? '' : undefined)
 			}, token);
 
 			const raceResult = await Promise.race([

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -527,47 +527,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				dto.userSelectedTools = request.userSelectedTools && { ...request.userSelectedTools };
 
 				prepareTimeWatch = StopWatch.create(true);
-				const forceConfirmationReason = preToolUseHookResult?.permissionDecision === 'ask' ? (preToolUseHookResult.permissionDecisionReason || true) : undefined;
-				preparedInvocation = await this.prepareToolInvocation(tool, dto, forceConfirmationReason, token);
+				preparedInvocation = await this.prepareToolInvocationWithHookResult(tool, dto, preToolUseHookResult, token);
 				prepareTimeWatch.stop();
 
-				// Determine auto-confirm based on hook result and normal settings
-				// Hook decisions have priority: 'allow' auto-approves, 'ask' forces confirmation
-				let autoConfirmed: ConfirmedReason | undefined;
-				if (preToolUseHookResult?.permissionDecision === 'allow') {
-					// Hook explicitly allows - auto-approve with reason
-					autoConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
-					this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} auto-approved by preToolUse hook`);
-				} else if (preToolUseHookResult?.permissionDecision === 'ask') {
-					// Hook explicitly requires confirmation - never auto-approve
-					autoConfirmed = undefined;
-					this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} requires confirmation (preToolUse hook returned 'ask')`);
-					// Ensure confirmation messages exist when hook requires confirmation
-					if (!preparedInvocation?.confirmationMessages?.title) {
-						if (!preparedInvocation) {
-							preparedInvocation = {};
-						}
-						const fullReferenceName = getToolFullReferenceName(tool.data);
-						const hookReason = preToolUseHookResult.permissionDecisionReason;
-						// Use MarkdownString for message so the input editor is shown
-						// (chatToolConfirmationSubPart only shows editor when typeof message !== 'string')
-						const baseMessage = localize('hookRequiresConfirmation.message', "{0} hook confirmation required", HookType.PreToolUse);
-						preparedInvocation.confirmationMessages = {
-							...preparedInvocation.confirmationMessages,
-							title: localize('hookRequiresConfirmation.title', "Use the '{0}' tool?", fullReferenceName),
-							message: new MarkdownString(hookReason ? `${baseMessage}\n\n${hookReason}` : baseMessage),
-							allowAutoConfirm: false,
-						};
-						// Show input editor for confirmation
-						preparedInvocation.toolSpecificData = {
-							kind: 'input',
-							rawInput: dto.parameters,
-						};
-					}
-				} else {
-					// No hook decision - use normal auto-confirm logic
-					autoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, dto.context?.sessionResource);
-				}
+				const autoConfirmed = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, dto.context?.sessionResource);
 
 
 				// Important: a tool invocation that will be autoconfirmed should never
@@ -612,42 +575,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				}
 			} else {
 				prepareTimeWatch = StopWatch.create(true);
-				const forceConfirmationReasonFallback = preToolUseHookResult?.permissionDecision === 'ask' ? (preToolUseHookResult.permissionDecisionReason || true) : undefined;
-				preparedInvocation = await this.prepareToolInvocation(tool, dto, forceConfirmationReasonFallback, token);
+				preparedInvocation = await this.prepareToolInvocationWithHookResult(tool, dto, preToolUseHookResult, token);
 				prepareTimeWatch.stop();
-				// Determine auto-confirm based on hook result and normal settings
-				// Note: hooks only run with session context, but check anyway for consistency
-				let fallbackAutoConfirmed: ConfirmedReason | undefined;
-				if (preToolUseHookResult?.permissionDecision === 'allow') {
-					fallbackAutoConfirmed = { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
-				} else if (preToolUseHookResult?.permissionDecision === 'ask') {
-					fallbackAutoConfirmed = undefined;
 
-					// Ensure confirmation messages exist when hook requires confirmation
-					if (!preparedInvocation?.confirmationMessages?.title) {
-						if (!preparedInvocation) {
-							preparedInvocation = {};
-						}
-						const fullReferenceName = getToolFullReferenceName(tool.data);
-						const hookReason = preToolUseHookResult.permissionDecisionReason;
-						// Use MarkdownString for message so the input editor is shown
-						// (chatToolConfirmationSubPart only shows editor when typeof message !== 'string')
-						const baseMessage = localize('hookRequiresConfirmation.message', "{0} hook confirmation required", HookType.PreToolUse);
-						preparedInvocation.confirmationMessages = {
-							...preparedInvocation.confirmationMessages,
-							title: localize('hookRequiresConfirmation.title', "Use the '{0}' tool?", fullReferenceName),
-							message: new MarkdownString(hookReason ? `${baseMessage}\n\n${hookReason}` : baseMessage),
-							allowAutoConfirm: false,
-						};
-						// Show input editor for confirmation
-						preparedInvocation.toolSpecificData = {
-							kind: 'input',
-							rawInput: dto.parameters,
-						};
-					}
-				} else {
-					fallbackAutoConfirmed = await this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, undefined);
-				}
+				const fallbackAutoConfirmed = await this.resolveAutoConfirmFromHook(preToolUseHookResult, tool, dto, preparedInvocation, undefined);
 				if (preparedInvocation?.confirmationMessages?.title && !fallbackAutoConfirmed) {
 					const result = await this._dialogService.confirm({ message: renderAsPlaintext(preparedInvocation.confirmationMessages.title), detail: renderAsPlaintext(preparedInvocation.confirmationMessages.message!) });
 					if (!result.confirmed) {
@@ -732,7 +663,58 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 	}
 
-	private async prepareToolInvocation(tool: IToolEntry, dto: IToolInvocation, forceConfirmationReason: string | true | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+	private async prepareToolInvocationWithHookResult(tool: IToolEntry, dto: IToolInvocation, hookResult: IPreToolUseHookResult | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
+		const forceConfirmationReason = hookResult?.permissionDecision === 'ask' ? (hookResult.permissionDecisionReason ?? '') : undefined;
+		return this.prepareToolInvocation(tool, dto, forceConfirmationReason, token);
+	}
+
+	/**
+	 * Determines the auto-confirm decision based on a preToolUse hook result.
+	 * If the hook returned 'allow', auto-approves. If 'ask', forces confirmation
+	 * and ensures confirmation messages exist on `preparedInvocation`. Otherwise
+	 * falls back to normal auto-confirm logic.
+	 */
+	private async resolveAutoConfirmFromHook(
+		hookResult: IPreToolUseHookResult | undefined,
+		tool: IToolEntry,
+		dto: IToolInvocation,
+		preparedInvocation: IPreparedToolInvocation | undefined,
+		sessionResource: URI | undefined,
+	): Promise<ConfirmedReason | undefined> {
+		if (hookResult?.permissionDecision === 'allow') {
+			this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} auto-approved by preToolUse hook`);
+			return { type: ToolConfirmKind.ConfirmationNotNeeded, reason: localize('hookAllowed', "Allowed by hook") };
+		}
+
+		if (hookResult?.permissionDecision === 'ask') {
+			this._logService.debug(`[LanguageModelToolsService#invokeTool] Tool ${dto.toolId} requires confirmation (preToolUse hook returned 'ask')`);
+			// Ensure confirmation messages exist when hook requires confirmation
+			if (!preparedInvocation?.confirmationMessages?.title) {
+				if (!preparedInvocation) {
+					preparedInvocation = {};
+				}
+				const fullReferenceName = getToolFullReferenceName(tool.data);
+				const hookReason = hookResult.permissionDecisionReason;
+				const baseMessage = localize('hookRequiresConfirmation.message', "{0} hook confirmation required", HookType.PreToolUse);
+				preparedInvocation.confirmationMessages = {
+					...preparedInvocation.confirmationMessages,
+					title: localize('hookRequiresConfirmation.title', "Use the '{0}' tool?", fullReferenceName),
+					message: new MarkdownString(hookReason ? `${baseMessage}\n\n${hookReason}` : baseMessage),
+					allowAutoConfirm: false,
+				};
+				preparedInvocation.toolSpecificData = {
+					kind: 'input',
+					rawInput: dto.parameters,
+				};
+			}
+			return undefined;
+		}
+
+		// No hook decision - use normal auto-confirm logic
+		return this.shouldAutoConfirm(tool.data.id, tool.data.runsInWorkspace, tool.data.source, dto.parameters, sessionResource);
+	}
+
+	private async prepareToolInvocation(tool: IToolEntry, dto: IToolInvocation, forceConfirmationReason: string | undefined, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
 		let prepared: IPreparedToolInvocation | undefined;
 		if (tool.impl!.prepareToolInvocation) {
 			const preparePromise = tool.impl!.prepareToolInvocation({
@@ -741,7 +723,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				chatSessionId: dto.context?.sessionId,
 				chatSessionResource: dto.context?.sessionResource,
 				chatInteractionId: dto.chatInteractionId,
-				forceConfirmationReason: typeof forceConfirmationReason === 'string' ? forceConfirmationReason : (forceConfirmationReason ? '' : undefined)
+				forceConfirmationReason: forceConfirmationReason
 			}, token);
 
 			const raceResult = await Promise.race([

--- a/src/vs/workbench/contrib/chat/common/hooks/hooksTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/hooks/hooksTypes.ts
@@ -67,7 +67,7 @@ export interface IPreToolUseCallerInput {
 export const preToolUseOutputValidator = vObj({
 	hookSpecificOutput: vOptionalProp(vObj({
 		hookEventName: vOptionalProp(vString()),
-		permissionDecision: vEnum('allow', 'deny'),
+		permissionDecision: vEnum('allow', 'deny', 'ask'),
 		permissionDecisionReason: vOptionalProp(vString()),
 		additionalContext: vOptionalProp(vString()),
 	})),
@@ -75,8 +75,11 @@ export const preToolUseOutputValidator = vObj({
 
 /**
  * Valid permission decisions for preToolUse hooks.
+ * - 'allow': Auto-approve the tool execution (skip user confirmation)
+ * - 'deny': Deny the tool execution
+ * - 'ask': Always require user confirmation (never auto-approve)
  */
-export type PreToolUsePermissionDecision = 'allow' | 'deny';
+export type PreToolUsePermissionDecision = 'allow' | 'deny' | 'ask';
 
 /**
  * Result from preToolUse hooks with permission decision fields.

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -203,6 +203,8 @@ export interface IToolInvocationPreparationContext {
 	chatSessionId?: string;
 	chatSessionResource: URI | undefined;
 	chatInteractionId?: string;
+	/** If set, tells the tool that it should include confirmmation messages. */
+	forceConfirmationReason?: string;
 }
 
 export type ToolInputOutputBase = {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -3864,5 +3864,93 @@ suite('LanguageModelToolsService', () => {
 
 			assert.strictEqual(invokeCalled, false, 'Tool invoke should not be called when hook denies');
 		});
+
+		test('when hook returns ask, tool is not auto-approved', async () => {
+			mockHooksService.preToolUseHookResult = {
+				output: undefined,
+				success: true,
+				permissionDecision: 'ask',
+				permissionDecisionReason: 'Requires user confirmation',
+			};
+
+			let invokeCompleted = false;
+			const tool = registerToolForTest(hookService, store, 'hookAskTool', {
+				invoke: async () => {
+					invokeCompleted = true;
+					return { content: [{ kind: 'text', value: 'success' }] };
+				},
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool requires confirmation',
+						allowAutoConfirm: true
+					}
+				})
+			});
+
+			const capture: { invocation?: ChatToolInvocation } = {};
+			stubGetSession(hookChatService, 'hook-test-ask', { requestId: 'req1', capture });
+
+			// Start invocation - it should wait for confirmation
+			const invokePromise = hookService.invokeTool(
+				tool.makeDto({ test: 1 }, { sessionId: 'hook-test-ask' }),
+				async () => 0,
+				CancellationToken.None
+			);
+
+			// Wait for invocation to be captured
+			await new Promise(resolve => setTimeout(resolve, 50));
+			const invocation = capture.invocation;
+			assert.ok(invocation, 'Tool invocation should be created');
+
+			// Check that the tool is waiting for confirmation (not auto-approved)
+			const state = invocation.state.get();
+			assert.strictEqual(state.type, IChatToolInvocation.StateKind.WaitingForConfirmation,
+				'Tool should be waiting for confirmation when hook returns ask');
+
+			// Confirm the tool to let the test complete
+			IChatToolInvocation.confirmWith(invocation, { type: ToolConfirmKind.UserAction });
+			await invokePromise;
+
+			assert.strictEqual(invokeCompleted, true, 'Tool should complete after confirmation');
+		});
+
+		test('when hook returns allow, tool is auto-approved', async () => {
+			mockHooksService.preToolUseHookResult = {
+				output: undefined,
+				success: true,
+				permissionDecision: 'allow',
+			};
+
+			let invokeCompleted = false;
+			const tool = registerToolForTest(hookService, store, 'hookAutoApproveTool', {
+				invoke: async () => {
+					invokeCompleted = true;
+					return { content: [{ kind: 'text', value: 'success' }] };
+				},
+				prepareToolInvocation: async () => ({
+					confirmationMessages: {
+						title: 'Confirm this action?',
+						message: 'This tool would normally require confirmation',
+						allowAutoConfirm: true
+					}
+				})
+			});
+
+			const capture: { invocation?: ChatToolInvocation } = {};
+			stubGetSession(hookChatService, 'hook-test-auto-approve', { requestId: 'req1', capture });
+
+			// Invoke the tool - it should auto-approve due to hook
+			const result = await hookService.invokeTool(
+				tool.makeDto({ test: 1 }, { sessionId: 'hook-test-auto-approve' }),
+				async () => 0,
+				CancellationToken.None
+			);
+
+			// Tool should have completed without waiting for confirmation
+			assert.strictEqual(invokeCompleted, true, 'Tool should complete immediately when hook allows');
+			assert.strictEqual(result.content[0].kind, 'text');
+			assert.strictEqual((result.content[0] as IToolResultTextPart).value, 'success');
+		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -639,7 +639,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
-		const shouldShowConfirmation = !isFinalAutoApproved || !!context.forceConfirmationReason;
+		const shouldShowConfirmation = !isFinalAutoApproved || context.forceConfirmationReason !== undefined;
 		const confirmationMessages = shouldShowConfirmation ? {
 			title: confirmationTitle,
 			message: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal)),

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -638,12 +638,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}
 
-		const confirmationMessages = isFinalAutoApproved ? undefined : {
+		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
+		const shouldShowConfirmation = !isFinalAutoApproved || !!context.forceConfirmationReason;
+		const confirmationMessages = shouldShowConfirmation ? {
 			title: confirmationTitle,
 			message: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal)),
 			disclaimer,
 			terminalCustomActions: customActions,
-		};
+		} : undefined;
 
 		return {
 			confirmationMessages,

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -272,6 +272,10 @@ declare module 'vscode' {
 		chatSessionId?: string;
 		chatSessionResource?: Uri;
 		chatInteractionId?: string;
+		/**
+		 * If set, tells the tool that it should include confirmation messages.
+		 */
+		forceConfirmationReason?: string;
 	}
 
 	export interface PreparedToolInvocation {


### PR DESCRIPTION
The changes improve the preToolUse hook by adding a new permission decision option and ensuring confirmation messages are displayed based on the context. Code cleanup enhances readability and maintainability.