### PR TITLE
Terminal: update auto replies configuration

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration.ts
@@ -26,6 +26,7 @@ export const terminalAutoRepliesConfiguration: IStringDictionary<IConfigurationP
 			},
 			{ type: 'null' }]
 		},
+		restricted: true,
 		default: {}
 	},
 };


### PR DESCRIPTION
fix #294200

`terminal.integrated.autoReplies` can cause commands to be repeatedly auto-executed in previously trusted folders, and the behavior persists across folders until a completely new window is opened.

The fix is to mark `terminal.integrated.autoReplies` as `restricted: true`.