### PR TITLE
Fix esbuild transpile on Windows

### DIFF
--- a/build/lib/watch/index.ts
+++ b/build/lib/watch/index.ts
@@ -5,7 +5,8 @@
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const watch = process.platform === 'win32' ? require('./watch-win32.ts').default : require('vscode-gulp-watch');
+// Use dynamic import for watch-win32.ts to preserve ESM context (import.meta.dirname)
+const watch = process.platform === 'win32' ? (await import('./watch-win32.ts')).default : require('vscode-gulp-watch');
 
 export default function (...args: any[]): ReturnType<typeof watch> {
 	return watch.apply(null, args);


### PR DESCRIPTION
Copilot's reasoning:

The issue was that watch-win32.ts:14 uses import.meta.dirname, but index.ts was loading it via require(), which doesn't properly support import.meta in that context. Changed to use dynamic import() instead.