### PR TITLE
Add engines property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,5 +239,9 @@
   },
   "optionalDependencies": {
     "windows-foreground-love": "0.6.1"
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Add the `engines` property to the root `package.json` to specify the required Node.js and npm versions for contributing to VS Code.

## Changes

- Added `engines` field with:
  - `node`: >=22.0.0
  - `npm`: >=10.0.0

## Benefits

1. **Quick reference**: Contributors can immediately see which Node.js and npm versions are required
2. **Error prevention**: npm will throw an error if an unsupported version is used
3. **Clear documentation**: Aligns with the How to Contribute wiki guide

## Issue

Resolves #252372