### PR TITLE
Support for confirmation with custom buttons via toolcall

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -569,6 +569,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 						return toolResult;
 					}
 
+					if (userConfirmed.type === ToolConfirmKind.UserAction && userConfirmed.selectedButton) {
+						dto.selectedCustomButton = userConfirmed.selectedButton;
+					}
+
 					if (dto.toolSpecificData?.kind === 'input') {
 						dto.parameters = dto.toolSpecificData.rawInput;
 						dto.toolSpecificData = undefined;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -530,7 +530,7 @@ export type ConfirmedReason =
 	| { type: ToolConfirmKind.ConfirmationNotNeeded; reason?: string | IMarkdownString }
 	| { type: ToolConfirmKind.Setting; id: string }
 	| { type: ToolConfirmKind.LmServicePerTool; scope: 'session' | 'workspace' | 'profile' }
-	| { type: ToolConfirmKind.UserAction }
+	| { type: ToolConfirmKind.UserAction; selectedButton?: string }
 	| { type: ToolConfirmKind.Skipped };
 
 export interface IChatToolInvocation {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/confirmationTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/confirmationTool.ts
@@ -9,6 +9,7 @@ import { IChatTerminalToolInvocationData } from '../../chatService/chatService.j
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolInvocationPresentation, ToolProgress } from '../languageModelToolsService.js';
 
 export const ConfirmationToolId = 'vscode_get_confirmation';
+export const ConfirmationToolWithOptionsId = 'vscode_get_confirmation_with_options';
 
 export const ConfirmationToolData: IToolData = {
 	id: ConfirmationToolId,
@@ -41,11 +42,39 @@ export const ConfirmationToolData: IToolData = {
 	}
 };
 
+export const ConfirmationToolWithOptionsData: IToolData = {
+	id: ConfirmationToolWithOptionsId,
+	displayName: 'Confirmation Tool with Options',
+	modelDescription: 'A tool that demonstrates different types of confirmations. Takes a title, message, and buttons.',
+	source: ToolDataSource.Internal,
+	inputSchema: {
+		type: 'object',
+		properties: {
+			title: {
+				type: 'string',
+				description: 'Title for the confirmation dialog'
+			},
+			message: {
+				type: 'string',
+				description: 'Message to show in the confirmation dialog'
+			},
+			buttons: {
+				type: 'array',
+				items: { type: 'string' },
+				description: 'Custom button labels to display. A Cancel button is always added. If not provided, the default Allow/Skip buttons are shown.'
+			}
+		},
+		required: ['title', 'message', 'buttons'],
+		additionalProperties: false
+	}
+};
+
 export interface IConfirmationToolParams {
 	title: string;
 	message: string;
 	confirmationType?: 'basic' | 'terminal';
 	terminalCommand?: string;
+	buttons?: string[];
 }
 
 export class ConfirmationTool implements IToolImpl {
@@ -78,7 +107,8 @@ export class ConfirmationTool implements IToolImpl {
 			confirmationMessages: {
 				title: parameters.title,
 				message: new MarkdownString(parameters.message),
-				allowAutoConfirm: true
+				allowAutoConfirm: (parameters.buttons || []).length ? false : true, // We cannot auto confirm if there are custom buttons, as we don't know which one to select
+				customButtons: parameters.buttons,
 			},
 			toolSpecificData,
 			presentation: ToolInvocationPresentation.HiddenAfterComplete
@@ -86,7 +116,17 @@ export class ConfirmationTool implements IToolImpl {
 	}
 
 	async invoke(invocation: IToolInvocation, countTokens: CountTokensCallback, progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
-		// This is a no-op tool - just return success
+		// If a custom button was selected, return the button label
+		if (invocation.selectedCustomButton) {
+			return {
+				content: [{
+					kind: 'text',
+					value: invocation.selectedCustomButton
+				}]
+			};
+		}
+
+		// Default: return 'yes' for standard Allow confirmation
 		return {
 			content: [{
 				kind: 'text',

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/confirmationTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/confirmationTool.ts
@@ -61,7 +61,7 @@ export const ConfirmationToolWithOptionsData: IToolData = {
 			buttons: {
 				type: 'array',
 				items: { type: 'string' },
-				description: 'Custom button labels to display. A Cancel button is always added. If not provided, the default Allow/Skip buttons are shown.'
+				description: 'Custom button labels to display.'
 			}
 		},
 		required: ['title', 'message', 'buttons'],

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/tools.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/tools.ts
@@ -7,7 +7,7 @@ import { Disposable, IDisposable } from '../../../../../../base/common/lifecycle
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../../../common/contributions.js';
 import { ILanguageModelToolsService } from '../languageModelToolsService.js';
-import { ConfirmationTool, ConfirmationToolData } from './confirmationTool.js';
+import { ConfirmationTool, ConfirmationToolData, ConfirmationToolWithOptionsData } from './confirmationTool.js';
 import { EditTool, EditToolData } from './editFileTool.js';
 import { createManageTodoListToolData, ManageTodoListTool } from './manageTodoListTool.js';
 import { RunSubagentTool } from './runSubagentTool.js';
@@ -32,6 +32,7 @@ export class BuiltinToolsContribution extends Disposable implements IWorkbenchCo
 		// Register the confirmation tool
 		const confirmationTool = instantiationService.createInstance(ConfirmationTool);
 		this._register(toolsService.registerTool(ConfirmationToolData, confirmationTool));
+		this._register(toolsService.registerTool(ConfirmationToolWithOptionsData, confirmationTool));
 
 		const runSubagentTool = this._register(instantiationService.createInstance(RunSubagentTool));
 

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -182,6 +182,8 @@ export interface IToolInvocation {
 	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData;
 	modelId?: string;
 	userSelectedTools?: UserSelectedTools;
+	/** The label of the custom button selected by the user during confirmation, if custom buttons were used. */
+	selectedCustomButton?: string;
 }
 
 export interface IToolInvocationContext {
@@ -314,6 +316,8 @@ export interface IToolConfirmationMessages {
 	confirmResults?: boolean;
 	/** If title is not set (no confirmation needed), this reason will be shown to explain why confirmation was not needed */
 	confirmationNotNeededReason?: string | IMarkdownString;
+	/** Custom button labels to display instead of the default Allow/Skip buttons. */
+	customButtons?: string[];
 }
 
 export interface IToolConfirmationAction {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -522,6 +522,95 @@ suite('LanguageModelToolsService', () => {
 		assert.strictEqual(result.content[0].value, 'ran');
 	});
 
+	test('selectedCustomButton is passed to tool invoke when user selects a custom button', async () => {
+		let receivedInvocation: IToolInvocation | undefined;
+		const tool = registerToolForTest(service, store, 'testToolCustomButton', {
+			prepareToolInvocation: async () => ({
+				confirmationMessages: {
+					title: 'Confirm',
+					message: 'Pick an option',
+					customButtons: ['Option A', 'Option B'],
+					allowAutoConfirm: false,
+				}
+			}),
+			invoke: async (invocation) => {
+				receivedInvocation = invocation;
+				return { content: [{ kind: 'text', value: invocation.selectedCustomButton ?? 'none' }] };
+			},
+		});
+
+		const sessionId = 'sessionId-custom-btn';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-custom-btn', capture });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+
+		const promise = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction, selectedButton: 'Option A' });
+		const result = await promise;
+		assert.strictEqual(receivedInvocation?.selectedCustomButton, 'Option A');
+		assert.strictEqual(result.content[0].value, 'Option A');
+	});
+
+	test('selectedCustomButton is not set when user confirms without custom button', async () => {
+		let receivedInvocation: IToolInvocation | undefined;
+		const tool = registerToolForTest(service, store, 'testToolNoCustomBtn', {
+			prepareToolInvocation: async () => ({
+				confirmationMessages: { title: 'Confirm', message: 'Go?' }
+			}),
+			invoke: async (invocation) => {
+				receivedInvocation = invocation;
+				return { content: [{ kind: 'text', value: 'ok' }] };
+			},
+		});
+
+		const sessionId = 'sessionId-no-custom-btn';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-no-custom-btn', capture });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+
+		const promise = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published);
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction });
+		const result = await promise;
+		assert.strictEqual(receivedInvocation?.selectedCustomButton, undefined);
+		assert.strictEqual(result.content[0].value, 'ok');
+	});
+
+	test('confirmationMessages with customButtons disables allowAutoConfirm', async () => {
+		const tool = registerToolForTest(service, store, 'testToolCustomBtnNoAuto', {
+			prepareToolInvocation: async () => ({
+				confirmationMessages: {
+					title: 'Confirm',
+					message: 'Choose',
+					customButtons: ['Yes', 'No'],
+					allowAutoConfirm: false,
+				}
+			}),
+			invoke: async () => ({ content: [{ kind: 'text', value: 'done' }] }),
+		});
+
+		const sessionId = 'sessionId-custom-noauto';
+		const capture: { invocation?: any } = {};
+		stubGetSession(chatService, sessionId, { requestId: 'requestId-custom-noauto', capture });
+
+		const dto = tool.makeDto({ x: 1 }, { sessionId });
+
+		const promise = service.invokeTool(dto, async () => 0, CancellationToken.None);
+		const published = await waitForPublishedInvocation(capture);
+		assert.ok(published, 'expected ChatToolInvocation to be published');
+		assert.deepStrictEqual(published.confirmationMessages?.customButtons, ['Yes', 'No']);
+
+		IChatToolInvocation.confirmWith(published, { type: ToolConfirmKind.UserAction, selectedButton: 'Yes' });
+		await promise;
+	});
+
 	test('cancel tool call', async () => {
 		const toolBarrier = new Barrier();
 		const tool = registerToolForTest(service, store, 'testTool', {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


Similar to stream.confirmation this makes use of the confirmation tool, but supports the buttons option.

Currently confirmations are displayed using `confirmation` in stream, however this doesn't work in backgroudn sessions when handling requests and using stream to get confirmations is a very convoluted approach (i.e. waiting for response via another request)
Basically extending the confirmation tool, which simplifies the code quite significantly and makes it possible to display confirmations while in a request