### PR TITLE
Update menu separator color and enhance backdrop-filter for context menus

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -94,7 +94,7 @@
 		"menu.foreground": "#bfbfbf",
 		"menu.selectionBackground": "#3994BC26",
 		"menu.selectionForeground": "#bfbfbf",
-		"menu.separatorBackground": "#838485",
+		"menu.separatorBackground": "#2A2B2C",
 		"menu.border": "#2A2B2CFF",
 		"commandCenter.foreground": "#bfbfbf",
 		"commandCenter.activeForeground": "#bfbfbf",

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -284,7 +284,6 @@
 /* Context Menus */
 .monaco-workbench .monaco-menu .monaco-action-bar.vertical {
 	border-radius: var(--radius-lg);
-	border-radius: inherit;
 }
 
 .monaco-workbench .context-view .monaco-menu {

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -283,16 +283,30 @@
 
 /* Context Menus */
 .monaco-workbench .monaco-menu .monaco-action-bar.vertical {
-	box-shadow: var(--shadow-lg);
 	border-radius: var(--radius-lg);
+}
+
+/* Use ::before for backdrop-filter so it doesn't create a containing block
+   for position:fixed submenu children (which would clip them via overflow:hidden). */
+.monaco-workbench .monaco-menu .monaco-action-bar.vertical::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
 	backdrop-filter: var(--backdrop-blur-md);
 	-webkit-backdrop-filter: var(--backdrop-blur-md);
+	z-index: -1;
 }
 
 .monaco-workbench .context-view .monaco-menu {
 	box-shadow: var(--shadow-lg);
 	border: none;
 	border-radius: var(--radius-lg);
+}
+
+.monaco-workbench .monaco-menu-container > .monaco-scrollable-element {
+	border-radius: var(--radius-lg) !important;
+	box-shadow: var(--shadow-lg) !important;
 }
 
 .monaco-workbench .action-widget {

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -284,18 +284,7 @@
 /* Context Menus */
 .monaco-workbench .monaco-menu .monaco-action-bar.vertical {
 	border-radius: var(--radius-lg);
-}
-
-/* Use ::before for backdrop-filter so it doesn't create a containing block
-   for position:fixed submenu children (which would clip them via overflow:hidden). */
-.monaco-workbench .monaco-menu .monaco-action-bar.vertical::before {
-	content: '';
-	position: absolute;
-	inset: 0;
 	border-radius: inherit;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-	z-index: -1;
 }
 
 .monaco-workbench .context-view .monaco-menu {


### PR DESCRIPTION
Improve the visual appearance of context menus by updating the separator color and enhancing the backdrop-filter effect. This change enhances the overall user interface experience.

