### PR TITLE
Git - add exclude command

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -764,6 +764,12 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.exclude",
+        "title": "%command.exclude%",
+        "category": "Git",
+        "enablement": "!operationInProgress"
+      },
+      {
         "command": "git.revealInExplorer",
         "title": "%command.revealInExplorer%",
         "category": "Git"
@@ -1586,6 +1592,10 @@
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && resourceScheme == file && scmActiveResourceRepository"
         },
         {
+          "command": "git.exclude",
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && resourceScheme == file && scmActiveResourceRepository"
+        },
+        {
           "command": "git.stashIncludeUntracked",
           "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
@@ -2293,6 +2303,11 @@
           "group": "1_modification@3"
         },
         {
+          "command": "git.exclude",
+          "when": "scmProvider == git && scmResourceGroup == workingTree",
+          "group": "1_modification@4"
+        },
+        {
           "command": "git.stage",
           "when": "scmProvider == git && scmResourceGroup == untracked",
           "group": "1_modification"
@@ -2316,6 +2331,11 @@
           "command": "git.ignore",
           "when": "scmProvider == git && scmResourceGroup == untracked",
           "group": "1_modification@3"
+        },
+        {
+          "command": "git.exclude",
+          "when": "scmProvider == git && scmResourceGroup == untracked",
+          "group": "1_modification@4"
         }
       ],
       "scm/resourceState/context": [
@@ -2480,6 +2500,11 @@
           "group": "1_modification@3"
         },
         {
+          "command": "git.exclude",
+          "when": "scmProvider == git && scmResourceGroup == workingTree",
+          "group": "1_modification@4"
+        },
+        {
           "command": "git.revealFileInOS.linux",
           "when": "scmProvider == git && scmResourceGroup == workingTree && remoteName == '' && isLinux",
           "group": "2_view@1"
@@ -2548,6 +2573,11 @@
           "command": "git.ignore",
           "when": "scmProvider == git && scmResourceGroup == untracked",
           "group": "1_modification@3"
+        },
+        {
+          "command": "git.exclude",
+          "when": "scmProvider == git && scmResourceGroup == untracked",
+          "group": "1_modification@4"
         }
       ],
       "scm/history/title": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -109,6 +109,7 @@
 	"command.publish": "Publish Branch...",
 	"command.showOutput": "Show Git Output",
 	"command.ignore": "Add to .gitignore",
+	"command.exclude": "Add to .git/info/exclude",
 	"command.revealInExplorer": "Reveal in Explorer View",
 	"command.revealFileInOS.linux": "Open Containing Folder",
 	"command.revealFileInOS.mac": "Reveal in Finder",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4383,8 +4383,7 @@ export class CommandCenter {
 		}
 	}
 
-	@command('git.ignore')
-	async ignore(...resourceStates: SourceControlResourceState[]): Promise<void> {
+	private async runIgnoreRuleCommand(resourceStates: SourceControlResourceState[], fn: (repository: Repository, resources: Uri[]) => Promise<void>): Promise<void> {
 		resourceStates = resourceStates.filter(s => !!s);
 
 		if (resourceStates.length === 0 || (resourceStates[0] && !(resourceStates[0].resourceUri instanceof Uri))) {
@@ -4405,7 +4404,17 @@ export class CommandCenter {
 			return;
 		}
 
-		await this.runByRepository(resources, async (repository, resources) => repository.ignore(resources));
+		await this.runByRepository(resources, async (repository, resources) => fn(repository, resources));
+	}
+
+	@command('git.ignore')
+	async ignore(...resourceStates: SourceControlResourceState[]): Promise<void> {
+		await this.runIgnoreRuleCommand(resourceStates, (repository, resources) => repository.ignore(resources));
+	}
+
+	@command('git.exclude')
+	async exclude(...resourceStates: SourceControlResourceState[]): Promise<void> {
+		await this.runIgnoreRuleCommand(resourceStates, (repository, resources) => repository.exclude(resources));
 	}
 
 	@command('git.revealInExplorer')

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2430,27 +2430,44 @@ export class Repository implements Disposable {
 		return await this.run(Operation.GetCommitTemplate, async () => this.repository.getCommitTemplate());
 	}
 
+	private async appendToIgnoreRuleFile(ignoreFile: string, files: Uri[]): Promise<void> {
+		const textToAppend = files
+			.map(uri => relativePath(this.repository.root, uri.fsPath)
+				.replace(/\\|\[/g, match => match === '\\' ? '/' : `\\${match}`))
+			.join('\n');
+
+		await fsPromises.mkdir(path.dirname(ignoreFile), { recursive: true });
+
+		const document = await new Promise(c => fs.exists(ignoreFile, c))
+			? await workspace.openTextDocument(ignoreFile)
+			: await workspace.openTextDocument(Uri.file(ignoreFile).with({ scheme: 'untitled' }));
+
+		await window.showTextDocument(document);
+
+		const edit = new WorkspaceEdit();
+		const lastLine = document.lineAt(document.lineCount - 1);
+		const text = lastLine.isEmptyOrWhitespace ? `${textToAppend}\n` : `\n${textToAppend}\n`;
+
+		edit.insert(document.uri, lastLine.range.end, text);
+		await workspace.applyEdit(edit);
+		await document.save();
+	}
+
 	async ignore(files: Uri[]): Promise<void> {
 		return await this.run(Operation.Ignore, async () => {
-			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
-			const textToAppend = files
-				.map(uri => relativePath(this.repository.root, uri.fsPath)
-					.replace(/\\|\[/g, match => match === '\\' ? '/' : `\\${match}`))
-				.join('\n');
+			const ignoreFile = path.join(this.repository.root, '.gitignore');
+			await this.appendToIgnoreRuleFile(ignoreFile, files);
+		});
+	}
 
-			const document = await new Promise(c => fs.exists(ignoreFile, c))
-				? await workspace.openTextDocument(ignoreFile)
-				: await workspace.openTextDocument(Uri.file(ignoreFile).with({ scheme: 'untitled' }));
-
-			await window.showTextDocument(document);
-
-			const edit = new WorkspaceEdit();
-			const lastLine = document.lineAt(document.lineCount - 1);
-			const text = lastLine.isEmptyOrWhitespace ? `${textToAppend}\n` : `\n${textToAppend}\n`;
-
-			edit.insert(document.uri, lastLine.range.end, text);
-			await workspace.applyEdit(edit);
-			await document.save();
+	async exclude(files: Uri[]): Promise<void> {
+		return await this.run(Operation.Ignore, async () => {
+			const excludeFile = path.join(
+				this.repository.dotGit.commonPath ?? this.repository.dotGit.path,
+				'info',
+				'exclude',
+			);
+			await this.appendToIgnoreRuleFile(excludeFile, files);
 		});
 	}
 


### PR DESCRIPTION
Added support for excluding files locally by appending entries to .git/info/exclude, and refactored the existing .gitignore handling to share the same implementation.

Related issue: #186640