### PR TITLE
Apply consistent border-radius to tables, code blocks, and code block toolbars in chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/codeBlockPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/codeBlockPart.css
@@ -21,6 +21,7 @@
 	line-height: 26px;
 	background-color: var(--vscode-interactive-result-editor-background-color, var(--vscode-editor-background));
 	border: 1px solid var(--vscode-chat-requestBorder);
+	border-radius: var(--vscode-cornerRadius-medium);
 	z-index: 100;
 	max-width: 70%;
 	text-overflow: ellipsis;
@@ -32,7 +33,6 @@
 }
 
 .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
-	border-radius: 3px;
 	right: 10px;
 }
 
@@ -50,7 +50,6 @@
 .interactive-result-code-block .interactive-result-code-block-toolbar:focus-within,
 .interactive-result-code-block.focused .interactive-result-code-block-toolbar {
 	opacity: 1;
-	border-radius: 2px;
 	pointer-events: auto;
 }
 
@@ -79,7 +78,7 @@
 .interactive-result-code-block,
 .interactive-result-code-block .monaco-editor,
 .interactive-result-code-block .monaco-editor .overflow-guard {
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 }
 
 .interactive-result-code-block .interactive-result-vulns {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -304,14 +304,29 @@
 	width: 100%;
 	text-align: left;
 	margin-bottom: 16px;
+	border-radius: var(--vscode-cornerRadius-medium);
+	overflow: hidden;
+	border-collapse: separate;
+	border-spacing: 0;
+	border: 1px solid var(--vscode-chat-requestBorder);
 }
 
-.interactive-item-container .value .rendered-markdown table,
 .interactive-item-container .value .rendered-markdown table td,
 .interactive-item-container .value .rendered-markdown table th {
 	border: 1px solid var(--vscode-chat-requestBorder);
-	border-collapse: collapse;
+	border-top: none;
+	border-left: none;
 	padding: 4px 6px;
+}
+
+.interactive-item-container .value .rendered-markdown table td:last-child,
+.interactive-item-container .value .rendered-markdown table th:last-child {
+	border-right: none;
+}
+
+.interactive-item-container .value .rendered-markdown table tr:last-child td,
+.interactive-item-container .value .rendered-markdown table tr:last-child th {
+	border-bottom: none;
 }
 
 .interactive-item-container .value .rendered-markdown a,


### PR DESCRIPTION
Applies consistent `var(--vscode-cornerRadius-medium)` border-radius to rendered markdown elements in chat:

- **Tables**: rounded corners with clean cell borders (no doubled borders)
- **Code blocks**: updated from hardcoded `4px` to `var(--vscode-cornerRadius-medium)`
- **Code block toolbars**: added `var(--vscode-cornerRadius-medium)` to the hover toolbar container, removed redundant per-element radius overrides