### PR TITLE
Fix chat accessibility progress sound for queued and non-queued requests

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2228,7 +2228,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			queue: options?.queue,
 		});
 
-		if (this.viewModel.sessionResource && !options.queue) {
+		if (this.viewModel.sessionResource && !options.queue && (ChatSendResult.isRejected(result) || ChatSendResult.isQueued(result))) {
 			this.chatAccessibilityService.disposeRequest(this.viewModel.sessionResource);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2228,7 +2228,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			queue: options?.queue,
 		});
 
-		if (this.viewModel.sessionResource && !options.queue && (ChatSendResult.isRejected(result) || ChatSendResult.isQueued(result))) {
+		if (this.viewModel.sessionResource && !options.queue && ChatSendResult.isRejected(result)) {
 			this.chatAccessibilityService.disposeRequest(this.viewModel.sessionResource);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2245,6 +2245,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		// If this was a queued request that just got dequeued, start the progress sound now
+		if (options.queue && this.viewModel?.sessionResource) {
+			this.chatAccessibilityService.acceptRequest(this.viewModel.sessionResource, true);
+		}
+
 		this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });
 		this.handleDelegationExitIfNeeded(this._lockedAgent, sent.data.agent);
 		sent.data.responseCompletePromise.then(() => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2247,7 +2247,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		// If this was a queued request that just got dequeued, start the progress sound now
 		if (options.queue && this.viewModel?.sessionResource) {
-			this.chatAccessibilityService.acceptRequest(this.viewModel.sessionResource, true);
+			this.chatAccessibilityService.acceptRequest(this.viewModel.sessionResource);
 		}
 
 		this._onDidSubmitAgent.fire({ agent: sent.data.agent, slashCommand: sent.data.slashCommand });


### PR DESCRIPTION
fixes #293930

Queueing now goes through `_acceptInput`, where queued requests skip calling `acceptRequest` upfront (since another request is already running with its own progress sound). Once the queued request is dequeued and actually starts executing, we call `acceptRequest` to start the progress sound loop without replaying the "request sent" signal. The existing progress sound from the first request naturally ends when its response completes via `acceptResponse`.