### PR TITLE
Update update action button styles to match primary VS Code buttons

### DIFF
--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -558,13 +558,12 @@ export class ReleaseNotesManager extends Disposable {
 						font-size: var(--vscode-font-size);
 						font-family: var(--vscode-font-family);
 						white-space: nowrap;
-						box-shadow: 1px 1px 1px rgba(0,0,0,.25);
+						box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 						z-index: 100;
 						overflow: hidden;
 						display: flex;
 						align-items: center;
 						justify-content: center;
-						transition: border-radius 0.25s ease, padding 0.25s ease, width 0.25s ease;
 					}
 
 					#update-action-btn .icon {
@@ -587,16 +586,18 @@ export class ReleaseNotesManager extends Disposable {
 						max-width: 0;
 						opacity: 0;
 						margin-left: 0;
-						transition: max-width 0.25s ease, opacity 0.2s ease, margin-left 0.25s ease;
 					}
 
 					#update-action-btn:hover,
 					#update-action-btn.expanded {
 						background-color: var(--vscode-button-hoverBackground);
-						box-shadow: 2px 2px 2px rgba(0,0,0,.25);
+						box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 						width: auto;
-						border-radius: 20px;
-						padding: 0 14px;
+						height: auto;
+						max-height: 40px;
+						border-radius: var(--vscode-cornerRadius-small);
+						padding: 6px 10px;
+						line-height: 16px;
 					}
 
 					#update-action-btn:hover .label,
@@ -608,6 +609,7 @@ export class ReleaseNotesManager extends Disposable {
 
 					#update-action-btn.expanded {
 						background-color: var(--vscode-button-background);
+						box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 					}
 
 					body.vscode-high-contrast #update-action-btn {


### PR DESCRIPTION
Per UX feedback

Scrolled to the top:
<img width="966" height="443" alt="image" src="https://github.com/user-attachments/assets/e8622213-b754-47ea-b94e-fd4b8fcacedd" />

Scrolled down:
<img width="972" height="399" alt="image" src="https://github.com/user-attachments/assets/87657d16-83b8-47c1-bf40-a12af29f2a4c" />
