### PR TITLE
Add terminal-only mode and UI adjustments

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -142,6 +142,7 @@ export interface NativeParsedArgs {
 	'enable-rdp-display-tracking'?: boolean;
 	'disable-layout-restore'?: boolean;
 	'disable-experiments'?: boolean;
+	'terminal'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -98,6 +98,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'remove': { type: 'boolean', cat: 'o', args: 'folder', description: localize('remove', "Remove folder(s) from the last active window.") },
 	'goto': { type: 'boolean', cat: 'o', alias: 'g', args: 'file:line[:character]', description: localize('goto', "Open a file at the path on the specified line and character position.") },
 	'new-window': { type: 'boolean', cat: 'o', alias: 'n', description: localize('newWindow', "Force to open a new window.") },
+	'terminal': { type: 'boolean', cat: 'o', alias: 't', description: localize('terminal', "Open a terminal window.") },
 	'reuse-window': { type: 'boolean', cat: 'o', alias: 'r', description: localize('reuseWindow', "Force to open a file or folder in an already opened window.") },
 	'wait': { type: 'boolean', cat: 'o', alias: 'w', description: localize('wait', "Wait for the files to be closed before returning.") },
 	'waitMarkerFilePath': { type: 'string' },

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -6,7 +6,7 @@
 import { Disposable } from '../../base/common/lifecycle.js';
 import { IContextKeyService, IContextKey, setConstant as setConstantContextKey } from '../../platform/contextkey/common/contextkey.js';
 import { IsMacContext, IsLinuxContext, IsWindowsContext, IsWebContext, IsMacNativeContext, IsDevelopmentContext, IsIOSContext, ProductQualityContext, IsMobileContext } from '../../platform/contextkey/common/contextkeys.js';
-import { SplitEditorsVertically, InEditorZenModeContext, AuxiliaryBarVisibleContext, SideBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelVisibleContext, EmbedderIdentifierContext, EditorTabsVisibleContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, DirtyWorkingCopiesContext, EmptyWorkspaceSupportContext, EnterMultiRootWorkspaceSupportContext, HasWebFileSystemAccess, IsMainWindowFullscreenContext, OpenFolderWorkspaceSupportContext, RemoteNameContext, VirtualWorkspaceContext, WorkbenchStateContext, WorkspaceFolderCountContext, PanelPositionContext, TemporaryWorkspaceContext, TitleBarVisibleContext, TitleBarStyleContext, IsAuxiliaryWindowFocusedContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorGroupLockedContext, MultipleEditorGroupsContext, EditorsVisibleContext, AuxiliaryBarMaximizedContext, InAutomationContext, IsAgentSessionsWorkspaceContext, WorkbenchModeContext } from '../common/contextkeys.js';
+import { SplitEditorsVertically, InEditorZenModeContext, AuxiliaryBarVisibleContext, SideBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelVisibleContext, EmbedderIdentifierContext, EditorTabsVisibleContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, DirtyWorkingCopiesContext, EmptyWorkspaceSupportContext, EnterMultiRootWorkspaceSupportContext, HasWebFileSystemAccess, IsMainWindowFullscreenContext, OpenFolderWorkspaceSupportContext, RemoteNameContext, VirtualWorkspaceContext, WorkbenchStateContext, WorkspaceFolderCountContext, PanelPositionContext, TemporaryWorkspaceContext, TitleBarVisibleContext, TitleBarStyleContext, IsAuxiliaryWindowFocusedContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorGroupLockedContext, MultipleEditorGroupsContext, EditorsVisibleContext, AuxiliaryBarMaximizedContext, InAutomationContext, IsAgentSessionsWorkspaceContext, WorkbenchModeContext, TerminalModeContext } from '../common/contextkeys.js';
 import { preferredSideBySideGroupDirection, GroupDirection, IEditorGroupsService } from '../services/editor/common/editorGroupsService.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { IWorkbenchEnvironmentService } from '../services/environment/common/environmentService.js';
@@ -118,6 +118,9 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		// Automation
 		this.inAutomationContext = InAutomationContext.bindTo(this.contextKeyService);
 		this.inAutomationContext.set(!!this.environmentService.enableSmokeTestDriver);
+
+		// Terminal Mode
+		TerminalModeContext.bindTo(this.contextKeyService).set(!!this.environmentService.terminal);
 
 		// Editor Groups
 		this.activeEditorGroupEmpty = ActiveEditorGroupEmptyContext.bindTo(this.contextKeyService);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -746,7 +746,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		// Sidebar View Container To Restore
-		if (this.isVisible(Parts.SIDEBAR_PART)) {
+		if (!this.environmentService.terminal && this.isVisible(Parts.SIDEBAR_PART)) {
 			let viewContainerToRestore = this.storageService.get(SidebarPart.activeViewletSettingsKey, StorageScope.WORKSPACE, this.viewDescriptorService.getDefaultViewContainer(ViewContainerLocation.Sidebar)?.id);
 			if (
 				!this.environmentService.isBuilt ||

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -100,7 +100,8 @@ enum LayoutClasses {
 	STATUSBAR_HIDDEN = 'nostatusbar',
 	FULLSCREEN = 'fullscreen',
 	MAXIMIZED = 'maximized',
-	WINDOW_BORDER = 'border'
+	WINDOW_BORDER = 'border',
+	TERMINAL_MODE = 'terminal-mode'
 }
 
 interface IPathToOpen extends IPath {
@@ -734,6 +735,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			runtime: layoutRuntimeState,
 		};
 
+		// Terminal Mode: --terminal flag opens a terminal-only window
+		if (this.environmentService.terminal) {
+			this.stateModel.setRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN, true);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.ACTIVITYBAR_HIDDEN, true);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.AUXILIARYBAR_HIDDEN, true);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_HIDDEN, false);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN, true);
+			this.state.initialization.views.containerToRestore.panel = 'terminal';
+		}
+
 		// Sidebar View Container To Restore
 		if (this.isVisible(Parts.SIDEBAR_PART)) {
 			let viewContainerToRestore = this.storageService.get(SidebarPart.activeViewletSettingsKey, StorageScope.WORKSPACE, this.viewDescriptorService.getDefaultViewContainer(ViewContainerLocation.Sidebar)?.id);
@@ -822,6 +833,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	protected willRestoreEditors(): boolean {
+		if (this.environmentService.terminal) {
+			return false;
+		}
+
 		return this.state.initialization.editor.restoreEditors;
 	}
 
@@ -1150,6 +1165,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			// or auxiliary bar are maximized.
 			if (getActiveElement() === mainWindow.document.body && (this.isPanelMaximized() || this.isAuxiliaryBarMaximized())) {
 				this.focus();
+			}
+
+			// Focus the panel when in terminal mode
+			if (this.environmentService.terminal && getActiveElement() === mainWindow.document.body) {
+				this.focusPart(Parts.PANEL_PART);
 			}
 
 			this.whenReadyPromise.complete();
@@ -1853,7 +1873,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			!this.isVisible(Parts.PANEL_PART) ? LayoutClasses.PANEL_HIDDEN : undefined,
 			!this.isVisible(Parts.AUXILIARYBAR_PART) ? LayoutClasses.AUXILIARYBAR_HIDDEN : undefined,
 			!this.isVisible(Parts.STATUSBAR_PART) ? LayoutClasses.STATUSBAR_HIDDEN : undefined,
-			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined
+			this.state.runtime.mainWindowFullscreen ? LayoutClasses.FULLSCREEN : undefined,
+			this.environmentService.terminal ? LayoutClasses.TERMINAL_MODE : undefined
 		]);
 	}
 
@@ -1993,6 +2014,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	private setPanelHidden(hidden: boolean, skipLayout?: boolean): void {
+		// Block hiding the panel in terminal mode
+		if (hidden && this.environmentService.terminal) {
+			return;
+		}
+
 		if (!this.workbenchGrid) {
 			return; // Return if not initialized fully (https://github.com/microsoft/vscode/issues/105480)
 		}
@@ -2196,6 +2222,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	private setAuxiliaryBarHidden(hidden: boolean, skipLayout?: boolean): void {
+		// Block showing the auxiliary bar in terminal mode
+		if (!hidden && this.environmentService.terminal) {
+			return;
+		}
+
 		if (hidden && this.setAuxiliaryBarMaximized(false) && !this.isVisible(Parts.AUXILIARYBAR_PART)) {
 			return; // return: leaving maximised auxiliary bar made this part hidden
 		}

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -435,6 +435,11 @@ export class PaneCompositeBar extends Disposable {
 		const viewContainer = isString(viewContainerOrId) ? this.getViewContainer(viewContainerOrId) : viewContainerOrId;
 		const viewContainerId = isString(viewContainerOrId) ? viewContainerOrId : viewContainerOrId.id;
 
+		// In terminal mode, hide all non-terminal panel view containers
+		if (this.environmentService.terminal && this.part === Parts.PANEL_PART && viewContainerId !== 'terminal') {
+			return true;
+		}
+
 		if (viewContainer) {
 			if (viewContainer.hideIfEmpty) {
 				if (this.viewService.isViewContainerActive(viewContainerId)) {

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -98,3 +98,9 @@
 	display: inline-block;
 	transform: rotate(180deg);
 }
+
+/* Terminal mode: hide per-composite toolbar and global actions in panel */
+.monaco-workbench.terminal-mode .part.panel > .composite.title > .title-actions,
+.monaco-workbench.terminal-mode .part.panel > .composite.title > .global-actions {
+	display: none !important;
+}

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -9,7 +9,7 @@ import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
 import { MenuId, MenuRegistry, registerAction2, Action2, IAction2Options } from '../../../../platform/actions/common/actions.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { isHorizontal, IWorkbenchLayoutService, PanelAlignment, Parts, Position, positionToString } from '../../../services/layout/browser/layoutService.js';
-import { IsAuxiliaryWindowContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext } from '../../../common/contextkeys.js';
+import { IsAuxiliaryWindowContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext, TerminalModeContext } from '../../../common/contextkeys.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
@@ -79,7 +79,8 @@ MenuRegistry.appendMenuItem(MenuId.PanelTitle, {
 		icon: closeIcon
 	},
 	group: 'navigation',
-	order: 2
+	order: 2,
+	when: TerminalModeContext.negate()
 });
 
 registerAction2(class extends Action2 {
@@ -317,7 +318,7 @@ MenuRegistry.appendMenuItem(MenuId.PanelTitle, {
 	},
 	group: 'navigation',
 	order: 1,
-	when: ContextKeyExpr.and(panelMaximizationSupportedWhen, PanelMaximizedContext.negate())
+	when: ContextKeyExpr.and(panelMaximizationSupportedWhen, PanelMaximizedContext.negate(), TerminalModeContext.negate())
 });
 
 MenuRegistry.appendMenuItem(MenuId.PanelTitle, {
@@ -328,7 +329,7 @@ MenuRegistry.appendMenuItem(MenuId.PanelTitle, {
 	},
 	group: 'navigation',
 	order: 1,
-	when: ContextKeyExpr.and(panelMaximizationSupportedWhen, PanelMaximizedContext)
+	when: ContextKeyExpr.and(panelMaximizationSupportedWhen, PanelMaximizedContext, TerminalModeContext.negate())
 });
 
 MenuRegistry.appendMenuItems([

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -808,7 +808,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	}
 
 	protected get isCommandCenterVisible() {
-		return !this.isCompact && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== false;
+		return !this.isCompact && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== false && !this.environmentService.terminal;
 	}
 
 	private get editorActionsEnabled(): boolean {

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -43,6 +43,8 @@ export const EmbedderIdentifierContext = new RawContextKey<string | undefined>('
 
 export const InAutomationContext = new RawContextKey<boolean>('inAutomation', false, localize('inAutomation', "Whether VS Code is running under automation/smoke test"));
 
+export const TerminalModeContext = new RawContextKey<boolean>('isTerminalMode', false, localize('isTerminalMode', "Whether VS Code is running in terminal-only mode"));
+
 //#endregion
 
 //#region < --- Window --- >

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -232,6 +232,10 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 		return false;
 	}
 
+	if (environmentService.terminal) {
+		return false;
+	}
+
 	const startupEditor = configurationService.inspect<string>(configurationKey);
 	if (!startupEditor.userValue && !startupEditor.workspaceValue) {
 		const welcomeEnabled = configurationService.inspect(oldConfigurationKey);

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -255,6 +255,9 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 	get skipWelcome(): boolean { return this.payload?.get('skipWelcome') === 'true'; }
 
 	@memoize
+	get terminal(): boolean { return this.payload?.get('terminal') === 'true'; }
+
+	@memoize
 	get disableWorkspaceTrust(): boolean { return !this.options.enableWorkspaceTrust; }
 
 	@memoize

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -36,6 +36,7 @@ export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 	readonly skipWelcome: boolean;
 	readonly disableWorkspaceTrust: boolean;
 	readonly webviewExternalEndpoint: string;
+	readonly terminal: boolean;
 
 	// --- Development
 	readonly debugRenderer: boolean;

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -118,6 +118,9 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get skipWelcome(): boolean { return !!this.args['skip-welcome']; }
 
 	@memoize
+	get terminal(): boolean { return !!this.args['terminal']; }
+
+	@memoize
 	get logExtensionHostCommunication(): boolean { return !!this.args.logExtensionHostCommunication; }
 
 	@memoize


### PR DESCRIPTION
[EXPERIMENTAL] https://github.com/microsoft/vscode/issues/34442

**What**
Introduce a terminal-only mode driven by a new --terminal CLI flag and environmentService. Adds 'terminal' to NativeParsedArgs and OPTIONS (-t alias) and exposes terminal on browser/electron/common environment services. 

<img width="1312" height="804" alt="image" src="https://github.com/user-attachments/assets/288dcca5-fa6f-43a3-9c8d-4a048097a33d" />

**Why**
Im a fan of the vscode terminal and wish there was a way i could open just that minus all the other distractions. Now I can do `code --terminal`.

**How**
Using existing features (ContextKeyExpr, LayoutClasses, shouldBeHidden, etc.) and guards to disable the "other distractions" and only showing the terminal. Loads everything else as normal so _in theory_ everything else should still work. Introduces TerminalModeContext and uses it across workbench to adjust behavior: hide editors/activity/side/auxiliary bars, force panel visibility/focus, block panel hiding/showing of auxiliary bar, hide non-terminal panel view containers, suppress panel title actions, and disable command center and startup page in terminal mode. Adds a `.terminal-mode` CSS class to hide per-composite toolbar/global actions. 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

> [!IMPORTANT]
> This is more a **proof of concept** (and for **personal use**) at this stage. I have not tested the impact of this on the rest of the codebase 🤷🏽