### PR TITLE
Update proposed API versioning instructions

### DIFF
--- a/.github/instructions/api-version.instructions.md
+++ b/.github/instructions/api-version.instructions.md
@@ -11,7 +11,7 @@ When a proposed API is changed in a non-backwards-compatible way, the version nu
 // version: 1
 ```
 
-No semver, just a basic incrementing integer. The corresponding version number in the extension's package.json must be incremented to match (you could remind the user of this if you don't have access to the extension code yourself).
+No semver, just a basic incrementing integer. See existing examples in `vscode.proposed.chatParticipantPrivate.d.ts` (version 12), `vscode.proposed.chatProvider.d.ts` (version 4), and other chat/languageModel proposals. The corresponding version number in the extension's package.json must be incremented to match (you could remind the user of this if you don't have access to the extension code yourself).
 
 An example of a non-backwards-compatible change is removing a non-optional property or changing the type to one that is incompatible with the previous type.
 


### PR DESCRIPTION
Updates `.github/instructions/api-version.instructions.md` for proposed API versioning.

## Content

- Version number format (`// version: N`) for proposed APIs
- Required for chat and languageModel proposals
- Backwards-compatible vs breaking change examples
- Extension package.json version alignment

## Reviewer

@roblourens — Original author, deep expertise in chat/languageModel proposal lifecycle (PRs #293265, #292961, #292463)