### PR TITLE
fix(git): detect shallow clones and warn on publish

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4318,6 +4318,19 @@ export class CommandCenter {
 
 	@command('git.publish', { repository: true })
 	async publish(repository: Repository): Promise<void> {
+		if (repository.isShallow) {
+			const proceed = l10n.t('Proceed');
+			const result = await window.showWarningMessage(
+				l10n.t('This repository is a shallow clone. Publishing it will create a new repository with truncated history. Are you sure you want to proceed?'),
+				{ modal: true },
+				proceed
+			);
+
+			if (result !== proceed) {
+				return;
+			}
+		}
+
 		const branchName = repository.HEAD && repository.HEAD.name || '';
 		const remotes = repository.remotes;
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1412,6 +1412,15 @@ export class Repository {
 		});
 	}
 
+	async isShallow(): Promise<boolean> {
+		try {
+			const result = await this.exec(['rev-parse', '--is-shallow-repository']);
+			return result.stdout.trim() === 'true';
+		} catch {
+			return false;
+		}
+	}
+
 	async log(options?: LogOptions, cancellationToken?: CancellationToken): Promise<Commit[]> {
 		const spawnOptions: SpawnOptions = { cancellationToken };
 		const args = ['log', `--format=${COMMIT_FORMAT}`, '-z'];

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -883,6 +883,9 @@ export class Repository implements Disposable {
 	private _isHidden: boolean;
 	get isHidden(): boolean { return this._isHidden; }
 
+	private _isShallow: boolean = false;
+	get isShallow(): boolean { return this._isShallow; }
+
 	private isRepositoryHuge: false | { limit: number } = false;
 	private didWarnAboutLimit = false;
 
@@ -2740,7 +2743,7 @@ export class Repository implements Disposable {
 				this._updateResourceGroupsState(optimisticResourcesGroups);
 			}
 
-			const [HEAD, remotes, submodules, worktrees, rebaseCommit, mergeInProgress, cherryPickInProgress, commitTemplate] =
+			const [HEAD, remotes, submodules, worktrees, rebaseCommit, mergeInProgress, cherryPickInProgress, commitTemplate, isShallow] =
 				await Promise.all([
 					this.repository.getHEADRef(),
 					this.repository.getRemotes(),
@@ -2749,7 +2752,8 @@ export class Repository implements Disposable {
 					this.getRebaseCommit(),
 					this.isMergeInProgress(),
 					this.isCherryPickInProgress(),
-					this.getInputTemplate()]);
+					this.getInputTemplate(),
+					this.repository.isShallow()]);
 
 			// Reset the list of unpublished commits if HEAD has
 			// changed (ex: checkout, fetch, pull, push, publish, etc.).
@@ -2769,8 +2773,11 @@ export class Repository implements Disposable {
 			this.rebaseCommit = rebaseCommit;
 			this.mergeInProgress = mergeInProgress;
 			this.cherryPickInProgress = cherryPickInProgress;
+			this._isShallow = isShallow;
 
 			this._sourceControl.commitTemplate = commitTemplate;
+
+			commands.executeCommand('setContext', 'gitIsShallow', this._isShallow);
 
 			// Execute cancellable long-running operation
 			const [resourceGroups, refs] =


### PR DESCRIPTION
Fixes #180317. This PR adds detection for shallow repositories using 'git rev-parse --is-shallow-repository' and warns the user when attempting to publish a branch from a shallow clone.