### PR TITLE
Adjust agent session list item sizing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -8,7 +8,7 @@ import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IOpenEvent, WorkbenchCompressibleAsyncDataTree } from '../../../../../platform/list/browser/listService.js';
-import { $, addDisposableListener, append, EventHelper } from '../../../../../base/browser/dom.js';
+import { $, append, EventHelper } from '../../../../../base/browser/dom.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, IMarshalledAgentSessionContext, isAgentSession, isAgentSessionSection } from './agentSessionsModel.js';
 import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionsSorter, IAgentSessionsFilter, IAgentSessionsSorterOptions } from './agentSessionsViewer.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
@@ -175,14 +175,6 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		)) as WorkbenchCompressibleAsyncDataTree<IAgentSessionsModel, AgentSessionListItem, FuzzyScore>;
 
 		ChatContextKeys.agentSessionsViewerFocused.bindTo(list.contextKeyService);
-
-		// Track mouse vs keyboard focus to suppress focus outlines on mouse clicks
-		this._register(addDisposableListener(this.sessionsContainer!, 'mousedown', () => {
-			this.sessionsContainer!.classList.add('mouse-focused');
-		}));
-		this._register(addDisposableListener(this.sessionsContainer!, 'keydown', () => {
-			this.sessionsContainer!.classList.remove('mouse-focused');
-		}));
 
 		const model = this.agentSessionsService.model;
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -502,7 +502,7 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 
 export class AgentSessionsListDelegate implements IListVirtualDelegate<AgentSessionListItem> {
 
-	static readonly ITEM_HEIGHT = 40;
+	static readonly ITEM_HEIGHT = 44;
 	static readonly SECTION_HEIGHT = 26;
 
 	getHeight(element: AgentSessionListItem): number {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -68,7 +68,7 @@
 
 	/* On hover or keyboard focus: show toolbar, hide status */
 	.monaco-list-row:hover,
-	&:not(.mouse-focused) .monaco-list-row.focused {
+	.monaco-list-row.focused {
 
 		.agent-session-title-toolbar {
 			display: block;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -17,12 +17,6 @@
 		border-radius: 6px;
 	}
 
-	/* Hide focus outlines on mouse click, preserve for keyboard navigation */
-	&.mouse-focused .monaco-list-row.focused,
-	&.mouse-focused .monaco-list-row.focused.selected {
-		outline: none !important;
-	}
-
 	.monaco-list-row .force-no-twistie {
 		display: none !important;
 	}
@@ -104,7 +98,7 @@
 		.agent-session-icon-col {
 			display: flex;
 			align-items: flex-start;
-			line-height: 16px;
+			line-height: 17px;
 
 			.agent-session-icon {
 				flex-shrink: 0;
@@ -148,15 +142,15 @@
 		}
 
 		.agent-session-title-row {
-			line-height: 16px;
-			padding-bottom: 2px;
+			line-height: 17px;
+			padding-bottom: 4px;
 		}
 
 		.agent-session-details-row {
 			gap: 4px;
-			font-size: 11px;
-			line-height: 14px;
-			max-height: 14px;
+			font-size: 12px;
+			line-height: 15px;
+			max-height: 15px;
 			color: var(--vscode-disabledForeground);
 
 			.rendered-markdown {
@@ -239,7 +233,7 @@
 		}
 
 		.agent-session-title {
-			font-size: 12px;
+			font-size: 13px;
 			color: var(--vscode-descriptionForeground);
 		}
 
@@ -247,7 +241,7 @@
 			display: flex;
 			align-items: center;
 			font-variant-numeric: tabular-nums;
-			font-size: 11px;
+			font-size: 12px;
 			color: var(--vscode-disabledForeground);
 			white-space: nowrap;
 

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
@@ -127,7 +127,7 @@
 	}
 
 	.agent-session-section {
-		padding: 0 6px 0px 14px;
+		padding: 0 6px 0 14px;
 	}
 
 	/* Right position: symmetric padding */

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
@@ -127,7 +127,7 @@
 	}
 
 	.agent-session-section {
-		padding: 0 12px;
+		padding: 0 6px 0px 14px;
 	}
 
 	/* Right position: symmetric padding */

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatViewPane.css
@@ -138,7 +138,7 @@
 		}
 
 		.agent-session-section {
-			padding: 0 12px 0 8px;
+			padding: 0 6px 0 8px;
 		}
 	}
 

--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -852,14 +852,14 @@ export class AgentSessionsWelcomePage extends EditorPane {
 		// TODO: @osortega this is a weird way of doing this, maybe we handle the 2-colum layout in the control itself?
 		const sessionsWidth = Math.min(800, this.lastDimension.width - 80);
 		// Calculate height based on actual visible sessions (capped at MAX_SESSIONS)
-		// Use 52px per item from AgentSessionsListDelegate.ITEM_HEIGHT
+		// Use 54px per item from AgentSessionsListDelegate.ITEM_HEIGHT
 		// Give the list FULL height so virtualization renders all items
 		// CSS transforms handle the 2-column visual layout
 		const visibleSessions = Math.min(
 			this.agentSessionsService.model.sessions.filter(s => !s.isArchived()).length,
 			MAX_SESSIONS
 		);
-		const sessionsHeight = visibleSessions * 52;
+		const sessionsHeight = visibleSessions * 56;
 		this.sessionsControl.layout(sessionsHeight, sessionsWidth);
 
 		// Set margin offset for 2-column layout: actual height - visual height


### PR DESCRIPTION
Fixes #293602

- Title font size: 12px → 13px
- Details row + status time font size: 11px → 12px
- Title row line-height: 16px → 17px, padding-bottom: 2px → 4px
- Details row line-height: 14px → 15px
- Icon col line-height: 16px → 17px
- List item height: 40px → 44px
- Remove mouse-focused outline override
- Update welcome page hardcoded height