### PR TITLE
Fix typescript.tsdk path resolution when path starts with workspace folder name

### DIFF
--- a/extensions/typescript-language-features/src/utils/relativePathResolver.ts
+++ b/extensions/typescript-language-features/src/utils/relativePathResolver.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 export class RelativeWorkspacePathResolver {
 	public static asAbsoluteWorkspacePath(relativePath: string): string | undefined {
 		for (const root of vscode.workspace.workspaceFolders || []) {
-			const rootPrefixes = [`./${root.name}/`, `${root.name}/`, `.\\${root.name}\\`, `${root.name}\\`];
+			const rootPrefixes = [`./${root.name}/`, `.\\${root.name}\\`];
 			for (const rootPrefix of rootPrefixes) {
 				if (relativePath.startsWith(rootPrefix)) {
 					return path.join(root.uri.fsPath, relativePath.replace(rootPrefix, ''));


### PR DESCRIPTION
## Problem

When a workspace folder is named `x` and `typescript.tsdk` is set to `x/.yarn/sdks/typescript/lib`, the path resolves incorrectly to `<workspace>/.yarn/sdks/typescript/lib` instead of `<workspace>/x/.yarn/sdks/typescript/lib`.

This happens because `RelativeWorkspacePathResolver` matches the bare workspace folder name prefix (`x/`) in addition to the explicit dot-slash form (`./x/`). When a subdirectory happens to share the workspace folder's name, the bare prefix match incorrectly strips it.

## Fix

Remove the bare workspace folder name prefixes (`name/`, `name\\`) from the prefix list, keeping only the explicit dot-slash forms (`./name/`, `.\\name\\`).

The original implementation ([733e208](https://github.com/microsoft/vscode/commit/733e208be4cfa85e5a1b2e2ea415843f0a9a7b6d)) only matched the `./name/` form. The bare prefix was inadvertently introduced in [d3cd393](https://github.com/microsoft/vscode/commit/d3cd393e95e195afd84f8692e158f9904e70e167) when the logic was extracted into `RelativeWorkspacePathResolver`.

## Workaround (no longer needed)

Previously users could work around this with `"typescript.tsdk": ".//x/.yarn/sdks/typescript/lib"`.

Fixes #272761