### PR TITLE
chore: bump extension versions

### DIFF
--- a/extensions/bat/package.json
+++ b/extensions/bat/package.json
@@ -2,7 +2,7 @@
   "name": "bat",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/clojure/package.json
+++ b/extensions/clojure/package.json
@@ -2,7 +2,7 @@
   "name": "clojure",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/coffeescript/package.json
+++ b/extensions/coffeescript/package.json
@@ -2,7 +2,7 @@
   "name": "coffeescript",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/configuration-editing/package-lock.json
+++ b/extensions/configuration-editing/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configuration-editing",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configuration-editing",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.1.1",

--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -2,7 +2,7 @@
   "name": "configuration-editing",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -2,7 +2,7 @@
   "name": "cpp",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/csharp/package.json
+++ b/extensions/csharp/package.json
@@ -2,7 +2,7 @@
   "name": "csharp",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/css-language-features/package-lock.json
+++ b/extensions/css-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "css-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "css-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.0-next.18",

--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "css-language-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/css-language-features/server/package-lock.json
+++ b/extensions/css-language-features/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-css-languageserver",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-css-languageserver",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",

--- a/extensions/css-language-features/server/package.json
+++ b/extensions/css-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-css-languageserver",
   "description": "CSS/LESS/SCSS language server",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/extensions/css/package.json
+++ b/extensions/css/package.json
@@ -2,7 +2,7 @@
   "name": "css",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/dart/package.json
+++ b/extensions/dart/package.json
@@ -2,7 +2,7 @@
 	"name": "dart",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "1.0.0",
+	"version": "10.0.0",
 	"publisher": "vscode",
 	"license": "MIT",
 	"engines": {

--- a/extensions/debug-auto-launch/package-lock.json
+++ b/extensions/debug-auto-launch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debug-auto-launch",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debug-auto-launch",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/debug-auto-launch/package.json
+++ b/extensions/debug-auto-launch/package.json
@@ -2,7 +2,7 @@
   "name": "debug-auto-launch",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/debug-server-ready/package-lock.json
+++ b/extensions/debug-server-ready/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debug-server-ready",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debug-server-ready",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/debug-server-ready/package.json
+++ b/extensions/debug-server-ready/package.json
@@ -2,7 +2,7 @@
   "name": "debug-server-ready",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/diff/package.json
+++ b/extensions/diff/package.json
@@ -2,7 +2,7 @@
   "name": "diff",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -2,7 +2,7 @@
   "name": "docker",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/dotenv/package.json
+++ b/extensions/dotenv/package.json
@@ -2,7 +2,7 @@
   "name": "dotenv",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/emmet/package-lock.json
+++ b/extensions/emmet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emmet",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emmet",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -2,7 +2,7 @@
   "name": "emmet",
   "displayName": "Emmet",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/extension-editing/package-lock.json
+++ b/extensions/extension-editing/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extension-editing",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extension-editing",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",

--- a/extensions/extension-editing/package.json
+++ b/extensions/extension-editing/package.json
@@ -2,7 +2,7 @@
   "name": "extension-editing",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/fsharp/package.json
+++ b/extensions/fsharp/package.json
@@ -2,7 +2,7 @@
   "name": "fsharp",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/git-base/package-lock.json
+++ b/extensions/git-base/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-base",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-base",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/git-base/package.json
+++ b/extensions/git-base/package.json
@@ -2,7 +2,7 @@
   "name": "git-base",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/git/package-lock.json
+++ b/extensions/git/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@joaomoreno/unique-names-generator": "^5.2.0",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -4,7 +4,7 @@
   "description": "%description%",
   "publisher": "vscode",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "engines": {
     "vscode": "^1.5.0"
   },

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -2,7 +2,7 @@
   "name": "go",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -2,7 +2,7 @@
   "name": "groovy",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/grunt/package-lock.json
+++ b/extensions/grunt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grunt",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grunt",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/grunt/package.json
+++ b/extensions/grunt/package.json
@@ -3,7 +3,7 @@
   "publisher": "vscode",
   "description": "Extension to add Grunt capabilities to VS Code.",
   "displayName": "Grunt support for VS Code",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "private": true,
   "icon": "images/grunt.png",
   "license": "MIT",

--- a/extensions/gulp/package-lock.json
+++ b/extensions/gulp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gulp",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gulp",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/gulp/package.json
+++ b/extensions/gulp/package.json
@@ -3,7 +3,7 @@
   "publisher": "vscode",
   "description": "%description%",
   "displayName": "%displayName%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "icon": "images/gulp.png",
   "license": "MIT",
   "engines": {

--- a/extensions/handlebars/package.json
+++ b/extensions/handlebars/package.json
@@ -2,7 +2,7 @@
   "name": "handlebars",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/hlsl/package.json
+++ b/extensions/hlsl/package.json
@@ -2,7 +2,7 @@
   "name": "hlsl",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/html-language-features/package-lock.json
+++ b/extensions/html-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "html-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "html-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "html-language-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/extensions/html-language-features/server/package-lock.json
+++ b/extensions/html-language-features/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-html-languageserver",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-html-languageserver",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",

--- a/extensions/html-language-features/server/package.json
+++ b/extensions/html-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-html-languageserver",
   "description": "HTML language server",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {

--- a/extensions/html/package.json
+++ b/extensions/html/package.json
@@ -2,7 +2,7 @@
   "name": "html",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -2,7 +2,7 @@
   "name": "ini",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "private": true,
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/ipynb/package-lock.json
+++ b/extensions/ipynb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipynb",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ipynb",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@enonic/fnv-plus": "^1.3.0",

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "license": "MIT",
   "icon": "media/icon.png",
   "engines": {

--- a/extensions/jake/package-lock.json
+++ b/extensions/jake/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jake",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jake",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/jake/package.json
+++ b/extensions/jake/package.json
@@ -4,7 +4,7 @@
   "description": "%description%",
   "displayName": "%displayName%",
   "icon": "images/cowboy_hat.png",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "license": "MIT",
   "engines": {
     "vscode": "*"

--- a/extensions/java/package.json
+++ b/extensions/java/package.json
@@ -2,7 +2,7 @@
   "name": "java",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -2,7 +2,7 @@
   "name": "javascript",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/json-language-features/package-lock.json
+++ b/extensions/json-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "json-language-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -2,7 +2,7 @@
   "name": "json",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/julia/package.json
+++ b/extensions/julia/package.json
@@ -2,7 +2,7 @@
 	"name": "julia",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "1.0.0",
+	"version": "10.0.0",
 	"publisher": "vscode",
 	"license": "MIT",
 	"engines": {

--- a/extensions/latex/package.json
+++ b/extensions/latex/package.json
@@ -2,7 +2,7 @@
   "name": "latex",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/less/package.json
+++ b/extensions/less/package.json
@@ -2,7 +2,7 @@
   "name": "less",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/log/package.json
+++ b/extensions/log/package.json
@@ -2,7 +2,7 @@
   "name": "log",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/lua/package.json
+++ b/extensions/lua/package.json
@@ -2,7 +2,7 @@
   "name": "lua",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -2,7 +2,7 @@
   "name": "make",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -2,7 +2,7 @@
   "name": "markdown",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-language-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "icon": "icon.png",
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/markdown-math/package-lock.json
+++ b/extensions/markdown-math/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-math",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-math",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/markdown-it-katex": "^1.1.2"

--- a/extensions/markdown-math/package.json
+++ b/extensions/markdown-math/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-math",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "icon": "icon.png",
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/media-preview/package-lock.json
+++ b/extensions/media-preview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "media-preview",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "media-preview",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/extensions/media-preview/package.json
+++ b/extensions/media-preview/package.json
@@ -6,7 +6,7 @@
     "ui",
     "workspace"
   ],
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "icon": "icon.png",
   "license": "MIT",

--- a/extensions/merge-conflict/package-lock.json
+++ b/extensions/merge-conflict/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merge-conflict",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merge-conflict",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8"

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -4,7 +4,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "icon": "media/icon.png",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "license": "MIT",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "engines": {

--- a/extensions/mermaid-chat-features/package-lock.json
+++ b/extensions/mermaid-chat-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mermaid-chat-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mermaid-chat-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.7",

--- a/extensions/mermaid-chat-features/package.json
+++ b/extensions/mermaid-chat-features/package.json
@@ -2,7 +2,7 @@
   "name": "mermaid-chat-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "repository": {

--- a/extensions/notebook-renderers/package-lock.json
+++ b/extensions/notebook-renderers/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "builtin-notebook-renderers",
-	"version": "1.0.0",
+	"version": "10.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "builtin-notebook-renderers",
-			"version": "1.0.0",
+			"version": "10.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jsdom": "^21.1.0",

--- a/extensions/notebook-renderers/package.json
+++ b/extensions/notebook-renderers/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%displayName%",
 	"description": "%description%",
 	"publisher": "vscode",
-	"version": "1.0.0",
+	"version": "10.0.0",
 	"license": "MIT",
 	"icon": "media/icon.png",
 	"engines": {

--- a/extensions/objective-c/package.json
+++ b/extensions/objective-c/package.json
@@ -2,7 +2,7 @@
   "name": "objective-c",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/perl/package.json
+++ b/extensions/perl/package.json
@@ -2,7 +2,7 @@
   "name": "perl",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/php-language-features/package-lock.json
+++ b/extensions/php-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "php-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "php-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "which": "^2.0.2"

--- a/extensions/php-language-features/package.json
+++ b/extensions/php-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "php-language-features",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "icon": "icons/logo.png",

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -2,7 +2,7 @@
   "name": "php",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -2,7 +2,7 @@
   "name": "powershell",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/prompt-basics/package.json
+++ b/extensions/prompt-basics/package.json
@@ -2,7 +2,7 @@
   "name": "prompt",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/pug/package.json
+++ b/extensions/pug/package.json
@@ -2,7 +2,7 @@
   "name": "pug",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -2,7 +2,7 @@
   "name": "python",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/r/package.json
+++ b/extensions/r/package.json
@@ -2,7 +2,7 @@
   "name": "r",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/razor/package.json
+++ b/extensions/razor/package.json
@@ -2,7 +2,7 @@
   "name": "razor",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/references-view/package-lock.json
+++ b/extensions/references-view/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "references-view",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "references-view",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/references-view/package.json
+++ b/extensions/references-view/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "icon": "media/icon.png",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/restructuredtext/package.json
+++ b/extensions/restructuredtext/package.json
@@ -2,7 +2,7 @@
 	"name": "restructuredtext",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "1.0.0",
+	"version": "10.0.0",
 	"publisher": "vscode",
 	"license": "MIT",
 	"engines": {

--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -2,7 +2,7 @@
   "name": "ruby",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -2,7 +2,7 @@
   "name": "rust",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/scss/package.json
+++ b/extensions/scss/package.json
@@ -2,7 +2,7 @@
   "name": "scss",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/search-result/package-lock.json
+++ b/extensions/search-result/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-result",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-result",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.18.10"

--- a/extensions/search-result/package.json
+++ b/extensions/search-result/package.json
@@ -2,7 +2,7 @@
   "name": "search-result",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/extensions/shaderlab/package.json
+++ b/extensions/shaderlab/package.json
@@ -2,7 +2,7 @@
   "name": "shaderlab",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -2,7 +2,7 @@
   "name": "shellscript",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/simple-browser/package-lock.json
+++ b/extensions/simple-browser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-browser",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-browser",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8"

--- a/extensions/simple-browser/package.json
+++ b/extensions/simple-browser/package.json
@@ -5,7 +5,7 @@
   "enabledApiProposals": [
     "externalUriOpener"
   ],
-  "version": "1.0.0",
+  "version": "10.0.0",
   "icon": "media/icon.png",
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/sql/package.json
+++ b/extensions/sql/package.json
@@ -2,7 +2,7 @@
   "name": "sql",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/swift/package.json
+++ b/extensions/swift/package.json
@@ -2,7 +2,7 @@
   "name": "swift",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-abyss/package.json
+++ b/extensions/theme-abyss/package.json
@@ -2,7 +2,7 @@
   "name": "theme-abyss",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -5,7 +5,7 @@
   "categories": [
     "Themes"
   ],
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-kimbie-dark/package.json
+++ b/extensions/theme-kimbie-dark/package.json
@@ -2,7 +2,7 @@
   "name": "theme-kimbie-dark",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-monokai-dimmed/package.json
+++ b/extensions/theme-monokai-dimmed/package.json
@@ -2,7 +2,7 @@
   "name": "theme-monokai-dimmed",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-monokai/package.json
+++ b/extensions/theme-monokai/package.json
@@ -2,7 +2,7 @@
   "name": "theme-monokai",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-quietlight/package.json
+++ b/extensions/theme-quietlight/package.json
@@ -2,7 +2,7 @@
   "name": "theme-quietlight",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-red/package.json
+++ b/extensions/theme-red/package.json
@@ -2,7 +2,7 @@
   "name": "theme-red",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-seti/package.json
+++ b/extensions/theme-seti/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-theme-seti",
   "private": true,
-  "version": "1.0.0",
+  "version": "10.0.0",
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",

--- a/extensions/theme-solarized-dark/package.json
+++ b/extensions/theme-solarized-dark/package.json
@@ -2,7 +2,7 @@
   "name": "theme-solarized-dark",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-solarized-light/package.json
+++ b/extensions/theme-solarized-light/package.json
@@ -2,7 +2,7 @@
   "name": "theme-solarized-light",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/theme-tomorrow-night-blue/package.json
+++ b/extensions/theme-tomorrow-night-blue/package.json
@@ -2,7 +2,7 @@
   "name": "theme-tomorrow-night-blue",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/tunnel-forwarding/package-lock.json
+++ b/extensions/tunnel-forwarding/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tunnel-forwarding",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tunnel-forwarding",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.x"

--- a/extensions/tunnel-forwarding/package.json
+++ b/extensions/tunnel-forwarding/package.json
@@ -2,7 +2,7 @@
   "name": "tunnel-forwarding",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -2,7 +2,7 @@
   "name": "typescript",
   "description": "%description%",
   "displayName": "%displayName%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "author": "vscode",
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/typescript-language-features/package-lock.json
+++ b/extensions/typescript-language-features/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-language-features",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-language-features",
-      "version": "1.0.0",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-language-features",
   "description": "%description%",
   "displayName": "%displayName%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "author": "vscode",
   "publisher": "vscode",
   "license": "MIT",

--- a/extensions/vb/package.json
+++ b/extensions/vb/package.json
@@ -2,7 +2,7 @@
   "name": "vb",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -2,7 +2,7 @@
   "name": "xml",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {

--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -2,7 +2,7 @@
   "name": "yaml",
   "displayName": "%displayName%",
   "description": "%description%",
-  "version": "1.0.0",
+  "version": "10.0.0",
   "publisher": "vscode",
   "license": "MIT",
   "engines": {
@@ -96,7 +96,7 @@
         "editor.autoIndent": "advanced",
         "diffEditor.ignoreTrimWhitespace": false,
         "editor.defaultColorDecorators": "never",
-        "editor.quickSuggestions": { 
+        "editor.quickSuggestions": {
           "strings": "on"
         }
       },


### PR DESCRIPTION
This PR bumps the version number of several built-in extensions in order to stop Component Governance (CG) from flagging them as outdated. CG currently does not distinguish between VS Code built-in extensions and published third-party npm packages with the same names.

After this PR is merged, we will be able to revert microsoft/component-detection#1348, re-enable Component Governance scanning for our built-in extensions, and unblock downstream teams. CC @dtivel

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=406336&view=results