### PR TITLE
Ask @vscode should never open Ask mode, only agent

### DIFF
--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -349,6 +349,7 @@ class AskVSCodeCopilot extends Action2 {
 		const commandService = accessor.get(ICommandService);
 		commandService.executeCommand('workbench.action.chat.open', { mode: 'agent', query: '@vscode ', isPartialQuery: true });
 	
+	}
 }
 
 MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -348,7 +348,7 @@ class AskVSCodeCopilot extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const commandService = accessor.get(ICommandService);
 		commandService.executeCommand('workbench.action.chat.open', { mode: 'agent', query: '@vscode ', isPartialQuery: true });
-	
+
 	}
 }
 

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -347,8 +347,8 @@ class AskVSCodeCopilot extends Action2 {
 
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const commandService = accessor.get(ICommandService);
-		commandService.executeCommand('workbench.action.chat.open', { mode: 'ask', query: '@vscode ', isPartialQuery: true });
-	}
+		commandService.executeCommand('workbench.action.chat.open', { mode: 'agent', query: '@vscode ', isPartialQuery: true });
+	
 }
 
 MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {


### PR DESCRIPTION
Ensures that VS Code always opens the agent, not ask mode, when invoking @vscode from the Help menu.