### PR TITLE
Use chat sessions controllers for extHost <-> mainThread

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -5,8 +5,7 @@
 
 import { raceCancellationError } from '../../../base/common/async.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
-import { isCancellationError } from '../../../base/common/errors.js';
-import { Emitter } from '../../../base/common/event.js';
+import { Emitter, Event } from '../../../base/common/event.js';
 import { IMarkdownString, MarkdownString } from '../../../base/common/htmlContent.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../base/common/map.js';
@@ -321,12 +320,47 @@ export class ObservableChatSession extends Disposable implements IChatSession {
 	}
 }
 
+class MainThreadChatSessionItemController extends Disposable implements IChatSessionItemController {
+
+	private readonly _proxy: ExtHostChatSessionsShape;
+	private readonly _handle: number;
+
+	private readonly _onDidChangeChatSessionItems = this._register(new Emitter<void>());
+	readonly onDidChangeChatSessionItems: Event<void> = this._onDidChangeChatSessionItems.event;
+
+	constructor(
+		proxy: ExtHostChatSessionsShape,
+		handle: number
+	) {
+		super();
+		this._proxy = proxy;
+		this._handle = handle;
+	}
+
+	private _items: IChatSessionItem[] = [];
+	get items(): IChatSessionItem[] {
+		return this._items;
+	}
+
+	refresh(token: CancellationToken): Promise<void> {
+		return this._proxy.$refreshChatSessionItems(this._handle, token);
+	}
+
+	setItems(items: IChatSessionItem[]): void {
+		this._items = items;
+		this._onDidChangeChatSessionItems.fire();
+	}
+
+	fireOnDidChangeChatSessionItems(): void {
+		this._onDidChangeChatSessionItems.fire();
+	}
+}
+
 @extHostNamedCustomer(MainContext.MainThreadChatSessions)
 export class MainThreadChatSessions extends Disposable implements MainThreadChatSessionsShape {
 	private readonly _itemControllerRegistrations = this._register(new DisposableMap<number, IDisposable & {
 		readonly chatSessionType: string;
-		readonly controller: IChatSessionItemController;
-		readonly onDidChangeItems: Emitter<void>;
+		readonly controller: MainThreadChatSessionItemController;
 	}>());
 	private readonly _contentProvidersRegistrations = this._register(new DisposableMap<number>());
 	private readonly _sessionTypeToHandle = new Map<string, number>();
@@ -375,51 +409,69 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		return this._sessionTypeToHandle.get(chatSessionType);
 	}
 
-	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void {
-		// Register the provider handle - this tracks that a provider exists
+	$registerChatSessionItemController(handle: number, chatSessionType: string): void {
+		// Register the controller handle - items will be pushed via $setChatSessionItems
 		const disposables = new DisposableStore();
-		const changeEmitter = disposables.add(new Emitter<void>());
 
-
-		const self = this;
-
-		const controller = new class implements IChatSessionItemController {
-
-			items: IChatSessionItem[] = [];
-
-			get onDidChangeChatSessionItems() {
-				return changeEmitter.event;
-			}
-
-			async refresh(token: CancellationToken): Promise<void> {
-				try {
-					this.items = await self._provideChatSessionItems(handle, token);
-				} catch (err) {
-					if (isCancellationError(err)) {
-						return;
-					}
-					throw err;
-				}
-			}
-		};
+		const controller = new MainThreadChatSessionItemController(this._proxy, handle);
+		disposables.add(controller);
 		disposables.add(this._chatSessionsService.registerChatSessionItemController(chatSessionType, controller));
 
 		this._itemControllerRegistrations.set(handle, {
 			dispose: () => disposables.dispose(),
 			chatSessionType,
 			controller,
-			onDidChangeItems: changeEmitter,
 		});
 
 		disposables.add(this._chatSessionsService.registerChatModelChangeListeners(
 			this._chatService,
 			chatSessionType,
-			() => changeEmitter.fire()
+			() => controller.fireOnDidChangeChatSessionItems()
 		));
 	}
 
 	$onDidChangeChatSessionItems(handle: number): void {
-		this._itemControllerRegistrations.get(handle)?.onDidChangeItems.fire();
+		this._itemControllerRegistrations.get(handle)?.controller.fireOnDidChangeChatSessionItems();
+	}
+
+	async $setChatSessionItems(handle: number, items: Dto<IChatSessionItem>[]): Promise<void> {
+		const registration = this._itemControllerRegistrations.get(handle);
+		if (!registration) {
+			this._logService.warn(`No controller registered for handle ${handle}`);
+			return;
+		}
+
+		const resolvedItems = await Promise.all(items.map(async item => {
+			const uri = URI.revive(item.resource);
+			const model = this._chatService.getSession(uri);
+			if (model) {
+				item = await this.handleSessionModelOverrides(model, item);
+			}
+
+			// We can still get stats if there is no model or if fetching from model failed
+			if (!item.changes || !model) {
+				const stats = (await this._chatService.getMetadataForSession(uri))?.stats;
+				const diffs: IAgentSession['changes'] = {
+					files: stats?.fileCount || 0,
+					insertions: stats?.added || 0,
+					deletions: stats?.removed || 0
+				};
+				if (hasValidDiff(diffs)) {
+					item.changes = diffs;
+				}
+			}
+
+			return {
+				...item,
+				changes: revive(item.changes),
+				resource: uri,
+				iconPath: item.iconPath,
+				tooltip: item.tooltip ? this._reviveTooltip(item.tooltip) : undefined,
+				archived: item.archived,
+			} satisfies IChatSessionItem;
+		}));
+
+		registration.controller.setItems(resolvedItems);
 	}
 
 	$onDidChangeChatSessionOptions(handle: number, sessionResourceComponents: UriComponents, updates: ReadonlyArray<{ optionId: string; value: string }>): void {
@@ -503,46 +555,6 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		}
 	}
 
-	private async _provideChatSessionItems(handle: number, token: CancellationToken): Promise<IChatSessionItem[]> {
-		try {
-			// Get all results as an array from the RPC call
-			const sessions = await this._proxy.$provideChatSessionItems(handle, token);
-			return Promise.all(sessions.map(async session => {
-				const uri = URI.revive(session.resource);
-				const model = this._chatService.getSession(uri);
-				if (model) {
-					session = await this.handleSessionModelOverrides(model, session);
-				}
-
-				// We can still get stats if there is no model or if fetching from model failed
-				if (!session.changes || !model) {
-					const stats = (await this._chatService.getMetadataForSession(uri))?.stats;
-					// TODO: we shouldn't be converting this, the types should match
-					const diffs: IAgentSession['changes'] = {
-						files: stats?.fileCount || 0,
-						insertions: stats?.added || 0,
-						deletions: stats?.removed || 0
-					};
-					if (hasValidDiff(diffs)) {
-						session.changes = diffs;
-					}
-				}
-
-				return {
-					...session,
-					changes: revive(session.changes),
-					resource: uri,
-					iconPath: session.iconPath,
-					tooltip: session.tooltip ? this._reviveTooltip(session.tooltip) : undefined,
-					archived: session.archived,
-				} satisfies IChatSessionItem;
-			}));
-		} catch (error) {
-			this._logService.error('Error providing chat sessions:', error);
-		}
-		return [];
-	}
-
 	private async handleSessionModelOverrides(model: IChatModel, session: Dto<IChatSessionItem>): Promise<Dto<IChatSessionItem>> {
 		// Override desciription if there's an in-progress count
 		const inProgress = model.getRequests().filter(r => r.response && !r.response.isComplete);
@@ -611,7 +623,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		}
 	}
 
-	$unregisterChatSessionItemProvider(handle: number): void {
+	$unregisterChatSessionItemController(handle: number): void {
 		this._itemControllerRegistrations.deleteAndDispose(handle);
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3428,8 +3428,9 @@ export interface IChatSessionProviderOptions {
 }
 
 export interface MainThreadChatSessionsShape extends IDisposable {
-	$registerChatSessionItemProvider(handle: number, chatSessionType: string): void;
-	$unregisterChatSessionItemProvider(handle: number): void;
+	$registerChatSessionItemController(handle: number, chatSessionType: string): void;
+	$unregisterChatSessionItemController(handle: number): void;
+	$setChatSessionItems(handle: number, items: Dto<IChatSessionItem>[]): void;
 	$onDidChangeChatSessionItems(handle: number): void;
 	$onDidCommitChatSessionItem(handle: number, original: UriComponents, modified: UriComponents): void;
 	$registerChatSessionContentProvider(handle: number, chatSessionScheme: string): void;
@@ -3443,7 +3444,7 @@ export interface MainThreadChatSessionsShape extends IDisposable {
 }
 
 export interface ExtHostChatSessionsShape {
-	$provideChatSessionItems(providerHandle: number, token: CancellationToken): Promise<Dto<IChatSessionItem>[]>;
+	$refreshChatSessionItems(providerHandle: number, token: CancellationToken): Promise<void>;
 	$onDidChangeChatSessionItemState(providerHandle: number, sessionResource: UriComponents, archived: boolean): void;
 
 	$provideChatSessionContent(providerHandle: number, sessionResource: UriComponents, token: CancellationToken): Promise<ChatSessionDto>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -3430,7 +3430,7 @@ export interface IChatSessionProviderOptions {
 export interface MainThreadChatSessionsShape extends IDisposable {
 	$registerChatSessionItemController(handle: number, chatSessionType: string): void;
 	$unregisterChatSessionItemController(handle: number): void;
-	$setChatSessionItems(handle: number, items: Dto<IChatSessionItem>[]): void;
+	$setChatSessionItems(handle: number, items: Dto<IChatSessionItem>[]): Promise<void>;
 	$onDidChangeChatSessionItems(handle: number): void;
 	$onDidCommitChatSessionItem(handle: number, original: UriComponents, modified: UriComponents): void;
 	$registerChatSessionContentProvider(handle: number, chatSessionScheme: string): void;

--- a/src/vs/workbench/api/common/extHostChatSessions.ts
+++ b/src/vs/workbench/api/common/extHostChatSessions.ts
@@ -9,7 +9,7 @@ import { coalesce } from '../../../base/common/arrays.js';
 import { DeferredPromise } from '../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { CancellationError } from '../../../base/common/errors.js';
-import { Emitter, Event } from '../../../base/common/event.js';
+import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../base/common/map.js';
 import { MarshalledId } from '../../../base/common/marshallingIds.js';
@@ -257,17 +257,9 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 	private readonly _proxy: Proxied<MainThreadChatSessionsShape>;
 
-	private _itemProviderHandlePool = 0;
-	private readonly _chatSessionItemProviders = new Map</* handle */ number, {
-		readonly sessionType: string;
-		readonly provider: vscode.ChatSessionItemProvider;
-		readonly extension: IExtensionDescription;
-		readonly disposable: DisposableStore;
-	}>();
-
 	private _itemControllerHandlePool = 0;
 	private readonly _chatSessionItemControllers = new Map</* handle */ number, {
-		readonly sessionType: string;
+		readonly chatSessionType: string;
 		readonly controller: vscode.ChatSessionItemController;
 		readonly extension: IExtensionDescription;
 		readonly disposable: DisposableStore;
@@ -326,14 +318,47 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 	}
 
 	registerChatSessionItemProvider(extension: IExtensionDescription, chatSessionType: string, provider: vscode.ChatSessionItemProvider): vscode.Disposable {
-		const handle = this._itemProviderHandlePool++;
+		// The legacy provider api is implemented using the new controller API on the backend
+		const handle = this._itemControllerHandlePool++;
 		const disposables = new DisposableStore();
 
-		this._chatSessionItemProviders.set(handle, { provider, extension, disposable: disposables, sessionType: chatSessionType });
-		this._proxy.$registerChatSessionItemProvider(handle, chatSessionType);
+		const onDidChangeChatSessionItemStateEmitter = disposables.add(new Emitter<vscode.ChatSessionItem>());
+
+
+		// Helper to fetch and push items to main thread
+		const updateItems = async (items: readonly vscode.ChatSessionItem[]) => {
+			const convertedItems: IChatSessionItem[] = [];
+			for (const sessionContent of items) {
+				this._sessionItems.set(sessionContent.resource, sessionContent);
+				convertedItems.push(this.convertChatSessionItem(sessionContent));
+			}
+			this._proxy.$setChatSessionItems(handle, convertedItems);
+		};
+
+		const controller: vscode.ChatSessionItemController = {
+			id: chatSessionType,
+			get items(): vscode.ChatSessionItemCollection {
+				throw new Error('not implemented');
+			},
+			createChatSessionItem: (_resource: vscode.Uri, _label: string) => {
+				throw new Error('not implemented');
+			},
+			onDidChangeChatSessionItemState: onDidChangeChatSessionItemStateEmitter.event,
+			dispose: () => {
+				disposables.dispose();
+			},
+			refreshHandler: async (token: vscode.CancellationToken) => {
+				const items = await provider.provideChatSessionItems(token) ?? [];
+				updateItems(items);
+			},
+		};
+
+		this._chatSessionItemControllers.set(handle, { chatSessionType: chatSessionType, controller, extension, disposable: disposables, onDidChangeChatSessionItemStateEmitter });
+		this._proxy.$registerChatSessionItemController(handle, chatSessionType);
+
 		if (provider.onDidChangeChatSessionItems) {
 			disposables.add(provider.onDidChangeChatSessionItems(() => {
-				this._logService.trace(`ExtHostChatSessions. Firing $onDidChangeChatSessionItems for ${chatSessionType}`);
+				this._logService.trace(`ExtHostChatSessions. Provider items changed for ${chatSessionType}`);
 				this._proxy.$onDidChangeChatSessionItems(handle);
 			}));
 		}
@@ -347,35 +372,30 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 		return {
 			dispose: () => {
-				this._chatSessionItemProviders.delete(handle);
+				this._chatSessionItemControllers.delete(handle);
 				disposables.dispose();
-				this._proxy.$unregisterChatSessionItemProvider(handle);
+				this._proxy.$unregisterChatSessionItemController(handle);
 			}
 		};
 	}
-
 
 	createChatSessionItemController(extension: IExtensionDescription, id: string, refreshHandler: (token: vscode.CancellationToken) => Thenable<void>): vscode.ChatSessionItemController {
 		const controllerHandle = this._itemControllerHandlePool++;
 		const disposables = new DisposableStore();
 
 		let isDisposed = false;
-		let refreshIdPool = 0;
-		let activeRefreshId: number | undefined = undefined;
-
-		const onDidChangeItemsEmitter = disposables.add(new Emitter<void>());
 		const onDidChangeChatSessionItemStateEmitter = disposables.add(new Emitter<vscode.ChatSessionItem>());
 
-		const notifyItemsChanged = () => {
-			// Suppress updates when a refresh is already happening
-			if (typeof activeRefreshId === 'undefined') {
-				onDidChangeItemsEmitter.fire();
+		const onItemsChanged = () => {
+			const items: IChatSessionItem[] = [];
+			for (const [_, item] of collection) {
+				this._sessionItems.set(item.resource, item);
+				items.push(this.convertChatSessionItem(item));
 			}
+			this._proxy.$setChatSessionItems(controllerHandle, items);
 		};
 
-		const collection = new ChatSessionItemCollectionImpl(() => {
-			notifyItemsChanged();
-		});
+		const collection = new ChatSessionItemCollectionImpl(onItemsChanged);
 
 		const controller = Object.freeze<vscode.ChatSessionItemController>({
 			id,
@@ -384,17 +404,8 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 					throw new Error('ChatSessionItemController has been disposed');
 				}
 
-				const opId = ++refreshIdPool;
-				activeRefreshId = opId;
-
-				try {
-					this._logService.trace(`ExtHostChatSessions. Controller(${id}).refresh()`);
-					await refreshHandler(refreshToken);
-				} finally {
-					if (activeRefreshId === opId) {
-						activeRefreshId = undefined;
-					}
-				}
+				this._logService.trace(`ExtHostChatSessions. Controller(${id}).refresh()`);
+				await refreshHandler(refreshToken);
 			},
 			items: collection,
 			onDidChangeChatSessionItemState: onDidChangeChatSessionItemStateEmitter.event,
@@ -405,7 +416,7 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 
 				return new ChatSessionItemImpl(resource, label, () => {
 					// TODO: Optimize to only update the specific item
-					notifyItemsChanged();
+					onItemsChanged();
 				});
 			},
 			dispose: () => {
@@ -414,21 +425,14 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			},
 		});
 
-		this._chatSessionItemControllers.set(controllerHandle, { controller, extension, disposable: disposables, sessionType: id, onDidChangeChatSessionItemStateEmitter });
+		this._chatSessionItemControllers.set(controllerHandle, { controller, extension, disposable: disposables, chatSessionType: id, onDidChangeChatSessionItemStateEmitter });
 
-		// Controllers are implemented using providers on the ext host side for now
-		disposables.add(this.registerChatSessionItemProvider(extension, id, {
-			onDidChangeChatSessionItems: onDidChangeItemsEmitter.event,
-			onDidCommitChatSessionItem: Event.None,
-			provideChatSessionItems: async (token: CancellationToken): Promise<vscode.ChatSessionItem[]> => {
-				await controller.refreshHandler(token);
-				return Array.from(controller.items, x => x[1]);
-			},
-		}));
+		// Register the controller with the main thread
+		this._proxy.$registerChatSessionItemController(controllerHandle, id);
 
 		disposables.add(toDisposable(() => {
 			this._chatSessionItemControllers.delete(controllerHandle);
-			this._proxy.$unregisterChatSessionItemProvider(controllerHandle);
+			this._proxy.$unregisterChatSessionItemController(controllerHandle);
 		}));
 
 		return controller;
@@ -501,27 +505,6 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			changes: sessionContent.changes instanceof Array ? sessionContent.changes : undefined,
 			metadata: sessionContent.metadata,
 		};
-	}
-
-	async $provideChatSessionItems(handle: number, token: vscode.CancellationToken): Promise<IChatSessionItem[]> {
-		const itemProvider = this._chatSessionItemProviders.get(handle);
-		if (!itemProvider) {
-			this._logService.error(`No provider registered for handle ${handle}`);
-			return [];
-		}
-
-		this._logService.trace(`ExtHostChatSessions:$provideChatSessionItems(${itemProvider.sessionType})`);
-		const items = await itemProvider.provider.provideChatSessionItems(token) ?? [];
-		if (token.isCancellationRequested) {
-			return [];
-		}
-
-		const response: IChatSessionItem[] = [];
-		for (const sessionContent of items) {
-			this._sessionItems.set(sessionContent.resource, sessionContent);
-			response.push(this.convertChatSessionItem(sessionContent));
-		}
-		return response;
 	}
 
 	async $provideChatSessionContent(handle: number, sessionResourceComponents: UriComponents, token: CancellationToken): Promise<ChatSessionDto> {
@@ -783,6 +766,16 @@ export class ExtHostChatSessions extends Disposable implements ExtHostChatSessio
 			this._logService.error(`Error calling onSearch for option group ${optionGroupId}:`, error);
 			return [];
 		}
+	}
+
+	async $refreshChatSessionItems(handle: number, token: CancellationToken): Promise<void> {
+		const controllerData = this._chatSessionItemControllers.get(handle);
+		if (!controllerData) {
+			this._logService.warn(`No controller found for handle ${handle}`);
+			return;
+		}
+
+		await controllerData.controller.refreshHandler(token);
 	}
 
 	$onDidChangeChatSessionItemState(controllerHandle: number, sessionResourceComponents: UriComponents, archived: boolean): void {

--- a/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatSessions.test.ts
@@ -60,7 +60,7 @@ suite('ObservableChatSession', function () {
 			$interruptChatSessionActiveResponse: sinon.stub(),
 			$invokeChatSessionRequestHandler: sinon.stub(),
 			$disposeChatSessionContent: sinon.stub(),
-			$provideChatSessionItems: sinon.stub(),
+			$refreshChatSessionItems: sinon.stub(),
 			$onDidChangeChatSessionItemState: sinon.stub(),
 		};
 	});
@@ -357,7 +357,7 @@ suite('MainThreadChatSessions', function () {
 			$interruptChatSessionActiveResponse: sinon.stub(),
 			$invokeChatSessionRequestHandler: sinon.stub(),
 			$disposeChatSessionContent: sinon.stub(),
-			$provideChatSessionItems: sinon.stub(),
+			$refreshChatSessionItems: sinon.stub(),
 			$onDidChangeChatSessionItemState: sinon.stub(),
 		};
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -796,6 +796,10 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		const results: Array<{ readonly chatSessionType: string; readonly items: readonly IChatSessionItem[] }> = [];
 		await Promise.all(Array.from(this._itemControllers).map(async ([chatSessionType, controllerEntry]) => {
 			const resolvedType = this._resolveToPrimaryType(chatSessionType) ?? chatSessionType;
+			if (providersToResolve && !providersToResolve.includes(resolvedType)) {
+				return; // skip: not considered for resolving
+			}
+
 			try {
 				await controllerEntry.initialRefresh; // Ensure initial refresh is complete before accessing items
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -851,6 +851,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 		return {
 			dispose: () => {
+				initialRefreshCts.cancel();
 				disposables.dispose();
 
 				const controller = this._itemControllers.get(chatSessionType);

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -228,10 +228,15 @@ export interface IChatSessionsService {
 	getInputPlaceholderForSessionType(chatSessionType: string): string | undefined;
 
 	/**
-	 * Get the list of chat session items grouped by session type.
+	 * Get the list of current chat session items grouped by session type.
 	 * @param providerTypeFilter If specified, only returns items from the given providers. If undefined, returns items from all providers.
 	 */
 	getChatSessionItems(providerTypeFilter: readonly string[] | undefined, token: CancellationToken): Promise<Array<{ readonly chatSessionType: string; readonly items: readonly IChatSessionItem[] }>>;
+
+	/**
+	 * Forces the controllers to refresh their session items, optionally filtered by provider type.
+	 */
+	refreshChatSessionItems(providerTypeFilter: readonly string[] | undefined, token: CancellationToken): Promise<void>;
 
 	reportInProgress(chatSessionType: string, count: number): void;
 	getInProgress(): { displayName: string; count: number }[];

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionViewModel.test.ts
@@ -532,6 +532,9 @@ suite('AgentSessions', () => {
 				};
 
 				mockChatSessionsService.registerChatSessionItemController('test-type', controller);
+				// Registering calls a refresh initially
+				assert.strictEqual(controllerCallCount, 1);
+
 				viewModel = createViewModel();
 
 				// Make multiple rapid resolve calls
@@ -543,8 +546,8 @@ suite('AgentSessions', () => {
 
 				await Promise.all(resolvePromises);
 
-				// Should only call controller once due to throttling
-				assert.strictEqual(controllerCallCount, 1);
+				// Should only call controller once more due to throttling
+				assert.strictEqual(controllerCallCount, 2);
 				assert.strictEqual(viewModel.sessions.length, 1);
 			});
 		});
@@ -590,8 +593,8 @@ suite('AgentSessions', () => {
 				// First resolve all
 				await viewModel.resolve(undefined);
 				assert.strictEqual(viewModel.sessions.length, 2);
-				assert.strictEqual(controller1CallCount, 1);
-				assert.strictEqual(controller2CallCount, 1);
+				assert.strictEqual(controller1CallCount, 2); // One from registration and one from resolve
+				assert.strictEqual(controller2CallCount, 2); // One from registration and one from resolve
 
 				// Now resolve only type-2
 				await viewModel.resolve('type-2');
@@ -599,9 +602,9 @@ suite('AgentSessions', () => {
 				// Should still have only one session
 				assert.strictEqual(viewModel.sessions.length, 1);
 				// Controller 1 should not be called again
-				assert.strictEqual(controller1CallCount, 1);
+				assert.strictEqual(controller1CallCount, 2);
 				// Controller 2 should be called again
-				assert.strictEqual(controller2CallCount, 2);
+				assert.strictEqual(controller2CallCount, 3);
 			});
 		});
 


### PR DESCRIPTION
Continues adopting the controller model (push based) in core. A bit messy since lots of code in core is using read/refresh interchangeably right now

cc @TylerLeonhardt @bpasero 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
