### PR TITLE
Remove `IToolInvocationContext.sessionId`

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -186,7 +186,6 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 		if (isProposedApiEnabled(item.extension, 'chatParticipantPrivate')) {
 			options.chatRequestId = dto.chatRequestId;
 			options.chatInteractionId = dto.chatInteractionId;
-			options.chatSessionId = dto.context?.sessionId;
 			options.chatSessionResource = URI.revive(dto.context?.sessionResource);
 			options.subAgentInvocationId = dto.subAgentInvocationId;
 		}
@@ -289,7 +288,6 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 		const options: vscode.LanguageModelToolInvocationPrepareOptions<any> = {
 			input: context.parameters,
 			chatRequestId: context.chatRequestId,
-			chatSessionId: context.chatSessionId,
 			chatSessionResource: context.chatSessionResource,
 			chatInteractionId: context.chatInteractionId,
 			forceConfirmationReason: context.forceConfirmationReason

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3428,7 +3428,7 @@ export namespace ChatAgentRequest {
 			acceptedConfirmationData: request.acceptedConfirmationData,
 			rejectedConfirmationData: request.rejectedConfirmationData,
 			location2,
-			toolInvocationToken: Object.freeze<IToolInvocationContext>({ sessionId, sessionResource: request.sessionResource }) as never,
+			toolInvocationToken: Object.freeze<IToolInvocationContext>({ sessionResource: request.sessionResource }) as never,
 			tools,
 			model,
 			editedFileEvents: request.editedFileEvents,

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -659,7 +659,7 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				'languageModelToolInvoked',
 				{
 					result,
-					chatSessionId: dto.context?.sessionId,
+					chatSessionId: dto.context?.sessionResource ? chatSessionResourceToId(dto.context.sessionResource) : undefined,
 					toolId: tool.data.id,
 					toolExtensionId: tool.data.source.type === 'extension' ? tool.data.source.extensionId.value : undefined,
 					toolSourceKind: tool.data.source.type,
@@ -753,7 +753,6 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 				parameters: dto.parameters,
 				toolCallId: dto.callId,
 				chatRequestId: dto.chatRequestId,
-				chatSessionId: dto.context?.sessionId,
 				chatSessionResource: dto.context?.sessionResource,
 				chatInteractionId: dto.chatInteractionId,
 				modelId: dto.modelId,

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -199,14 +199,12 @@ export interface IToolInvocation {
 }
 
 export interface IToolInvocationContext {
-	/** @deprecated Use {@link sessionResource} instead */
-	readonly sessionId: string;
 	readonly sessionResource: URI;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isToolInvocationContext(obj: any): obj is IToolInvocationContext {
-	return typeof obj === 'object' && typeof obj.sessionId === 'string' && URI.isUri(obj.sessionResource);
+	return typeof obj === 'object' && URI.isUri(obj.sessionResource);
 }
 
 export interface IToolInvocationPreparationContext {
@@ -214,8 +212,6 @@ export interface IToolInvocationPreparationContext {
 	parameters: any;
 	toolCallId: string;
 	chatRequestId?: string;
-	/** @deprecated Use {@link chatSessionResource} instead */
-	chatSessionId?: string;
 	chatSessionResource: URI | undefined;
 	chatInteractionId?: string;
 	modelId?: string;

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -204,7 +204,7 @@ export interface IToolInvocationContext {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isToolInvocationContext(obj: any): obj is IToolInvocationContext {
-	return typeof obj === 'object' && URI.isUri(obj.sessionResource);
+	return obj !== null && typeof obj === 'object' && URI.isUri((obj as any).sessionResource);
 }
 
 export interface IToolInvocationPreparationContext {

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -204,7 +204,7 @@ export interface IToolInvocationContext {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isToolInvocationContext(obj: any): obj is IToolInvocationContext {
-	return obj !== null && typeof obj === 'object' && URI.isUri((obj as any).sessionResource);
+	return obj !== null && typeof obj === 'object' && URI.isUri(obj.sessionResource);
 }
 
 export interface IToolInvocationPreparationContext {

--- a/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/tools/languageModelToolsService.test.ts
@@ -77,7 +77,6 @@ function registerToolForTest(service: LanguageModelToolsService, store: any, id:
 			tokenBudget: 100,
 			parameters,
 			context: context ? {
-				sessionId: context.sessionId,
 				sessionResource: LocalChatSessionUri.forSession(context.sessionId),
 			} : undefined,
 		}),
@@ -2902,7 +2901,6 @@ suite('LanguageModelToolsService', () => {
 			tokenBudget: 100,
 			parameters: { test: 1 },
 			context: {
-				sessionId,
 				sessionResource: LocalChatSessionUri.forSession(sessionId),
 			},
 			chatStreamToolCallId: 'stream-call-id', // This should correlate

--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -19,7 +19,6 @@ import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../plat
 import { ChatElicitationRequestPart } from '../../chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
 import { ChatModel } from '../../chat/common/model/chatModel.js';
 import { ElicitationState, IChatService } from '../../chat/common/chatService/chatService.js';
-import { LocalChatSessionUri } from '../../chat/common/model/chatUri.js';
 import { ElicitationKind, ElicitResult, IFormModeElicitResult, IMcpElicitationService, IMcpServer, IMcpToolCallContext, IUrlModeElicitResult, McpConnectionState, MpcResponseError } from '../common/mcpTypes.js';
 import { mcpServerToSourceData } from '../common/mcpTypesUtils.js';
 import { MCP } from '../common/modelContextProtocol.js';
@@ -85,7 +84,7 @@ export class McpElicitationService implements IMcpElicitationService {
 	private async _elicitForm(server: IMcpServer, context: IMcpToolCallContext | undefined, elicitation: MCP.ElicitRequestFormParams | Pre20251125ElicitationParams, token: CancellationToken): Promise<IFormModeElicitResult> {
 		const store = new DisposableStore();
 		const value = await new Promise<MCP.ElicitResult>(resolve => {
-			const chatModel = context?.chatSessionId && this._chatService.getSession(LocalChatSessionUri.forSession(context.chatSessionId));
+			const chatModel = context?.chatSessionResource && this._chatService.getSession(context.chatSessionResource);
 			if (chatModel instanceof ChatModel) {
 				const request = chatModel.getRequests().at(-1);
 				if (request) {
@@ -152,7 +151,7 @@ export class McpElicitationService implements IMcpElicitationService {
 
 		const store = new DisposableStore();
 		const value = await new Promise<MCP.ElicitResult>(resolve => {
-			const chatModel = context?.chatSessionId && this._chatService.getSession(LocalChatSessionUri.forSession(context.chatSessionId));
+			const chatModel = context?.chatSessionResource && this._chatService.getSession(context.chatSessionResource);
 			if (chatModel instanceof ChatModel) {
 				const request = chatModel.getRequests().at(-1);
 				if (request) {

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -251,7 +251,7 @@ class McpToolImplementation implements IToolImpl {
 			content: []
 		};
 
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, { chatRequestId: invocation.chatRequestId }, token);
+		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, { chatRequestId: invocation.chatRequestId, chatSessionResource: undefined }, token);
 		const details: Mutable<IToolResultInputOutputDetails> = {
 			input: JSON.stringify(invocation.parameters, undefined, 2),
 			output: [],

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -251,7 +251,7 @@ class McpToolImplementation implements IToolImpl {
 			content: []
 		};
 
-		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, { chatRequestId: invocation.chatRequestId, chatSessionId: invocation.context?.sessionId }, token);
+		const callResult = await this._tool.callWithProgress(invocation.parameters as Record<string, unknown>, progress, { chatRequestId: invocation.chatRequestId }, token);
 		const details: Mutable<IToolResultInputOutputDetails> = {
 			input: JSON.stringify(invocation.parameters, undefined, 2),
 			output: [],

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -30,6 +30,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IOutputService } from '../../../services/output/common/output.js';
+import { chatSessionResourceToId } from '../../chat/common/model/chatUri.js';
 import { ToolProgress } from '../../chat/common/tools/languageModelToolsService.js';
 import { mcpActivationEvent } from './mcpConfiguration.js';
 import { McpDevModeServerAttache } from './mcpDevMode.js';
@@ -1069,8 +1070,8 @@ export class McpTool implements IMcpTool {
 			}
 
 			const meta: Record<string, unknown> = { progressToken };
-			if (context?.chatSessionId) {
-				meta['vscode.conversationId'] = context.chatSessionId;
+			if (context?.chatSessionResource) {
+				meta['vscode.conversationId'] = chatSessionResourceToId(context.chatSessionResource);
 			}
 			if (context?.chatRequestId) {
 				meta['vscode.requestId'] = context.chatRequestId;

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -434,7 +434,7 @@ export const mcpPromptPrefix = (definition: McpDefinitionReference) =>
 export interface IMcpPromptMessage extends MCP.PromptMessage { }
 
 export interface IMcpToolCallContext {
-	chatSessionId?: string;
+	chatSessionResource: URI | undefined;
 	chatRequestId?: string;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool.ts
@@ -5,7 +5,6 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolInvocationPresentation, ToolProgress } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { RunInTerminalTool } from './runInTerminalTool.js';
@@ -60,18 +59,6 @@ export const ConfirmTerminalCommandToolData: IToolData = {
 
 export class ConfirmTerminalCommandTool extends RunInTerminalTool {
 	override async prepareToolInvocation(context: IToolInvocationPreparationContext, token: CancellationToken): Promise<IPreparedToolInvocation | undefined> {
-		// Safe-guard: If session is the chat provider specific id
-		// then convert it to the session id understood by chat service
-		try {
-			const sessionUri = context.chatSessionId ? URI.parse(context.chatSessionId) : undefined;
-			const sessionId = sessionUri ? this._chatService.getSession(sessionUri)?.sessionId : undefined;
-			if (sessionId) {
-				context.chatSessionId = sessionId;
-			}
-		}
-		catch {
-			// Ignore parse errors or session lookup failures; fallback to using the original chatSessionId.
-		}
 		const preparedInvocation = await super.prepareToolInvocation(context, token);
 		if (preparedInvocation) {
 			preparedInvocation.presentation = ToolInvocationPresentation.HiddenAfterComplete;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputMonitor.test.ts
@@ -362,5 +362,5 @@ suite('OutputMonitor', () => {
 
 });
 function createTestContext(id: string): IToolInvocationContext {
-	return { sessionId: id, sessionResource: LocalChatSessionUri.forSession(id) };
+	return { sessionResource: LocalChatSessionUri.forSession(id) };
 }

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -262,8 +262,6 @@ declare module 'vscode' {
 
 	export interface LanguageModelToolInvocationOptions<T> {
 		chatRequestId?: string;
-		/** @deprecated Use {@link chatSessionResource} instead */
-		chatSessionId?: string;
 		chatSessionResource?: Uri;
 		chatInteractionId?: string;
 		terminalCommand?: string;
@@ -289,8 +287,6 @@ declare module 'vscode' {
 		 */
 		input: T;
 		chatRequestId?: string;
-		/** @deprecated Use {@link chatSessionResource} instead */
-		chatSessionId?: string;
 		chatSessionResource?: Uri;
 		chatInteractionId?: string;
 		/**


### PR DESCRIPTION
For #274403

We have the sessionResource that should be used instead. Confirmed that this does not seem to be used in copilot

