### PR TITLE
Add onDidExecuteHook event to HooksExecutionService

### DIFF
--- a/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
+++ b/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../../../base/common/stopwatch.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
@@ -95,10 +95,11 @@ export interface IHooksExecutionService {
  */
 const redactedInputKeys = ['toolArgs'];
 
-export class HooksExecutionService extends Disposable implements IHooksExecutionService {
+export class HooksExecutionService implements IHooksExecutionService {
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _onDidExecuteHook = this._register(new Emitter<IHookExecutedEvent>());
+	private readonly _disposables = new DisposableStore();
+	private readonly _onDidExecuteHook = this._disposables.add(new Emitter<IHookExecutedEvent>());
 	readonly onDidExecuteHook: Event<IHookExecutedEvent> = this._onDidExecuteHook.event;
 
 	private _proxy: IHooksExecutionProxy | undefined;
@@ -109,9 +110,7 @@ export class HooksExecutionService extends Disposable implements IHooksExecution
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		@IOutputService private readonly _outputService: IOutputService,
-	) {
-		super();
-	}
+	) { }
 
 	setProxy(proxy: IHooksExecutionProxy): void {
 		this._proxy = proxy;
@@ -267,48 +266,51 @@ export class HooksExecutionService extends Disposable implements IHooksExecution
 	}
 
 	async executeHook(hookType: HookTypeValue, sessionResource: URI, options?: IHooksExecutionOptions): Promise<IHookResult[]> {
-		if (!this._proxy) {
-			return [];
-		}
-
-		const hooks = this.getHooksForSession(sessionResource);
-		if (!hooks) {
-			return [];
-		}
-
-		const hookCommands = hooks[hookType];
-		if (!hookCommands || hookCommands.length === 0) {
-			return [];
-		}
-
-		const requestId = this._requestCounter++;
-		const token = options?.token ?? CancellationToken.None;
 		const sw = StopWatch.create();
-
-		this._logService.debug(`[HooksExecutionService] Executing ${hookCommands.length} hook(s) for type '${hookType}'`);
-		this._log(requestId, hookType, `Executing ${hookCommands.length} hook(s)`);
-
 		const results: IHookResult[] = [];
-		for (const hookCommand of hookCommands) {
-			const result = await this._runSingleHook(requestId, hookType, hookCommand, sessionResource, options?.input, token);
-			results.push(result);
 
-			// If stopReason is set, stop processing remaining hooks
-			if (result.stopReason) {
-				this._log(requestId, hookType, `Stopping: ${result.stopReason}`);
-				break;
+		try {
+			if (!this._proxy) {
+				return results;
 			}
+
+			const hooks = this.getHooksForSession(sessionResource);
+			if (!hooks) {
+				return results;
+			}
+
+			const hookCommands = hooks[hookType];
+			if (!hookCommands || hookCommands.length === 0) {
+				return results;
+			}
+
+			const requestId = this._requestCounter++;
+			const token = options?.token ?? CancellationToken.None;
+
+			this._logService.debug(`[HooksExecutionService] Executing ${hookCommands.length} hook(s) for type '${hookType}'`);
+			this._log(requestId, hookType, `Executing ${hookCommands.length} hook(s)`);
+
+			for (const hookCommand of hookCommands) {
+				const result = await this._runSingleHook(requestId, hookType, hookCommand, sessionResource, options?.input, token);
+				results.push(result);
+
+				// If stopReason is set, stop processing remaining hooks
+				if (result.stopReason) {
+					this._log(requestId, hookType, `Stopping: ${result.stopReason}`);
+					break;
+				}
+			}
+
+			return results;
+		} finally {
+			this._onDidExecuteHook.fire({
+				hookType,
+				sessionResource,
+				input: options?.input,
+				results,
+				durationMs: Math.round(sw.elapsed()),
+			});
 		}
-
-		this._onDidExecuteHook.fire({
-			hookType,
-			sessionResource,
-			input: options?.input,
-			results,
-			durationMs: Math.round(sw.elapsed()),
-		});
-
-		return results;
 	}
 
 	async executePreToolUseHook(sessionResource: URI, input: IPreToolUseCallerInput, token?: CancellationToken): Promise<IPreToolUseHookResult | undefined> {

--- a/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
+++ b/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { DisposableStore, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { StopWatch } from '../../../../../base/common/stopwatch.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
@@ -95,11 +95,10 @@ export interface IHooksExecutionService {
  */
 const redactedInputKeys = ['toolArgs'];
 
-export class HooksExecutionService implements IHooksExecutionService {
+export class HooksExecutionService extends Disposable implements IHooksExecutionService {
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _disposables = new DisposableStore();
-	private readonly _onDidExecuteHook = this._disposables.add(new Emitter<IHookExecutedEvent>());
+	private readonly _onDidExecuteHook = this._register(new Emitter<IHookExecutedEvent>());
 	readonly onDidExecuteHook: Event<IHookExecutedEvent> = this._onDidExecuteHook.event;
 
 	private _proxy: IHooksExecutionProxy | undefined;
@@ -110,7 +109,9 @@ export class HooksExecutionService implements IHooksExecutionService {
 	constructor(
 		@ILogService private readonly _logService: ILogService,
 		@IOutputService private readonly _outputService: IOutputService,
-	) { }
+	) {
+		super();
+	}
 
 	setProxy(proxy: IHooksExecutionProxy): void {
 		this._proxy = proxy;

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -8,6 +8,7 @@ import { Barrier } from '../../../../../../base/common/async.js';
 import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { CancellationError, isCancellationError } from '../../../../../../base/common/errors.js';
+import { Event } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
@@ -65,6 +66,7 @@ class TestTelemetryService implements Partial<ITelemetryService> {
 
 class MockHooksExecutionService implements IHooksExecutionService {
 	readonly _serviceBrand: undefined;
+	readonly onDidExecuteHook = Event.None;
 	public preToolUseHookResult: IPreToolUseHookResult | undefined = undefined;
 	public lastPreToolUseInput: IPreToolUseCallerInput | undefined = undefined;
 

--- a/src/vs/workbench/contrib/chat/test/common/hooksExecutionService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/hooksExecutionService.test.ts
@@ -34,7 +34,7 @@ suite('HooksExecutionService', () => {
 	const sessionUri = URI.file('/test/session');
 
 	setup(() => {
-		service = new HooksExecutionService(new NullLogService(), createMockOutputService());
+		service = store.add(new HooksExecutionService(new NullLogService(), createMockOutputService()));
 	});
 
 	suite('registerHooks', () => {


### PR DESCRIPTION
Adds an `onDidExecuteHook` event to the HooksExecutionService that fires after a hook finishes executing.

The event payload (`IHookExecutedEvent`) includes:
- `hookType` - which hook type was executed
- `sessionResource` - the session URI
- `input` - the input passed to the hook
- `results` - array of results from all executed hooks
- `durationMs` - total execution time