### PR TITLE
Sanity test updates

### DIFF
--- a/build/azure-pipelines/product-sanity-tests.yml
+++ b/build/azure-pipelines/product-sanity-tests.yml
@@ -55,6 +55,8 @@ resources:
       # allow-any-unicode-next-line
       source: '⭐️ VS Code'
       trigger:
+        stages:
+          - Publish
         branches:
           include:
             - main

--- a/build/azure-pipelines/product-sanity-tests.yml
+++ b/build/azure-pipelines/product-sanity-tests.yml
@@ -15,6 +15,7 @@ parameters:
   - name: buildCommit
     displayName: Published Build Commit
     type: string
+    default: ''
 
   - name: npmRegistry
     displayName: Custom NPM Registry URL
@@ -27,9 +28,17 @@ variables:
   - name: Codeql.SkipTaskAutoInjection
     value: true
   - name: BUILD_COMMIT
-    value: ${{ parameters.buildCommit }}
+    ${{ if ne(parameters.buildCommit, '') }}:
+      value: ${{ parameters.buildCommit }}
+    ${{ else }}:
+      value: $(resources.pipeline.vscode.sourceCommit)
   - name: BUILD_QUALITY
-    value: ${{ parameters.buildQuality }}
+    ${{ if ne(parameters.buildCommit, '') }}:
+      value: ${{ parameters.buildQuality }}
+    ${{ elseif startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+      value: stable
+    ${{ else }}:
+      value: insider
   - name: NPM_REGISTRY
     value: ${{ parameters.npmRegistry }}
 
@@ -41,6 +50,14 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+  pipelines:
+    - pipeline: vscode
+      source: 'VS Code'
+      trigger:
+        branches:
+          include:
+            - main
+            - release/*
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines

--- a/build/azure-pipelines/product-sanity-tests.yml
+++ b/build/azure-pipelines/product-sanity-tests.yml
@@ -52,7 +52,8 @@ resources:
       ref: refs/tags/release
   pipelines:
     - pipeline: vscode
-      source: 'VS Code'
+      # allow-any-unicode-next-line
+      source: '⭐️ VS Code'
       trigger:
         branches:
           include:

--- a/test/sanity/src/uiTest.ts
+++ b/test/sanity/src/uiTest.ts
@@ -125,7 +125,7 @@ export class UITest {
 
 		this.context.log('Typing extension name to search for');
 		await page.getByText('Search Extensions in Marketplace').focus();
-		await page.keyboard.type('GitHub Pull Requests');
+		await page.keyboard.insertText('GitHub Pull Requests');
 
 		this.context.log('Clicking Install on the first extension in the list');
 		await page.locator('.extension-list-item').getByText(/^GitHub Pull Requests$/).waitFor();


### PR DESCRIPTION
Use `insertText` instead of `type` for extension name to avoid Extensions view reloading multiple times.
Enable sanity tests to run automatically on published builds from `main` and `release/*` branches.
