### PR TITLE
chatParticipantAdditions: fix build bug

### DIFF
--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -5,6 +5,8 @@
 
 // version: 3
 
+/// <reference path="vscode.proposed.chatHooks.d.ts" />
+
 declare module 'vscode' {
 
 	export interface ChatParticipant {


### PR DESCRIPTION
Without this, the compilation fails:

```
[09:56:13] Finished compile-extension:vscode-colorize-tests after 5236 ms
[09:56:14] 'compile' errored after 6.19 s
[09:56:14] Error: tsgo exited with code 1
    at ChildProcess.<anonymous> (file:///Users/Harald/git-repos/github.com/microsoft/vscode/build/lib/tsgo.ts:93:11)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess.emit (node:domain:552:15)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
    at Process.callbackTrampoline (node:internal/async_hooks:130:17)
```
