### PR TITLE
improve question carousel accessibility

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -87,6 +87,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 		content.push(localize('chat.showHiddenTerminals', 'If there are any hidden chat terminals, you can view them by invoking the View Hidden Chat Terminals command{0}.', '<keybinding:workbench.action.terminal.chat.viewHiddenChatTerminals>'));
 		content.push(localize('chat.focusMostRecentTerminal', 'To focus the last chat terminal that ran a tool, invoke the Focus Most Recent Chat Terminal command{0}.', `<keybinding:${TerminalContribCommandId.FocusMostRecentChatTerminal}>`));
 		content.push(localize('chat.focusMostRecentTerminalOutput', 'To focus the output from the last chat terminal tool, invoke the Focus Most Recent Chat Terminal Output command{0}.', `<keybinding:${TerminalContribCommandId.FocusMostRecentChatTerminalOutput}>`));
+		content.push(localize('chat.focusQuestionCarousel', 'When a chat question appears, toggle focus between the question and the chat input{0}.', '<keybinding:workbench.action.chat.focusQuestionCarousel>'));
 	}
 	if (type === 'editsView' || type === 'agentView') {
 		if (type === 'agentView') {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -781,6 +781,34 @@ export function registerChatActions() {
 		}
 	});
 
+	registerAction2(class FocusQuestionCarouselAction extends Action2 {
+		static readonly ID = 'workbench.action.chat.focusQuestionCarousel';
+
+		constructor() {
+			super({
+				id: FocusQuestionCarouselAction.ID,
+				title: localize2('interactiveSession.focusQuestionCarousel.label', "Chat: Toggle Focus Between Question and Input"),
+				category: CHAT_CATEGORY,
+				f1: true,
+				precondition: ChatContextKeys.inChatSession,
+				keybinding: [{
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+					when: ChatContextKeys.inChatSession,
+				}]
+			});
+		}
+
+		run(accessor: ServicesAccessor): void {
+			const widgetService = accessor.get(IChatWidgetService);
+			const widget = widgetService.lastFocusedWidget;
+
+			if (!widget || !widget.toggleQuestionCarouselFocus()) {
+				alert(localize('chat.questionCarousel.focusUnavailable', "No chat question to focus right now."));
+			}
+		}
+	});
+
 	const nonEnterpriseCopilotUsers = ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.notEquals(`config.${defaultChat.completionsAdvancedSetting}.authProvider`, defaultChat.provider.enterprise.id));
 	registerAction2(class extends Action2 {
 		constructor() {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -376,6 +376,16 @@ export interface IChatWidget {
 	 * @returns Whether the operation succeeded (i.e., the focus was toggled).
 	 */
 	toggleTodosViewFocus(): boolean;
+	/**
+	 * Focuses the question carousel in the chat widget.
+	 * @returns Whether the operation succeeded (i.e., the question carousel was focused).
+	 */
+	focusQuestionCarousel(): boolean;
+	/**
+	 * Toggles focus between the question carousel and the chat input.
+	 * @returns Whether the operation succeeded (i.e., the focus was toggled).
+	 */
+	toggleQuestionCarouselFocus(): boolean;
 	hasInputFocus(): boolean;
 	getModeRequestOptions(): Partial<IChatSendRequestOptions>;
 	getCodeBlockInfoForEditor(uri: URI): IChatCodeBlockInfo | undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -10,6 +10,7 @@ import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 import { localize } from '../../../../../../nls.js';
+import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultInputBoxStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
 import { Button } from '../../../../../../base/browser/ui/button/button.js';
 import { InputBox } from '../../../../../../base/browser/ui/inputbox/inputBox.js';
@@ -66,10 +67,16 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		context: IChatContentPartRenderContext,
 		private readonly _options: IChatQuestionCarouselOptions,
 		@IHoverService private readonly _hoverService: IHoverService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
 		super();
 
 		this.domNode = dom.$('.chat-question-carousel-container');
+
+		// Set up accessibility attributes for the carousel container
+		this.domNode.tabIndex = 0;
+		this.domNode.setAttribute('role', 'region');
+		this._updateAriaLabel();
 
 		// Restore answers from carousel data if already submitted (e.g., after re-render due to virtualization)
 		if (carousel.data) {
@@ -195,7 +202,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		if (newIndex >= 0 && newIndex < this.carousel.questions.length) {
 			this.saveCurrentAnswer();
 			this._currentIndex = newIndex;
-			this.renderCurrentQuestion();
+			this.renderCurrentQuestion(true);
 		}
 	}
 
@@ -209,11 +216,28 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		if (this._currentIndex < this.carousel.questions.length - 1) {
 			// Move to next question
 			this._currentIndex++;
-			this.renderCurrentQuestion();
+			this.renderCurrentQuestion(true);
 		} else {
 			// Submit
 			this._options.onSubmit(this._answers);
 			this.hideAndShowSummary();
+		}
+	}
+
+	/**
+	 * Focuses the container element and announces the question for screen reader users.
+	 */
+	private _focusContainerAndAnnounce(): void {
+		this.domNode.focus();
+		const question = this.carousel.questions[this._currentIndex];
+		if (question) {
+			const questionText = question.message ?? question.title;
+			const messageContent = typeof questionText === 'string' ? questionText : questionText.value;
+			const questionCount = this.carousel.questions.length;
+			const alertMessage = questionCount === 1
+				? messageContent
+				: localize('chat.questionCarousel.questionAlertMulti', 'Question {0} of {1}: {2}', this._currentIndex + 1, questionCount, messageContent);
+			this._accessibilityService.alert(alertMessage);
 		}
 	}
 
@@ -352,7 +376,54 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 	}
 
-	private renderCurrentQuestion(): void {
+	/**
+	 * Returns whether auto-focus should be enabled.
+	 * Disabled when screen reader mode is active or when explicitly disabled via options.
+	 */
+	private _shouldAutoFocus(): boolean {
+		if (this._options.shouldAutoFocus === false) {
+			return false;
+		}
+		// Disable auto-focus for screen reader users to allow them to read the question first
+		return !this._accessibilityService.isScreenReaderOptimized();
+	}
+
+	/**
+	 * Updates the aria-label of the carousel container based on the current question.
+	 */
+	private _updateAriaLabel(): void {
+		const question = this.carousel.questions[this._currentIndex];
+		if (!question) {
+			this.domNode.setAttribute('aria-label', localize('chat.questionCarousel.label', 'Chat question'));
+			return;
+		}
+
+		const questionText = question.message ?? question.title;
+		const messageContent = typeof questionText === 'string' ? questionText : questionText.value;
+		const questionCount = this.carousel.questions.length;
+
+		if (questionCount === 1) {
+			this.domNode.setAttribute('aria-label', localize('chat.questionCarousel.singleQuestionLabel', 'Chat question: {0}', messageContent));
+		} else {
+			this.domNode.setAttribute('aria-label', localize('chat.questionCarousel.multiQuestionLabel', 'Chat question {0} of {1}: {2}', this._currentIndex + 1, questionCount, messageContent));
+		}
+	}
+
+	/**
+	 * Focuses the carousel container element.
+	 */
+	public focus(): void {
+		this.domNode.focus();
+	}
+
+	/**
+	 * Returns whether the carousel container has focus.
+	 */
+	public hasFocus(): boolean {
+		return dom.isAncestorOfActiveElement(this.domNode);
+	}
+
+	private renderCurrentQuestion(focusContainerForScreenReader: boolean = false): void {
 		if (!this._questionContainer || !this._prevButton || !this._nextButton) {
 			return;
 		}
@@ -445,6 +516,15 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			this._nextButtonHover.value = this._hoverService.setupDelayedHover(this._nextButton!.element, { content: nextLabel });
 		}
 
+		// Update aria-label to reflect the current question
+		this._updateAriaLabel();
+
+		// In screen reader mode, focus the container and announce the question
+		// This must happen after all render calls to avoid focus being stolen
+		if (focusContainerForScreenReader && this._accessibilityService.isScreenReaderOptimized()) {
+			this._focusContainerAndAnnounce();
+		}
+
 		this._onDidChangeHeight.fire();
 	}
 
@@ -493,7 +573,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		this._textInputBoxes.set(question.id, inputBox);
 
 		// Focus on input when rendered using proper DOM scheduling
-		if (this._options.shouldAutoFocus !== false) {
+		if (this._shouldAutoFocus()) {
 			this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(inputBox.element), () => inputBox.focus()));
 		}
 	}
@@ -696,7 +776,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 
 		// focus on the row when first rendered or textarea if it has content
-		if (this._options.shouldAutoFocus !== false) {
+		if (this._shouldAutoFocus()) {
 			if (previousFreeform) {
 				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => {
 					freeformTextarea.focus();
@@ -891,7 +971,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 
 		// Focus on the appropriate row when rendered or textarea if it has content
-		if (this._options.shouldAutoFocus !== false) {
+		if (this._shouldAutoFocus()) {
 			if (previousFreeform) {
 				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => {
 					freeformTextarea.focus();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -76,6 +76,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		// Set up accessibility attributes for the carousel container
 		this.domNode.tabIndex = 0;
 		this.domNode.setAttribute('role', 'region');
+		this.domNode.setAttribute('aria-roledescription', localize('chat.questionCarousel.roleDescription', 'chat question'));
 		this._updateAriaLabel();
 
 		// Restore answers from carousel data if already submitted (e.g., after re-render due to virtualization)

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -719,6 +719,27 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		return this.input.focusTodoList();
 	}
 
+	focusQuestionCarousel(): boolean {
+		if (!this.input.questionCarousel) {
+			return false;
+		}
+
+		return this.input.focusQuestionCarousel();
+	}
+
+	toggleQuestionCarouselFocus(): boolean {
+		if (!this.input.questionCarousel) {
+			return false;
+		}
+
+		if (this.input.isQuestionCarouselFocused()) {
+			this.focusInput();
+			return true;
+		}
+
+		return this.input.focusQuestionCarousel();
+	}
+
 	hasInputFocus(): boolean {
 		return this.input.hasFocus();
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2452,6 +2452,20 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return this._chatQuestionCarouselWidget.value;
 	}
 
+	focusQuestionCarousel(): boolean {
+		const carousel = this._chatQuestionCarouselWidget.value;
+		if (carousel) {
+			carousel.focus();
+			return true;
+		}
+		return false;
+	}
+
+	isQuestionCarouselFocused(): boolean {
+		const carousel = this._chatQuestionCarouselWidget.value;
+		return carousel?.hasFocus() ?? false;
+	}
+
 	setWorkingSetCollapsed(collapsed: boolean): void {
 		this._workingSetCollapsed.set(collapsed, undefined);
 	}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/292917

- Disables `auto-focus` when in screen reader mode
- Adds `ctrlCmd+shift+A` keybinding to toggle focus between the question and the chat input to align with the confirmation prompt behavior
- Adds keyboard focus to the container and sets the aria label to be the the current question
- Alerts the question title when iterating through them
- Adds info about the command to the accessibility help dialog

https://github.com/user-attachments/assets/3982512e-df3d-4934-a338-c402d41a3ed3

https://github.com/user-attachments/assets/866ea3c4-3e2c-492d-b845-2196c7743265

