### PR TITLE
Use font-weight 600 for bold in rendered markdown

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -300,6 +300,10 @@
 	border-color: var(--vscode-textBlockQuote-border);
 }
 
+.interactive-item-container .value .rendered-markdown strong {
+	font-weight: 600;
+}
+
 .interactive-item-container .value .rendered-markdown table {
 	width: 100%;
 	text-align: left;


### PR DESCRIPTION
Sets `font-weight: 600` on `strong` elements in chat rendered markdown for better visual weight.