### PR TITLE
Recognize `ssh://` protocol URLs for GitHub remotes

### DIFF
--- a/extensions/github/src/util.ts
+++ b/extensions/github/src/util.ts
@@ -64,7 +64,8 @@ export function groupBy<T>(data: ReadonlyArray<T>, compare: (a: T, b: T) => numb
 
 export function getRepositoryFromUrl(url: string): { owner: string; repo: string } | undefined {
 	const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(\.git)?$/i.exec(url)
-		|| /^git@github\.com:([^/]+)\/([^/]+?)(\.git)?$/i.exec(url);
+		|| /^git@github\.com:([^/]+)\/([^/]+?)(\.git)?$/i.exec(url)
+		|| /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(\.git)?$/i.exec(url);
 	return match ? { owner: match[1], repo: match[2] } : undefined;
 }
 


### PR DESCRIPTION
MEMO: Code changes and testing were performed by humans.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix: #293742

## Summary
- Repositories cloned with `ssh://git@github.com/owner/repo.git` URLs were not recognized as GitHub repositories, causing features like "Open on GitHub" to be unavailable
- Add a regex pattern to match the `ssh://` URL format alongside the existing HTTPS and `git@` patterns

## Test Plan

- [x] I confirmed that the issue does not reproduce when following the steps to reproduce in #293742.

<img width="1003" height="601" alt="スクリーンショット 2026-02-08 18 06 08" src="https://github.com/user-attachments/assets/a1740890-71a4-4371-815c-fba116fe5e57" />

