### PR TITLE
Chat input styling: border radius, icon colors, toolbar tweaks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -61,7 +61,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		this._primaryActionAction = this._register(new Action(
 			'chat.queuePickerPrimary',
 			isSteerDefault ? localize('chat.steerWithMessage', "Steer with Message") : localize('chat.queueMessage', "Add to Queue"),
-			ThemeIcon.asClassName(Codicon.send),
+			ThemeIcon.asClassName(Codicon.arrowUp),
 			!!contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key),
 			() => this._runDefaultAction()
 		));
@@ -194,7 +194,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			label: localize('chat.sendImmediately', "Stop and Send"),
 			tooltip: '',
 			enabled: true,
-			icon: Codicon.send,
+			icon: Codicon.arrowUp,
 			class: undefined,
 			hover: {
 				content: localize('chat.sendImmediately.hover', "Cancel the current request and send this message immediately."),

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -18,6 +18,8 @@ import { IKeybindingService } from '../../../../../../platform/keybinding/common
 import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { asCssVariable } from '../../../../../../platform/theme/common/colorRegistry.js';
+import { disabledForeground } from '../../../../../../platform/theme/common/colors/baseColors.js';
 import { AgentSessionProviders, backgroundAgentDisplayName, getAgentSessionProvider, getAgentSessionProviderDescription, getAgentSessionProviderIcon, getAgentSessionProviderName, isFirstPartyAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
 import { ISessionTypePickerDelegate } from '../../chat.js';
@@ -197,6 +199,9 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 	}
 
 	protected _getSessionDescription(sessionTypeItem: ISessionTypeItem): string | undefined {
+		if (sessionTypeItem.type === AgentSessionProviders.Background) {
+			return 'Copilot CLI';
+		}
 		return undefined;
 	}
 
@@ -211,6 +216,13 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
 		if (currentType !== AgentSessionProviders.Local || !this.pickerOptions.onlyShowIconsForDefaultActions.get()) {
 			labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
+			if (currentType === AgentSessionProviders.Background) {
+				const suffix = dom.$('span.chat-input-picker-label', undefined, 'Copilot CLI');
+				suffix.style.color = asCssVariable(disabledForeground);
+				suffix.style.marginLeft = '4px';
+				suffix.style.marginRight = '2px';
+				labelElements.push(suffix);
+			}
 		}
 		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -798,7 +798,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	cursor: text;
 	background-color: var(--vscode-input-background);
 	border: 1px solid var(--vscode-input-border, transparent);
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-large);
 	padding: 0 6px 6px 6px;
 	/* top padding is inside the editor widget */
 	width: 100%;
@@ -840,7 +840,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-editor-background);
 	border: 1px solid var(--vscode-input-border, transparent);
 	border-bottom: none;
-	border-radius: 4px 4px 0 0;
+	border-radius: var(--vscode-cornerRadius-large) var(--vscode-cornerRadius-large) 0 0;
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
@@ -934,7 +934,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		border-radius: 2px;
 		border: none;
 		background-color: unset;
-		color: var(--vscode-foreground)
+		color: var(--vscode-descriptionForeground)
 	}
 
 	.monaco-button:focus-visible {
@@ -1314,6 +1314,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding-left: 4px;
 }
 
+.interactive-session .chat-editor-container .monaco-editor .view-lines {
+	padding-left: 4px;
+}
+
 .interactive-session .chat-input-toolbars {
 	display: flex;
 }
@@ -1385,11 +1389,18 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 3px 0px 3px 6px;
 	display: flex;
 	align-items: center;
+	color: var(--vscode-descriptionForeground);
 }
 
 
-.interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
+/* Override dynamically injected foreground color on toolbar icons (doubled class for higher specificity) */
+.monaco-workbench .interactive-session .chat-input-toolbars .monaco-action-bar .action-item .codicon.codicon,
+.monaco-workbench .interactive-session .chat-input-toolbars .action-label .codicon.codicon {
+	color: var(--vscode-descriptionForeground) !important;
+}
+
+.monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
+.monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
 	font-size: 12px;
 	margin-left: 2px;
 }


### PR DESCRIPTION
- Use cornerRadius-large for chat input container and attachment bar
- Swap send icon to arrowUp
- Use descriptionForeground for toolbar icons and picker labels
- Add Copilot CLI suffix label for background agent sessions
- Add editor view-lines padding