### PR TITLE
Fix VSCode formatting settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,9 +24,11 @@
 		"files.insertFinalNewline": false
 	},
 	"[typescript]": {
+		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[javascript]": {
+		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[rust]": {


### PR DESCRIPTION
The VSCode settings of this project specify VSCode should autoformat JavaScript and TypeScript code on save. However, it doesn’t specify which formatter to use. That means it uses the formatter specified in user settings, which is not the intention.