### PR TITLE
Restore box-shadow for activity bar in nosidebar layout

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -37,9 +37,12 @@
 
 /* Activity Bar */
 .monaco-workbench .part.activitybar {
-	box-shadow: var(--shadow-md);
 	z-index: 50;
 	position: relative;
+}
+
+.monaco-workbench.nosidebar .part.activitybar {
+	box-shadow: var(--shadow-md);
 }
 
 .monaco-workbench.activitybar-right .part.activitybar {


### PR DESCRIPTION
Restore the box-shadow for the activity bar when in a nosidebar layout to improve visual consistency.

