### PR TITLE
Fix `in` context evaluation on Windows

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -937,11 +937,29 @@ export class ContextKeyInExpr implements IContextKeyExpression {
 
 		if (Array.isArray(source)) {
 			// eslint-disable-next-line local/code-no-any-casts
-			return source.includes(item as any);
+			if (source.includes(item as any)) {
+				return true;
+			}
+			// On Windows, file paths are case-insensitive so file URI
+			// comparisons must be done in a case-insensitive manner.
+			if (isWindows && typeof item === 'string' && item.startsWith('file:///')) {
+				const itemLower = item.toLowerCase();
+				return source.some(s => typeof s === 'string' && s.toLowerCase() === itemLower);
+			}
+			return false;
 		}
 
 		if (typeof item === 'string' && typeof source === 'object' && source !== null) {
-			return hasOwnProperty.call(source, item);
+			if (hasOwnProperty.call(source, item)) {
+				return true;
+			}
+			// On Windows, file paths are case-insensitive so file URI
+			// property lookups must be done in a case-insensitive manner.
+			if (isWindows && item.startsWith('file:///')) {
+				const itemLower = item.toLowerCase();
+				return Object.keys(source).some(key => key.toLowerCase() === itemLower);
+			}
+			return false;
 		}
 		return false;
 	}

--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -183,6 +183,19 @@ suite('ContextKeyExpr', () => {
 		assert.strictEqual(ainb.evaluate(createContext({ 'a': 'x', 'b': { 'x': false } })), true);
 		assert.strictEqual(ainb.evaluate(createContext({ 'a': 'x', 'b': { 'x': true } })), true);
 		assert.strictEqual(ainb.evaluate(createContext({ 'a': 'prototype', 'b': {} })), false);
+
+		// file URI case-insensitive comparison on Windows
+		if (isWindows) {
+			// Array source: file URIs with different casing should match on Windows
+			assert.strictEqual(ainb.evaluate(createContext({ 'a': 'file:///c%3A/Users/path/file.ts', 'b': ['file:///c%3A/users/path/file.ts'] })), true);
+			assert.strictEqual(ainb.evaluate(createContext({ 'a': 'file:///c%3A/users/path/file.ts', 'b': ['file:///c%3A/Users/path/file.ts'] })), true);
+			// Object source: file URIs with different casing should match on Windows
+			assert.strictEqual(ainb.evaluate(createContext({ 'a': 'file:///c%3A/Users/path/file.ts', 'b': { 'file:///c%3A/users/path/file.ts': true } })), true);
+			// Non-file URIs should still be case-sensitive
+			assert.strictEqual(ainb.evaluate(createContext({ 'a': 'git:/path/File.ts', 'b': ['git:/path/file.ts'] })), false);
+			// Exact match still works
+			assert.strictEqual(ainb.evaluate(createContext({ 'a': 'file:///c%3A/Users/path/file.ts', 'b': ['file:///c%3A/Users/path/file.ts'] })), true);
+		}
 	});
 
 	test('ContextKeyNotInExpr', () => {
@@ -198,6 +211,13 @@ suite('ContextKeyExpr', () => {
 		assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'x', 'b': { 'x': false } })), false);
 		assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'x', 'b': { 'x': true } })), false);
 		assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'prototype', 'b': {} })), true);
+
+		// file URI case-insensitive comparison on Windows
+		if (isWindows) {
+			assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'file:///c%3A/Users/path/file.ts', 'b': ['file:///c%3A/users/path/file.ts'] })), false);
+			assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'file:///c%3A/users/path/file.ts', 'b': ['file:///c%3A/Users/path/file.ts'] })), false);
+			assert.strictEqual(aNotInB.evaluate(createContext({ 'a': 'git:/path/File.ts', 'b': ['git:/path/file.ts'] })), true);
+		}
 	});
 
 	test('issue #106524: distributing AND should normalize', () => {


### PR DESCRIPTION
Found this issue with the "Complete Merge" button in the merge editor