### PR TITLE
Update status bar entry bug fixes

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -27,7 +27,13 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 	@memoize private get onRawError(): Event<string> { return Event.fromNodeEventEmitter(electron.autoUpdater, 'error', (_, message) => message); }
 	@memoize private get onRawUpdateNotAvailable(): Event<void> { return Event.fromNodeEventEmitter<void>(electron.autoUpdater, 'update-not-available'); }
 	@memoize private get onRawUpdateAvailable(): Event<void> { return Event.fromNodeEventEmitter(electron.autoUpdater, 'update-available'); }
-	@memoize private get onRawUpdateDownloaded(): Event<IUpdate> { return Event.fromNodeEventEmitter(electron.autoUpdater, 'update-downloaded', (_, version: string, productVersion: string, timestamp: number) => ({ version, productVersion, timestamp })); }
+	@memoize private get onRawUpdateDownloaded(): Event<IUpdate> {
+		return Event.fromNodeEventEmitter(electron.autoUpdater, 'update-downloaded', (_, version: string, productVersion: string, releaseDate: Date | number) => ({
+			version,
+			productVersion,
+			timestamp: releaseDate instanceof Date ? releaseDate.getTime() || undefined : releaseDate
+		}));
+	}
 
 	constructor(
 		@ILifecycleMainService lifecycleMainService: ILifecycleMainService,

--- a/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
@@ -7,8 +7,8 @@
 	display: flex;
 	flex-direction: column;
 	padding: 4px 0;
-	min-width: 300px;
-	max-width: 400px;
+	min-width: 310px;
+	max-width: 410px;
 }
 
 /* Header with title and gear icon */

--- a/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
@@ -362,17 +362,23 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 		const productVersion = this.productService.version;
 		if (productVersion) {
 			const currentVersion = dom.append(details, dom.$('.product-version'));
-			currentVersion.textContent = nls.localize('updateStatus.currentVersionLabel', "Current Version: {0}", productVersion);
+			const currentCommitId = this.productService.commit?.substring(0, 7);
+			currentVersion.textContent = currentCommitId
+				? nls.localize('updateStatus.currentVersionLabelWithCommit', "Current Version: {0} ({1})", productVersion, currentCommitId)
+				: nls.localize('updateStatus.currentVersionLabel', "Current Version: {0}", productVersion);
 		}
 
 		const version = update?.productVersion;
 		if (version) {
 			const latestVersion = dom.append(details, dom.$('.product-version'));
-			latestVersion.textContent = nls.localize('updateStatus.latestVersionLabel', "Latest Version: {0}", version);
+			const updateCommitId = update.version?.substring(0, 7);
+			latestVersion.textContent = updateCommitId
+				? nls.localize('updateStatus.latestVersionLabelWithCommit', "Latest Version: {0} ({1})", version, updateCommitId)
+				: nls.localize('updateStatus.latestVersionLabel', "Latest Version: {0}", version);
 		}
 
 		const releaseDate = update?.timestamp ?? tryParseDate(this.productService.date);
-		if (releaseDate) {
+		if (typeof releaseDate === 'number' && releaseDate > 0) {
 			const releaseDateNode = dom.append(details, dom.$('.product-release-date'));
 			releaseDateNode.textContent = nls.localize('updateStatus.releasedLabel', "Released {0}", formatDate(releaseDate));
 		}
@@ -416,11 +422,11 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
  * Tries to parse a date string and returns the timestamp or undefined if parsing fails.
  */
 export function tryParseDate(date: string | undefined): number | undefined {
-	try {
-		return date !== undefined ? Date.parse(date) : undefined;
-	} catch {
+	if (date === undefined) {
 		return undefined;
 	}
+	const parsed = Date.parse(date);
+	return isNaN(parsed) ? undefined : parsed;
 }
 
 /**

--- a/src/vs/workbench/contrib/update/test/browser/updateStatusBarEntry.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateStatusBarEntry.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import * as sinon from 'sinon';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Downloading, StateType } from '../../../../../platform/update/common/update.js';
-import { computeDownloadSpeed, computeDownloadTimeRemaining, formatBytes, formatTimeRemaining } from '../../browser/updateStatusBarEntry.js';
+import { computeDownloadSpeed, computeDownloadTimeRemaining, formatBytes, formatDate, formatTimeRemaining, tryParseDate } from '../../browser/updateStatusBarEntry.js';
 
 suite('UpdateStatusBarEntry', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -126,6 +126,32 @@ suite('UpdateStatusBarEntry', () => {
 			assert.strictEqual(formatBytes(1126), '1.1 KB');
 			assert.strictEqual(formatBytes(1075), '1 KB');
 			assert.strictEqual(formatBytes(1024 * 1024 * 25.35), '25.4 MB');
+		});
+	});
+
+	suite('tryParseDate', () => {
+		test('returns undefined for undefined input', () => {
+			assert.strictEqual(tryParseDate(undefined), undefined);
+		});
+
+		test('returns undefined for invalid date strings', () => {
+			assert.strictEqual(tryParseDate(''), undefined);
+			assert.strictEqual(tryParseDate('not-a-date'), undefined);
+		});
+
+		test('parses valid ISO date strings', () => {
+			const result = tryParseDate('2026-02-06T05:03:03.991Z');
+			assert.ok(result !== undefined);
+			assert.strictEqual(typeof result, 'number');
+			assert.ok(result > 0);
+		});
+	});
+
+	suite('formatDate', () => {
+		test('formats a timestamp as a readable date', () => {
+			const result = formatDate(1705276800000);
+			assert.ok(result.length > 0);
+			assert.ok(result.includes('2024'));
 		});
 	});
 


### PR DESCRIPTION
Fixes #293387
It seems that Electron installer is returning `Date` and we were expecting a `number`. Fixed to handle both.
Added commit ID to version text.
