### PR TITLE
Fix chat question title rendering with markdown support

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -62,7 +62,7 @@
 .chat-question-header-row {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	gap: 8px;
 	min-width: 0;
 	padding-bottom: 5px;
@@ -184,6 +184,38 @@
 	font-weight: 500;
 	font-size: var(--vscode-chat-font-size-body-s);
 	margin: 0;
+}
+
+/* Markdown content in title */
+.chat-question-title .rendered-markdown {
+	font-weight: 500;
+	font-size: var(--vscode-chat-font-size-body-s);
+}
+
+.chat-question-title .rendered-markdown p {
+	margin: 0;
+}
+
+.chat-question-title .rendered-markdown p:not(:last-child) {
+	margin-bottom: 4px;
+}
+
+.chat-question-title .rendered-markdown code {
+	font-family: var(--monaco-monospace-font);
+	font-size: 0.9em;
+	background-color: var(--vscode-textCodeBlock-background);
+	padding: 1px 4px;
+	border-radius: 3px;
+}
+
+.chat-question-title .rendered-markdown ul,
+.chat-question-title .rendered-markdown ol {
+	margin: 4px 0;
+	padding-left: 20px;
+}
+
+.chat-question-title .rendered-markdown li {
+	margin: 2px 0;
 }
 
 .chat-question-title-main {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { ChatQuestionCarouselPart, IChatQuestionCarouselOptions } from '../../../../browser/widget/chatContentParts/chatQuestionCarouselPart.js';
@@ -83,6 +84,21 @@ suite('ChatQuestionCarouselPart', () => {
 			assert.ok(title, 'title element should exist when only title is provided');
 			// Title should fall back to title property when message is not provided
 			assert.ok(title?.textContent?.includes('Fallback title text'));
+		});
+
+		test('renders markdown content in question message', () => {
+			const markdownMessage = new MarkdownString('**Bold text** and `code`');
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Question 1', message: markdownMessage }
+			]);
+			createWidget(carousel);
+
+			const title = widget.domNode.querySelector('.chat-question-title');
+			assert.ok(title, 'title element should exist');
+			// When message is IMarkdownString, it should render markdown content
+			const renderedMarkdown = title?.querySelector('.rendered-markdown');
+			assert.ok(renderedMarkdown, 'Should render markdown when message is IMarkdownString');
+			assert.ok(title?.textContent?.includes('Bold text'), 'Should contain the markdown text content');
 		});
 
 		test('renders progress indicator correctly', () => {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/294036

Enhance the chat question title rendering to support markdown formatting. This change allows titles to display formatted text when provided as an `IMarkdownString`. Update tests to verify the correct rendering of markdown content in titles.

<img width="649" height="494" alt="image" src="https://github.com/user-attachments/assets/9a2b6253-4cb4-4e75-8b49-5403af2b8197" />


