### PR TITLE
Remove backdrop-filter from minimap in dark theme for improved performance

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -560,7 +560,6 @@
 
 /* Minimap */
 
-.monaco-workbench.vs-dark .monaco-editor .minimap,
 .monaco-workbench .monaco-editor .minimap canvas {
 	opacity: 0.85;
 }

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -559,11 +559,8 @@
 }
 
 /* Minimap */
-.monaco-workbench .monaco-editor .minimap {
-	backdrop-filter: var(--backdrop-blur-lg) !important;
-	-webkit-backdrop-filter: var(--backdrop-blur-lg) !important;
-}
 
+.monaco-workbench.vs-dark .monaco-editor .minimap,
 .monaco-workbench .monaco-editor .minimap canvas {
 	opacity: 0.85;
 }


### PR DESCRIPTION
Eliminate the backdrop-filter from the minimap in the dark theme to enhance performance. This change simplifies the rendering process and improves responsiveness. Testing can be done by observing the minimap's performance in the dark theme before and after the change.

