### PR TITLE
Fix remote terminal env var collection using wrong workspace scope

### DIFF
--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -9,7 +9,6 @@ import { cloneAndChange } from '../../base/common/objects.js';
 import { Disposable } from '../../base/common/lifecycle.js';
 import * as path from '../../base/common/path.js';
 import * as platform from '../../base/common/platform.js';
-import { isEqualOrParent } from '../../base/common/resources.js';
 import { URI } from '../../base/common/uri.js';
 import { IURITransformer } from '../../base/common/uriIpc.js';
 import { IServerChannel } from '../../base/parts/ipc/common/ipc.js';
@@ -252,20 +251,8 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			}
 			const envVariableCollections = new Map<string, IEnvironmentVariableCollection>(entries);
 			const mergedCollection = new MergedEnvironmentVariableCollection(envVariableCollections);
-			// Determine workspace folder for env var collection scoping from the terminal's
-			// CWD, not the last active editor. This ensures extensions like Python Environments
-			// that set workspace-scoped env vars activate the correct environment.
-			let envVarWorkspaceFolder = activeWorkspaceFolder ?? undefined;
-			if (initialCwd) {
-				const cwdUri = URI.file(initialCwd);
-				for (const wf of workspaceFolders) {
-					if (isEqualOrParent(cwdUri, wf.uri)) {
-						envVarWorkspaceFolder = wf;
-						break;
-					}
-				}
-			}
-			await mergedCollection.applyToProcessEnvironment(env, { workspaceFolder: envVarWorkspaceFolder }, variableResolver);
+			const workspaceFolder = activeWorkspaceFolder ? activeWorkspaceFolder ?? undefined : undefined;
+			await mergedCollection.applyToProcessEnvironment(env, { workspaceFolder }, variableResolver);
 		}
 
 		// Fork the process and listen for messages

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -9,6 +9,7 @@ import { cloneAndChange } from '../../base/common/objects.js';
 import { Disposable } from '../../base/common/lifecycle.js';
 import * as path from '../../base/common/path.js';
 import * as platform from '../../base/common/platform.js';
+import { isEqualOrParent } from '../../base/common/resources.js';
 import { URI } from '../../base/common/uri.js';
 import { IURITransformer } from '../../base/common/uriIpc.js';
 import { IServerChannel } from '../../base/parts/ipc/common/ipc.js';
@@ -251,8 +252,20 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			}
 			const envVariableCollections = new Map<string, IEnvironmentVariableCollection>(entries);
 			const mergedCollection = new MergedEnvironmentVariableCollection(envVariableCollections);
-			const workspaceFolder = activeWorkspaceFolder ? activeWorkspaceFolder ?? undefined : undefined;
-			await mergedCollection.applyToProcessEnvironment(env, { workspaceFolder }, variableResolver);
+			// Determine workspace folder for env var collection scoping from the terminal's
+			// CWD, not the last active editor. This ensures extensions like Python Environments
+			// that set workspace-scoped env vars activate the correct environment.
+			let envVarWorkspaceFolder = activeWorkspaceFolder ?? undefined;
+			if (initialCwd) {
+				const cwdUri = URI.file(initialCwd);
+				for (const wf of workspaceFolders) {
+					if (isEqualOrParent(cwdUri, wf.uri)) {
+						envVarWorkspaceFolder = wf;
+						break;
+					}
+				}
+			}
+			await mergedCollection.applyToProcessEnvironment(env, { workspaceFolder: envVarWorkspaceFolder }, variableResolver);
 		}
 
 		// Fork the process and listen for messages

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -28,6 +28,7 @@ import { ICompleteTerminalConfiguration, ITerminalConfiguration, TERMINAL_CONFIG
 import { TerminalStorageKeys } from '../common/terminalStorageKeys.js';
 import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { IHistoryService } from '../../../services/history/common/history.js';
+import { getWorkspaceForTerminal } from '../common/terminalEnvironment.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { IStatusbarService } from '../../../services/statusbar/browser/statusbar.js';
 
@@ -193,7 +194,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 			tabActions: shellLaunchConfig.tabActions,
 			shellIntegrationEnvironmentReporting: shellLaunchConfig.shellIntegrationEnvironmentReporting,
 		};
-		const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot();
+		const activeWorkspaceRootUri = getWorkspaceForTerminal(shellLaunchConfig.cwd, this._workspaceContextService, this._historyService)?.uri;
 
 		const result = await this._remoteTerminalChannel.createProcess(
 			shellLaunchConfigDto,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python-environments/issues/986

Hi @eleanorjboyd and @anthonykim1. I gave it a try at fixing the `shellStartup` issue reported [here](https://github.com/microsoft/vscode-python-environments/issues/986). I'd appreciate it if you could review this PR.

In remote/devcontainer multi-root workspaces, env var collections were scoped to whichever workspace folder the user last had open in the editor, not the terminal's actual workspace folder. So if you had `proj1/main.py` open and created a terminal for `proj2`, you'd get `proj1`'s Python venv activated.

The local terminal path already handles this correctly by resolving the workspace folder from the terminal's CWD (`getWorkspaceForTerminal`). The remote path just used `getLastActiveWorkspaceRoot()` unconditionally. There's even a TODO in the codebase noting that "last active workspace is known to be unreliable".

The fix matches `initialCwd` against workspace folders on the server side before applying env var collections, falling back to the old behavior when the CWD doesn't match anything.