### PR TITLE
Fix build error when using tsgo

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1876,7 +1876,9 @@ export default tseslint.config(
 				},
 				{
 					'target': 'src/vscode-dts/**',
-					'restrictions': []
+					'restrictions': [
+						'src/vscode-dts/*'
+					]
 				},
 				{
 					'target': 'src/vs/nls.ts',

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -5,6 +5,8 @@
 
 // version: 3
 
+import './vscode.proposed.chatHooks.d.ts';
+
 declare module 'vscode' {
 
 	export interface ChatParticipant {


### PR DESCRIPTION
ChatParticipantAdditions started using types from chatHooks, but doesn't have an explicit dependency on it. Looks like tsgo is more strict about not picking this up automatically so we need to make sure there is an import so the dependency is picked up
