### PR TITLE
fix: ensure folding icons are clickable in sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -54,6 +54,9 @@
 	transition: var(--vscode-editorStickyScroll-foldingOpacityTransition);
 	position: absolute;
 	margin-left: 2px;
+	z-index: 10;
+	cursor: pointer;
+	pointer-events: auto;
 }
 
 .monaco-editor .sticky-widget .sticky-line-content {


### PR DESCRIPTION
Add z-index and pointer-events to folding icons in sticky scroll to ensure they are always clickable and appear above other elements.

This fixes an issue where folding controls would either disappear from the line margin or appear but not respond to clicks when a foldable region entered the sticky scroll area.

Fixes #292042