### PR TITLE
Set textPreformat.background in dark 2026 theme

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -15,6 +15,7 @@
 		"textCodeBlock.background": "#242526",
 		"textLink.foreground": "#48A0C7",
 		"textLink.activeForeground": "#53A5CA",
+		"textPreformat.background": "#262626",
 		"textPreformat.foreground": "#888888",
 		"textSeparator.foreground": "#2a2a2aFF",
 		"button.background": "#3994BCF2",


### PR DESCRIPTION
Adds an explicit `textPreformat.background` color (`#262626`) to the 2026 dark theme for inline code spans in rendered markdown.