### PR TITLE
add more tips, make all of them contextual

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -809,6 +809,24 @@ export function registerChatActions() {
 		}
 	});
 
+	registerAction2(class ShowContextUsageAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.chat.showContextUsage',
+				title: localize2('interactiveSession.showContextUsage.label', "Show Context Window Usage"),
+				category: CHAT_CATEGORY,
+				f1: true,
+				precondition: ChatContextKeys.enabled,
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const widgetService = accessor.get(IChatWidgetService);
+			const widget = widgetService.lastFocusedWidget ?? (await widgetService.revealWidget());
+			widget?.input.showContextUsageDetails();
+		}
+	});
+
 	const nonEnterpriseCopilotUsers = ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.notEquals(`config.${defaultChat.completionsAdvancedSetting}.authProvider`, defaultChat.provider.enterprise.id));
 	registerAction2(class extends Action2 {
 		constructor() {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1699,6 +1699,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
+	 * Shows the context usage details popup and focuses it.
+	 * @returns Whether the details were successfully shown.
+	 */
+	showContextUsageDetails(): boolean {
+		return this.contextUsageWidget?.showDetails() ?? false;
+	}
+
+	/**
 	 * Updates the context usage widget based on the current model.
 	 */
 	private updateContextUsageWidget(): void {

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatContextUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatContextUsageWidget.ts
@@ -13,6 +13,9 @@ import { IObservable, observableValue } from '../../../../../../base/common/obse
 import { localize } from '../../../../../../nls.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
 import { ILanguageModelsService } from '../../../common/languageModels.js';
 import { ChatContextUsageDetails, IChatContextUsageData } from './chatContextUsageDetails.js';
@@ -113,10 +116,16 @@ export class ChatContextUsageWidget extends Disposable {
 
 	private currentData: IChatContextUsageData | undefined;
 
+	private static readonly _OPENED_STORAGE_KEY = 'chat.contextUsage.hasBeenOpened';
+
+	private readonly _contextUsageOpenedKey: IContextKey<boolean>;
+
 	constructor(
 		@IHoverService private readonly hoverService: IHoverService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -131,8 +140,53 @@ export class ChatContextUsageWidget extends Disposable {
 		this.progressIndicator = new CircularProgressIndicator();
 		iconContainer.appendChild(this.progressIndicator.domNode);
 
+		// Track context usage opened state
+		this._contextUsageOpenedKey = ChatContextKeys.contextUsageHasBeenOpened.bindTo(this.contextKeyService);
+
+		// Restore persisted state
+		if (this.storageService.getBoolean(ChatContextUsageWidget._OPENED_STORAGE_KEY, StorageScope.WORKSPACE, false)) {
+			this._contextUsageOpenedKey.set(true);
+		}
+
 		// Set up hover - will be configured when data is available
 		this.setupHover();
+	}
+
+	/**
+	 * Shows the sticky context usage details hover and records that the user
+	 * has opened it. Returns `true` if the details were shown.
+	 */
+	showDetails(): boolean {
+		const details = this._createDetails();
+		if (!details) {
+			return false;
+		}
+		this.hoverService.showInstantHover(
+			{ ...this._hoverOptions, content: details.domNode, target: this.domNode, persistence: { hideOnHover: false, sticky: true } },
+			true
+		);
+		this._markOpened();
+		return true;
+	}
+
+	private readonly _hoverOptions: Omit<IDelayedHoverOptions, 'content'> = {
+		appearance: { showPointer: true, compact: true },
+		persistence: { hideOnHover: false },
+		trapFocus: true
+	};
+
+	private _createDetails(): ChatContextUsageDetails | undefined {
+		if (!this._isVisible.get() || !this.currentData) {
+			return undefined;
+		}
+		this._contextUsageDetails.value = this.instantiationService.createInstance(ChatContextUsageDetails);
+		this._contextUsageDetails.value.update(this.currentData);
+		return this._contextUsageDetails.value;
+	}
+
+	private _markOpened(): void {
+		this._contextUsageOpenedKey.set(true);
+		this.storageService.store(ChatContextUsageWidget._OPENED_STORAGE_KEY, true, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 	}
 
 	private setupHover(): void {
@@ -140,40 +194,15 @@ export class ChatContextUsageWidget extends Disposable {
 		const store = new DisposableStore();
 		this._hoverDisposable.value = store;
 
-		const createDetails = (): ChatContextUsageDetails | undefined => {
-			if (!this._isVisible.get() || !this.currentData) {
-				return undefined;
-			}
-			this._contextUsageDetails.value = this.instantiationService.createInstance(ChatContextUsageDetails);
-			this._contextUsageDetails.value.update(this.currentData);
-			return this._contextUsageDetails.value;
-		};
-
-		const hoverOptions: Omit<IDelayedHoverOptions, 'content'> = {
-			appearance: { showPointer: true, compact: true },
-			persistence: { hideOnHover: false },
-			trapFocus: true
-		};
-
 		store.add(this.hoverService.setupDelayedHover(this.domNode, () => ({
-			...hoverOptions,
-			content: createDetails()?.domNode ?? ''
+			...this._hoverOptions,
+			content: this._createDetails()?.domNode ?? ''
 		})));
-
-		const showStickyHover = () => {
-			const details = createDetails();
-			if (details) {
-				this.hoverService.showInstantHover(
-					{ ...hoverOptions, content: details.domNode, target: this.domNode, persistence: { hideOnHover: false, sticky: true } },
-					true
-				);
-			}
-		};
 
 		// Show sticky + focused hover on click
 		store.add(addDisposableListener(this.domNode, EventType.CLICK, e => {
 			e.stopPropagation();
-			showStickyHover();
+			this.showDetails();
 		}));
 
 		// Show sticky + focused hover on keyboard activation (Space/Enter)
@@ -181,7 +210,7 @@ export class ChatContextUsageWidget extends Disposable {
 			const evt = new StandardKeyboardEvent(e);
 			if (evt.equals(KeyCode.Space) || evt.equals(KeyCode.Enter)) {
 				e.preventDefault();
-				showStickyHover();
+				this.showDetails();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -120,6 +120,8 @@ export namespace ChatContextKeys {
 	export const hasAgentSessionChanges = new RawContextKey<boolean>('agentSessionHasChanges', false, { type: 'boolean', description: localize('agentSessionHasChanges', "True when the current agent session item has changes.") });
 
 	export const isKatexMathElement = new RawContextKey<boolean>('chatIsKatexMathElement', false, { type: 'boolean', description: localize('chatIsKatexMathElement', "True when focusing a KaTeX math element.") });
+
+	export const contextUsageHasBeenOpened = new RawContextKey<boolean>('chatContextUsageHasBeenOpened', false, { type: 'boolean', description: localize('chatContextUsageHasBeenOpened', "True when the user has opened the context window usage details.") });
 }
 
 export namespace ChatContextKeyExprs {


### PR DESCRIPTION
fixes #290019
fixes https://github.com/microsoft/vscode/issues/293536

Added 10 new tips: custom agents, skills, message queueing, yolo mode, mermaid, GitHub repo, subagents, context usage, send to new chat. 

Introduced two new exclusion mechanisms on tip definitions: 
- `excludeWhenToolsInvoked` suppresses a tip after a specific tool has been used
- `excludeWhenPromptFilesExist` suppresses a tip when prompt files of a given type are found in the workspace 

Also adds a new command to focus the `Context Window Usage` widget, so we can allow users to open that from the hint.