### PR TITLE
feat(tree-view) Added configurable left-side action buttons for tree-view

### DIFF
--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -330,6 +330,12 @@
           "description": "%config.npm.scriptHover%",
           "default": true,
           "scope": "window"
+        },
+        "npm.scriptExplorerLeftActions": {
+          "type": "boolean",
+          "description": "%config.npm.scriptExplorerLeftActions%",
+          "default": false,
+          "scope": "window"
         }
       }
     },

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -25,6 +25,7 @@
 	"config.npm.enableRunFromFolder": "Enable running npm scripts contained in a folder from the Explorer context menu.",
 	"config.npm.fetchOnlinePackageInfo": "Fetch data from https://registry.npmjs.org and https://registry.bower.io to provide auto-completion and information on hover features on npm dependencies.",
 	"config.npm.scriptHover": "Display hover with 'Run' and 'Debug' commands for scripts.",
+	"config.npm.scriptExplorerLeftActions": "Keep action buttons on the left side.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
 	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be omitted.",

--- a/extensions/npm/src/npmMain.ts
+++ b/extensions/npm/src/npmMain.ts
@@ -44,7 +44,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 				treeDataProvider.refresh();
 			}
 		}
-		if (e.affectsConfiguration('npm.scriptExplorerAction')) {
+		if (e.affectsConfiguration('npm.scriptExplorerAction') || e.affectsConfiguration('npm.scriptExplorerLeftActions')) {
 			if (treeDataProvider) {
 				treeDataProvider.refresh();
 			}

--- a/extensions/npm/src/npmView.ts
+++ b/extensions/npm/src/npmView.ts
@@ -119,6 +119,9 @@ class NpmScript extends TreeItem {
 			this.tooltip = this.task.detail;
 			this.description = this.task.detail;
 		}
+
+		const enableLeftActions = workspace.getConfiguration('npm').get<boolean>('scriptExplorerLeftActions', false);
+		this.leftActions = enableLeftActions;
 	}
 
 	getFolder(): WorkspaceFolder {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -942,6 +942,7 @@ class ExtHostTreeView<T> extends Disposable {
 			collapsibleState: isUndefinedOrNull(extensionTreeItem.collapsibleState) ? extHostTypes.TreeItemCollapsibleState.None : extensionTreeItem.collapsibleState,
 			accessibilityInformation: extensionTreeItem.accessibilityInformation,
 			checkbox: this._getCheckbox(extensionTreeItem),
+			leftActions: extensionTreeItem.leftActions,
 		};
 
 		return {

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -251,6 +251,35 @@
 	display: block;
 }
 
+
+.customview-tree .monaco-list .monaco-list-row .custom-view-tree-node-item.left-actions .actions {
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	display: none;
+	align-items: center;
+	padding-left: 8px;
+	padding-right: 8px;
+	z-index: 1;
+	/* Gradient background to fade out the label text */
+	background: linear-gradient(to right, transparent 0%, var(--vscode-sideBar-background) 4px, var(--vscode-sideBar-background) 100%);
+}
+
+.customview-tree .monaco-list .monaco-list-row.focused .custom-view-tree-node-item.left-actions .actions {
+	background: linear-gradient(to right, transparent 0%, var(--vscode-list-focusBackground) 4px, var(--vscode-list-focusBackground) 100%);
+}
+
+.customview-tree .monaco-list .monaco-list-row:hover .custom-view-tree-node-item.left-actions .actions {
+	background: linear-gradient(to right, transparent 0%, var(--vscode-list-hoverBackground) 4px, var(--vscode-list-hoverBackground) 100%);
+}
+
+.customview-tree .monaco-list .monaco-list-row:hover .custom-view-tree-node-item.left-actions .actions,
+.customview-tree .monaco-list .monaco-list-row.selected .custom-view-tree-node-item.left-actions .actions,
+.customview-tree .monaco-list .monaco-list-row.focused .custom-view-tree-node-item.left-actions .actions {
+	display: flex;
+}
+
 /* filter view pane */
 
 .monaco-workbench .auxiliarybar.pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item.viewpane-filter-container {

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -1293,7 +1293,7 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 		const checkboxContainer = DOM.append(container, DOM.$(''));
 		const resourceLabel = this.labels.create(container, { supportHighlights: true, hoverDelegate: this._hoverDelegate });
 		const icon = DOM.prepend(resourceLabel.element, DOM.$('.custom-view-tree-node-item-icon'));
-		const actionsContainer = DOM.append(resourceLabel.element, DOM.$('.actions'));
+		const actionsContainer = DOM.append(container, DOM.$('.actions'));
 		const actionBar = new ActionBar(actionsContainer, {
 			actionViewItemProvider: this.actionViewItemProvider
 		});
@@ -1494,6 +1494,13 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 			templateData.actionBar.actionRunner = this._actionRunner;
 		}
 		this.setAlignment(templateData.container, node);
+
+		// Apply left actions class if enabled
+		if (node.leftActions) {
+			templateData.container.classList.add('left-actions');
+		} else {
+			templateData.container.classList.remove('left-actions');
+		}
 
 		// remember rendered element, an element can be rendered multiple times
 		const renderedItems = this._renderedElements.get(element.element.handle) ?? [];

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -768,6 +768,8 @@ export interface ITreeItem {
 	accessibilityInformation?: IAccessibilityInformation;
 
 	checkbox?: ITreeItemCheckboxState;
+
+	leftActions?: boolean;
 }
 
 export class ResolvableTreeItem implements ITreeItem {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -12385,6 +12385,12 @@ declare module 'vscode' {
 		};
 
 		/**
+		 * When set to `true`, action buttons for this tree item will remain visible during horizontal scrolling.
+		 * This is useful for keeping important actions accessible even when the tree item label is scrolled out of view.
+		 */
+		leftActions?: boolean;
+
+		/**
 		 * @param label A human-readable string describing this item
 		 * @param collapsibleState {@link TreeItemCollapsibleState} of the tree item. Default is {@link TreeItemCollapsibleState.None}
 		 */


### PR DESCRIPTION
Fixes #251722

## Summary

This PR introduces an opt-in setting, `npm.scriptExplorerLeftActions`, that allows action buttons in the npm scripts tree view to be positioned on the **left side** of each item. When enabled, action buttons remain visible and accessible, improving usability—especially when horizontal scrolling is present.

## Motivation

Currently, action buttons in the npm scripts tree view scroll along with the content. This can make them hard to reach when script names are long or when horizontal scrolling is required. Providing an option to pin actions to the left improves discoverability and interaction without changing the default behavior.

## Preview
<img width="1491" height="912" alt="Screenshot 2026-02-10 at 3 38 54 PM" src="https://github.com/user-attachments/assets/0dc0a61d-3358-43c8-a493-bf9a24ca8880" />

https://github.com/user-attachments/assets/a17b713c-ea49-4ef8-bddb-b0d8d73a09f1



## Changes

### Core Infrastructure
- Added `leftActions?: boolean` to the public `TreeItem` API  
  (`src/vscode-dts/vscode.d.ts`)
- Extended internal `ITreeItem` interface to carry the `leftActions` property  
  (`src/vs/workbench/common/views.ts`)
- Propagated the property from extension host tree items to the workbench  
  (`src/vs/workbench/api/common/extHostTreeViews.ts`)
- Updated tree view rendering logic to apply a `left-actions` CSS class based on the property  
  (`src/vs/workbench/browser/parts/views/treeView.ts`)

### Styling
- Added styles for the `left-actions` class to position action buttons on the left while preserving correct hover, focus, and selection behavior  
  (`src/vs/workbench/browser/parts/views/media/views.css`)

### NPM Extension
- Added `npm.scriptExplorerLeftActions` configuration setting (default: `false`)  
  (`extensions/npm/package.json`)
- Added localized description for the setting  
  (`extensions/npm/package.nls.json`)
- Updated `NpmScript` to read and apply the configuration  
  (`extensions/npm/src/npmView.ts`)
- Added a configuration change listener to refresh the tree when the setting changes  
  (`extensions/npm/src/npmMain.ts`)
- Removed leftover debug logging and unused comments

## Behavior

- **Without horizontal scrolling**: Action buttons appear consistently on the left, improving visibility.
- **With horizontal scrolling**: Action buttons remain fixed in place while the item content scrolls underneath.

## Testing

1. Open a workspace containing npm scripts
2. Enable the setting `npm.scriptExplorerLeftActions`
3. Verify that action buttons appear on the left side of script items
4. Introduce horizontal scrolling and confirm actions remain visible
5. Disable the setting and confirm the default behavior is restored

## Breaking Changes

None. The behavior is fully opt-in and defaults to `false`, preserving existing UX.