### PR TITLE
Skip bash shell integration on busybox ash

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -3,6 +3,11 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 
+# Skip shell integration for non-bash shells (e.g. busybox ash symlinked as /bin/bash)
+if [ -z "${BASH_VERSION-}" ]; then
+	return 2>/dev/null || :
+fi
+
 # Prevent the script recursing when setting up
 if [[ -n "${VSCODE_SHELL_INTEGRATION:-}" ]]; then
 	builtin return


### PR DESCRIPTION
## Problem

On Alpine Linux and similar embedded/minimal systems, `/bin/bash` may be a symlink to busybox ash. When VS Code injects the bash shell integration script, it causes a cascade of errors because the script uses bash-specific features (`[[ ]]`, `builtin`, `BASH_VERSINFO`, arrays, etc.) that busybox ash doesn't support.

## Fix

Add a POSIX-compatible guard at the very top of `shellIntegration-bash.sh` that checks for `$BASH_VERSION`. Real bash always sets this variable; busybox ash (even when symlinked as `/bin/bash`) does not.

The check uses:
- `[ ]` instead of `[[ ]]` for POSIX compatibility
- `${BASH_VERSION-}` (POSIX parameter expansion) to handle unset variables
- `return 2>/dev/null || :` to exit cleanly whether sourced or executed

This is a minimal, zero-risk change for real bash since `$BASH_VERSION` is always set there.

Fixes #170868