### PR TITLE
fix action list not scrolling

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -411,10 +411,20 @@ export class ActionList<T> extends Disposable {
 
 	focusPrevious() {
 		this._list.focusPrevious(1, true, undefined, this.focusCondition);
+		const focused = this._list.getFocus();
+		if (focused.length > 0) {
+			this._list.reveal(focused[0]);
+		}
+		this._list.domFocus();
 	}
 
 	focusNext() {
 		this._list.focusNext(1, true, undefined, this.focusCondition);
+		const focused = this._list.getFocus();
+		if (focused.length > 0) {
+			this._list.reveal(focused[0]);
+		}
+		this._list.domFocus();
 	}
 
 	acceptSelected(preview?: boolean) {
@@ -447,6 +457,7 @@ export class ActionList<T> extends Disposable {
 	}
 
 	private onFocus() {
+		this._list.domFocus();
 		const focused = this._list.getFocus();
 		if (focused.length === 0) {
 			return;


### PR DESCRIPTION
fix #294017

When up arrowing in the action list, the focused item wasn't scrolled to and thus wasn't visible. This fixes that.

Before

https://github.com/user-attachments/assets/508e5223-2636-487a-9cb8-c780dbf7037d


After

https://github.com/user-attachments/assets/c3899692-4b06-4e4f-88cb-d2055ca79485


