### PR TITLE
modal editor - bind `EditorPartModalContext` to the global context

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1446,7 +1446,7 @@ function registerModalEditorCommands(): void {
 				precondition: EditorPartModalContext,
 				keybinding: {
 					primary: KeyCode.Escape,
-					weight: KeybindingWeight.WorkbenchContrib + 10,
+					weight: KeybindingWeight.WorkbenchContrib,
 					when: EditorPartModalContext
 				},
 				menu: {

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -166,6 +166,9 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 		const id = ModalEditorPartImpl.COUNTER++;
 		super(editorPartsView, `workbench.parts.modalEditor.${id}`, groupsLabel, windowId, instantiationService, themeService, configurationService, storageService, layoutService, hostService, contextKeyService);
 
+		EditorPartModalContext.bindTo(contextKeyService).set(true);
+		this._register(toDisposable(() => EditorPartModalContext.bindTo(contextKeyService).set(false)));
+
 		this.enforceModalPartOptions();
 	}
 
@@ -183,13 +186,6 @@ class ModalEditorPartImpl extends EditorPart implements IModalEditorPart {
 
 	notifyActiveEditorChanged(): void {
 		this.enforceModalPartOptions();
-	}
-
-	protected override handleContextKeys(): void {
-		const isModalEditorPartContext = EditorPartModalContext.bindTo(this.scopedContextKeyService);
-		isModalEditorPartContext.set(true);
-
-		super.handleContextKeys();
 	}
 
 	override removeGroup(group: number | IEditorGroupView, preserveFocus?: boolean): void {


### PR DESCRIPTION
This helps ensuring ESC key closes the modal.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
