### PR TITLE
fix: permit internal infrastructure tools when agent mode is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -207,9 +207,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			return true;
 		}
 
-		// Internal tools that cannot be referenced in prompts are always permitted
+		// Internal tools that explicitly cannot be referenced in prompts are always permitted
 		// since they are infrastructure tools (e.g. inline_chat_exit), not user-facing agent tools
-		if (!isToolSet(toolOrToolSet) && !toolOrToolSet.canBeReferencedInPrompt && toolOrToolSet.source.type === 'internal') {
+		if (!isToolSet(toolOrToolSet) && toolOrToolSet.canBeReferencedInPrompt === false && toolOrToolSet.source.type === 'internal') {
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -209,7 +209,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 		// Internal tools that cannot be referenced in prompts are always permitted
 		// since they are infrastructure tools (e.g. inline_chat_exit), not user-facing agent tools
-		if (!isToolSet(toolOrToolSet) && !toolOrToolSet.canBeReferencedInPrompt && toolOrToolSet.source === ToolDataSource.Internal) {
+		if (!isToolSet(toolOrToolSet) && !toolOrToolSet.canBeReferencedInPrompt && toolOrToolSet.source.type === 'internal') {
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -206,6 +206,13 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		if (agentModeEnabled !== false) {
 			return true;
 		}
+
+		// Internal tools that cannot be referenced in prompts are always permitted
+		// since they are infrastructure tools (e.g. inline_chat_exit), not user-facing agent tools
+		if (!isToolSet(toolOrToolSet) && !toolOrToolSet.canBeReferencedInPrompt && toolOrToolSet.source === ToolDataSource.Internal) {
+			return true;
+		}
+
 		const permittedInternalToolSetIds = [SpecedToolAliases.read, SpecedToolAliases.search, SpecedToolAliases.web];
 		if (isToolSet(toolOrToolSet)) {
 			const permitted = toolOrToolSet.source.type === 'internal' && permittedInternalToolSetIds.includes(toolOrToolSet.referenceName);

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -3475,6 +3475,52 @@ suite('LanguageModelToolsService', () => {
 		assert.ok(toolIds.includes('multiSetTool'), 'Tool should be permitted if it belongs to at least one permitted toolset');
 	});
 
+	test('isPermitted allows internal tools with canBeReferencedInPrompt=false when agent mode is disabled (issue #292935)', () => {
+		// Disable agent mode
+		configurationService.setUserConfiguration(ChatConfiguration.AgentEnabled, false);
+
+		// Create internal infrastructure tool that explicitly cannot be referenced in prompts
+		const infrastructureTool: IToolData = {
+			id: 'infrastructureToolInternal',
+			toolReferenceName: 'infrastructureToolRef',
+			modelDescription: 'Infrastructure Tool',
+			displayName: 'Infrastructure Tool',
+			source: ToolDataSource.Internal,
+			canBeReferencedInPrompt: false,
+		};
+		store.add(service.registerToolData(infrastructureTool));
+
+		// Create internal tool with canBeReferencedInPrompt=true (should be blocked)
+		const referencableTool: IToolData = {
+			id: 'referencableTool',
+			toolReferenceName: 'referencableToolRef',
+			modelDescription: 'Referencable Tool',
+			displayName: 'Referencable Tool',
+			source: ToolDataSource.Internal,
+			canBeReferencedInPrompt: true,
+		};
+		store.add(service.registerToolData(referencableTool));
+
+		// Create internal tool with canBeReferencedInPrompt=undefined (should be blocked)
+		const undefinedTool: IToolData = {
+			id: 'undefinedTool',
+			toolReferenceName: 'undefinedToolRef',
+			modelDescription: 'Undefined Tool',
+			displayName: 'Undefined Tool',
+			source: ToolDataSource.Internal,
+			// canBeReferencedInPrompt is undefined
+		};
+		store.add(service.registerToolData(undefinedTool));
+
+		// Get tools - only the infrastructure tool should be available
+		const tools = Array.from(service.getTools(undefined));
+		const toolIds = tools.map(t => t.id);
+
+		assert.ok(toolIds.includes('infrastructureToolInternal'), 'Internal infrastructure tool with canBeReferencedInPrompt=false should be permitted when agent mode is disabled');
+		assert.ok(!toolIds.includes('referencableTool'), 'Internal tool with canBeReferencedInPrompt=true should NOT be permitted when agent mode is disabled');
+		assert.ok(!toolIds.includes('undefinedTool'), 'Internal tool with canBeReferencedInPrompt=undefined should NOT be permitted when agent mode is disabled');
+	});
+
 	suite('ToolSet when clause filtering (issue #291154)', () => {
 		test('ToolSet.getTools filters tools by when clause', () => {
 			// Create a context key for testing


### PR DESCRIPTION
When agent mode is disabled (`chat.agent.enabled: false`), the `isPermitted` check in
`LanguageModelToolsService` filters visible tools down to only read/search/web tool sets.
This inadvertently blocks the `inline_chat_exit` tool — an internal infrastructure tool
required for inline chat v2 to function — causing the "Missing inline chat exit tool" error.

The fix: internal tools with `canBeReferencedInPrompt: false` are always permitted regardless
of agent mode, since they are system plumbing, not user-facing agent tools.

Fixes #292935