### PR TITLE
Allow contributed configurations to define additional "search terms"

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -201,9 +201,9 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	enumItemLabels?: string[];
 
 	/**
-	 * Optional terms used for search purposes.
+	 * Optional keywords used for search purposes.
 	 */
-	searchTerms?: string[];
+	keywords?: string[];
 
 	/**
 	 * When specified, controls the presentation format of string settings.

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -201,6 +201,11 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	enumItemLabels?: string[];
 
 	/**
+	 * Optional terms used for search purposes.
+	 */
+	searchTerms?: string[];
+
+	/**
 	 * When specified, controls the presentation format of string settings.
 	 * Otherwise, the presentation format defaults to `singleline`.
 	 */

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -116,6 +116,13 @@ const configurationEntrySchema: IJSONSchema = {
 								type: 'boolean',
 								description: nls.localize('scope.ignoreSync', 'When enabled, Settings Sync will not sync the user value of this configuration by default.')
 							},
+							searchTerms: {
+								type: 'array',
+								items: {
+									type: 'string'
+								},
+								description: nls.localize('scope.searchTerms', 'A list of additional search terms that help users find this setting in the Settings editor. These are not shown to the user.')
+							},
 							tags: {
 								type: 'array',
 								items: {

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -116,12 +116,12 @@ const configurationEntrySchema: IJSONSchema = {
 								type: 'boolean',
 								description: nls.localize('scope.ignoreSync', 'When enabled, Settings Sync will not sync the user value of this configuration by default.')
 							},
-							searchTerms: {
+							keywords: {
 								type: 'array',
 								items: {
 									type: 'string'
 								},
-								description: nls.localize('scope.searchTerms', 'A list of additional search terms that help users find this setting in the Settings editor. These are not shown to the user.')
+								description: nls.localize('scope.keywords', 'A list of keywords that help users find this setting in the Settings editor. These are not shown to the user.')
 							},
 							tags: {
 								type: 'array',

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -242,9 +242,9 @@ export class SettingMatches {
 		// Search the description if we found non-contiguous key matches at best.
 		const hasContiguousKeyMatchTypes = this.matchType >= SettingMatchType.ContiguousWordsInSettingsLabel;
 		if (this.searchDescription && !hasContiguousKeyMatchTypes) {
-			// Search the description lines and any additional search terms.
-			const searchableLines = setting.searchTerms?.length
-				? [...setting.description, setting.searchTerms.join(' ')]
+			// Search the description lines and any additional keywords.
+			const searchableLines = setting.keywords?.length
+				? [...setting.description, setting.keywords.join(' ')]
 				: setting.description;
 			for (const word of queryWords) {
 				for (let lineIndex = 0; lineIndex < searchableLines.length; lineIndex++) {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -242,10 +242,13 @@ export class SettingMatches {
 		// Search the description if we found non-contiguous key matches at best.
 		const hasContiguousKeyMatchTypes = this.matchType >= SettingMatchType.ContiguousWordsInSettingsLabel;
 		if (this.searchDescription && !hasContiguousKeyMatchTypes) {
+			// Search the description lines and any additional search terms.
+			const searchableLines = setting.searchTerms?.length
+				? [...setting.description, setting.searchTerms.join(' ')]
+				: setting.description;
 			for (const word of queryWords) {
-				// Search the description lines.
-				for (let lineIndex = 0; lineIndex < setting.description.length; lineIndex++) {
-					const descriptionMatches = matchesBaseContiguousSubString(word, setting.description[lineIndex]);
+				for (let lineIndex = 0; lineIndex < searchableLines.length; lineIndex++) {
+					const descriptionMatches = matchesBaseContiguousSubString(word, searchableLines[lineIndex]);
 					if (descriptionMatches?.length) {
 						descriptionMatchingWords.set(word, descriptionMatches.map(match => this.toDescriptionRange(setting, match, lineIndex)));
 					}

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -64,7 +64,7 @@ export interface ISetting {
 	value: any;
 	valueRange: IRange;
 	description: string[];
-	searchTerms?: string[];
+	keywords?: string[];
 	descriptionIsMarkdown?: boolean;
 	descriptionRanges: IRange[];
 	overrides?: ISetting[];

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -64,6 +64,7 @@ export interface ISetting {
 	value: any;
 	valueRange: IRange;
 	description: string[];
+	searchTerms?: string[];
 	descriptionIsMarkdown?: boolean;
 	descriptionRanges: IRange[];
 	overrides?: ISetting[];

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -723,7 +723,7 @@ export class DefaultSettings extends Disposable {
 			value,
 			description: descriptionLines,
 			descriptionIsMarkdown: !!prop.markdownDescription,
-			searchTerms: prop.searchTerms,
+			keywords: prop.keywords,
 			range: nullRange,
 			keyRange: nullRange,
 			valueRange: nullRange,

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -723,6 +723,7 @@ export class DefaultSettings extends Disposable {
 			value,
 			description: descriptionLines,
 			descriptionIsMarkdown: !!prop.markdownDescription,
+			searchTerms: prop.searchTerms,
 			range: nullRange,
 			keyRange: nullRange,
 			valueRange: nullRange,


### PR DESCRIPTION
For #292934

With the current settings, the only way I can get my settings to show up correctly for searches such as "javascript" or "typescript" is the include those words in the setting description. This can make the setting description less clear. I also tried a setting name such as  `javascript/typescript.mySetting`, but this is pretty long and still doesn't show up correctly when searching

This PR proposes a new "searchTerms" field for configurations to solve this. The search terms are basically just added onto the description for search, but are not show to the user. This will let us use a more readable setting id and description for #292934

@sandy081 @rzhao271 Let me know what you think about this proposal. Happy to try other approaches too if you have any suggestions 