### PR TITLE
Fix line navigation when opening files with line fragments

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -829,7 +829,7 @@ export class CodeApplication extends Disposable {
 
 		// File path
 		if (uri.authority === Schemas.file) {
-			const fileUri = URI.file(uri.fsPath);
+			const fileUri = URI.file(uri.fsPath).with({ query: uri.query, fragment: uri.fragment });
 
 			if (hasWorkspaceFileExtension(fileUri)) {
 				return { workspaceUri: fileUri };

--- a/src/vs/editor/contrib/links/browser/linkDetectorUtils.ts
+++ b/src/vs/editor/contrib/links/browser/linkDetectorUtils.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Schemas } from '../../../../base/common/network.js';
+import * as resources from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+
+/**
+ * Resolve file links of the shape `file://./relativeFile.txt` against the model URI.
+ */
+export function resolveRelativeFileLink(uri: string | URI, modelUri: URI): string | URI {
+	if (typeof uri !== 'string' || modelUri.scheme !== Schemas.file || !uri.startsWith(`${Schemas.file}:`)) {
+		return uri;
+	}
+
+	const parsedUri = URI.parse(uri);
+	if (parsedUri.scheme !== Schemas.file) {
+		return uri;
+	}
+
+	const fsPath = resources.originalFSPath(parsedUri);
+
+	let relativePath: string | null = null;
+	if (fsPath.startsWith('/./') || fsPath.startsWith('\\.\\')) {
+		relativePath = `.${fsPath.substr(1)}`;
+	} else if (fsPath.startsWith('//./') || fsPath.startsWith('\\\\.\\')) {
+		relativePath = `.${fsPath.substr(2)}`;
+	}
+
+	if (!relativePath) {
+		return uri;
+	}
+
+	return resources.joinPath(modelUri, relativePath).with({
+		query: parsedUri.query,
+		fragment: parsedUri.fragment
+	});
+}

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -8,11 +8,8 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { Schemas } from '../../../../base/common/network.js';
 import * as platform from '../../../../base/common/platform.js';
-import * as resources from '../../../../base/common/resources.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
-import { URI } from '../../../../base/common/uri.js';
 import './links.css';
 import { ICodeEditor, MouseTargetType } from '../../../browser/editorBrowser.js';
 import { EditorAction, EditorContributionInstantiation, registerEditorAction, registerEditorContribution, ServicesAccessor } from '../../../browser/editorExtensions.js';
@@ -27,6 +24,7 @@ import { IFeatureDebounceInformation, ILanguageFeatureDebounceService } from '..
 import { ILanguageFeaturesService } from '../../../common/services/languageFeatures.js';
 import { ClickLinkGesture, ClickLinkKeyboardEvent, ClickLinkMouseEvent } from '../../gotoSymbol/browser/link/clickLinkGesture.js';
 import { getLinks, Link, LinksList } from './getLinks.js';
+import { resolveRelativeFileLink } from './linkDetectorUtils.js';
 import * as nls from '../../../../nls.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -229,25 +227,8 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 		link.resolve(CancellationToken.None).then(uri => {
 
 			// Support for relative file URIs of the shape file://./relativeFile.txt or file:///./relativeFile.txt
-			if (typeof uri === 'string' && this.editor.hasModel()) {
-				const modelUri = this.editor.getModel().uri;
-				if (modelUri.scheme === Schemas.file && uri.startsWith(`${Schemas.file}:`)) {
-					const parsedUri = URI.parse(uri);
-					if (parsedUri.scheme === Schemas.file) {
-						const fsPath = resources.originalFSPath(parsedUri);
-
-						let relativePath: string | null = null;
-						if (fsPath.startsWith('/./') || fsPath.startsWith('\\.\\')) {
-							relativePath = `.${fsPath.substr(1)}`;
-						} else if (fsPath.startsWith('//./') || fsPath.startsWith('\\\\.\\')) {
-							relativePath = `.${fsPath.substr(2)}`;
-						}
-
-						if (relativePath) {
-							uri = resources.joinPath(modelUri, relativePath);
-						}
-					}
-				}
+			if (this.editor.hasModel()) {
+				uri = resolveRelativeFileLink(uri, this.editor.getModel().uri);
 			}
 
 			return this.openerService.open(uri, { openToSide, fromUserGesture, allowContributedOpeners: true, allowCommands: true, fromWorkspace: true });

--- a/src/vs/editor/contrib/links/test/browser/linkDetectorUtils.test.ts
+++ b/src/vs/editor/contrib/links/test/browser/linkDetectorUtils.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { resolveRelativeFileLink } from '../../browser/linkDetectorUtils.js';
+
+suite('LinkDetectorUtils', () => {
+	test('resolves file://./ links and preserves fragment', () => {
+		const modelUri = URI.file('/workspace/folder/source.txt');
+
+		const actual = resolveRelativeFileLink('file://./target.txt#L99', modelUri);
+
+		assert.ok(URI.isUri(actual));
+		assert.strictEqual(actual.toString(), 'file:///workspace/folder/target.txt#L99');
+	});
+
+	test('resolves file:///./ links and preserves query and fragment', () => {
+		const modelUri = URI.file('/workspace/folder/source.txt');
+
+		const actual = resolveRelativeFileLink('file:///./target.txt?x=1#L99', modelUri);
+
+		assert.ok(URI.isUri(actual));
+		assert.strictEqual(actual.toString(), 'file:///workspace/folder/target.txt?x%3D1#L99');
+	});
+
+	test('leaves non-relative file links unchanged', () => {
+		const modelUri = URI.file('/workspace/folder/source.txt');
+		const uri = 'file:///workspace/folder/target.txt#L99';
+
+		const actual = resolveRelativeFileLink(uri, modelUri);
+
+		assert.strictEqual(actual, uri);
+	});
+});

--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -58,6 +58,7 @@ import { IAuxiliaryWindowsMainService } from '../../auxiliaryWindow/electron-mai
 import { IAuxiliaryWindow } from '../../auxiliaryWindow/electron-main/auxiliaryWindow.js';
 import { ICSSDevelopmentService } from '../../cssDev/node/cssDevService.js';
 import { ResourceSet } from '../../../base/common/map.js';
+import { extractSelection } from '../../opener/common/opener.js';
 
 //#region Helper Interfaces
 
@@ -1049,7 +1050,7 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 		return undefined;
 	}
 
-	private async resolveOpenable(openable: IWindowOpenable, options: IPathResolveOptions = Object.create(null)): Promise<IPathToOpen | undefined> {
+	private async resolveOpenable(openable: IWindowOpenable, options: IPathResolveOptions = Object.create(null)): Promise<IPathToOpen<ITextEditorOptions> | undefined> {
 
 		// handle file:// openables with some extra validation
 		const uri = this.resourceFromOpenable(openable);
@@ -1058,7 +1059,14 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 				options = { ...options, forceOpenWorkspaceAsFile: true };
 			}
 
-			return this.doResolveFilePath(uri.fsPath, options);
+			const { uri: uriWithoutSelection, selection } = extractSelection(uri);
+			const resolved = await this.doResolveFilePath(uriWithoutSelection.fsPath, options);
+			// Only apply selection from the original URI fragment to files when resolved options don't already provide one.
+			if (resolved?.fileUri && selection && !resolved.options?.selection) {
+				return { ...resolved, options: { ...(resolved.options ?? {}), selection } };
+			}
+
+			return resolved;
 		}
 
 		// handle non file:// openables


### PR DESCRIPTION
This PR fixes two line-navigation regressions for file links that include a fragment like `#L99`.

Related issue: https://github.com/microsoft/vscode/issues/170405

### Rationale

File deep-linking is increasingly important with external AI coding tools that use VS Code as the editor/diff viewer. In these workflows, opening a file at an exact location (and, in related scenarios, specific ranges) is core to review and iteration speed. Preserving URI fragments such as `#L99` or `#L99-L105` avoids making users manually browse large files and lose the exact location being referenced.

### Problem summary

VS Code supports opening file links with line fragments (e.g. `#L99`), but the fragment was getting dropped in two important paths:

1. **Inside VS Code** when clicking a **relative** `file://` link.
2. **Outside VS Code** when opening via protocol URL (`vscode://file/...#L99` or `code-oss://file/...#L99`).

### Reproduction matrix (with concrete paths)

Target file for all cases:
- `/tmp/vscode-link-repro/target.txt`

Contents:
```text
Line 1 ...
Line 2 ...
<continues 100 times>
```

Source file used for in-editor link clicks:
- `/tmp/vscode-link-repro/source.txt`

Contents:
```text
relative: file://./target.txt#L99
absolute: file:///tmp/vscode-link-repro/target.txt#L99
```

Cases:

1. **Inside VS Code × relative `file://`**
- Link: `file://./target.txt#L99` (from `/tmp/vscode-link-repro/source.txt`)
- Before: opens file, **does not** go to line 99
- After this PR: opens file and **goes to line 99**

2. **Inside VS Code × absolute `file://`**
- Link: `file:///tmp/vscode-link-repro/target.txt#L99`
- Before: **goes to line 99**
- After: unchanged (**still works**)

3. **Outside VS Code (macOS `open`) × `vscode://` URL**
- Code - OSS command:
  - `open -b com.visualstudio.code.oss -u "code-oss://file/tmp/vscode-link-repro/target.txt#L99"`
- VS Code stable command:
  - `open -b com.microsoft.VSCode -u "vscode://file/tmp/vscode-link-repro/target.txt#L99"`
- Before: opens file, **does not** go to line 99
- After this PR: opens file and **goes to line 99**

4. **Outside VS Code (macOS `open`) × `file://` URL**
- Command:
  - `open -b com.visualstudio.code.oss -u "file:///tmp/vscode-link-repro/target.txt#L99"`
- Behavior: opens file, **does not** go to line 99
- Status: **not fixable in VS Code**. macOS delivers this as `open-file` with a filesystem path and strips the URI **fragment** (`#L99`) before VS Code receives it.

### What changed

1. **Editor link handling (`src/vs/editor/contrib/links/browser/links.ts`)**
- Preserve query/fragment when resolving relative `file://./...` links against the active model URI.
- This fixes in-editor relative links losing `#L...`.

2. **Protocol URL handling in main process (`src/vs/code/electron-main/app.ts`)**
- Preserve `query` and `fragment` when converting protocol file URLs into `fileUri` openables.

3. **Openable resolution (`src/vs/platform/windows/electron-main/windowsMainService.ts`)**
- Extract line selection from URI fragment (e.g. `#L99`) before resolving local file path.
- Carry selection into editor open options, while still using filesystem path for file existence checks.

### Tests

Added regression tests:
- `src/vs/editor/contrib/links/test/browser/linkDetectorUtils.test.ts`

Validated:
- Relative `file://./...#L99` now preserves fragment and resolves to line selection.
- Existing absolute in-editor behavior remains unchanged.
