### PR TITLE
Enhance dark theme with brightness reduction for better contrast

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -26,6 +26,13 @@
 	--backdrop-blur-lg: blur(40px) saturate(180%);
 }
 
+/* Dark theme: add brightness reduction for contrast-safe luminosity blending over bright backgrounds */
+.monaco-workbench.vs-dark {
+	--backdrop-blur-sm: blur(12px) brightness(0.55);
+	--backdrop-blur-md: blur(20px) saturate(180%) brightness(0.55);
+	--backdrop-blur-lg: blur(40px) saturate(180%) brightness(0.55);
+}
+
 /* Stealth Shadows - shadow-based depth for UI elements, controlled by workbench.stealthShadows.enabled */
 
 /* Activity Bar */
@@ -179,7 +186,6 @@
 	background-color: color-mix(in srgb, var(--vscode-quickInput-background) 60%, transparent) !important;
 	backdrop-filter: var(--backdrop-blur-lg);
 	-webkit-backdrop-filter: var(--backdrop-blur-lg);
-	-webkit-backdrop-filter: blur(40px) saturate(180%);
 }
 
 .monaco-workbench.vs-dark .quick-input-widget {


### PR DESCRIPTION
Improve the dark theme by adding brightness reduction to enhance contrast and ensure better visibility over bright backgrounds. This change modifies the backdrop blur settings to achieve a more contrast-safe luminosity blending.

Addresses: https://github.com/microsoft/vscode/issues/293177

