### PR TITLE
prompt actions: add extension points for folder and editor overrides

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/hookActions.ts
@@ -96,7 +96,8 @@ async function addHookToFile(
 	fileService: IFileService,
 	editorService: IEditorService,
 	notificationService: INotificationService,
-	bulkEditService: IBulkEditService
+	bulkEditService: IBulkEditService,
+	openEditorOverride?: (resource: URI, options?: { selection?: ITextEditorSelection }) => Promise<void>,
 ): Promise<void> {
 	// Parse existing file
 	let hooksContent: { hooks: Record<string, unknown[]> };
@@ -240,13 +241,17 @@ async function addHookToFile(
 		const selection = findHookCommandSelection(jsonContent, keyToUse, newHookIndex, 'command');
 
 		// Open editor with selection (or re-focus if already open)
-		await editorService.openEditor({
-			resource: hookFileUri,
-			options: {
-				selection,
-				pinned: false
-			}
-		});
+		if (openEditorOverride) {
+			await openEditorOverride(hookFileUri, { selection });
+		} else {
+			await editorService.openEditor({
+				resource: hookFileUri,
+				options: {
+					selection,
+					pinned: false
+				}
+			});
+		}
 	}
 }
 
@@ -291,11 +296,24 @@ const enum Step {
 }
 
 /**
+ * Optional callbacks for customizing the hook creation and opening behaviour.
+ * The agentic editor passes these to open hooks in the embedded editor and
+ * track worktree files for auto-commit.
+ */
+export interface IHookQuickPickCallbacks {
+	/** Override how the hook file is opened. If not provided, uses editorService.openEditor. */
+	readonly openEditor?: (resource: URI, options?: { selection?: ITextEditorSelection }) => Promise<void>;
+	/** Called after a new hook file is created on disk. */
+	readonly onHookFileCreated?: (uri: URI) => void;
+}
+
+/**
  * Shows the Configure Hooks quick pick UI, allowing the user to view,
  * open, or create hooks. Can be called from the action or slash command.
  */
 export async function showConfigureHooksQuickPick(
 	accessor: ServicesAccessor,
+	callbacks?: IHookQuickPickCallbacks,
 ): Promise<void> {
 	const promptsService = accessor.get(IPromptsService);
 	const quickInputService = accessor.get(IQuickInputService);
@@ -470,13 +488,17 @@ export async function showConfigureHooksQuickPick(
 					}
 
 					picker.hide();
-					await editorService.openEditor({
-						resource: entry.fileUri,
-						options: {
-							selection,
-							pinned: false
-						}
-					});
+					if (callbacks?.openEditor) {
+						await callbacks.openEditor(entry.fileUri, { selection });
+					} else {
+						await editorService.openEditor({
+							resource: entry.fileUri,
+							options: {
+								selection,
+								pinned: false
+							}
+						});
+					}
 					return;
 				}
 
@@ -548,7 +570,8 @@ export async function showConfigureHooksQuickPick(
 						fileService,
 						editorService,
 						notificationService,
-						bulkEditService
+						bulkEditService,
+						callbacks?.openEditor,
 					);
 					return;
 				}
@@ -679,7 +702,8 @@ export async function showConfigureHooksQuickPick(
 						fileService,
 						editorService,
 						notificationService,
-						bulkEditService
+						bulkEditService,
+						callbacks?.openEditor,
 					);
 					return;
 				}
@@ -704,18 +728,24 @@ export async function showConfigureHooksQuickPick(
 				const jsonContent = JSON.stringify(hooksContent, null, '\t');
 				await fileService.writeFile(hookFileUri, VSBuffer.fromString(jsonContent));
 
+				callbacks?.onHookFileCreated?.(hookFileUri);
+
 				// Find the selection for the new hook's command field
 				const selection = findHookCommandSelection(jsonContent, hookTypeKey, 0, 'command');
 
 				// Open editor with selection
 				store.dispose();
-				await editorService.openEditor({
-					resource: hookFileUri,
-					options: {
-						selection,
-						pinned: false
-					}
-				});
+				if (callbacks?.openEditor) {
+					await callbacks.openEditor(hookFileUri, { selection });
+				} else {
+					await editorService.openEditor({
+						resource: hookFileUri,
+						options: {
+							selection,
+							pinned: false
+						}
+					});
+				}
 				return;
 			}
 		}


### PR DESCRIPTION
Add INewPromptOptions to AbstractNewPromptFileAction and NewSkillFileAction so callers can pre-resolve the target folder and override how the created file is opened. Add IHookQuickPickCallbacks to showConfigureHooksQuickPick so callers can override editor opening and react to file creation.

When no options are passed, behavior is identical to before.

 This will be used for the AI window experiment to limit code duplication (see 8e691f567)
