### PR TITLE
Add native private field to property transform for esbuild bundles

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -187,6 +187,7 @@ function runEsbuildBundle(outDir: string, minify: boolean, nls: boolean, target:
 		const args = [scriptPath, 'bundle', '--out', outDir, '--target', target];
 		if (minify) {
 			args.push('--minify');
+			args.push('--mangle-privates');
 		}
 		if (nls) {
 			args.push('--nls');

--- a/build/gulpfile.vscode.web.ts
+++ b/build/gulpfile.vscode.web.ts
@@ -39,6 +39,7 @@ function runEsbuildBundle(outDir: string, minify: boolean, nls: boolean): Promis
 		const args = [scriptPath, 'bundle', '--out', outDir, '--target', 'web'];
 		if (minify) {
 			args.push('--minify');
+			args.push('--mangle-privates');
 		}
 		if (nls) {
 			args.push('--nls');

--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -229,18 +229,6 @@ const commonResourcePatterns = [
 	'vs/workbench/browser/parts/editor/media/letterpress*.svg',
 ];
 
-// Resources only needed for dev/transpile builds (these get bundled into the main
-// JS/CSS bundles for production, so separate copies are redundant)
-const devOnlyResourcePatterns = [
-	// Fonts (esbuild file loader copies to media/codicon.ttf for production)
-	'vs/base/browser/ui/codicons/codicon/codicon.ttf',
-
-	// Vendor JavaScript libraries (bundled into workbench main JS for production)
-	'vs/base/common/marked/marked.js',
-	'vs/base/common/semver/semver.js',
-	'vs/base/browser/dompurify/dompurify.js',
-];
-
 // Resources for desktop target
 const desktopResourcePatterns = [
 	...commonResourcePatterns,
@@ -368,28 +356,6 @@ function getResourcePatternsForTarget(target: BuildTarget): string[] {
 	}
 }
 
-// Test fixtures (only copied for development builds, not production)
-const testFixturePatterns = [
-	'**/test/**/*.json',
-	'**/test/**/*.txt',
-	'**/test/**/*.snap',
-	'**/test/**/*.tst',
-	'**/test/**/*.html',
-	'**/test/**/*.js',
-	'**/test/**/*.jxs',
-	'**/test/**/*.tsx',
-	'**/test/**/*.css',
-	'**/test/**/*.png',
-	'**/test/**/*.md',
-	'**/test/**/*.zip',
-	'**/test/**/*.pdf',
-	'**/test/**/*.qwoff',
-	'**/test/**/*.wuff',
-	'**/test/**/*.less',
-	// Files without extensions (executables, etc.)
-	'**/test/**/fixtures/executable/*',
-];
-
 // ============================================================================
 // Utilities
 // ============================================================================
@@ -511,34 +477,57 @@ async function compileStandaloneFiles(outDir: string, doMinify: boolean, target:
 	console.log(`[standalone] Done`);
 }
 
-async function copyCssFiles(outDir: string, excludeTests = false): Promise<number> {
-	// Copy all CSS files from src to output (they're imported by JS)
-	const cssFiles = await globAsync('**/*.css', {
+/**
+ * Copy ALL non-TypeScript files from src/ to the output directory.
+ * This matches the old gulp build behavior where `gulp.src('src/**')` streams
+ * every file and non-TS files bypass the compiler via tsFilter.restore.
+ * Used for development/transpile builds only - production bundles use
+ * copyResources() with curated per-target patterns instead.
+ */
+async function copyAllNonTsFiles(outDir: string, excludeTests: boolean): Promise<void> {
+	console.log(`[resources] Copying all non-TS files to ${outDir}...`);
+
+	const ignorePatterns = [
+		// Exclude .ts files but keep .d.ts files (they're needed at runtime for type references)
+		'**/*.ts',
+	];
+	if (excludeTests) {
+		ignorePatterns.push('**/test/**');
+	}
+
+	const files = await globAsync('**/*', {
+		cwd: path.join(REPO_ROOT, SRC_DIR),
+		nodir: true,
+		ignore: ignorePatterns,
+	});
+
+	// Re-include .d.ts files that were excluded by the *.ts ignore
+	const dtsFiles = await globAsync('**/*.d.ts', {
 		cwd: path.join(REPO_ROOT, SRC_DIR),
 		ignore: excludeTests ? ['**/test/**'] : [],
 	});
 
-	for (const file of cssFiles) {
+	const allFiles = [...new Set([...files, ...dtsFiles])];
+
+	await Promise.all(allFiles.map(file => {
 		const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
 		const destPath = path.join(REPO_ROOT, outDir, file);
+		return copyFile(srcPath, destPath);
+	}));
 
-		await copyFile(srcPath, destPath);
-	}
-
-	return cssFiles.length;
+	console.log(`[resources] Copied ${allFiles.length} files`);
 }
 
-async function copyResources(outDir: string, target: BuildTarget, excludeDevFiles = false, excludeTests = false): Promise<void> {
+/**
+ * Copy curated resource files for production bundles.
+ * Uses specific per-target patterns matching the old build's vscodeResourceIncludes,
+ * serverResourceIncludes, etc. Only called by bundle() - transpile uses copyAllNonTsFiles().
+ */
+async function copyResources(outDir: string, target: BuildTarget): Promise<void> {
 	console.log(`[resources] Copying to ${outDir} for target '${target}'...`);
 	let copied = 0;
 
-	const ignorePatterns: string[] = [];
-	if (excludeTests) {
-		ignorePatterns.push('**/test/**');
-	}
-	if (excludeDevFiles) {
-		ignorePatterns.push('**/*-dev.html');
-	}
+	const ignorePatterns = ['**/test/**', '**/*-dev.html'];
 
 	const resourcePatterns = getResourcePatternsForTarget(target);
 	for (const pattern of resourcePatterns) {
@@ -556,47 +545,7 @@ async function copyResources(outDir: string, target: BuildTarget, excludeDevFile
 		}
 	}
 
-	// Copy test fixtures (only for development builds)
-	if (!excludeTests) {
-		for (const pattern of testFixturePatterns) {
-			const files = await globAsync(pattern, {
-				cwd: path.join(REPO_ROOT, SRC_DIR),
-			});
-
-			for (const file of files) {
-				const srcPath = path.join(REPO_ROOT, SRC_DIR, file);
-				const destPath = path.join(REPO_ROOT, outDir, file);
-
-				await copyFile(srcPath, destPath);
-				copied++;
-			}
-		}
-	}
-
-	// Copy dev-only resources (vendor JS, codicon font) - only for development/transpile
-	// builds. In production bundles these are inlined by esbuild.
-	if (!excludeDevFiles) {
-		for (const pattern of devOnlyResourcePatterns) {
-			const files = await globAsync(pattern, {
-				cwd: path.join(REPO_ROOT, SRC_DIR),
-				ignore: ignorePatterns,
-			});
-			for (const file of files) {
-				await copyFile(path.join(REPO_ROOT, SRC_DIR, file), path.join(REPO_ROOT, outDir, file));
-				copied++;
-			}
-		}
-	}
-
-	// Copy CSS files (only for development/transpile builds, not production bundles
-	// where CSS is already bundled into combined files like workbench.desktop.main.css)
-	if (!excludeDevFiles) {
-		const cssCount = await copyCssFiles(outDir, excludeTests);
-		copied += cssCount;
-		console.log(`[resources] Copied ${copied} files (${cssCount} CSS)`);
-	} else {
-		console.log(`[resources] Copied ${copied} files (CSS skipped - bundled)`);
-	}
+	console.log(`[resources] Copied ${copied} files`);
 }
 
 // ============================================================================
@@ -978,8 +927,8 @@ ${tslib}`,
 		console.log(`[mangle-privates] Total: ${totalClasses} classes, ${totalFields} fields, ${totalEdits} edits, ${totalElapsed}ms`);
 	}
 
-	// Copy resources (exclude dev files and tests for production)
-	await copyResources(outDir, target, true, true);
+	// Copy resources (curated per-target patterns for production)
+	await copyResources(outDir, target);
 
 	// Compile standalone TypeScript files (like Electron preload scripts) that cannot be bundled
 	await compileStandaloneFiles(outDir, doMinify, target);
@@ -1012,7 +961,7 @@ async function watch(): Promise<void> {
 	const t1 = Date.now();
 	try {
 		await transpile(outDir, false);
-		await copyResources(outDir, 'desktop', false, false);
+		await copyAllNonTsFiles(outDir, false);
 		console.log(`Finished transpilation with 0 errors after ${Date.now() - t1} ms`);
 	} catch (err) {
 		console.error('[watch] Initial build failed:', err);
@@ -1063,9 +1012,6 @@ async function watch(): Promise<void> {
 		}
 	};
 
-	// Extensions to watch and copy (non-TypeScript resources)
-	const copyExtensions = ['.css', '.html', '.js', '.json', '.ttf', '.svg', '.png', '.mp3', '.scm', '.sh', '.ps1', '.psm1', '.fish', '.zsh', '.scpt'];
-
 	// Watch src directory using existing gulp-watch based watcher
 	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 	const srcDir = path.join(REPO_ROOT, SRC_DIR);
@@ -1074,7 +1020,8 @@ async function watch(): Promise<void> {
 	watchStream.on('data', (file: { path: string }) => {
 		if (file.path.endsWith('.ts') && !file.path.endsWith('.d.ts')) {
 			pendingTsFiles.add(file.path);
-		} else if (copyExtensions.some(ext => file.path.endsWith(ext))) {
+		} else {
+			// Copy any non-TS file (matches old gulp build's `src/**` behavior)
 			pendingCopyFiles.add(file.path);
 		}
 
@@ -1151,7 +1098,7 @@ async function main(): Promise<void> {
 					console.log(`[transpile] ${SRC_DIR} → ${outDir}${options.excludeTests ? ' (excluding tests)' : ''}`);
 					const t1 = Date.now();
 					await transpile(outDir, options.excludeTests);
-					await copyResources(outDir, 'desktop', false, options.excludeTests);
+					await copyAllNonTsFiles(outDir, options.excludeTests);
 					console.log(`[transpile] Done in ${Date.now() - t1}ms`);
 				}
 				break;

--- a/build/next/private-to-property.ts
+++ b/build/next/private-to-property.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as ts from 'typescript';
+
+/**
+ * Converts native ES private fields (`#foo`) into regular JavaScript properties with short,
+ * globally unique names (e.g., `$a`, `$b`). This achieves two goals:
+ *
+ * 1. **Performance**: Native private fields are slower than regular properties in V8.
+ * 2. **Mangling**: Short replacement names reduce bundle size.
+ *
+ * ## Why not simply strip `#`?
+ *
+ * - **Inheritance collision**: If `class B extends A` and both declare `#x`, stripping `#`
+ *   yields `x` on both - collision on child instances.
+ * - **Public property shadowing**: `class Foo extends Error { static #name = ... }` - stripping
+ *   `#` produces `name` which shadows `Error.name`.
+ *
+ * ## Strategy: Globally unique names with `$` prefix
+ *
+ * Each (class, privateFieldName) pair gets a unique name from a global counter: `$a`, `$b`, ...
+ * This guarantees no inheritance collision and no shadowing of public properties.
+ *
+ * ## Why this is safe with syntax-only analysis
+ *
+ * Native `#` fields are **lexically scoped** to their declaring class body. Every declaration
+ * and every usage site is syntactically inside the class body. A single AST walk is sufficient
+ * to find all sites - no cross-file analysis or type checker needed.
+ */
+
+// Short name generator: $a, $b, ..., $z, $A, ..., $Z, $aa, $ab, ...
+const CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+function generateShortName(index: number): string {
+	let name = '';
+	do {
+		name = CHARS[index % CHARS.length] + name;
+		index = Math.floor(index / CHARS.length) - 1;
+	} while (index >= 0);
+	return '$' + name;
+}
+
+interface Edit {
+	start: number;
+	end: number;
+	newText: string;
+}
+
+// Private name → replacement name per class (identified by position in file)
+type ClassScope = Map<string, string>;
+
+export interface ConvertPrivateFieldsResult {
+	readonly code: string;
+	readonly classCount: number;
+	readonly fieldCount: number;
+	readonly editCount: number;
+	readonly elapsed: number;
+}
+
+/**
+ * Converts all native `#` private fields/methods in the given JavaScript source to regular
+ * properties with short, globally unique names.
+ *
+ * @param code The JavaScript source code (typically a bundled output file).
+ * @param filename Used for TypeScript parser diagnostics only.
+ * @returns The transformed source code with `#` fields replaced, plus stats.
+ */
+export function convertPrivateFields(code: string, filename: string): ConvertPrivateFieldsResult {
+	const t1 = Date.now();
+	// Quick bail-out: if there are no `#` characters, nothing to do
+	if (!code.includes('#')) {
+		return { code, classCount: 0, fieldCount: 0, editCount: 0, elapsed: Date.now() - t1 };
+	}
+
+	const sourceFile = ts.createSourceFile(filename, code, ts.ScriptTarget.ESNext, false, ts.ScriptKind.JS);
+
+	// Global counter for unique name generation
+	let nameCounter = 0;
+	let classCount = 0;
+
+	// Collect all edits
+	const edits: Edit[] = [];
+
+	// Class stack for resolving private names in nested classes.
+	// When a PrivateIdentifier is encountered, we search from innermost to outermost
+	// class scope - matching JS lexical resolution semantics.
+	const classStack: ClassScope[] = [];
+
+	visit(sourceFile);
+
+	if (edits.length === 0) {
+		return { code, classCount: 0, fieldCount: 0, editCount: 0, elapsed: Date.now() - t1 };
+	}
+
+	// Apply edits using substring concatenation (O(N+K), not O(N*K) like char-array splice)
+	edits.sort((a, b) => a.start - b.start);
+	const parts: string[] = [];
+	let lastEnd = 0;
+	for (const edit of edits) {
+		parts.push(code.substring(lastEnd, edit.start));
+		parts.push(edit.newText);
+		lastEnd = edit.end;
+	}
+	parts.push(code.substring(lastEnd));
+	return { code: parts.join(''), classCount, fieldCount: nameCounter, editCount: edits.length, elapsed: Date.now() - t1 };
+
+	// --- AST walking ---
+
+	function visit(node: ts.Node): void {
+		if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+			visitClass(node);
+			return;
+		}
+		ts.forEachChild(node, visit);
+	}
+
+	function visitClass(node: ts.ClassDeclaration | ts.ClassExpression): void {
+		// 1) Collect all private field/method/accessor declarations in THIS class
+		const scope: ClassScope = new Map();
+		for (const member of node.members) {
+			if (member.name && ts.isPrivateIdentifier(member.name)) {
+				const name = member.name.text;
+				if (!scope.has(name)) {
+					scope.set(name, generateShortName(nameCounter++));
+				}
+			}
+		}
+
+		if (scope.size > 0) {
+			classCount++;
+		}
+		classStack.push(scope);
+
+		// 2) Walk the class body, replacing PrivateIdentifier nodes
+		ts.forEachChild(node, function walkInClass(child: ts.Node): void {
+			// Nested class: process independently with its own scope
+			if ((ts.isClassDeclaration(child) || ts.isClassExpression(child)) && child !== node) {
+				visitClass(child);
+				return;
+			}
+
+			// Handle `#field in expr` (ergonomic brand check) - needs string literal replacement
+			if (ts.isBinaryExpression(child) &&
+				child.operatorToken.kind === ts.SyntaxKind.InKeyword &&
+				ts.isPrivateIdentifier(child.left)) {
+				const resolved = resolvePrivateName(child.left.text);
+				if (resolved !== undefined) {
+					edits.push({
+						start: child.left.getStart(sourceFile),
+						end: child.left.getEnd(),
+						newText: `'${resolved}'`
+					});
+				}
+				// Still need to walk the right-hand side for any private field usages
+				ts.forEachChild(child.right, walkInClass);
+				return;
+			}
+
+			// Normal PrivateIdentifier usage (declaration, property access, method call)
+			if (ts.isPrivateIdentifier(child)) {
+				const resolved = resolvePrivateName(child.text);
+				if (resolved !== undefined) {
+					edits.push({
+						start: child.getStart(sourceFile),
+						end: child.getEnd(),
+						newText: resolved
+					});
+				}
+				return;
+			}
+
+			ts.forEachChild(child, walkInClass);
+		});
+
+		classStack.pop();
+	}
+
+	function resolvePrivateName(name: string): string | undefined {
+		// Walk from innermost to outermost class scope (matches JS lexical resolution)
+		for (let i = classStack.length - 1; i >= 0; i--) {
+			const resolved = classStack[i].get(name);
+			if (resolved !== undefined) {
+				return resolved;
+			}
+		}
+		return undefined;
+	}
+}

--- a/build/next/test/private-to-property.test.ts
+++ b/build/next/test/private-to-property.test.ts
@@ -1,0 +1,275 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { convertPrivateFields } from '../private-to-property.ts';
+
+suite('convertPrivateFields', () => {
+
+	test('no # characters — quick bail-out', () => {
+		const result = convertPrivateFields('const x = 1; function foo() { return x; }', 'test.js');
+		assert.strictEqual(result.code, 'const x = 1; function foo() { return x; }');
+		assert.strictEqual(result.editCount, 0);
+		assert.strictEqual(result.classCount, 0);
+		assert.strictEqual(result.fieldCount, 0);
+	});
+
+	test('class without private fields — identity', () => {
+		const code = 'class Plain { x = 1; get() { return this.x; } }';
+		const result = convertPrivateFields(code, 'test.js');
+		assert.strictEqual(result.code, code);
+		assert.strictEqual(result.editCount, 0);
+	});
+
+	test('basic private field', () => {
+		const code = 'class Foo { #x = 1; get() { return this.#x; } }';
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#x'), 'should not contain #x');
+		assert.ok(result.code.includes('$a'), 'should contain replacement $a');
+		assert.strictEqual(result.classCount, 1);
+		assert.strictEqual(result.fieldCount, 1);
+		assert.strictEqual(result.editCount, 2);
+	});
+
+	test('multiple private fields in one class', () => {
+		const code = 'class Foo { #x = 1; #y = 2; get() { return this.#x + this.#y; } }';
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#x'));
+		assert.ok(!result.code.includes('#y'));
+		assert.strictEqual(result.fieldCount, 2);
+		assert.strictEqual(result.editCount, 4);
+	});
+
+	test('inheritance — same private name in parent and child get different replacements', () => {
+		const code = [
+			'class Parent { #a = 1; getA() { return this.#a; } }',
+			'class Child extends Parent { #a = 2; getChildA() { return this.#a; } }',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#a'));
+		assert.ok(result.code.includes('$a'), 'Parent should get $a');
+		assert.ok(result.code.includes('$b'), 'Child should get $b');
+	});
+
+	test('static private field — no clash with inherited public property', () => {
+		const code = [
+			'class MyError extends Error {',
+			'  static #name = "MyError";',
+			'  check(data) { return data.name !== MyError.#name; }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#name'));
+		assert.ok(result.code.includes('$a'));
+		assert.ok(result.code.includes('data.name'), 'public property should be preserved');
+	});
+
+	test('private method', () => {
+		const code = [
+			'class Bar {',
+			'  #normalize(s) { return s.toLowerCase(); }',
+			'  process(s) { return this.#normalize(s); }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#normalize'));
+		assert.strictEqual(result.fieldCount, 1);
+	});
+
+	test('getter/setter pair', () => {
+		const code = [
+			'class WithAccessors {',
+			'  #_val;',
+			'  get #val() { return this.#_val; }',
+			'  set #val(v) { this.#_val = v; }',
+			'  init() { this.#val = 42; }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#_val'));
+		assert.ok(!result.code.includes('#val'));
+		assert.strictEqual(result.fieldCount, 2);
+	});
+
+	test('nested classes — separate scopes', () => {
+		const code = [
+			'class Outer {',
+			'  #x = 1;',
+			'  method() {',
+			'    class Inner {',
+			'      #y = 2;',
+			'      foo() { return this.#y; }',
+			'    }',
+			'    return this.#x;',
+			'  }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#x'));
+		assert.ok(!result.code.includes('#y'));
+		assert.strictEqual(result.classCount, 2);
+	});
+
+	test('nested class accessing outer private field', () => {
+		const code = [
+			'class Outer {',
+			'  #x = 1;',
+			'  method() {',
+			'    class Inner {',
+			'      foo(o) { return o.#x; }',
+			'    }',
+			'    return this.#x;',
+			'  }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#x'));
+		const matches = result.code.match(/\$a/g);
+		assert.strictEqual(matches?.length, 3, 'decl + this.#x + o.#x = 3');
+	});
+
+	test('nested classes — same private name get different replacements', () => {
+		const code = [
+			'class Outer {',
+			'  #x = 1;',
+			'  m() {',
+			'    class Inner {',
+			'      #x = 2;',
+			'      f() { return this.#x; }',
+			'    }',
+			'    return this.#x;',
+			'  }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#x'));
+		assert.ok(result.code.includes('$a'), 'Outer.#x → $a');
+		assert.ok(result.code.includes('$b'), 'Inner.#x → $b');
+	});
+
+	test('unrelated classes with same private name', () => {
+		const code = [
+			'class A { #data = 1; get() { return this.#data; } }',
+			'class B { #data = 2; get() { return this.#data; } }',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#data'));
+		assert.ok(result.code.includes('$a'));
+		assert.ok(result.code.includes('$b'));
+	});
+
+	test('cross-instance access', () => {
+		const code = [
+			'class Foo {',
+			'  #secret = 42;',
+			'  equals(other) { return this.#secret === other.#secret; }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#secret'));
+		const matches = result.code.match(/\$a/g);
+		assert.strictEqual(matches?.length, 3);
+	});
+
+	test('string containing # is not modified', () => {
+		const code = [
+			'class Foo {',
+			'  #x = 1;',
+			'  label = "use #x for private";',
+			'  get() { return this.#x; }',
+			'}',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(result.code.includes('"use #x for private"'), 'string preserved');
+		assert.ok(!result.code.includes('this.#x'), 'usage replaced');
+	});
+
+	test('#field in expr — brand check uses quoted string', () => {
+		const code = 'class Foo { #brand; static check(x) { if (#brand in x) return true; } }';
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(!result.code.includes('#brand'));
+		assert.ok(result.code.includes('\'$a\' in x'), 'quoted string for in-check');
+	});
+
+	test('string #brand in obj is not treated as private field', () => {
+		const code = 'class Foo { #brand = true; isFoo(obj) { return "#brand" in obj; } }';
+		const result = convertPrivateFields(code, 'test.js');
+		assert.ok(result.code.includes('"#brand" in obj'), 'string literal preserved');
+	});
+
+	test('transformed code is valid JavaScript', () => {
+		const code = [
+			'class Base { #id = 0; getId() { return this.#id; } }',
+			'class Derived extends Base { #name; constructor(n) { super(); this.#name = n; } getName() { return this.#name; } }',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.doesNotThrow(() => new Function(result.code));
+	});
+
+	test('transformed code executes correctly', () => {
+		const code = [
+			'class Counter {',
+			'  #count = 0;',
+			'  increment() { this.#count++; }',
+			'  get value() { return this.#count; }',
+			'}',
+			'const c = new Counter();',
+			'c.increment(); c.increment(); c.increment();',
+			'return c.value;',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.strictEqual(new Function(result.code)(), 3);
+	});
+
+	test('transformed code executes correctly with inheritance', () => {
+		const code = [
+			'class Animal {',
+			'  #sound;',
+			'  constructor(s) { this.#sound = s; }',
+			'  speak() { return this.#sound; }',
+			'}',
+			'class Dog extends Animal {',
+			'  #tricks = [];',
+			'  constructor() { super("woof"); }',
+			'  learn(trick) { this.#tricks.push(trick); }',
+			'  show() { return this.#tricks.join(","); }',
+			'}',
+			'const d = new Dog();',
+			'd.learn("sit"); d.learn("shake");',
+			'return d.speak() + ":" + d.show();',
+		].join('\n');
+		const result = convertPrivateFields(code, 'test.js');
+		assert.strictEqual(new Function(result.code)(), 'woof:sit,shake');
+	});
+
+	suite('name generation', () => {
+
+		test('generates $a through $Z for 52 fields', () => {
+			const fields = [];
+			const usages = [];
+			for (let i = 0; i < 52; i++) {
+				fields.push(`#f${i};`);
+				usages.push(`this.#f${i}`);
+			}
+			const code = `class Big { ${fields.join(' ')} get() { return ${usages.join(' + ')}; } }`;
+			const result = convertPrivateFields(code, 'test.js');
+			assert.ok(result.code.includes('$a'));
+			assert.ok(result.code.includes('$Z'));
+			assert.strictEqual(result.fieldCount, 52);
+		});
+
+		test('wraps to $aa after $Z', () => {
+			const fields = [];
+			const usages = [];
+			for (let i = 0; i < 53; i++) {
+				fields.push(`#f${i};`);
+				usages.push(`this.#f${i}`);
+			}
+			const code = `class Big { ${fields.join(' ')} get() { return ${usages.join(' + ')}; } }`;
+			const result = convertPrivateFields(code, 'test.js');
+			assert.ok(result.code.includes('$aa'));
+		});
+	});
+});

--- a/build/package.json
+++ b/build/package.json
@@ -70,7 +70,7 @@
     "pretypecheck": "npm run copy-policy-dto",
     "typecheck": "cd .. && npx tsgo --project build/tsconfig.json",
     "watch": "npm run typecheck -- --watch",
-    "test": "mocha --ui tdd 'lib/**/*.test.ts'"
+    "test": "mocha --ui tdd '{lib,next}/**/*.test.ts'"
   },
   "optionalDependencies": {
     "tree-sitter-typescript": "^0.23.2",


### PR DESCRIPTION
Just re-validated https://issues.chromium.org/issues/42204066, native privates are still slower. But they mangle nice, so we should have this now:

1) team should adopt native privates
2) esbuilt doing full mangling
3) post-processor undoing native privates
