### PR TITLE
fix: Extension contributes snippets defaultSnippets

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetsService.ts
@@ -94,10 +94,10 @@ namespace snippetExt {
 	export const snippetsContribution: IJSONSchema = {
 		description: localize('vscode.extension.contributes.snippets', 'Contributes snippets.'),
 		type: 'array',
-		defaultSnippets: [{ body: [{ language: '', path: '' }] }],
+		defaultSnippets: [{ body: [{ language: '${1:id}', path: './snippets/$1$2.json' }] }],
 		items: {
 			type: 'object',
-			defaultSnippets: [{ body: { language: '${1:id}', path: './snippets/${2:id}.json.' } }],
+			defaultSnippets: [{ body: { language: '${1:id}', path: './snippets/$1$2.json' } }],
 			properties: {
 				language: {
 					description: localize('vscode.extension.contributes.snippets-language', 'Language identifier for which this snippet is contributed to.'),


### PR DESCRIPTION
Fixes broken `defaultSnippets`
1st `defaultSnippets` was blank. now is populated 
2nd `defaultSnippets` had extra erroneous dot `.`. is now removed
both snippets united

before:
<img width="334" height="212" alt="image" src="https://github.com/user-attachments/assets/7c4cbd49-59e3-40d3-977a-747b1c923294" />
<img width="525" height="214" alt="image" src="https://github.com/user-attachments/assets/05c090e5-12c0-423f-8117-19a793c6a26c" />

after:
<img width="505" height="208" alt="image" src="https://github.com/user-attachments/assets/8a9aca30-c4fa-4e36-933d-054f7783eab0" />
