### PR TITLE
Improve URI error handling and validation in logger IPC

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -22,7 +22,7 @@ function _validateUri(ret: URI, _strict?: boolean): void {
 	// scheme, https://tools.ietf.org/html/rfc3986#section-3.1
 	// ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 	if (ret.scheme && !_schemePattern.test(ret.scheme)) {
-		throw new Error('[UriError]: Scheme contains illegal characters.');
+		throw new Error(`[UriError]: Scheme contains illegal characters. scheme:"${ret.scheme.substring(0, 50)}" (len:${ret.scheme.length})`);
 	}
 
 	// path, http://tools.ietf.org/html/rfc3986#section-3.3


### PR DESCRIPTION
Fixes #293503

## Problem

`LoggerChannelClient.deregisterLogger` narrowed its parameter type to only `URI`, but the base interface `ILoggerService.deregisterLogger` accepts `URI | string`. Callers passing string logger IDs (e.g., MCP server passing `this._loggerId`) sent raw strings over IPC. On the main process, `URI.revive(stringValue)` treated the entire string as a URI scheme, which failed `_validateUri` with `[UriError]: Scheme contains illegal characters.`

This was the #1 unhandled error by volume: **1.4M hits, 567K affected users**.

## Fix

1. **Producer fix** (`src/vs/platform/log/common/logIpc.ts`): Changed `deregisterLogger` to accept `URI | string` and call `this.toResource(idOrResource)` before sending over IPC — matching the pattern already used by `setVisibility`.

2. **Error enrichment** (`src/vs/base/common/uri.ts`): Enhanced the `_validateUri` error message to include the actual invalid scheme value (truncated to 50 chars) and its length, so future telemetry from any call site reveals what data was passed.