### PR TITLE
Fix IDisposable leaks in logsDataCleaner, serverServices, and standaloneServices

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -721,11 +721,11 @@ export class StandaloneConfigurationService implements IConfigurationService {
 	}
 }
 
-class StandaloneResourceConfigurationService implements ITextResourceConfigurationService {
+class StandaloneResourceConfigurationService extends Disposable implements ITextResourceConfigurationService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _onDidChangeConfiguration = new Emitter<ITextResourceConfigurationChangeEvent>();
+	private readonly _onDidChangeConfiguration = this._register(new Emitter<ITextResourceConfigurationChangeEvent>());
 	public readonly onDidChangeConfiguration = this._onDidChangeConfiguration.event;
 
 	constructor(
@@ -733,9 +733,10 @@ class StandaloneResourceConfigurationService implements ITextResourceConfigurati
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService
 	) {
-		this.configurationService.onDidChangeConfiguration((e) => {
+		super();
+		this._register(this.configurationService.onDidChangeConfiguration((e) => {
 			this._onDidChangeConfiguration.fire({ affectedKeys: e.affectedKeys, affectsConfiguration: (resource: URI, configuration: string) => e.affectsConfiguration(configuration) });
-		});
+		}));
 	}
 
 	getValue<T>(resource: URI, section?: string): T;

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -115,7 +115,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	socketServer.registerChannel('logger', new LoggerChannel(loggerService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));
 
 	const logger = loggerService.createLogger('remoteagent', { name: localize('remoteExtensionLog', "Server") });
-	const logService = new LogService(logger, [new ServerLogger(getLogLevel(environmentService))]);
+	const logService = disposables.add(new LogService(logger, [new ServerLogger(getLogLevel(environmentService))]));
 	services.set(ILogService, logService);
 	setTimeout(() => cleanupOlderLogs(environmentService.logsHome.with({ scheme: Schemas.file }).fsPath).then(null, err => logService.error(err)), 10000);
 	disposables.add(logService.onDidChangeLogLevel(logLevel => log(logService, logLevel, `Log level changed to ${LogLevelToString(logService.getLevel())}`)));

--- a/src/vs/workbench/contrib/logs/common/logsDataCleaner.ts
+++ b/src/vs/workbench/contrib/logs/common/logsDataCleaner.ts
@@ -33,11 +33,11 @@ export class LogsDataCleaner extends Disposable {
 				Promises.settled(toDelete.map(stat => this.fileService.del(stat.resource, { recursive: true })));
 			}
 		}, 10 * 1000);
-		this.lifecycleService.onWillShutdown(() => {
+		this._register(this.lifecycleService.onWillShutdown(() => {
 			if (handle) {
 				clearTimeout(handle);
 				handle = undefined;
 			}
-		});
+		}));
 	}
 }


### PR DESCRIPTION
Fix IDisposable leaks attributed to @sandy081 in #293200:

- **logsDataCleaner.ts**: `lifecycleService.onWillShutdown()` subscription was not registered. Wrapped with `this._register()`.
- **serverServices.ts**: `new LogService(...)` was not added to the `disposables` store. Wrapped with `disposables.add()`.
- **standaloneServices.ts**: `StandaloneResourceConfigurationService` didn't extend `Disposable`, so the `Emitter` and `onDidChangeConfiguration` subscription were never disposed. Changed to extend `Disposable`, registered both with `this._register()`.
