### PR TITLE
Ensure gulp min writes the ISO date file

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -15,7 +15,7 @@ import electron from '@vscode/gulp-electron';
 import jsonEditor from 'gulp-json-editor';
 import * as util from './lib/util.ts';
 import { getVersion } from './lib/getVersion.ts';
-import { readISODate } from './lib/date.ts';
+import { readISODate, writeISODate } from './lib/date.ts';
 import * as task from './lib/task.ts';
 import buildfile from './buildfile.ts';
 import * as optimize from './lib/optimize.ts';
@@ -253,6 +253,7 @@ const coreCIEsbuild = task.define('core-ci-esbuild', task.series(
 	cleanExtensionsBuildTask,
 	compileNonNativeExtensionsBuildTask,
 	compileExtensionMediaBuildTask,
+	writeISODate('out-build'),
 	// Type-check with tsgo (no emit)
 	task.define('tsgo-typecheck', () => runTsGoTypeCheck()),
 	// Transpile individual files to out-build first (for unit tests)
@@ -638,6 +639,7 @@ BUILD_TARGETS.forEach(buildTarget => {
 				cleanExtensionsBuildTask,
 				compileNonNativeExtensionsBuildTask,
 				compileExtensionMediaBuildTask,
+				writeISODate('out-build'),
 				esbuildBundleTask,
 				vscodeTaskCI
 			));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Previosuly the build was failing for me with


```
[11:28:13] Error: ENOENT: no such file or directory, open '/Users/lramos15/dev/vscode/out-build/date'
at Object.readFileSync (node:fs:441:20)
at readISODate (file:///Users/lramos15/dev/vscode/build/lib/date.ts:32:12)
at task (/Users/lramos15/dev/vscode/build/gulpfile.vscode.ts:373:37)
at file:///Users/lramos15/dev/vscode/build/lib/task.ts:62:22
at new Promise (<anonymous>)
at _doExecute (file:///Users/lramos15/dev/vscode/build/lib/task.ts:50:9)
at _execute (file:///Users/lramos15/dev/vscode/build/lib/task.ts:40:8)
at result (file:///Users/lramos15/dev/vscode/build/lib/task.ts:85:10)
at async _execute (file:///Users/lramos15/dev/vscode/build/lib/task.ts:40:2)
at async result (file:///Users/lramos15/dev/vscode/build/lib/task.ts:85:4)
npm run gulp vscode-min 144.30s user 20.05s system 329% cpu 49.902 total
```