### PR TITLE
Add support for restart required extensions in the extensions view

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsIcons.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsIcons.ts
@@ -38,3 +38,4 @@ export const infoIcon = registerIcon('extensions-info-message', Codicon.info, lo
 
 export const trustIcon = registerIcon('extension-workspace-trust', Codicon.shield, localize('trustIcon', 'Icon shown with a workspace trust message in the extension editor.'));
 export const activationTimeIcon = registerIcon('extension-activation-time', Codicon.history, localize('activationtimeIcon', 'Icon shown with a activation time message in the extension editor.'));
+export const restartRequiredIcon = registerIcon('extension-restart-required', Codicon.refresh, localize('restartRequiredIcon', 'Icon shown when an extension requires a restart in the extensions view.'));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsList.ts
@@ -12,9 +12,9 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { IPagedRenderer } from '../../../../base/browser/ui/list/listPaging.js';
 import { IExtension, ExtensionContainers, ExtensionState, IExtensionsWorkbenchService, IExtensionsViewState } from '../common/extensions.js';
-import { ManageExtensionAction, ExtensionRuntimeStateAction, ExtensionStatusLabelAction, RemoteInstallAction, ExtensionStatusAction, LocalInstallAction, ButtonWithDropDownExtensionAction, InstallDropdownAction, InstallingLabelAction, ButtonWithDropdownExtensionActionViewItem, DropDownExtensionAction, WebInstallAction, MigrateDeprecatedExtensionAction, SetLanguageAction, ClearLanguageAction, UpdateAction } from './extensionsActions.js';
+import { ManageExtensionAction, ExtensionStatusLabelAction, RemoteInstallAction, ExtensionStatusAction, LocalInstallAction, ButtonWithDropDownExtensionAction, InstallDropdownAction, InstallingLabelAction, ButtonWithDropdownExtensionActionViewItem, DropDownExtensionAction, WebInstallAction, MigrateDeprecatedExtensionAction, SetLanguageAction, ClearLanguageAction, UpdateAction } from './extensionsActions.js';
 import { areSameExtensions } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
-import { RatingsWidget, InstallCountWidget, RecommendationWidget, RemoteBadgeWidget, ExtensionPackCountWidget as ExtensionPackBadgeWidget, SyncIgnoredWidget, ExtensionHoverWidget, ExtensionRuntimeStatusWidget, PreReleaseBookmarkWidget, PublisherWidget, ExtensionKindIndicatorWidget, ExtensionIconWidget } from './extensionsWidgets.js';
+import { RatingsWidget, InstallCountWidget, RecommendationWidget, RemoteBadgeWidget, ExtensionPackCountWidget as ExtensionPackBadgeWidget, SyncIgnoredWidget, ExtensionHoverWidget, ExtensionRuntimeStatusWidget, ExtensionRestartRequiredWidget, PreReleaseBookmarkWidget, PublisherWidget, ExtensionKindIndicatorWidget, ExtensionIconWidget } from './extensionsWidgets.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IWorkbenchExtensionEnablementService } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -79,6 +79,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const headerContainer = append(details, $('.header-container'));
 		const header = append(headerContainer, $('.header'));
 		const name = append(header, $('span.name'));
+		const restartRequired = append(header, $('span.restart-required'));
 		const installCount = append(header, $('span.install-count'));
 		const ratings = append(header, $('span.ratings'));
 		const syncIgnore = append(header, $('span.sync-ignored'));
@@ -115,7 +116,6 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const actions = [
 			this.instantiationService.createInstance(ExtensionStatusLabelAction),
 			this.instantiationService.createInstance(MigrateDeprecatedExtensionAction, true),
-			this.instantiationService.createInstance(ExtensionRuntimeStateAction),
 			this.instantiationService.createInstance(UpdateAction, false),
 			this.instantiationService.createInstance(InstallDropdownAction),
 			this.instantiationService.createInstance(InstallingLabelAction),
@@ -138,6 +138,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 			publisherWidget,
 			extensionHoverWidget,
 			this.instantiationService.createInstance(SyncIgnoredWidget, syncIgnore),
+			this.instantiationService.createInstance(ExtensionRestartRequiredWidget, restartRequired),
 			this.instantiationService.createInstance(ExtensionRuntimeStatusWidget, this.extensionViewState, activationStatus),
 			this.instantiationService.createInstance(InstallCountWidget, installCount, true),
 			this.instantiationService.createInstance(RatingsWidget, ratings, true),

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -64,12 +64,9 @@ import { createActionViewItem } from '../../../../platform/actions/browser/menuE
 import { SeverityIcon } from '../../../../base/browser/ui/severityIcon/severityIcon.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
-import { Codicon } from '../../../../base/common/codicons.js';
 import { IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { URI } from '../../../../base/common/uri.js';
 import { DEFAULT_ACCOUNT_SIGN_IN_COMMAND } from '../../../services/accounts/browser/defaultAccount.js';
-import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 
 export const ExtensionsSortByContext = new RawContextKey<string>('extensionsSortByValue', '');
 export const SearchMarketplaceExtensionsContext = new RawContextKey<boolean>('searchMarketplaceExtensions', false);
@@ -86,6 +83,7 @@ export const BuiltInExtensionsContext = new RawContextKey<boolean>('builtInExten
 const SearchBuiltInExtensionsContext = new RawContextKey<boolean>('searchBuiltInExtensions', false);
 const SearchUnsupportedWorkspaceExtensionsContext = new RawContextKey<boolean>('searchUnsupportedWorkspaceExtensions', false);
 const SearchDeprecatedExtensionsContext = new RawContextKey<boolean>('searchDeprecatedExtensions', false);
+const SearchRestartRequiredExtensionsContext = new RawContextKey<boolean>('searchRestartRequiredExtensions', false);
 export const RecommendedExtensionsContext = new RawContextKey<boolean>('recommendedExtensions', false);
 const SortByUpdateDateContext = new RawContextKey<boolean>('sortByUpdateDate', false);
 export const ExtensionsSearchValueContext = new RawContextKey<string>('extensionsSearchValue', '');
@@ -505,6 +503,13 @@ export class ExtensionsViewletViewsContribution extends Disposable implements IW
 			when: ContextKeyExpr.and(SearchDeprecatedExtensionsContext),
 		});
 
+		viewDescriptors.push({
+			id: 'workbench.views.extensions.restartRequired',
+			name: localize2('restart required', "Restart Required"),
+			ctorDescriptor: new SyncDescriptor(ExtensionsListView, [{}]),
+			when: ContextKeyExpr.and(SearchRestartRequiredExtensionsContext),
+		});
+
 		return viewDescriptors;
 	}
 
@@ -531,6 +536,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 	private readonly searchBuiltInExtensionsContextKey: IContextKey<boolean>;
 	private readonly searchWorkspaceUnsupportedExtensionsContextKey: IContextKey<boolean>;
 	private readonly searchDeprecatedExtensionsContextKey: IContextKey<boolean>;
+	private readonly searchRestartRequiredExtensionsContextKey: IContextKey<boolean>;
 	private readonly recommendedExtensionsContextKey: IContextKey<boolean>;
 
 	private searchDelayer: Delayer<void>;
@@ -563,7 +569,6 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 		@IPreferencesService private readonly preferencesService: IPreferencesService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ILogService logService: ILogService,
-		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super(VIEWLET_ID, { mergeViewWithContainerWhenSingleView: true }, instantiationService, configurationService, layoutService, contextMenuService, telemetryService, extensionService, themeService, storageService, contextService, viewDescriptorService, logService);
 
@@ -581,6 +586,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 		this.searchExtensionUpdatesContextKey = SearchExtensionUpdatesContext.bindTo(contextKeyService);
 		this.searchWorkspaceUnsupportedExtensionsContextKey = SearchUnsupportedWorkspaceExtensionsContext.bindTo(contextKeyService);
 		this.searchDeprecatedExtensionsContextKey = SearchDeprecatedExtensionsContext.bindTo(contextKeyService);
+		this.searchRestartRequiredExtensionsContextKey = SearchRestartRequiredExtensionsContext.bindTo(contextKeyService);
 		this.searchOutdatedExtensionsContextKey = SearchOutdatedExtensionsContext.bindTo(contextKeyService);
 		this.searchEnabledExtensionsContextKey = SearchEnabledExtensionsContext.bindTo(contextKeyService);
 		this.searchDisabledExtensionsContextKey = SearchDisabledExtensionsContext.bindTo(contextKeyService);
@@ -760,14 +766,15 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 		clearNode(this.notificationContainer);
 		this.notificationDisposables.value = new DisposableStore();
 		const status = this.extensionsWorkbenchService.getExtensionsNotification();
-		const query = status?.extensions.map(extension => `@id:${extension.identifier.id}`).join(' ');
+		const query = status?.query ?? status?.extensions.map(extension => `@id:${extension.identifier.id}`).join(' ');
 		if (status && (query === this.searchBox?.getValue() || !this.searchMarketplaceExtensionsContextKey.get())) {
 			this.notificationContainer.setAttribute('aria-label', status.message);
 			this.notificationContainer.classList.remove('hidden');
 			const messageContainer = append(this.notificationContainer, $('.message-container'));
 			append(messageContainer, $('span')).className = SeverityIcon.className(status.severity);
-			append(messageContainer, $('span.message', undefined, status.message));
-			const showAction = append(messageContainer,
+			const messageText = append(messageContainer, $('span.message-text'));
+			append(messageText, $('span.message', undefined, status.message));
+			const showAction = append(messageText,
 				$('span.message-text-action', {
 					'tabindex': '0',
 					'role': 'button',
@@ -781,24 +788,29 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 				}
 				standardKeyboardEvent.stopPropagation();
 			}));
-			const dismissAction = append(this.notificationContainer,
-				$(`span.message-action${ThemeIcon.asCSSSelector(Codicon.close)}`, {
-					'tabindex': '0',
-					'role': 'button',
-					'aria-label': localize('dismiss', "Dismiss"),
+			const actionsContainer = append(this.notificationContainer, $('.notification-actions'));
+			if (status.action) {
+				const actionButton = append(actionsContainer,
+					$('span.message-action-button', {
+						'tabindex': '0',
+						'role': 'button',
+						'aria-label': status.action.label,
+					}, status.action.label));
+				this.notificationDisposables.value.add(addDisposableListener(actionButton, EventType.CLICK, () => status.action!.run()));
+				this.notificationDisposables.value.add(addDisposableListener(actionButton, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const standardKeyboardEvent = new StandardKeyboardEvent(e);
+					if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
+						status.action!.run();
+					}
+					standardKeyboardEvent.stopPropagation();
 				}));
-			this.notificationDisposables.value.add(this.hoverService.setupDelayedHover(dismissAction, { content: localize('dismiss hover', "Dismiss") }));
-			this.notificationDisposables.value.add(addDisposableListener(dismissAction, EventType.CLICK, () => status.dismiss()));
-			this.notificationDisposables.value.add(addDisposableListener(dismissAction, EventType.KEY_DOWN, (e: KeyboardEvent) => {
-				const standardKeyboardEvent = new StandardKeyboardEvent(e);
-				if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
-					status.dismiss();
-				}
-				standardKeyboardEvent.stopPropagation();
-			}));
+			}
 		} else {
 			this.notificationContainer.removeAttribute('aria-label');
 			this.notificationContainer.classList.add('hidden');
+			if (this.searchBox && ExtensionsListView.isRestartRequiredQuery(this.searchBox.getValue())) {
+				this.search('');
+			}
 		}
 
 		if (this._dimension) {
@@ -853,6 +865,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 			this.searchBuiltInExtensionsContextKey.set(ExtensionsListView.isSearchBuiltInExtensionsQuery(value));
 			this.searchWorkspaceUnsupportedExtensionsContextKey.set(ExtensionsListView.isSearchWorkspaceUnsupportedExtensionsQuery(value));
 			this.searchDeprecatedExtensionsContextKey.set(ExtensionsListView.isSearchDeprecatedExtensionsQuery(value));
+			this.searchRestartRequiredExtensionsContextKey.set(ExtensionsListView.isRestartRequiredQuery(value));
 			this.builtInExtensionsContextKey.set(ExtensionsListView.isBuiltInExtensionsQuery(value));
 			this.recommendedExtensionsContextKey.set(isRecommendedExtensionsQuery);
 			this.searchMcpServersContextKey.set(!!value && /@mcp\s?.*/i.test(value));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -796,11 +796,13 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer<IExtensionsVi
 						'role': 'button',
 						'aria-label': status.action.label,
 					}, status.action.label));
-				this.notificationDisposables.value.add(addDisposableListener(actionButton, EventType.CLICK, () => status.action!.run()));
+				this.notificationDisposables.value.add(addDisposableListener(actionButton, EventType.CLICK, () => {
+					Promise.resolve(status.action!.run()).catch(error => this.notificationService.error(error));
+				}));
 				this.notificationDisposables.value.add(addDisposableListener(actionButton, EventType.KEY_DOWN, (e: KeyboardEvent) => {
 					const standardKeyboardEvent = new StandardKeyboardEvent(e);
 					if (standardKeyboardEvent.keyCode === KeyCode.Enter || standardKeyboardEvent.keyCode === KeyCode.Space) {
-						status.action!.run();
+						Promise.resolve(status.action!.run()).catch(error => this.notificationService.error(error));
 					}
 					standardKeyboardEvent.stopPropagation();
 				}));

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -1001,13 +1001,11 @@ export class StatusUpdater extends Disposable implements IWorkbenchContribution 
 		let badge: IBadge | undefined;
 
 		const extensionsNotification = this.extensionsWorkbenchService.getExtensionsNotification();
-		if (extensionsNotification) {
-			if (extensionsNotification.severity === Severity.Warning) {
-				badge = new WarningBadge(() => extensionsNotification.message);
-			}
+		if (extensionsNotification && extensionsNotification.severity === Severity.Warning) {
+			badge = new WarningBadge(() => extensionsNotification.message);
 		}
 
-		else {
+		if (!badge) {
 			const actionRequired = this.configurationService.getValue(AutoRestartConfigurationKey) === true ? [] : this.extensionsWorkbenchService.installed.filter(e => e.runtimeState !== undefined);
 			const outdated = this.extensionsWorkbenchService.outdated.reduce((r, e) => r + (this.extensionEnablementService.isEnabled(e.local!) && !actionRequired.includes(e) ? 1 : 0), 0);
 			const newBadgeNumber = outdated + actionRequired.length;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -400,6 +400,10 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 			extensions = this.filterRecentlyUpdatedExtensions(local, query, options);
 		}
 
+		else if (/@restartrequired/i.test(query.value)) {
+			extensions = this.filterRestartRequiredExtensions(local, query, options);
+		}
+
 		else if (/@contribute:/i.test(query.value)) {
 			extensions = this.filterExtensionsByFeature(local, query);
 		}
@@ -657,6 +661,19 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 			&& this.filterExtensionByCategory(e, includedCategories, excludedCategories));
 
 		options.sortBy = options.sortBy ?? LocalSortBy.UpdateDate;
+
+		return this.sortExtensions(result, options);
+	}
+
+	private filterRestartRequiredExtensions(local: IExtension[], query: Query, options: IQueryOptions): IExtension[] {
+		let { value, includedCategories, excludedCategories } = this.parseCategories(query.value);
+		local = local.filter(e => e.runtimeState !== undefined);
+
+		value = value.replace(/@restartrequired/g, '').replace(/@sort:(\w+)(-\w*)?/g, '').trim().toLowerCase();
+
+		const result = local.filter(e =>
+			(e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1)
+			&& this.filterExtensionByCategory(e, includedCategories, excludedCategories));
 
 		return this.sortExtensions(result, options);
 	}
@@ -1157,6 +1174,7 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 			|| this.isSearchDeprecatedExtensionsQuery(query)
 			|| this.isSearchWorkspaceUnsupportedExtensionsQuery(query)
 			|| this.isSearchRecentlyUpdatedQuery(query)
+			|| this.isRestartRequiredQuery(query)
 			|| this.isSearchExtensionUpdatesQuery(query)
 			|| this.isSortInstalledExtensionsQuery(query, sortBy)
 			|| this.isFeatureExtensionsQuery(query);
@@ -1244,6 +1262,10 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 
 	static isSearchRecentlyUpdatedQuery(query: string): boolean {
 		return /@recentlyUpdated/i.test(query);
+	}
+
+	static isRestartRequiredQuery(query: string): boolean {
+		return /@restartrequired/i.test(query);
 	}
 
 	static isSearchExtensionUpdatesQuery(query: string): boolean {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -669,7 +669,7 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 		let { value, includedCategories, excludedCategories } = this.parseCategories(query.value);
 		local = local.filter(e => e.runtimeState !== undefined);
 
-		value = value.replace(/@restartrequired/g, '').replace(/@sort:(\w+)(-\w*)?/g, '').trim().toLowerCase();
+		value = value.replace(/@restartrequired/gi, '').replace(/@sort:(\w+)(-\w*)?/g, '').trim().toLowerCase();
 
 		const result = local.filter(e =>
 			(e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1)

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -715,10 +715,15 @@ export class ExtensionRestartRequiredWidget extends ExtensionWidget {
 		this.disposables.clear();
 		this.container.innerText = '';
 
-		if (this.extension?.runtimeState) {
+		const runtimeState = this.extension?.runtimeState;
+		const reason = typeof runtimeState?.reason === 'string' ? runtimeState.reason : '';
+
+		// Only show "Restart Required" when the runtime state reason clearly indicates
+		// a restart or reload is needed, to avoid mislabeling other runtime actions.
+		if (runtimeState && /restart|reload/i.test(reason)) {
 			const element = append(this.container, $('span.extension-restart-required' + ThemeIcon.asCSSSelector(restartRequiredIcon)));
 			append(this.container, $('span.extension-restart-required-label', undefined, localize('restart required', "Restart Required")));
-			this.disposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), element, this.extension.runtimeState.reason));
+			this.disposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), element, reason));
 		}
 	}
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -22,7 +22,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { CountBadge } from '../../../../base/browser/ui/countBadge/countBadge.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IUserDataSyncEnablementService } from '../../../../platform/userDataSync/common/userDataSync.js';
-import { activationTimeIcon, errorIcon, infoIcon, installCountIcon, preReleaseIcon, privateExtensionIcon, ratingIcon, remoteIcon, sponsorIcon, starEmptyIcon, starFullIcon, starHalfIcon, syncIgnoredIcon, warningIcon } from './extensionsIcons.js';
+import { activationTimeIcon, errorIcon, infoIcon, installCountIcon, preReleaseIcon, privateExtensionIcon, ratingIcon, remoteIcon, restartRequiredIcon, sponsorIcon, starEmptyIcon, starFullIcon, starHalfIcon, syncIgnoredIcon, warningIcon } from './extensionsIcons.js';
 import { registerColor, textLinkForeground } from '../../../../platform/theme/common/colorRegistry.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
@@ -696,6 +696,29 @@ export class SyncIgnoredWidget extends ExtensionWidget {
 			const element = append(this.container, $('span.extension-sync-ignored' + ThemeIcon.asCSSSelector(syncIgnoredIcon)));
 			this.disposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), element, localize('syncingore.label', "This extension is ignored during sync.")));
 			element.classList.add(...ThemeIcon.asClassNameArray(syncIgnoredIcon));
+		}
+	}
+}
+
+export class ExtensionRestartRequiredWidget extends ExtensionWidget {
+
+	private readonly disposables = this._register(new DisposableStore());
+
+	constructor(
+		private readonly container: HTMLElement,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		super();
+	}
+
+	render(): void {
+		this.disposables.clear();
+		this.container.innerText = '';
+
+		if (this.extension?.runtimeState) {
+			const element = append(this.container, $('span.extension-restart-required' + ThemeIcon.asCSSSelector(restartRequiredIcon)));
+			append(this.container, $('span.extension-restart-required-label', undefined, localize('restart required', "Restart Required")));
+			this.disposables.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), element, this.extension.runtimeState.reason));
 		}
 	}
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -1449,6 +1449,8 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 					message: computedNotificiations[0].message,
 					severity: computedNotificiations[0].severity,
 					extensions: computedNotificiations[0].extensions,
+					query: computedNotificiations[0].query,
+					action: computedNotificiations[0].action,
 					key: computedNotificiations[0].key,
 					dismiss: () => {
 						this.setDismissedNotifications([...this.getDismissedNotifications(), computedNotificiations[0].key]);
@@ -1497,6 +1499,34 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 					severity: Severity.Warning,
 					extensions: invalidExtensions,
 					key: 'invalidExtensions:' + invalidExtensions.sort((a, b) => a.identifier.id.localeCompare(b.identifier.id)).map(e => `${e.identifier.id.toLowerCase()}@${e.local?.manifest.version}`).join('-'),
+				});
+			}
+		}
+
+		if (!this.configurationService.getValue(AutoRestartConfigurationKey)) {
+			const restartRequiredExtensions = this.local.filter(e => e.runtimeState !== undefined && (e.runtimeState.action === ExtensionRuntimeActionType.RestartExtensions || e.runtimeState.action === ExtensionRuntimeActionType.ReloadWindow));
+			if (restartRequiredExtensions.length) {
+				const needsReload = restartRequiredExtensions.some(e => e.runtimeState?.action === ExtensionRuntimeActionType.ReloadWindow);
+				computedNotificiations.push({
+					message: needsReload
+						? nls.localize('extensions need reload', "Extensions require a window reload to take effect.")
+						: nls.localize('extensions need restart', "Extensions require a restart to take effect."),
+					severity: Severity.Info,
+					extensions: restartRequiredExtensions,
+					query: '@restartrequired',
+					action: {
+						label: needsReload
+							? nls.localize('reload window', "Reload Window")
+							: nls.localize('restart extensions action', "Restart Extensions"),
+						run: () => {
+							if (needsReload) {
+								this.hostService.reload();
+							} else {
+								this.updateRunningExtensions();
+							}
+						}
+					},
+					key: 'restartRequired:' + restartRequiredExtensions.sort((a, b) => a.identifier.id.localeCompare(b.identifier.id)).map(e => e.identifier.id.toLowerCase()).join('-'),
 				});
 			}
 		}

--- a/src/vs/workbench/contrib/extensions/browser/media/extension.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extension.css
@@ -73,10 +73,27 @@
 
 .extension-list-item > .details > .header-container > .header > .name {
 	font-weight: bold;
-	flex: 1;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	min-width: 0;
+}
+
+.extension-list-item > .details > .header-container > .header > .restart-required {
+	display: flex;
+	flex-shrink: 0;
+	margin-left: 8px;
+	align-items: center;
+}
+
+.extension-list-item > .details > .header-container > .header > .restart-required > .codicon {
+	font-size: 100%;
+}
+
+.extension-list-item > .details > .header-container > .header > .restart-required > .extension-restart-required-label {
+	font-size: 11px;
+	white-space: nowrap;
+	color: var(--vscode-descriptionForeground);
 }
 
 .extension-list-item.deprecated > .details > .header-container > .header > .name {
@@ -91,6 +108,10 @@
 	align-items: center;
 }
 
+.extension-list-item > .details > .header-container > .header > .install-count {
+	margin-left: auto;
+}
+
 .extension-list-item > .details > .header-container > .header .extension-kind-indicator {
 	font-size: 11px;
 	margin-left: 4px;
@@ -98,7 +119,7 @@
 
 .extension-list-item > .details > .header-container > .header > .install-count:not(:empty) {
 	font-size: 11px;
-	margin: 0 6px;
+	margin: 0 6px 0 auto;
 }
 
 .extension-list-item > .details > .header-container > .header > .activation-status:not(:empty) {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -93,7 +93,8 @@
 .extensions-viewlet .notification-container .message-action-button {
 	cursor: pointer;
 	padding: 1px 6px;
-	border-radius: 2px;
+	border-radius: var(--vscode-cornerRadius-small);
+	font-size: 11px;
 	color: var(--vscode-button-foreground);
 	background-color: var(--vscode-button-background);
 	white-space: nowrap;

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -55,16 +55,27 @@
 .extensions-viewlet > .header > .notification-container {
 	margin-top: 10px;
 	display: flex;
-	justify-content: space-between;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	gap: 4px 0;
 }
 
 .extensions-viewlet > .header .notification-container .message-container {
+	display: flex;
 	padding-left: 4px;
+	flex: 1 1 0;
+	min-width: 200px;
 }
 
 .extensions-viewlet > .header .notification-container .message-container .codicon {
-	vertical-align: text-top;
+	flex-shrink: 0;
 	padding-right: 5px;
+	padding-top: 2px;
+}
+
+.extensions-viewlet > .header .notification-container .message-container .message-text {
+	flex: 1;
+	min-width: 0;
 }
 
 .extensions-viewlet .notification-container .message-text-action {
@@ -79,16 +90,24 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
-.extensions-viewlet .notification-container .message-action {
+.extensions-viewlet .notification-container .message-action-button {
 	cursor: pointer;
-	padding: 2px;
-	border-radius: 5px;
-	height: 16px;
+	padding: 1px 6px;
+	border-radius: 2px;
+	color: var(--vscode-button-foreground);
+	background-color: var(--vscode-button-background);
+	white-space: nowrap;
 }
 
-.extensions-viewlet .notification-container .message-action:hover {
-	background-color: var(--vscode-toolbar-hoverBackground);
-	outline: 1px dashed var(--vscode-toolbar-hoverOutline);
+.extensions-viewlet .notification-container .message-action-button:hover {
+	background-color: var(--vscode-button-hoverBackground);
+}
+
+.extensions-viewlet .notification-container .notification-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 24px;
 }
 
 .extensions-viewlet > .extensions {

--- a/src/vs/workbench/contrib/extensions/common/extensionQuery.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensionQuery.ts
@@ -28,7 +28,7 @@ export class Query {
 			commands.push('category');
 		}
 
-		commands.push(...['tag', 'ext', 'id', 'outdated', 'recentlyUpdated']);
+		commands.push(...['tag', 'ext', 'id', 'outdated', 'recentlyUpdated', 'restartrequired']);
 		const sortCommands = [];
 		if (galleryManifest?.capabilities.extensionQuery?.sorting?.some(c => c.name === SortBy.InstallCount)) {
 			sortCommands.push('installs');

--- a/src/vs/workbench/contrib/extensions/common/extensionQuery.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensionQuery.ts
@@ -28,7 +28,7 @@ export class Query {
 			commands.push('category');
 		}
 
-		commands.push(...['tag', 'ext', 'id', 'outdated', 'recentlyUpdated', 'restartrequired']);
+		commands.push(...['tag', 'ext', 'id', 'outdated', 'recentlyUpdated', 'restartRequired']);
 		const sortCommands = [];
 		if (galleryManifest?.capabilities.extensionQuery?.sorting?.some(c => c.name === SortBy.InstallCount)) {
 			sortCommands.push('installs');

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -124,6 +124,8 @@ export interface IExtensionsNotification {
 	readonly message: string;
 	readonly severity: Severity;
 	readonly extensions: IExtension[];
+	readonly query?: string;
+	readonly action?: { readonly label: string; run(): void };
 	dismiss(): void;
 }
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -138,6 +138,8 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		instantiationService.stub(IExtensionService, {
 			onDidChangeExtensions: Event.None,
 			extensions: [],
+			canAddExtension(extension: any) { return false; },
+			canRemoveExtension(extension: any) { return false; },
 			async whenInstalledExtensionsRegistered() { return true; }
 		});
 


### PR DESCRIPTION
Introduce functionality to notify users when extensions require a restart or window reload. This includes updates to the extensions view, new icons, and filtering capabilities for extensions based on their restart requirements.

![Recording 2026-02-09 at 12 20 33](https://github.com/user-attachments/assets/2a9b094a-3caf-42a5-b99d-4602ad59fb4a)
