### PR TITLE
chore: lengthen several built-in extension names

### DIFF
--- a/extensions/bat/package.json
+++ b/extensions/bat/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bat",
+  "name": "bat-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/clojure/package.json
+++ b/extensions/clojure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "clojure",
+  "name": "clojure-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/coffeescript/package.json
+++ b/extensions/coffeescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "coffeescript",
+  "name": "coffeescript-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cpp",
+  "name": "cpp-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/csharp/package.json
+++ b/extensions/csharp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "csharp",
+  "name": "csharp-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/css/package.json
+++ b/extensions/css/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "css",
+  "name": "css-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/dart/package.json
+++ b/extensions/dart/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "dart",
+	"name": "dart-language-basics",
 	"displayName": "%displayName%",
 	"description": "%description%",
 	"version": "1.0.0",

--- a/extensions/diff/package.json
+++ b/extensions/diff/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "diff",
+  "name": "diff-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docker",
+  "name": "docker-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/dotenv/package.json
+++ b/extensions/dotenv/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotenv",
+  "name": "dotenv-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/emmet/package-lock.json
+++ b/extensions/emmet/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "emmet",
+  "name": "emmet-support",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "emmet",
+      "name": "emmet-support",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "emmet",
+  "name": "emmet-support",
   "displayName": "Emmet",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/fsharp/package.json
+++ b/extensions/fsharp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fsharp",
+  "name": "fsharp-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/git/package-lock.json
+++ b/extensions/git/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "git",
+  "name": "git-integration",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "git",
+      "name": "git-integration",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "git",
+  "name": "git-integration",
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",

--- a/extensions/github/package-lock.json
+++ b/extensions/github/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github",
+  "name": "github-features",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "github",
+      "name": "github-features",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github",
+  "name": "github-features",
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "go",
+  "name": "go-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "groovy",
+  "name": "groovy-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/grunt/package-lock.json
+++ b/extensions/grunt/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "grunt",
+  "name": "grunt-support",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "grunt",
+      "name": "grunt-support",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/extensions/grunt/package.json
+++ b/extensions/grunt/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grunt",
+  "name": "grunt-support",
   "publisher": "vscode",
   "description": "Extension to add Grunt capabilities to VS Code.",
   "displayName": "Grunt support for VS Code",

--- a/extensions/gulp/package-lock.json
+++ b/extensions/gulp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gulp",
+  "name": "gulp-support",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gulp",
+      "name": "gulp-support",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/extensions/gulp/package.json
+++ b/extensions/gulp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp",
+  "name": "gulp-support",
   "publisher": "vscode",
   "description": "%description%",
   "displayName": "%displayName%",

--- a/extensions/handlebars/package.json
+++ b/extensions/handlebars/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "handlebars",
+  "name": "handlebars-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/hlsl/package.json
+++ b/extensions/hlsl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hlsl",
+  "name": "hlsl-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/html/package.json
+++ b/extensions/html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "html",
+  "name": "html-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ini",
+  "name": "ini-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/ipynb/package-lock.json
+++ b/extensions/ipynb/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ipynb",
+  "name": "ipynb-support",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ipynb",
+      "name": "ipynb-support",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ipynb",
+  "name": "ipynb-support",
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",

--- a/extensions/jake/package-lock.json
+++ b/extensions/jake/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jake",
+  "name": "jake-support",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jake",
+      "name": "jake-support",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/extensions/jake/package.json
+++ b/extensions/jake/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jake",
+  "name": "jake-support",
   "publisher": "vscode",
   "description": "%description%",
   "displayName": "%displayName%",

--- a/extensions/java/package.json
+++ b/extensions/java/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "java",
+  "name": "java-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "javascript",
+  "name": "javascript-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "json",
+  "name": "json-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/julia/package.json
+++ b/extensions/julia/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "julia",
+	"name": "julia-language-basics",
 	"displayName": "%displayName%",
 	"description": "%description%",
 	"version": "1.0.0",

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "latex",
+  "name": "latex-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/less/package.json
+++ b/extensions/less/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "less",
+  "name": "less-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/log/package.json
+++ b/extensions/log/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "log",
+  "name": "log-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/lua/package.json
+++ b/extensions/lua/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lua",
+  "name": "lua-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "make",
+  "name": "make-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown",
+  "name": "markdown-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/npm/package-lock.json
+++ b/extensions/npm/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "npm",
+  "name": "npm-support",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "npm",
+      "name": "npm-support",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm",
+  "name": "npm-support",
   "publisher": "vscode",
   "displayName": "%displayName%",
   "description": "%description%",

--- a/extensions/objective-c/package.json
+++ b/extensions/objective-c/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "objective-c",
+  "name": "objective-c-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/perl/package.json
+++ b/extensions/perl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "perl",
+  "name": "perl-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "php",
+  "name": "php-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "powershell",
+  "name": "powershell-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prompt",
+  "name": "prompt-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/pug/package.json
+++ b/extensions/pug/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pug",
+  "name": "pug-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "python",
+  "name": "python-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/r/package.json
+++ b/extensions/r/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "r",
+  "name": "r-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/razor/package.json
+++ b/extensions/razor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "razor",
+  "name": "razor-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/restructuredtext/package.json
+++ b/extensions/restructuredtext/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "restructuredtext",
+	"name": "restructuredtext-language-basics",
 	"displayName": "%displayName%",
 	"description": "%description%",
 	"version": "1.0.0",

--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ruby",
+  "name": "ruby-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rust",
+  "name": "rust-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/scss/package.json
+++ b/extensions/scss/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scss",
+  "name": "scss-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/shaderlab/package.json
+++ b/extensions/shaderlab/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shaderlab",
+  "name": "shaderlab-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shellscript",
+  "name": "shellscript-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/sql/package.json
+++ b/extensions/sql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sql",
+  "name": "sql-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/swift/package.json
+++ b/extensions/swift/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swift",
+  "name": "swift-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript",
+  "name": "typescript-language-basics",
   "description": "%description%",
   "displayName": "%displayName%",
   "version": "1.0.0",

--- a/extensions/vb/package.json
+++ b/extensions/vb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vb",
+  "name": "vb-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xml",
+  "name": "xml-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",

--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yaml",
+  "name": "yaml-language-basics",
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",
@@ -96,7 +96,7 @@
         "editor.autoIndent": "advanced",
         "diffEditor.ignoreTrimWhitespace": false,
         "editor.defaultColorDecorators": "never",
-        "editor.quickSuggestions": { 
+        "editor.quickSuggestions": {
           "strings": "on"
         }
       },


### PR DESCRIPTION
This PR lengthens several built-in extension names in order to stop Component Governance from mistaking them with NPM packages with the same names.

After this PR is merged, we will be able to revert https://github.com/microsoft/component-detection/pull/1348, re-enable Component Governance scanning for our built-in extensions, and unblock downstream teams. CC @dtivel

This PR does not modify the extensions' display names, and I have also tested it on OSS, though I plan to test it with a custom Insiders build before merging, too.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=406317&view=results