### PR TITLE
Add generate commands for agent customization primitives and prompt run telemetry

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -76,6 +76,12 @@ export const CHAT_SETUP_ACTION_ID = 'workbench.action.chat.triggerSetup';
 export const CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID = 'workbench.action.chat.triggerSetupSupportAnonymousAction';
 const TOGGLE_CHAT_ACTION_ID = 'workbench.action.chat.toggle';
 
+export const GENERATE_INSTRUCTIONS_COMMAND_ID = 'workbench.action.chat.generateInstructions';
+export const GENERATE_INSTRUCTION_COMMAND_ID = 'workbench.action.chat.generateInstruction';
+export const GENERATE_PROMPT_COMMAND_ID = 'workbench.action.chat.generatePrompt';
+export const GENERATE_SKILL_COMMAND_ID = 'workbench.action.chat.generateSkill';
+export const GENERATE_AGENT_COMMAND_ID = 'workbench.action.chat.generateAgent';
+
 const defaultChat = {
 	manageSettingsUrl: product.defaultChatAgent?.manageSettingsUrl ?? '',
 	provider: product.defaultChatAgent?.provider ?? { enterprise: { id: '' } },
@@ -1094,12 +1100,12 @@ export function registerChatActions() {
 		}
 	});
 
-	registerAction2(class UpdateInstructionsAction extends Action2 {
+	registerAction2(class GenerateInstructionsAction extends Action2 {
 		constructor() {
 			super({
-				id: 'workbench.action.chat.generateInstructions',
-				title: localize2('generateInstructions', "Generate Workspace Instructions File"),
-				shortTitle: localize2('generateInstructions.short', "Generate Chat Instructions"),
+				id: GENERATE_INSTRUCTIONS_COMMAND_ID,
+				title: localize2('generateInstructions', "Generate Workspace Instructions with Agent"),
+				shortTitle: localize2('generateInstructions.short', "Generate Instructions with Agent"),
 				category: CHAT_CATEGORY,
 				icon: Codicon.sparkle,
 				f1: true,
@@ -1109,31 +1115,102 @@ export function registerChatActions() {
 
 		async run(accessor: ServicesAccessor): Promise<void> {
 			const commandService = accessor.get(ICommandService);
-
-			// Use chat command to open and send the query
-			const query = `Analyze this codebase to generate or update \`.github/copilot-instructions.md\` for guiding AI coding agents.
-
-Focus on discovering the essential knowledge that would help an AI agents be immediately productive in this codebase. Consider aspects like:
-- The "big picture" architecture that requires reading multiple files to understand - major components, service boundaries, data flows, and the "why" behind structural decisions
-- Critical developer workflows (builds, tests, debugging) especially commands that aren't obvious from file inspection alone
-- Project-specific conventions and patterns that differ from common practices
-- Integration points, external dependencies, and cross-component communication patterns
-
-Source existing AI conventions from \`**/{.github/copilot-instructions.md,AGENT.md,AGENTS.md,CLAUDE.md,.cursorrules,.windsurfrules,.clinerules,.cursor/rules/**,.windsurf/rules/**,.clinerules/**,README.md}\` (do one glob search).
-
-Guidelines (read more at https://aka.ms/vscode-instructions-docs):
-- If \`.github/copilot-instructions.md\` exists, merge intelligently - preserve valuable content while updating outdated sections
-- Write concise, actionable instructions (~20-50 lines) using markdown structure
-- Include specific examples from the codebase when describing patterns
-- Avoid generic advice ("write tests", "handle errors") - focus on THIS project's specific approaches
-- Document only discoverable patterns, not aspirational practices
-- Reference key files/directories that exemplify important patterns
-
-Update \`.github/copilot-instructions.md\` for the user, then ask for feedback on any unclear or incomplete sections to iterate.`;
-
 			await commandService.executeCommand('workbench.action.chat.open', {
 				mode: 'agent',
-				query: query,
+				query: '/init',
+				isPartialQuery: false,
+			});
+		}
+	});
+
+	registerAction2(class GenerateInstructionAction extends Action2 {
+		constructor() {
+			super({
+				id: GENERATE_INSTRUCTION_COMMAND_ID,
+				title: localize2('generateInstruction', "Generate On-demand Instruction with Agent"),
+				shortTitle: localize2('generateInstruction.short', "Generate Instruction with Agent"),
+				category: CHAT_CATEGORY,
+				icon: Codicon.sparkle,
+				f1: true,
+				precondition: ChatContextKeys.enabled
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.chat.open', {
+				mode: 'agent',
+				query: '/create-instruction ',
+				isPartialQuery: true,
+			});
+		}
+	});
+
+	registerAction2(class GeneratePromptAction extends Action2 {
+		constructor() {
+			super({
+				id: GENERATE_PROMPT_COMMAND_ID,
+				title: localize2('generatePrompt', "Generate Prompt File with Agent"),
+				shortTitle: localize2('generatePrompt.short', "Generate Prompt with Agent"),
+				category: CHAT_CATEGORY,
+				icon: Codicon.sparkle,
+				f1: true,
+				precondition: ChatContextKeys.enabled
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.chat.open', {
+				mode: 'agent',
+				query: '/create-prompt ',
+				isPartialQuery: true,
+			});
+		}
+	});
+
+	registerAction2(class GenerateSkillAction extends Action2 {
+		constructor() {
+			super({
+				id: GENERATE_SKILL_COMMAND_ID,
+				title: localize2('generateSkill', "Generate Skill with Agent"),
+				shortTitle: localize2('generateSkill.short', "Generate Skill with Agent"),
+				category: CHAT_CATEGORY,
+				icon: Codicon.sparkle,
+				f1: true,
+				precondition: ChatContextKeys.enabled
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.chat.open', {
+				mode: 'agent',
+				query: '/create-skill ',
+				isPartialQuery: true,
+			});
+		}
+	});
+
+	registerAction2(class GenerateAgentAction extends Action2 {
+		constructor() {
+			super({
+				id: GENERATE_AGENT_COMMAND_ID,
+				title: localize2('generateAgent', "Generate Custom Agent with Agent"),
+				shortTitle: localize2('generateAgent.short', "Generate Agent with Agent"),
+				category: CHAT_CATEGORY,
+				icon: Codicon.sparkle,
+				f1: true,
+				precondition: ChatContextKeys.enabled
+			});
+		}
+
+		async run(accessor: ServicesAccessor): Promise<void> {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.chat.open', {
+				mode: 'agent',
+				query: '/create-agent ',
+				isPartialQuery: true,
 			});
 		}
 	});

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/newPromptFileActions.ts
@@ -172,6 +172,9 @@ function getDefaultContentSnippet(promptType: PromptsType, name: string | undefi
 				`name: ${name ?? '${1:prompt-name}'}`,
 				`description: \${2:Describe when to use this prompt}`,
 				`---`,
+				``,
+				`<!-- Tip: Use /create-prompt in chat to generate content with agent assistance -->`,
+				``,
 				`\${3:Define the prompt content here. You can include instructions, examples, and any other relevant information to guide the AI's responses.}`,
 			].join('\n');
 		case PromptsType.instructions:
@@ -182,14 +185,20 @@ function getDefaultContentSnippet(promptType: PromptsType, name: string | undefi
 					`paths:`,
 					`. - "src/**/*.ts"`,
 					`---`,
+					``,
+					`<!-- Tip: Use /create-instruction in chat to generate content with agent assistance -->`,
+					``,
 					`\${2:Provide coding guidelines that AI should follow when generating code, answering questions, or reviewing changes.}`,
 				].join('\n');
 			} else {
 				return [
 					`---`,
-					`description: \${1:Describe when these instructions should be loaded}`,
+					`description: \${1:Describe when these instructions should be loaded by the agent based on task context}`,
 					`# applyTo: '\${1|**,**/*.ts|}' # when provided, instructions will automatically be added to the request context when the pattern matches an attached file`,
 					`---`,
+					``,
+					`<!-- Tip: Use /create-instruction in chat to generate content with agent assistance -->`,
+					``,
 					`\${2:Provide project context and coding guidelines that AI should follow when generating code, answering questions, or reviewing changes.}`,
 				].join('\n');
 			}
@@ -201,6 +210,9 @@ function getDefaultContentSnippet(promptType: PromptsType, name: string | undefi
 					`description: \${2:Describe what this custom agent does and when to use it.}`,
 					`tools: Read, Grep, Glob, Bash # specify the tools this agent can use. If not set, all enabled tools are allowed.`,
 					`---`,
+					``,
+					`<!-- Tip: Use /create-agent in chat to generate content with agent assistance -->`,
+					``,
 					`\${4:Define what this custom agent does, including its behavior, capabilities, and any specific instructions for its operation.}`,
 				].join('\n');
 			} else {
@@ -211,6 +223,9 @@ function getDefaultContentSnippet(promptType: PromptsType, name: string | undefi
 					`argument-hint: \${3:The inputs this agent expects, e.g., "a task to implement" or "a question to answer".}`,
 					`# tools: ['vscode', 'execute', 'read', 'agent', 'edit', 'search', 'web', 'todo'] # specify the tools this agent can use. If not set, all enabled tools are allowed.`,
 					`---`,
+					``,
+					`<!-- Tip: Use /create-agent in chat to generate content with agent assistance -->`,
+					``,
 					`\${4:Define what this custom agent does, including its behavior, capabilities, and any specific instructions for its operation.}`,
 				].join('\n');
 			}
@@ -220,6 +235,9 @@ function getDefaultContentSnippet(promptType: PromptsType, name: string | undefi
 				`name: ${name ?? '${1:skill-name}'}`,
 				`description: \${2:Describe what this skill does and when to use it. Include keywords that help agents identify relevant tasks.}`,
 				`---`,
+				``,
+				`<!-- Tip: Use /create-skill in chat to generate content with agent assistance -->`,
+				``,
 				`\${3:Define the functionality provided by this skill, including detailed instructions and examples}`,
 			].join('\n');
 		default:

--- a/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptSyntax/pickers/promptFilePickers.ts
@@ -17,6 +17,7 @@ import { ICommandService } from '../../../../../../platform/commands/common/comm
 import { getCleanPromptName } from '../../../common/promptSyntax/config/promptFileLocations.js';
 import { PromptsType, INSTRUCTIONS_DOCUMENTATION_URL, AGENT_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL, SKILL_DOCUMENTATION_URL, HOOK_DOCUMENTATION_URL } from '../../../common/promptSyntax/promptTypes.js';
 import { NEW_PROMPT_COMMAND_ID, NEW_INSTRUCTIONS_COMMAND_ID, NEW_AGENT_COMMAND_ID, NEW_SKILL_COMMAND_ID } from '../newPromptFileActions.js';
+import { GENERATE_INSTRUCTIONS_COMMAND_ID, GENERATE_INSTRUCTION_COMMAND_ID, GENERATE_PROMPT_COMMAND_ID, GENERATE_SKILL_COMMAND_ID, GENERATE_AGENT_COMMAND_ID } from '../../actions/chatActions.js';
 import { IKeyMods, IQuickInputButton, IQuickInputService, IQuickPick, IQuickPickItem, IQuickPickItemButtonEvent, IQuickPickSeparator } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { askForPromptFileName } from './askForPromptName.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
@@ -168,18 +169,33 @@ const NEW_INSTRUCTIONS_FILE_OPTION: IPromptPickerQuickPickItem = {
 };
 
 /**
- * A quick pick item that starts the 'Update Instructions' command.
+ * A quick pick item that starts the 'Generate Workspace Instructions' command.
  */
-const UPDATE_INSTRUCTIONS_OPTION: IPromptPickerQuickPickItem = {
+const GENERATE_WORKSPACE_INSTRUCTIONS_OPTION: IPromptPickerQuickPickItem = {
 	type: 'item',
-	label: `$(refresh) ${localize(
-		'commands.update-instructions.select-dialog.label',
-		'Generate agent instructions...',
+	label: `$(sparkle) ${localize(
+		'commands.generate-workspace-instructions.select-dialog.label',
+		'Generate workspace instructions with agent...',
 	)}`,
 	pickable: false,
 	alwaysShow: true,
 	buttons: [newHelpButton(PromptsType.instructions)],
-	commandId: 'workbench.action.chat.generateInstructions',
+	commandId: GENERATE_INSTRUCTIONS_COMMAND_ID,
+};
+
+/**
+ * A quick pick item that starts the 'Generate On-demand Instruction' command.
+ */
+const GENERATE_INSTRUCTION_OPTION: IPromptPickerQuickPickItem = {
+	type: 'item',
+	label: `$(sparkle) ${localize(
+		'commands.generate-instruction.select-dialog.label',
+		'Generate on-demand instruction with agent...',
+	)}`,
+	pickable: false,
+	alwaysShow: true,
+	buttons: [newHelpButton(PromptsType.instructions)],
+	commandId: GENERATE_INSTRUCTION_COMMAND_ID,
 };
 
 /**
@@ -210,6 +226,51 @@ const NEW_SKILL_FILE_OPTION: IPromptPickerQuickPickItem = {
 	alwaysShow: true,
 	buttons: [newHelpButton(PromptsType.skill)],
 	commandId: NEW_SKILL_COMMAND_ID,
+};
+
+/**
+ * A quick pick item that generates a prompt file with agent.
+ */
+const GENERATE_PROMPT_OPTION: IPromptPickerQuickPickItem = {
+	type: 'item',
+	label: `$(sparkle) ${localize(
+		'commands.generate-prompt.select-dialog.label',
+		'Generate prompt with agent...',
+	)}`,
+	pickable: false,
+	alwaysShow: true,
+	buttons: [newHelpButton(PromptsType.prompt)],
+	commandId: GENERATE_PROMPT_COMMAND_ID,
+};
+
+/**
+ * A quick pick item that generates a skill with agent.
+ */
+const GENERATE_SKILL_OPTION: IPromptPickerQuickPickItem = {
+	type: 'item',
+	label: `$(sparkle) ${localize(
+		'commands.generate-skill.select-dialog.label',
+		'Generate skill with agent...',
+	)}`,
+	pickable: false,
+	alwaysShow: true,
+	buttons: [newHelpButton(PromptsType.skill)],
+	commandId: GENERATE_SKILL_COMMAND_ID,
+};
+
+/**
+ * A quick pick item that generates a custom agent with agent.
+ */
+const GENERATE_AGENT_OPTION: IPromptPickerQuickPickItem = {
+	type: 'item',
+	label: `$(sparkle) ${localize(
+		'commands.generate-agent.select-dialog.label',
+		'Generate agent with agent...',
+	)}`,
+	pickable: false,
+	alwaysShow: true,
+	buttons: [newHelpButton(PromptsType.agent)],
+	commandId: GENERATE_AGENT_COMMAND_ID,
 };
 
 /**
@@ -462,13 +523,13 @@ export class PromptFilePickers {
 	private _getNewItems(type: PromptsType): IPromptPickerQuickPickItem[] {
 		switch (type) {
 			case PromptsType.prompt:
-				return [NEW_PROMPT_FILE_OPTION];
+				return [NEW_PROMPT_FILE_OPTION, GENERATE_PROMPT_OPTION];
 			case PromptsType.instructions:
-				return [NEW_INSTRUCTIONS_FILE_OPTION, UPDATE_INSTRUCTIONS_OPTION];
+				return [NEW_INSTRUCTIONS_FILE_OPTION, GENERATE_INSTRUCTION_OPTION, GENERATE_WORKSPACE_INSTRUCTIONS_OPTION];
 			case PromptsType.agent:
-				return [NEW_AGENT_FILE_OPTION];
+				return [NEW_AGENT_FILE_OPTION, GENERATE_AGENT_OPTION];
 			case PromptsType.skill:
-				return [NEW_SKILL_FILE_OPTION];
+				return [NEW_SKILL_FILE_OPTION, GENERATE_SKILL_OPTION];
 			default:
 				throw new Error(`Unknown prompt type '${type}'.`);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -13,6 +13,7 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
+import { hash } from '../../../../../base/common/hash.js';
 import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, thenIfNotDisposed } from '../../../../../base/common/lifecycle.js';
@@ -67,7 +68,7 @@ import { ILanguageModelToolsService, isToolSet } from '../../common/tools/langua
 import { ComputeAutomaticInstructions } from '../../common/promptSyntax/computeAutomaticInstructions.js';
 import { PromptsConfig } from '../../common/promptSyntax/config/config.js';
 import { IHandOff, PromptHeader } from '../../common/promptSyntax/promptFileParser.js';
-import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
+import { IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { handleModeSwitch } from '../actions/chatActions.js';
 import { ChatTreeItem, IChatAcceptInputOptions, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatListItemRendererOptions, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewModelChangeEvent, IChatWidgetViewOptions, isIChatResourceViewContext, isIChatViewViewContext } from '../chat.js';
 import { ChatAttachmentModel } from '../attachments/chatAttachmentModel.js';
@@ -151,6 +152,22 @@ type ChatHandoffWidgetShownClassification = {
 	comment: 'Event fired when the suggest-next widget is shown with handoff prompts';
 	agent: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The current agent/mode that has handoffs defined' };
 	handoffCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Number of handoff options shown to the user' };
+};
+
+type ChatPromptRunEvent = {
+	storage: PromptsStorage;
+	extensionId?: string;
+	promptName?: string;
+	promptNameHash?: string;
+};
+
+type ChatPromptRunClassification = {
+	owner: 'digitarald';
+	comment: 'Event fired when a prompt slash command is resolved into a follow instructions request';
+	storage: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Where the prompt is stored (local, user, extension).' };
+	extensionId?: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Identifier of the extension that contributed the prompt, when applicable.' };
+	promptName?: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Name of the core or extension-contributed prompt.' };
+	promptNameHash?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Hashed name of local or user prompt for privacy.' };
 };
 
 const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
@@ -2162,6 +2179,18 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		// remove the slash command from the input
 		requestInput.input = this.parsedInput.parts.filter(part => !(part instanceof ChatRequestSlashPromptPart)).map(part => part.text).join('').trim();
+
+		const promptPath = slashCommand.promptPath;
+		const promptRunEvent: ChatPromptRunEvent = {
+			storage: promptPath.storage,
+		};
+		if (promptPath.storage === PromptsStorage.extension) {
+			promptRunEvent.extensionId = promptPath.extension.identifier.value;
+			promptRunEvent.promptName = slashCommand.name;
+		} else {
+			promptRunEvent.promptNameHash = hash(slashCommand.name).toString(16);
+		}
+		this.telemetryService.publicLog2<ChatPromptRunEvent, ChatPromptRunClassification>('chat.promptRun', promptRunEvent);
 
 		const input = requestInput.input.trim();
 		requestInput.input = `Follow instructions in [${basename(parseResult.uri)}](${parseResult.uri.toString()}).`;


### PR DESCRIPTION
## Summary

Adds dedicated command palette actions for generating agent customization files (instructions, prompts, skills, agents) via agent mode, and adds telemetry for prompt slash command runs.

## Changes

### Generate commands (`chatActions.ts`)
- Export command IDs for all generate actions: `GENERATE_INSTRUCTIONS_COMMAND_ID`, `GENERATE_INSTRUCTION_COMMAND_ID`, `GENERATE_PROMPT_COMMAND_ID`, `GENERATE_SKILL_COMMAND_ID`, `GENERATE_AGENT_COMMAND_ID`
- Refactor `GenerateInstructionsAction` to use `/init` slash command instead of inline prompt text
- Add new actions: `GenerateInstructionAction` (`/create-instruction`), `GeneratePromptAction` (`/create-prompt`), `GenerateSkillAction` (`/create-skill`), `GenerateAgentAction` (`/create-agent`)
- All actions open agent mode with the appropriate slash command, using `isPartialQuery: true` for parameterized ones

### Prompt file pickers (`promptFilePickers.ts`)
- Add generate options (sparkle icon) to all prompt type quick picks alongside existing "New..." options
- Instructions picker: `Generate on-demand instruction with agent...` + `Generate workspace instructions with agent...`
- Prompts/Skills/Agents pickers: corresponding generate options

### Default content snippets (`newPromptFileActions.ts`)
- Add `<!-- Tip: Use /create-* in chat to generate content with agent assistance -->` comments to all new file templates

### Prompt run telemetry (`chatWidget.ts`)
- Add `chat.promptRun` telemetry event when a prompt slash command is resolved
- Tracks `storage` (local/user/extension), `extensionId` + `promptName` for extension prompts, `promptNameHash` for local/user prompts (privacy-safe)