### PR TITLE
Make chat session item timing properties readonly

### DIFF
--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -102,7 +102,7 @@ declare module 'vscode' {
 		 *
 		 * This is also called on first load to get the initial set of items.
 		 */
-		refreshHandler: (token: CancellationToken) => Thenable<void>;
+		readonly refreshHandler: (token: CancellationToken) => Thenable<void>;
 
 		/**
 		 * Fired when an item's archived state changes.
@@ -204,33 +204,33 @@ declare module 'vscode' {
 			/**
 			 * Timestamp when the session was created in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 			 */
-			created: number;
+			readonly created: number;
 
 			/**
 			 * Timestamp when the most recent request started in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 			 *
 			 * Should be undefined if no requests have been made yet.
 			 */
-			lastRequestStarted?: number;
+			readonly lastRequestStarted?: number;
 
 			/**
 			 * Timestamp when the most recent request completed in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 			 *
 			 * Should be undefined if the most recent request is still in progress or if no requests have been made yet.
 			 */
-			lastRequestEnded?: number;
+			readonly lastRequestEnded?: number;
 
 			/**
 			 * Session start timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 			 * @deprecated Use `created` and `lastRequestStarted` instead.
 			 */
-			startTime?: number;
+			readonly startTime?: number;
 
 			/**
 			 * Session end timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 			 * @deprecated Use `lastRequestEnded` instead.
 			 */
-			endTime?: number;
+			readonly endTime?: number;
 		};
 
 		/**


### PR DESCRIPTION
Clarifying that timing properties can't be updated individually on managed chat session items. If you want the change to apply, you need to re-set the whole property

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
