### PR TITLE
Enable tsgo by default in the workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,6 +94,7 @@
 		"**/*.snap": true,
 	},
 	// --- TypeScript ---
+	"typescript.experimental.useTsgo": true,
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"typescript.preferences.importModuleSpecifier": "relative",
 	"typescript.preferences.quoteStyle": "single",


### PR DESCRIPTION
Tsgo language tooling should be feature complete at this point. There still may be bugs or more minor gaps, but we want more dogfooding to find these

Enabling tsgo to help with this. It's still easy to switch back to tsc if you run into any work blockers. If you do need to do this, please file an issue and I'll get a fix prioritized 
