### PR TITLE
add context menu actions to tips

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -273,6 +273,7 @@ export class MenuId {
 	static readonly ChatEditingCodeBlockContext = new MenuId('ChatEditingCodeBlockContext');
 	static readonly ChatTitleBarMenu = new MenuId('ChatTitleBarMenu');
 	static readonly ChatAttachmentsContext = new MenuId('ChatAttachmentsContext');
+	static readonly ChatTipContext = new MenuId('ChatTipContext');
 	static readonly ChatToolOutputResourceToolbar = new MenuId('ChatToolOutputResourceToolbar');
 	static readonly ChatTextEditorMenu = new MenuId('ChatTextEditorMenu');
 	static readonly ChatToolOutputResourceContext = new MenuId('ChatToolOutputResourceContext');

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -5,26 +5,117 @@
 
 import './media/chatTipContent.css';
 import * as dom from '../../../../../../base/browser/dom.js';
+import { StandardMouseEvent } from '../../../../../../base/browser/mouseEvent.js';
 import { renderIcon } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Emitter } from '../../../../../../base/common/event.js';
+import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { localize2 } from '../../../../../../nls.js';
+import { getFlatContextMenuActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { Action2, IMenuService, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
-import { IChatTip } from '../../chatTipService.js';
+import { IChatTip, IChatTipService } from '../../chatTipService.js';
 
 const $ = dom.$;
 
 export class ChatTipContentPart extends Disposable {
 	public readonly domNode: HTMLElement;
 
+	private readonly _onDidHide = this._register(new Emitter<void>());
+	public readonly onDidHide = this._onDidHide.event;
+
+	private readonly _renderedContent = this._register(new MutableDisposable());
+
 	constructor(
 		tip: IChatTip,
-		renderer: IMarkdownRenderer,
+		private readonly _renderer: IMarkdownRenderer,
+		private readonly _chatTipService: IChatTipService,
+		private readonly _contextMenuService: IContextMenuService,
+		private readonly _menuService: IMenuService,
+		private readonly _contextKeyService: IContextKeyService,
+		private readonly _getNextTip: () => IChatTip | undefined,
 	) {
 		super();
 
 		this.domNode = $('.chat-tip-widget');
+		this._renderTip(tip);
+
+		this._register(this._chatTipService.onDidDismissTip(() => {
+			const nextTip = this._getNextTip();
+			if (nextTip) {
+				this._renderTip(nextTip);
+			} else {
+				this._onDidHide.fire();
+			}
+		}));
+
+		this._register(this._chatTipService.onDidDisableTips(() => {
+			this._onDidHide.fire();
+		}));
+
+		this._register(dom.addDisposableListener(this.domNode, dom.EventType.CONTEXT_MENU, (e: MouseEvent) => {
+			dom.EventHelper.stop(e, true);
+			const event = new StandardMouseEvent(dom.getWindow(this.domNode), e);
+			this._contextMenuService.showContextMenu({
+				getAnchor: () => event,
+				getActions: () => {
+					const menu = this._menuService.getMenuActions(MenuId.ChatTipContext, this._contextKeyService);
+					return getFlatContextMenuActions(menu);
+				},
+			});
+		}));
+	}
+
+	private _renderTip(tip: IChatTip): void {
+		dom.clearNode(this.domNode);
 		this.domNode.appendChild(renderIcon(Codicon.lightbulb));
-		const markdownContent = this._register(renderer.render(tip.content));
+		const markdownContent = this._renderer.render(tip.content);
+		this._renderedContent.value = markdownContent;
 		this.domNode.appendChild(markdownContent.element);
 	}
 }
+
+//#region Tip context menu actions
+
+registerAction2(class DismissTipAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.dismissTip',
+			title: localize2('chatTip.dismiss', "Dismiss This Tip"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipContext,
+				group: 'chatTip',
+				order: 1,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IChatTipService).dismissTip();
+	}
+});
+
+registerAction2(class DisableTipsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.disableTips',
+			title: localize2('chatTip.disableTips', "Disable Tips"),
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipContext,
+				group: 'chatTip',
+				order: 2,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IChatTipService).disableTips();
+	}
+});
+
+//#endregion

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -84,7 +84,7 @@ registerAction2(class DismissTipAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.chat.dismissTip',
-			title: localize2('chatTip.dismiss', "Dismiss This Tip"),
+			title: localize2('chatTip.dismiss', "Dismiss this tip"),
 			f1: false,
 			menu: [{
 				id: MenuId.ChatTipContext,
@@ -103,7 +103,7 @@ registerAction2(class DisableTipsAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.chat.disableTips',
-			title: localize2('chatTip.disableTips', "Disable Tips"),
+			title: localize2('chatTip.disableTips', "Disable tips"),
 			f1: false,
 			menu: [{
 				id: MenuId.ChatTipContext,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -34,7 +34,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { localize } from '../../../../../nls.js';
 import { IMenuEntryActionViewItemOptions, createActionViewItem } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { MenuWorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
-import { MenuId, MenuItemAction } from '../../../../../platform/actions/common/actions.js';
+import { MenuId, MenuItemAction, IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
@@ -254,6 +254,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		@IChatService private readonly chatService: IChatService,
 		@IChatTipService private readonly chatTipService: IChatTipService,
 		@IHostService private readonly hostService: IHostService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+		@IMenuService private readonly menuService: IMenuService,
 		@IAccessibilitySignalService private readonly accessibilitySignalService: IAccessibilitySignalService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
@@ -1056,9 +1058,20 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// Render tip above the request message (if available)
 		const tip = this.chatTipService.getNextTip(element.id, element.timestamp, this.contextKeyService);
 		if (tip) {
-			const tipPart = new ChatTipContentPart(tip, this.chatContentMarkdownRenderer);
+			const tipPart = new ChatTipContentPart(
+				tip,
+				this.chatContentMarkdownRenderer,
+				this.chatTipService,
+				this.contextMenuService,
+				this.menuService,
+				this.contextKeyService,
+				() => this.chatTipService.getNextTip(element.id, element.timestamp, this.contextKeyService),
+			);
 			templateData.value.appendChild(tipPart.domNode);
 			templateData.elementDisposables.add(tipPart);
+			templateData.elementDisposables.add(tipPart.onDidHide(() => {
+				tipPart.domNode.remove();
+			}));
 		}
 
 		let inlineSlashCommandRendered = false;


### PR DESCRIPTION
fixes #293507

Adds a right-click context menu to the chat tips widget with two actions: `Dismiss this tip` (persists the dismissal to workspace storage and cycles to the next eligible tip) and `Disable Tips` (turns off the `chat.tips.enabled setting`).

The intent is:
- to allow users to hide tips as they learn
- to make it easy for power users to hide this if they find it annoying 

<img width="498" height="137" alt="Screenshot 2026-02-09 at 1 51 56 PM" src="https://github.com/user-attachments/assets/4525ba67-c45e-4c2a-83ed-2d5249cea3ec" />
