### PR TITLE
Make custom agent show/hide eye icon behave like a toggle

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -257,8 +257,8 @@ const MAKE_VISIBLE_BUTTON: IQuickInputButton = {
  * Button that sets a prompt file to be invisible.
  */
 const MAKE_INVISIBLE_BUTTON: IQuickInputButton = {
-	tooltip: localize('makeInvisible', "Hide from agent picker"),
-	iconClass: ThemeIcon.asClassName(Codicon.eyeClosed),
+	tooltip: localize('makeInvisible', "Shown in chat view agent picker. Click to hide."),
+	iconClass: ThemeIcon.asClassName(Codicon.eye),
 };
 
 export class PromptFilePickers {


### PR DESCRIPTION
Instead of always showing the `eyeClosed` icon, show the `eye` or `eyeClosed` icon depending on the current visibility.

**Before change:**

https://github.com/user-attachments/assets/48466d63-e3f2-4f30-8ee9-d97fbb147d15



**After change:**

https://github.com/user-attachments/assets/71fc5c6a-6a87-43ee-8dd8-46abb23734e6