### PR TITLE
Handle multiple post/preToolUse hooks more correctly

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -453,8 +453,10 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 		}
 
 		if (hookResult?.additionalContext) {
-			// Append additional context to the tool result content
-			toolResult.content.push({ kind: 'text', value: '\n<PostToolUse-context>\n' + hookResult.additionalContext + '\n</PostToolUse-context>' });
+			// Append additional context from all hooks to the tool result content
+			for (const context of hookResult.additionalContext) {
+				toolResult.content.push({ kind: 'text', value: '\n<PostToolUse-context>\n' + context + '\n</PostToolUse-context>' });
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
+++ b/src/vs/workbench/contrib/chat/common/hooks/hooksExecutionService.ts
@@ -28,6 +28,7 @@ import {
 	IPreToolUseCallerInput,
 	IPreToolUseHookResult,
 	postToolUseOutputValidator,
+	PreToolUsePermissionDecision,
 	preToolUseOutputValidator
 } from './hooksTypes.js';
 
@@ -307,14 +308,17 @@ export class HooksExecutionService implements IHooksExecutionService {
 			token: token ?? CancellationToken.None,
 		});
 
-		// Collect all valid outputs - priority order: deny > ask > allow
-		let lastAskResult: IPreToolUseHookResult | undefined;
-		let lastAllowResult: IPreToolUseHookResult | undefined;
+		// Run all hooks and collapse results. Most restrictive decision wins: deny > ask > allow.
+		// Collect all additionalContext strings from every hook.
+		const allAdditionalContext: string[] = [];
+		let mostRestrictiveDecision: PreToolUsePermissionDecision | undefined;
+		let winningResult: IHookResult | undefined;
+		let winningReason: string | undefined;
+
 		for (const result of results) {
 			if (result.success && typeof result.output === 'object' && result.output !== null) {
 				const validationResult = preToolUseOutputValidator.validate(result.output);
 				if (!validationResult.error) {
-					// Extract from hookSpecificOutput wrapper
 					const hookSpecificOutput = validationResult.content.hookSpecificOutput;
 					if (hookSpecificOutput) {
 						// Validate hookEventName if present - must match the hook type
@@ -323,35 +327,44 @@ export class HooksExecutionService implements IHooksExecutionService {
 							continue;
 						}
 
-						const preToolUseResult: IPreToolUseHookResult = {
-							...result,
-							permissionDecision: hookSpecificOutput.permissionDecision,
-							permissionDecisionReason: hookSpecificOutput.permissionDecisionReason,
-							additionalContext: hookSpecificOutput.additionalContext,
-						};
+						// Collect additionalContext from every hook
+						if (hookSpecificOutput.additionalContext) {
+							allAdditionalContext.push(hookSpecificOutput.additionalContext);
+						}
 
-						// If any hook denies, return immediately with that denial
-						if (hookSpecificOutput.permissionDecision === 'deny') {
-							return preToolUseResult;
-						}
-						// Track 'ask' results (ask takes priority over allow)
-						if (hookSpecificOutput.permissionDecision === 'ask') {
-							lastAskResult = preToolUseResult;
-						}
-						// Track the last allow in case we need to return it
-						if (hookSpecificOutput.permissionDecision === 'allow') {
-							lastAllowResult = preToolUseResult;
+						// Track the most restrictive decision: deny > ask > allow
+						const decision = hookSpecificOutput.permissionDecision;
+						if (decision && this._isMoreRestrictive(decision, mostRestrictiveDecision)) {
+							mostRestrictiveDecision = decision;
+							winningResult = result;
+							winningReason = hookSpecificOutput.permissionDecisionReason;
 						}
 					}
 				} else {
-					// If validation fails, log a warning and continue to next result
 					this._logService.warn(`[HooksExecutionService] preToolUse hook output validation failed: ${validationResult.error.message}`);
 				}
 			}
 		}
 
-		// Return with priority: ask > allow > undefined
-		return lastAskResult ?? lastAllowResult;
+		if (!mostRestrictiveDecision || !winningResult) {
+			return undefined;
+		}
+
+		return {
+			...winningResult,
+			permissionDecision: mostRestrictiveDecision,
+			permissionDecisionReason: winningReason,
+			additionalContext: allAdditionalContext.length > 0 ? allAdditionalContext : undefined,
+		};
+	}
+
+	/**
+	 * Returns true if `candidate` is more restrictive than `current`.
+	 * Restriction order: deny > ask > allow.
+	 */
+	private _isMoreRestrictive(candidate: PreToolUsePermissionDecision, current: PreToolUsePermissionDecision | undefined): boolean {
+		const order: Record<PreToolUsePermissionDecision, number> = { 'deny': 2, 'ask': 1, 'allow': 0 };
+		return current === undefined || order[candidate] > order[current];
 	}
 
 	async executePostToolUseHook(sessionResource: URI, input: IPostToolUseCallerInput, token?: CancellationToken): Promise<IPostToolUseHookResult | undefined> {
@@ -377,8 +390,13 @@ export class HooksExecutionService implements IHooksExecutionService {
 			token: token ?? CancellationToken.None,
 		});
 
-		// Collect results - if any hook blocks, return it
-		let lastResultWithContext: IPostToolUseHookResult | undefined;
+		// Run all hooks and collapse results. Block is the most restrictive decision.
+		// Collect all additionalContext strings from every hook.
+		const allAdditionalContext: string[] = [];
+		let hasBlock = false;
+		let blockReason: string | undefined;
+		let blockResult: IHookResult | undefined;
+
 		for (const result of results) {
 			if (result.success && typeof result.output === 'object' && result.output !== null) {
 				const validationResult = postToolUseOutputValidator.validate(result.output);
@@ -391,21 +409,16 @@ export class HooksExecutionService implements IHooksExecutionService {
 						continue;
 					}
 
-					const postToolUseResult: IPostToolUseHookResult = {
-						...result,
-						decision: validated.decision,
-						reason: validated.reason,
-						additionalContext: validated.hookSpecificOutput?.additionalContext,
-					};
-
-					// If any hook blocks, return immediately with that block
-					if (validated.decision === 'block') {
-						return postToolUseResult;
+					// Collect additionalContext from every hook
+					if (validated.hookSpecificOutput?.additionalContext) {
+						allAdditionalContext.push(validated.hookSpecificOutput.additionalContext);
 					}
 
-					// Track last result that has additional context
-					if (validated.hookSpecificOutput?.additionalContext) {
-						lastResultWithContext = postToolUseResult;
+					// Track the first block decision (most restrictive)
+					if (validated.decision === 'block' && !hasBlock) {
+						hasBlock = true;
+						blockReason = validated.reason;
+						blockResult = result;
 					}
 				} else {
 					this._logService.warn(`[HooksExecutionService] postToolUse hook output validation failed: ${validationResult.error.message}`);
@@ -413,6 +426,17 @@ export class HooksExecutionService implements IHooksExecutionService {
 			}
 		}
 
-		return lastResultWithContext;
+		// Return combined result if there's a block decision or any additional context
+		if (!hasBlock && allAdditionalContext.length === 0) {
+			return undefined;
+		}
+
+		const baseResult = blockResult ?? results[0];
+		return {
+			...baseResult,
+			decision: hasBlock ? 'block' : undefined,
+			reason: blockReason,
+			additionalContext: allAdditionalContext.length > 0 ? allAdditionalContext : undefined,
+		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/hooks/hooksTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/hooks/hooksTypes.ts
@@ -83,12 +83,12 @@ export type PreToolUsePermissionDecision = 'allow' | 'deny' | 'ask';
 
 /**
  * Result from preToolUse hooks with permission decision fields.
- * Returned to VS Code callers.
+ * Returned to VS Code callers. Represents the collapsed result of all hooks.
  */
 export interface IPreToolUseHookResult extends IHookResult {
 	readonly permissionDecision?: PreToolUsePermissionDecision;
 	readonly permissionDecisionReason?: string;
-	readonly additionalContext?: string;
+	readonly additionalContext?: string[];
 }
 
 //#endregion
@@ -120,12 +120,12 @@ export type PostToolUseDecision = 'block';
 
 /**
  * Result from postToolUse hooks with decision fields.
- * Returned to VS Code callers.
+ * Returned to VS Code callers. Represents the collapsed result of all hooks.
  */
 export interface IPostToolUseHookResult extends IHookResult {
 	readonly decision?: PostToolUseDecision;
 	readonly reason?: string;
-	readonly additionalContext?: string;
+	readonly additionalContext?: string[];
 }
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -4002,7 +4002,7 @@ suite('LanguageModelToolsService', () => {
 			mockHooksService.postToolUseHookResult = {
 				output: undefined,
 				success: true,
-				additionalContext: 'Consider running tests after this change',
+				additionalContext: ['Consider running tests after this change'],
 			};
 
 			const tool = registerToolForTest(hookService, store, 'postHookContextTool', {
@@ -4075,7 +4075,7 @@ suite('LanguageModelToolsService', () => {
 				success: true,
 				decision: 'block',
 				reason: 'Security issue found',
-				additionalContext: 'Please review the file permissions',
+				additionalContext: ['Please review the file permissions'],
 			};
 
 			const tool = registerToolForTest(hookService, store, 'postHookBlockContextTool', {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -2009,35 +2009,31 @@ suite('LanguageModelToolsService', () => {
 		// Change the context key value
 		contextKeyService.createKey('dynamicKey', true);
 
-		// Wait a bit for the scheduler
-		await new Promise(resolve => setTimeout(resolve, 800));
+		service.flushToolUpdates();
 
 		assert.strictEqual(changeEventFired, true, 'onDidChangeTools should fire when context keys change');
 	});
 
 	test('configuration changes trigger tool updates', async () => {
-		return runWithFakedTimers({}, async () => {
-			let changeEventFired = false;
-			const disposable = service.onDidChangeTools(() => {
-				changeEventFired = true;
-			});
-			store.add(disposable);
-
-			// Change the correct configuration key
-			configurationService.setUserConfiguration('chat.extensionTools.enabled', false);
-			// Fire the configuration change event manually
-			configurationService.onDidChangeConfigurationEmitter.fire({
-				affectsConfiguration: () => true,
-				affectedKeys: new Set(['chat.extensionTools.enabled']),
-				change: null!,
-				source: ConfigurationTarget.USER
-			} satisfies IConfigurationChangeEvent);
-
-			// Wait a bit for the scheduler
-			await new Promise(resolve => setTimeout(resolve, 800));
-
-			assert.strictEqual(changeEventFired, true, 'onDidChangeTools should fire when configuration changes');
+		let changeEventFired = false;
+		const disposable = service.onDidChangeTools(() => {
+			changeEventFired = true;
 		});
+		store.add(disposable);
+
+		// Change the correct configuration key
+		configurationService.setUserConfiguration('chat.extensionTools.enabled', false);
+		// Fire the configuration change event manually
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: () => true,
+			affectedKeys: new Set(['chat.extensionTools.enabled']),
+			change: null!,
+			source: ConfigurationTarget.USER
+		} satisfies IConfigurationChangeEvent);
+
+		service.flushToolUpdates();
+
+		assert.strictEqual(changeEventFired, true, 'onDidChangeTools should fire when configuration changes');
 	});
 
 	test('toToolAndToolSetEnablementMap with MCP toolset enables contained tools', () => {
@@ -3100,47 +3096,44 @@ suite('LanguageModelToolsService', () => {
 		configurationService.setUserConfiguration(ChatConfiguration.ExtensionToolsEnabled, true);
 	});
 
-	test('observeTools changes when context key changes', async () => {
-		return runWithFakedTimers({}, async () => {
-			const testCtxKey = contextKeyService.createKey<string>('dynamicTestKey', 'value1');
+	test('observeTools changes when context key changes', () => {
+		const testCtxKey = contextKeyService.createKey<string>('dynamicTestKey', 'value1');
 
-			const tool1: IToolData = {
-				id: 'dynamicTool1',
-				modelDescription: 'Dynamic Tool 1',
-				displayName: 'Dynamic Tool 1',
-				source: ToolDataSource.Internal,
-				when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value1'),
-			};
+		const tool1: IToolData = {
+			id: 'dynamicTool1',
+			modelDescription: 'Dynamic Tool 1',
+			displayName: 'Dynamic Tool 1',
+			source: ToolDataSource.Internal,
+			when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value1'),
+		};
 
-			const tool2: IToolData = {
-				id: 'dynamicTool2',
-				modelDescription: 'Dynamic Tool 2',
-				displayName: 'Dynamic Tool 2',
-				source: ToolDataSource.Internal,
-				when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value2'),
-			};
+		const tool2: IToolData = {
+			id: 'dynamicTool2',
+			modelDescription: 'Dynamic Tool 2',
+			displayName: 'Dynamic Tool 2',
+			source: ToolDataSource.Internal,
+			when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value2'),
+		};
 
-			store.add(service.registerToolData(tool1));
-			store.add(service.registerToolData(tool2));
+		store.add(service.registerToolData(tool1));
+		store.add(service.registerToolData(tool2));
 
-			const toolsObs = service.observeTools(undefined);
+		const toolsObs = service.observeTools(undefined);
 
-			// Initial state: value1 matches tool1
-			let tools = toolsObs.get();
-			assert.strictEqual(tools.length, 1, 'should have 1 tool initially');
-			assert.strictEqual(tools[0].id, 'dynamicTool1', 'should be dynamicTool1');
+		// Initial state: value1 matches tool1
+		let tools = toolsObs.get();
+		assert.strictEqual(tools.length, 1, 'should have 1 tool initially');
+		assert.strictEqual(tools[0].id, 'dynamicTool1', 'should be dynamicTool1');
 
-			// Change context key to value2
-			testCtxKey.set('value2');
+		// Change context key to value2
+		testCtxKey.set('value2');
 
-			// Wait for scheduler to trigger
-			await new Promise(resolve => setTimeout(resolve, 800));
+		service.flushToolUpdates();
 
-			// Now tool2 should be available
-			tools = toolsObs.get();
-			assert.strictEqual(tools.length, 1, 'should have 1 tool after change');
-			assert.strictEqual(tools[0].id, 'dynamicTool2', 'should be dynamicTool2 after context change');
-		});
+		// Now tool2 should be available
+		tools = toolsObs.get();
+		assert.strictEqual(tools.length, 1, 'should have 1 tool after change');
+		assert.strictEqual(tools[0].id, 'dynamicTool2', 'should be dynamicTool2 after context change');
 	});
 
 	test('isPermitted allows tools in permitted toolsets when agent mode is disabled', () => {
@@ -3536,62 +3529,59 @@ suite('LanguageModelToolsService', () => {
 			assert.ok(!toolIds.includes('toolWithWhenTrue'), 'Tool with when=true should NOT be in tool set when context key is false');
 		});
 
-		test('ToolSet.getTools updates when context key changes', async () => {
-			return runWithFakedTimers({}, async () => {
-				// Create a context key for testing
-				const testKey = contextKeyService.createKey<string>('dynamicTestKey', 'value1');
+		test('ToolSet.getTools updates when context key changes', () => {
+			// Create a context key for testing
+			const testKey = contextKeyService.createKey<string>('dynamicTestKey', 'value1');
 
-				// Create tools with when clauses
-				const toolWithValue1: IToolData = {
-					id: 'toolWithValue1',
-					modelDescription: 'Tool with value1',
-					displayName: 'Tool with value1',
-					source: ToolDataSource.Internal,
-					when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value1'),
-				};
+			// Create tools with when clauses
+			const toolWithValue1: IToolData = {
+				id: 'toolWithValue1',
+				modelDescription: 'Tool with value1',
+				displayName: 'Tool with value1',
+				source: ToolDataSource.Internal,
+				when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value1'),
+			};
 
-				const toolWithValue2: IToolData = {
-					id: 'toolWithValue2',
-					modelDescription: 'Tool with value2',
-					displayName: 'Tool with value2',
-					source: ToolDataSource.Internal,
-					when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value2'),
-				};
+			const toolWithValue2: IToolData = {
+				id: 'toolWithValue2',
+				modelDescription: 'Tool with value2',
+				displayName: 'Tool with value2',
+				source: ToolDataSource.Internal,
+				when: ContextKeyEqualsExpr.create('dynamicTestKey', 'value2'),
+			};
 
-				// Create a tool set and add the tools
-				const dynamicToolSet = store.add(service.createToolSet(
-					ToolDataSource.Internal,
-					'dynamicToolSet',
-					'dynamicToolSetRef',
-					{ description: 'Dynamic Tool Set' }
-				));
+			// Create a tool set and add the tools
+			const dynamicToolSet = store.add(service.createToolSet(
+				ToolDataSource.Internal,
+				'dynamicToolSet',
+				'dynamicToolSetRef',
+				{ description: 'Dynamic Tool Set' }
+			));
 
-				store.add(service.registerToolData(toolWithValue1));
-				store.add(service.registerToolData(toolWithValue2));
+			store.add(service.registerToolData(toolWithValue1));
+			store.add(service.registerToolData(toolWithValue2));
 
-				store.add(dynamicToolSet.addTool(toolWithValue1));
-				store.add(dynamicToolSet.addTool(toolWithValue2));
+			store.add(dynamicToolSet.addTool(toolWithValue1));
+			store.add(dynamicToolSet.addTool(toolWithValue2));
 
-				// Initial state: value1 is set
-				let tools = Array.from(dynamicToolSet.getTools());
-				let toolIds = tools.map(t => t.id);
+			// Initial state: value1 is set
+			let tools = Array.from(dynamicToolSet.getTools());
+			let toolIds = tools.map(t => t.id);
 
-				assert.strictEqual(tools.length, 1, 'Should have 1 tool initially');
-				assert.strictEqual(toolIds[0], 'toolWithValue1', 'Should be toolWithValue1');
+			assert.strictEqual(tools.length, 1, 'Should have 1 tool initially');
+			assert.strictEqual(toolIds[0], 'toolWithValue1', 'Should be toolWithValue1');
 
-				// Change context key to value2
-				testKey.set('value2');
+			// Change context key to value2
+			testKey.set('value2');
 
-				// Wait for scheduler to trigger
-				await new Promise(resolve => setTimeout(resolve, 800));
+			service.flushToolUpdates();
 
-				// Now toolWithValue2 should be available
-				tools = Array.from(dynamicToolSet.getTools());
-				toolIds = tools.map(t => t.id);
+			// Now toolWithValue2 should be available
+			tools = Array.from(dynamicToolSet.getTools());
+			toolIds = tools.map(t => t.id);
 
-				assert.strictEqual(tools.length, 1, 'Should have 1 tool after change');
-				assert.strictEqual(toolIds[0], 'toolWithValue2', 'Should be toolWithValue2 after context change');
-			});
+			assert.strictEqual(tools.length, 1, 'Should have 1 tool after change');
+			assert.strictEqual(toolIds[0], 'toolWithValue2', 'Should be toolWithValue2 after context change');
 		});
 
 		test('ToolSet.getTools with complex when expressions', () => {
@@ -3904,9 +3894,7 @@ suite('LanguageModelToolsService', () => {
 				CancellationToken.None
 			);
 
-			// Wait for invocation to be captured
-			await new Promise(resolve => setTimeout(resolve, 50));
-			const invocation = capture.invocation;
+			const invocation = await waitForPublishedInvocation(capture);
 			assert.ok(invocation, 'Tool invocation should be created');
 
 			// Check that the tool is waiting for confirmation (not auto-approved)


### PR DESCRIPTION
Enhance the handling of multiple post and preToolUse hooks by allowing the aggregation of additional context from all hooks. Improve tests to ensure the new functionality works as intended.

