### PR TITLE
fix(chatAgentTools): auto-exit Vim on alternate-buffer entry in run-in-terminal flow Closes #295088

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -13,7 +13,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import { trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
-import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
+import { createAltBufferPromise, setupRecreatingStartMarker, tryAutoExitVim } from './strategyHelpers.js';
 
 /**
  * This strategy is used when shell integration is enabled, but rich command detection was not
@@ -133,12 +133,14 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 				throw new Error('The terminal was closed');
 			}
 			if (onDoneResult && onDoneResult.type === 'alternateBuffer') {
+				const attemptedAutoExitVim = await tryAutoExitVim(this._instance, commandLine, this._log.bind(this));
 				this._log('Detected alternate buffer entry, skipping output capture');
 				return {
 					output: undefined,
 					exitCode: undefined,
 					error: 'alternateBuffer',
-					didEnterAltBuffer: true
+					didEnterAltBuffer: true,
+					attemptedAutoExitVim,
 				};
 			}
 			const finishedCommand = onDoneResult && onDoneResult.type === 'success' ? onDoneResult.command : undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -30,6 +30,7 @@ export interface ITerminalExecuteStrategyResult {
 	exitCode?: number;
 	error?: string;
 	didEnterAltBuffer?: boolean;
+	attemptedAutoExitVim?: boolean;
 }
 
 export async function waitForIdle(onData: Event<unknown>, idleDurationMs: number): Promise<void> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -11,7 +11,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import { waitForIdle, waitForIdleWithPromptHeuristics, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
-import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
+import { createAltBufferPromise, setupRecreatingStartMarker, tryAutoExitVim } from './strategyHelpers.js';
 
 /**
  * This strategy is used when no shell integration is available. There are very few extension APIs
@@ -86,6 +86,7 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 				alternateBufferPromise.then(() => 'alternateBuffer' as const)
 			]);
 			if (promptResultOrAltBuffer === 'alternateBuffer') {
+				const attemptedAutoExitVim = await tryAutoExitVim(this._instance, commandLine, this._log.bind(this));
 				this._log('Detected alternate buffer entry, skipping output capture');
 				return {
 					output: undefined,
@@ -93,6 +94,7 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 					exitCode: undefined,
 					error: 'alternateBuffer',
 					didEnterAltBuffer: true,
+					attemptedAutoExitVim,
 				};
 			}
 			const promptResult = promptResultOrAltBuffer;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -13,7 +13,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
-import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
+import { createAltBufferPromise, setupRecreatingStartMarker, tryAutoExitVim } from './strategyHelpers.js';
 
 /**
  * This strategy is used when the terminal has rich shell integration/command detection is
@@ -87,12 +87,14 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 				throw new Error('The terminal was closed');
 			}
 			if (onDoneResult && onDoneResult.type === 'alternateBuffer') {
+				const attemptedAutoExitVim = await tryAutoExitVim(this._instance, commandLine, this._log.bind(this));
 				this._log('Detected alternate buffer entry, skipping output capture');
 				return {
 					output: undefined,
 					exitCode: undefined,
 					error: 'alternateBuffer',
-					didEnterAltBuffer: true
+					didEnterAltBuffer: true,
+					attemptedAutoExitVim,
 				};
 			}
 			const finishedCommand = onDoneResult && onDoneResult.type === 'success' ? onDoneResult.command : undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
@@ -7,6 +7,12 @@ import { DeferredPromise } from '../../../../../../base/common/async.js';
 import { DisposableStore, MutableDisposable, toDisposable, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
+interface IVimTerminalLike {
+	readonly processName?: string;
+	readonly title?: string;
+	sendText(text: string, addNewLine: boolean): Promise<void> | void;
+}
+
 /**
  * Sets up a recreating start marker which is resilient to prompts that clear/re-render (eg. transient
  * or powerlevel10k style prompts). The marker is recreated at the cursor position whenever the
@@ -69,4 +75,30 @@ export function createAltBufferPromise(
 	}
 
 	return deferred.p;
+}
+
+function _containsVimToken(value: string | undefined): boolean {
+	if (!value) {
+		return false;
+	}
+	return /(?:^|[^a-z0-9_])(n?vim|vi|view)(?:\.exe)?(?:$|[^a-z0-9_])/i.test(value);
+}
+
+export function shouldAutoExitVim(instance: IVimTerminalLike, commandLine: string): boolean {
+	return _containsVimToken(instance.processName) || _containsVimToken(instance.title) || _containsVimToken(commandLine);
+}
+
+export async function tryAutoExitVim(instance: IVimTerminalLike, commandLine: string, log?: (message: string) => void): Promise<boolean> {
+	if (!shouldAutoExitVim(instance, commandLine)) {
+		return false;
+	}
+
+	try {
+		log?.('Likely Vim state detected, sending "Esc :q Enter"');
+		await Promise.resolve(instance.sendText('\x1b:q\r', false));
+		return true;
+	} catch (error) {
+		log?.('Failed to send Vim exit sequence');
+		return false;
+	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -876,7 +876,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 						const state = toolSpecificData.terminalCommandState ?? {};
 						state.timestamp = state.timestamp ?? timingStart;
 						toolSpecificData.terminalCommandState = state;
-						toolResultMessage = altBufferMessage;
+						toolResultMessage = executeResult.attemptedAutoExitVim
+							? altBufferMessage + '\n' + localize('runInTerminalTool.altBufferMessage.autoExitVim', "Detected Vim and sent ':q' to exit.")
+							: altBufferMessage;
 						outputLineCount = 0;
 						error = executeResult.error ?? 'alternateBuffer';
 						altBufferResult = {
@@ -886,7 +888,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 							},
 							content: [{
 								kind: 'text',
-								value: altBufferMessage,
+								value: toolResultMessage,
 							}]
 						};
 					} else {


### PR DESCRIPTION
This PR fixes a Copilot terminal edge case where commands that enter Vim/vi (alternate-buffer mode) can leave run_in_terminal hanging until timeout.

What changed
Added Vim-state detection in chat agent terminal execute flow (checks process/title/command hints).
When alternate-buffer entry is detected and Vim is likely active, sends an auto-exit sequence: Esc :q Enter.
Applied behavior consistently across all execute strategies:
rich shell integration
basic shell integration
no shell integration
Extended execute result metadata with [attemptedAutoExitVim](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Updated terminal tool user message to indicate when Vim auto-exit was attempted.

Validation
Type/error checks passed on all touched files with no reported diagnostics.

Repro steps

Start a Copilot terminal run (non-background or awaited background).
Execute a command that opens Vim (example: vim file.txt).
Observe the run status.
Notice it does not complete until timeout/manual quit.