### PR TITLE
Fix stale rejected custom editor model cache on reopen

### DIFF
--- a/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
@@ -62,7 +62,15 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 			throw new Error('Model already exists');
 		}
 
-		this._references.set(key, { viewType, model, counter: 0 });
+		const trackedModel = model.then(undefined, error => {
+			// Model creation can fail (for example if the backing file does not exist).
+			// In that case, clear the cached entry so a subsequent open can retry model creation.
+			if (this._references.get(key)?.model === trackedModel) {
+				this._references.delete(key);
+			}
+			throw error;
+		});
+		this._references.set(key, { viewType, model: trackedModel, counter: 0 });
 		return this.tryRetain(resource, viewType)!;
 	}
 

--- a/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
+++ b/src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICustomEditorModel } from '../../common/customEditor.js';
+import { CustomEditorModelManager } from '../../common/customEditorModelManager.js';
+
+class TestCustomEditorModel implements ICustomEditorModel {
+	public readonly backupId = undefined;
+	public readonly canHotExit = true;
+	public readonly onDidChangeReadonly = Event.None;
+	public readonly onDidChangeOrphaned = Event.None;
+	public readonly onDidChangeDirty = Event.None;
+
+	constructor(
+		public readonly viewType: string,
+		public readonly resource: URI,
+	) { }
+
+	isReadonly(): boolean {
+		return false;
+	}
+
+	isOrphaned(): boolean {
+		return false;
+	}
+
+	isDirty(): boolean {
+		return false;
+	}
+
+	async revert(): Promise<void> {
+	}
+
+	async saveCustomEditor(): Promise<URI | undefined> {
+		return undefined;
+	}
+
+	async saveCustomEditorAs(): Promise<boolean> {
+		return true;
+	}
+
+	dispose(): void {
+	}
+}
+
+suite('CustomEditorModelManager', () => {
+	test('removes rejected models so a later open can recreate the model', async () => {
+		const manager = new CustomEditorModelManager();
+		const resource = URI.file('/test/customEditor.txt');
+		const viewType = 'test.customEditor';
+		const error = new Error('file not found');
+
+		await assert.rejects(manager.add(resource, viewType, Promise.reject(error)), error);
+
+		const retained = manager.tryRetain(resource, viewType);
+		if (retained) {
+			await assert.rejects(retained, error);
+		}
+		assert.strictEqual(retained, undefined);
+
+		const recoveredModel = new TestCustomEditorModel(viewType, resource);
+		const recoveredReference = await manager.add(resource, viewType, Promise.resolve(recoveredModel));
+		assert.strictEqual(recoveredReference.object, recoveredModel);
+
+		recoveredReference.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
Fixes #268301.

## Summary
- clear cached model entries when model creation promise rejects in `CustomEditorModelManager.add`
- allow subsequent open attempts to recreate custom editor models after transient failures (for example missing file at first open)
- add a regression test covering reject-then-recover behavior

## Test Plan
- [x] `npx tsx ./node_modules/mocha/bin/mocha --ui tdd src/vs/workbench/contrib/customEditor/test/common/customEditorModelManager.test.ts --timeout 10000`
