### PR TITLE
Color contrast ratio of tree view description text is 4.381:1 which is less than 4.5:1: A11y_Visual Studio Code Client_Default screen_Color Contrast

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/paneviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/paneviewlet.css
@@ -53,7 +53,7 @@
 	display: block;
 	font-weight: normal;
 	margin-left: 10px;
-	opacity: 0.6;
+	color: var(--vscode-panelTitle-inactiveForeground);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-transform: none;


### PR DESCRIPTION
Fixes #246455