### PR TITLE
elevate AI profiles in terminal dropdown

### DIFF
--- a/src/vs/platform/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/platform/extensions/common/extensionsApiProposals.ts
@@ -437,6 +437,9 @@ const _allApiProposals = {
 	terminalExecuteCommandEvent: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalExecuteCommandEvent.d.ts',
 	},
+	terminalProfileGroup: {
+		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalProfileGroup.d.ts',
+	},
 	terminalQuickFixProvider: {
 		proposal: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.terminalQuickFixProvider.d.ts',
 	},

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -962,6 +962,7 @@ export interface ITerminalProfileContribution {
 	id: string;
 	icon?: URI | { light: URI; dark: URI } | string;
 	color?: string;
+	group?: string;
 }
 
 export interface IExtensionTerminalProfile extends ITerminalProfileContribution {

--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -807,6 +807,36 @@ export function getTerminalActionBarArgs(location: ITerminalLocationOptions, pro
 	}))));
 	dropdownActions.push(new Separator());
 
+	// Partition contributed profiles into elevated (AI) and regular groups
+	const elevatedContributed = contributedProfiles.filter(p => p.group === 'ai');
+	const regularContributed = contributedProfiles.filter(p => p.group !== 'ai');
+
+	// Add elevated AI profiles first in their own section
+	for (const contributed of elevatedContributed) {
+		const isDefault = contributed.title === defaultProfileName;
+		const title = isDefault ? localize('defaultTerminalProfile', "{0} (Default)", contributed.title.replace(/[\n\r\t]/g, '')) : contributed.title.replace(/[\n\r\t]/g, '');
+		dropdownActions.push(disposableStore.add(new Action('contributed', title, undefined, true, () => terminalService.createAndFocusTerminal({
+			config: {
+				extensionIdentifier: contributed.extensionIdentifier,
+				id: contributed.id,
+				title
+			},
+			location
+		}))));
+		submenuActions.push(disposableStore.add(new Action('contributed-split', title, undefined, true, () => terminalService.createAndFocusTerminal({
+			config: {
+				extensionIdentifier: contributed.extensionIdentifier,
+				id: contributed.id,
+				title
+			},
+			location: splitLocation
+		}))));
+	}
+
+	if (elevatedContributed.length > 0) {
+		dropdownActions.push(new Separator());
+	}
+
 	profiles = profiles.filter(e => !e.isAutoDetected);
 	for (const p of profiles) {
 		const isDefault = p.profileName === defaultProfileName;
@@ -821,7 +851,7 @@ export function getTerminalActionBarArgs(location: ITerminalLocationOptions, pro
 		})));
 	}
 
-	for (const contributed of contributedProfiles) {
+	for (const contributed of regularContributed) {
 		const isDefault = contributed.title === defaultProfileName;
 		const title = isDefault ? localize('defaultTerminalProfile', "{0} (Default)", contributed.title.replace(/[\n\r\t]/g, '')) : contributed.title.replace(/[\n\r\t]/g, '');
 		dropdownActions.push(disposableStore.add(new Action('contributed', title, undefined, true, () => terminalService.createAndFocusTerminal({

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -693,6 +693,10 @@ export const terminalContributionsDescriptor: IExtensionPointDescriptor<ITermina
 								}
 							}]
 						},
+						group: {
+							description: nls.localize('vscode.extension.contributes.terminal.profiles.group', "The group for this terminal profile. Profiles with group 'ai' are elevated in the terminal dropdown."),
+							type: 'string',
+						},
 					},
 				},
 			},

--- a/src/vs/workbench/contrib/terminal/common/terminalExtensionPoints.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalExtensionPoints.ts
@@ -45,7 +45,12 @@ export class TerminalContributionService implements ITerminalContributionService
 		terminalsExtPoint.setHandler(contributions => {
 			this._terminalProfiles = contributions.map(c => {
 				return c.value?.profiles?.filter(p => hasValidTerminalIcon(p)).map(e => {
-					return { ...e, extensionIdentifier: c.description.identifier.value };
+					const profile: IExtensionTerminalProfile = { ...e, extensionIdentifier: c.description.identifier.value };
+					// Strip the group field if the extension does not have the proposed API enabled
+					if (profile.group && !isProposedApiEnabled(c.description, 'terminalProfileGroup')) {
+						delete profile.group;
+					}
+					return profile;
 				}) || [];
 			}).flat();
 

--- a/src/vscode-dts/vscode.proposed.terminalProfileGroup.d.ts
+++ b/src/vscode-dts/vscode.proposed.terminalProfileGroup.d.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/293554
+
+	/**
+	 * Additional options for terminal profile contributions declared in `contributes.terminal.profiles`.
+	 *
+	 * Allows extensions to specify a `group` to control the placement of the profile
+	 * in the terminal profile quick pick and dropdown.
+	 *
+	 * Currently recognized groups:
+	 * - `'ai'` — The profile will be elevated to a dedicated section near the top of the
+	 *   terminal profile list, improving discoverability of AI agent terminals.
+	 */
+}


### PR DESCRIPTION
fixes #293554

Adds a new proposed API terminalProfileGroup that lets extensions specify a `group` on contributed terminal profiles. Profiles with `group: "ai"` are shown in a dedicated section at the top of the terminal dropdown and quick pick, separated from regular profiles. 