### PR TITLE
Support prompt file slash commands in background agents

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -168,6 +168,10 @@ const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsEx
 						supportsSymbolAttachments: {
 							description: localize('chatSessionsExtPoint.supportsSymbolAttachments', 'Whether this chat session supports attaching symbols.'),
 							type: 'boolean'
+						},
+						supportsPromptAttachments: {
+							description: localize('chatSessionsExtPoint.supportsPromptAttachments', 'Whether this chat session supports attaching prompts.'),
+							type: 'boolean'
 						}
 					}
 				},

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -164,6 +164,7 @@ const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
 	supportsProblemAttachments: true,
 	supportsSymbolAttachments: true,
 	supportsTerminalAttachments: true,
+	supportsPromptAttachments: true,
 };
 
 const DISCLAIMER = localize('chatDisclaimer', "AI responses may be inaccurate.");
@@ -315,6 +316,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				.parseChatRequest(this.viewModel.sessionResource, this.getInput(), this.location, {
 					selectedAgent: this._lastSelectedAgent,
 					mode: this.input.currentModeKind,
+					attachmentCapabilities: this.attachmentCapabilities,
 					forcedAgent: this._lockedAgent?.id ? this.chatAgentService.getAgent(this._lockedAgent.id) : undefined
 				});
 			this._onDidChangeParsedInput.fire();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -197,7 +197,7 @@ class SlashCommandCompletions extends Disposable {
 					return null;
 				}
 
-				if (widget.lockedAgentId) {
+				if (widget.lockedAgentId && !widget.attachmentCapabilities.supportsPromptAttachments) {
 					return null;
 				}
 

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -50,6 +50,7 @@ export interface IChatAgentAttachmentCapabilities {
 	supportsProblemAttachments?: boolean;
 	supportsSymbolAttachments?: boolean;
 	supportsTerminalAttachments?: boolean;
+	supportsPromptAttachments?: boolean;
 }
 
 export interface IChatAgentData {

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -9,7 +9,7 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { IChatVariablesService, IDynamicVariable } from '../attachments/chatVariables.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
-import { IChatAgentData, IChatAgentService } from '../participants/chatAgents.js';
+import { IChatAgentAttachmentCapabilities, IChatAgentData, IChatAgentService } from '../participants/chatAgents.js';
 import { IChatSlashCommandService } from '../participants/chatSlashCommands.js';
 import { IPromptsService } from '../promptSyntax/service/promptsService.js';
 import { IToolData, IToolSet, isToolSet } from '../tools/languageModelToolsService.js';
@@ -25,6 +25,7 @@ export interface IChatParserContext {
 	mode?: ChatModeKind;
 	/** Parse as this agent, even when it does not appear in the query text */
 	forcedAgent?: IChatAgentData;
+	attachmentCapabilities?: IChatAgentAttachmentCapabilities;
 }
 
 export class ChatRequestParser {
@@ -215,7 +216,9 @@ export class ChatRequestParser {
 				// Valid agent subcommand
 				return new ChatRequestAgentSubcommandPart(slashRange, slashEditorRange, subCommand);
 			}
-		} else {
+		}
+
+		if (!usedAgent || context?.attachmentCapabilities?.supportsPromptAttachments) {
 			const slashCommands = this.slashCommandService.getCommands(location, context?.mode ?? ChatModeKind.Ask);
 			const slashCommand = slashCommands.find(c => c.command === command);
 			if (slashCommand) {

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -234,7 +234,7 @@ export class ChatRequestParser {
 				}
 			}
 
-			// if there's no agent, asume it is a prompt slash command
+			// if there's no agent or attachments are supported, asume it is a prompt slash command
 			const isPromptCommand = this.promptsService.isValidSlashCommandName(command);
 			if (isPromptCommand) {
 				return new ChatRequestSlashPromptPart(slashRange, slashEditorRange, command);

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_subcommand_still_takes_priority_with_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_agent_subcommand_still_takes_priority_with_supportsPromptAttachments.0.snap
@@ -1,0 +1,85 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 7
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 8
+      },
+      text: " ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 7,
+        endExclusive: 18
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 8,
+        endLineNumber: 1,
+        endColumn: 19
+      },
+      command: {
+        name: "subCommand",
+        description: ""
+      },
+      kind: "subcommand"
+    },
+    {
+      range: {
+        start: 18,
+        endExclusive: 31
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 19,
+        endLineNumber: 1,
+        endColumn: 32
+      },
+      text: " do something",
+      kind: "text"
+    }
+  ],
+  text: "@agent /subCommand do something"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_prompt_slash_command_with_agent_and_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_prompt_slash_command_with_agent_and_supportsPromptAttachments.0.snap
@@ -1,0 +1,82 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 7
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 8
+      },
+      text: " ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 7,
+        endExclusive: 16
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 8,
+        endLineNumber: 1,
+        endColumn: 17
+      },
+      name: "myPrompt",
+      kind: "prompt"
+    },
+    {
+      range: {
+        start: 16,
+        endExclusive: 29
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 17,
+        endLineNumber: 1,
+        endColumn: 30
+      },
+      text: " do something",
+      kind: "text"
+    }
+  ],
+  text: "@agent /myPrompt do something"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_prompt_slash_command_with_agent_but_no_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_prompt_slash_command_with_agent_but_no_supportsPromptAttachments.0.snap
@@ -1,0 +1,54 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 29
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 30
+      },
+      text: " /myPrompt do something",
+      kind: "text"
+    }
+  ],
+  text: "@agent /myPrompt do something"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_slash_command_with_agent_and_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_slash_command_with_agent_and_supportsPromptAttachments.0.snap
@@ -1,0 +1,82 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 7
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 8
+      },
+      text: " ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 7,
+        endExclusive: 11
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 8,
+        endLineNumber: 1,
+        endColumn: 12
+      },
+      slashCommand: { command: "fix" },
+      kind: "slash"
+    },
+    {
+      range: {
+        start: 11,
+        endExclusive: 16
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 12,
+        endLineNumber: 1,
+        endColumn: 17
+      },
+      text: " this",
+      kind: "text"
+    }
+  ],
+  text: "@agent /fix this"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -347,4 +347,97 @@ suite('ChatRequestParser', () => {
 		const result = parser.parseChatRequest(testSessionUri, '@agent Please \ndo /subCommand with #selection\nand #debugConsole');
 		await assertSnapshot(result);
 	});
+
+	test('prompt slash command with agent and supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({});
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatAgentService, agentsService as any);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.isValidSlashCommandName.callsFake((command: string) => {
+			return !!command.match(/^[\w_\-\.]+$/);
+		});
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /myPrompt do something', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: true }
+		});
+		await assertSnapshot(result);
+	});
+
+	test('prompt slash command with agent but no supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({});
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatAgentService, agentsService as any);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.isValidSlashCommandName.callsFake((command: string) => {
+			return !!command.match(/^[\w_\-\.]+$/);
+		});
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /myPrompt do something', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: false }
+		});
+		await assertSnapshot(result);
+	});
+
+	test('agent subcommand still takes priority with supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({});
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatAgentService, agentsService as any);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		const promptSlashCommandService = mockObject<IPromptsService>()({});
+		promptSlashCommandService.isValidSlashCommandName.callsFake((command: string) => {
+			return !!command.match(/^[\w_\-\.]+$/);
+		});
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IPromptsService, promptSlashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /subCommand do something', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: true }
+		});
+		await assertSnapshot(result);
+	});
+
+	test('slash command with agent and supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({});
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatAgentService, agentsService as any);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({});
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		// eslint-disable-next-line local/code-no-any-casts
+		instantiationService.stub(IChatSlashCommandService, slashCommandService as any);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /fix this', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: true }
+		});
+		await assertSnapshot(result);
+	});
 });


### PR DESCRIPTION
Enhance background agents to support prompt file slash commands. Update tests to ensure functionality.

