### PR TITLE
[duplicate] fix: enable text wrapping in parameter hints widget

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
@@ -56,6 +56,8 @@
 .monaco-editor .parameter-hints-widget .signature {
 	padding: 4px 5px;
 	position: relative;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 
 .monaco-editor .parameter-hints-widget .signature.has-docs::after {
@@ -71,6 +73,9 @@
 
 .monaco-editor .parameter-hints-widget .code {
 	font-family: var(--vscode-parameterHintsWidget-editorFontFamily), var(--vscode-parameterHintsWidget-editorFontFamilyDefault);
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 
 .monaco-editor .parameter-hints-widget .docs {


### PR DESCRIPTION
Add white-space: pre-wrap, word-wrap and overflow-wrap properties to parameter hints .code and .signature classes to allow long parameter descriptions and signatures to wrap instead of overflowing.

This fixes an issue where long parameter hints were not wrapped, making them unreadable when they extended beyond the visible area. Only vertical scrolling was available, not horizontal, which made navigation difficult.

Fixes #142888