### PR TITLE
Disable inline suggestions for protected files

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController.ts
@@ -26,6 +26,7 @@ import { observableCodeEditor } from '../../../../browser/observableCodeEditor.j
 import { TriggerInlineEditCommandsRegistry } from '../../../../browser/triggerInlineEditCommandsRegistry.js';
 import { getOuterEditor } from '../../../../browser/widget/codeEditor/embeddedCodeEditorWidget.js';
 import { EditorOption } from '../../../../common/config/editorOptions.js';
+import { ITextModel } from '../../../../common/model.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
 import { CursorChangeReason } from '../../../../common/cursorEvents.js';
@@ -43,6 +44,9 @@ import { InlineSuggestionsView } from '../view/inlineSuggestionsView.js';
 import { inlineSuggestCommitId } from './commandIds.js';
 import { setInlineCompletionsControllerGetter } from './common.js';
 import { InlineCompletionContextKeys } from './inlineCompletionContextKeys.js';
+import { match } from '../../../../../base/common/glob.js';
+import { relativePath } from '../../../../../base/common/resources.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 
 setInlineCompletionsControllerGetter((editor) => InlineCompletionsController.get(editor));
 
@@ -65,6 +69,30 @@ export class InlineCompletionsController extends Disposable {
 
 	public static get(editor: ICodeEditor): InlineCompletionsController | null {
 		return hotClassGetOriginalInstance(editor.getContribution<InlineCompletionsController>(InlineCompletionsController.ID));
+	}
+
+	private isSuggestionAllowed(model: ITextModel): boolean {
+	const rules = this._configurationService.getValue<Record<string, any>>('workspace.protectedFiles');
+	if (!rules) {
+		return true;
+	}
+	const resourcePath = model.uri.fsPath;
+	for (const pattern of Object.keys(rules)) {
+		let matches = match(pattern, resourcePath);
+		if (!matches) {
+			const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(model.uri);
+			if (workspaceFolder) {
+				const relative = relativePath(workspaceFolder.uri, model.uri);
+				if (relative && match(pattern, relative)) {
+					matches = true;
+				}
+			}
+		}
+		if (matches) {
+			return rules[pattern]?.suggest !== false;
+			}
+		}
+		return true;
 	}
 
 	private readonly _editorObs;
@@ -100,7 +128,7 @@ export class InlineCompletionsController extends Disposable {
 		if (this._editorObs.isReadonly.read(reader)) { return undefined; }
 		const textModel = this._editorObs.model.read(reader);
 		if (!textModel) { return undefined; }
-
+		if (!this.isSuggestionAllowed(textModel)) { return undefined; }
 		const model: InlineCompletionsModel = this._instantiationService.createInstance(
 			InlineCompletionsModel,
 			textModel,
@@ -130,7 +158,8 @@ export class InlineCompletionsController extends Disposable {
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService
 	) {
 		super();
 		this._editorObs = observableCodeEditor(this.editor);

--- a/src/vs/editor/contrib/inlineCompletions/test/browser/inlineProtectedFiles.test.ts
+++ b/src/vs/editor/contrib/inlineCompletions/test/browser/inlineProtectedFiles.test.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare function suite(name: string, fn: () => void): void;
+declare function test(name: string, fn: () => void): void;
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { InlineCompletionsController } from '../../browser/controller/inlineCompletionsController.js';
+import { ICodeEditor } from '../../../../browser/editorBrowser.js';
+import { ITextModel } from '../../../../common/model.js';
+
+suite('Inline Protected Files', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	class TestController extends InlineCompletionsController {
+		public testIsSuggestionAllowed(model: ITextModel): boolean {
+			// @ts-ignore
+			return this.isSuggestionAllowed(model);
+		}
+	}
+
+	test('Inline suggestions disabled for protected files', () => {
+		const configService = new TestConfigurationService();
+		configService.setUserConfiguration('workspace.protectedFiles', {
+			'**/.env': { suggest: false },
+			'**/secret.txt': { suggest: false }
+		});
+
+		const contextKeyService = new MockContextKeyService();
+		const instantiationService = new class extends mock<IInstantiationService>() {
+			override invokeFunction(fn: any, ...args: any[]): any {
+				return fn(new class extends mock<any>() {
+					get(id: any): any {
+						if (id === IConfigurationService) {
+							return configService;
+						}
+						if (id === IContextKeyService) {
+							return contextKeyService;
+						}
+						return undefined;
+					}
+				});
+			}
+		};
+
+		const workspaceContextService = new class extends mock<IWorkspaceContextService>() {
+			override getWorkspaceFolder(resource: URI): any {
+				return { uri: URI.file('/workspace') };
+			}
+		} as any;
+
+		const editor = new class extends mock<ICodeEditor>() {
+			override getOption(id: any): any {
+				return { value: true };
+			}
+			override getModel(): any {
+				return { uri: URI.file('/workspace/test.ts') };
+			}
+			
+			// Events
+			override onDidChangeModel: any = () => ({ dispose: () => { } });
+			override onDidChangeModelContent: any = () => ({ dispose: () => { } });
+			override onDidBlurEditorText: any = () => ({ dispose: () => { } });
+			override onDidFocusEditorText: any = () => ({ dispose: () => { } });
+			override onDidChangeCursorPosition: any = () => ({ dispose: () => { } });
+			override onMouseDown: any = () => ({ dispose: () => { } });
+			override onDidChangeConfiguration: any = () => ({ dispose: () => { } });
+		} as any;
+
+		const controller = new TestController(
+			editor,
+			instantiationService,
+			contextKeyService,
+			configService,
+			undefined as any, // commandService
+			undefined as any, // debounceService
+			undefined as any, // languageFeaturesService
+			undefined as any, // accessibilitySignalService
+			undefined as any, // keybindingService
+			undefined as any, // accessibilityService
+			workspaceContextService
+		);
+
+		const allowedEnv = controller.testIsSuggestionAllowed({ uri: URI.file('/workspace/.env') } as any);
+		assert.strictEqual(allowedEnv, false, '.env should be blocked');
+
+		const allowedSecret = controller.testIsSuggestionAllowed({ uri: URI.file('/workspace/src/secret.txt') } as any);
+		assert.strictEqual(allowedSecret, false, 'secret.txt should be blocked');
+
+		const allowedNormal = controller.testIsSuggestionAllowed({ uri: URI.file('/workspace/src/app.ts') } as any);
+		assert.strictEqual(allowedNormal, true, 'normal files should be allowed');
+
+		controller.dispose();
+	});
+});

--- a/src/vs/workbench/common/configuration.ts
+++ b/src/vs/workbench/common/configuration.ts
@@ -54,6 +54,41 @@ export const windowConfigurationNodeBase = Object.freeze<IConfigurationNode>({
 	'type': 'object',
 });
 
+export const workspaceConfigurationNodeBase = Object.freeze<IConfigurationNode>({
+    'id': 'workspace',
+    'order': 9,
+    'title': localize('workspaceConfigurationTitle', "Workspace"),
+    'type': 'object',
+    'properties': {
+        'workspace.protectedFiles': {
+            'type': 'object',
+            'default': {},
+            'description': localize('workspace.protectedFiles', "Glob patterns for files that should not be accessed programmatically by extensions."),
+            'additionalProperties': {
+                'type': 'object',
+                'properties': {
+                    'read': {
+                        'type': 'boolean',
+                        'default': false,
+                        'description': localize('workspace.protectedFiles.read', "Allow programmatic read access")
+                    },
+                    'write': {
+                        'type': 'boolean',
+                        'default': false,
+                        'description': localize('workspace.protectedFiles.write', "Allow programmatic write access")
+                    },
+                    'suggest': {
+                        'type': 'boolean',
+                        'default': false,
+                        'description': localize('workspace.protectedFiles.suggest', "Allow inline or completion-based suggestions")
+                    }
+                },
+                'additionalProperties': false
+            }
+        }
+    }
+});
+
 export const Extensions = {
 	ConfigurationMigration: 'base.contributions.configuration.migration'
 };


### PR DESCRIPTION
This PR adds an opt-in mechanism to disable inline and completion-based suggestions for user-defined protected files.

The goal is to allow users to mark sensitive files (e.g. `.env`) as human-only, preventing automated tooling from generating inline suggestions while keeping manual editing fully intact.

What’s included

- New `workspace.protectedFiles` configuration
- Support for `suggest: false` to disable inline suggestions
- Enforcement at the inline completions controller
- Glob-based matching with workspace-relative fallback
- Fully opt-in and backward compatible

Example:

```jsonc
"workspace.protectedFiles": {
  "**/.env": {
    "suggest": false
  }
}


This change applies to all inline and completion providers, not just AI tools. AI assistants are one motivating use case, but the mechanism is vendor-neutral and future-proof.
