### PR TITLE
Fix backdrop-filter issue in quick chat widget

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -177,6 +177,14 @@
 	-webkit-backdrop-filter: var(--backdrop-blur-lg);
 }
 
+/* Remove backdrop-filter when quick chat is active, because it creates a new
+   containing block that shifts position:fixed suggest widgets to the right. */
+.monaco-workbench .quick-input-widget:has(.interactive-session) {
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+	background-color: var(--vscode-quickInput-background) !important;
+}
+
 .monaco-workbench.vs-dark .quick-input-widget {
 	border: 1px solid var(--vscode-menu-border) !important;
 }


### PR DESCRIPTION
Remove backdrop-filter from the quick chat widget to prevent layout shifts of position:fixed suggest widgets when active. This change ensures a stable layout during interactions.

Addresses: https://github.com/microsoft/vscode/issues/293852