### PR TITLE
Settings Editor fixes: override indicator visibility and 'Edit in settings.json' shortcut

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -70,6 +70,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private readonly advancedIndicator: SettingIndicator;
 	private readonly workspaceTrustIndicator: SettingIndicator;
 	private readonly scopeOverridesIndicator: SettingIndicator;
+	private readonly applicationAttributesIndicator: SettingIndicator;
 	private readonly syncIgnoredIndicator: SettingIndicator;
 	private readonly defaultOverrideIndicator: SettingIndicator;
 
@@ -97,9 +98,10 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 		this.workspaceTrustIndicator = this.createWorkspaceTrustIndicator();
 		this.scopeOverridesIndicator = this.createScopeOverridesIndicator();
+		this.applicationAttributesIndicator = this.createApplicationAttributesIndicator();
 		this.syncIgnoredIndicator = this.createSyncIgnoredIndicator();
 		this.defaultOverrideIndicator = this.createDefaultOverrideIndicator();
-		this.parenthesizedIndicators = [this.workspaceTrustIndicator, this.scopeOverridesIndicator, this.syncIgnoredIndicator, this.defaultOverrideIndicator];
+		this.parenthesizedIndicators = [this.workspaceTrustIndicator, this.scopeOverridesIndicator, this.applicationAttributesIndicator, this.syncIgnoredIndicator, this.defaultOverrideIndicator];
 	}
 
 	private defaultHoverOptions: Partial<IHoverOptions> = {
@@ -179,6 +181,17 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		};
 	}
 
+	private createApplicationAttributesIndicator(): SettingIndicator {
+		const disposables = new DisposableStore();
+		const applicationAttributesElement = $('span.setting-indicator.setting-item-application-attributes');
+		const applicationAttributesLabel = disposables.add(new SimpleIconLabel(applicationAttributesElement));
+		return {
+			element: applicationAttributesElement,
+			label: applicationAttributesLabel,
+			disposables
+		};
+	}
+
 	private createSyncIgnoredIndicator(): SettingIndicator {
 		const disposables = new DisposableStore();
 		const syncIgnoredElement = $('span.setting-indicator.setting-item-ignored');
@@ -247,6 +260,26 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			label: advancedLabel,
 			disposables
 		};
+	}
+
+	updateApplicationAttributesIndicator(element: SettingsTreeSettingElement) {
+		this.applicationAttributesIndicator.disposables.clear();
+		this.applicationAttributesIndicator.element.style.display = 'none';
+		if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && this.configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
+			this.applicationAttributesIndicator.element.style.display = 'inline';
+			this.applicationAttributesIndicator.label.text = localize('applicationSetting', "Applies to all profiles");
+
+			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value when switching profiles.");
+			const showHover = (focus: boolean) => {
+				return this.hoverService.showInstantHover({
+					...this.defaultHoverOptions,
+					content,
+					target: this.applicationAttributesIndicator.element
+				}, focus);
+			};
+			this.addHoverDisposables(this.applicationAttributesIndicator.disposables, this.applicationAttributesIndicator.element, showHover);
+		}
+		this.render();
 	}
 
 	private render() {
@@ -413,21 +446,6 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 							onApplyFilter.fire(`@${POLICY_SETTING_TAG}`);
 						}
 					}],
-					target: this.scopeOverridesIndicator.element
-				}, focus);
-			};
-			this.addHoverDisposables(this.scopeOverridesIndicator.disposables, this.scopeOverridesIndicator.element, showHover);
-		} else if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && this.configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
-			this.scopeOverridesIndicator.element.style.display = 'inline';
-			this.scopeOverridesIndicator.element.classList.add('setting-indicator');
-
-			this.scopeOverridesIndicator.label.text = localize('applicationSetting', "Applies to all profiles");
-
-			const content = localize('applicationSettingDescription', "The setting is not specific to the current profile, and will retain its value when switching profiles.");
-			const showHover = (focus: boolean) => {
-				return this.hoverService.showInstantHover({
-					...this.defaultHoverOptions,
-					content,
 					target: this.scopeOverridesIndicator.element
 				}, focus);
 			};
@@ -620,9 +638,13 @@ export function getIndicatorsLabelAriaLabel(element: SettingsTreeSettingElement,
 
 	if (element.hasPolicyValue) {
 		ariaLabelSections.push(localize('policyDescriptionAccessible', "Managed by organization policy; setting value not applied"));
-	} else if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
+	}
+
+	if (element.settingsTarget === ConfigurationTarget.USER_LOCAL && configurationService.isSettingAppliedForAllProfiles(element.setting.key)) {
 		ariaLabelSections.push(localize('applicationSettingDescriptionAccessible', "Setting value retained when switching profiles"));
-	} else {
+	}
+
+	if (!element.hasPolicyValue) {
 		// Add other overrides text
 		const otherOverridesStart = element.isConfigured ?
 			localize('alsoConfiguredIn', "Also modified in") :

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -61,7 +61,7 @@ import { hasNativeContextMenu } from '../../../../platform/window/common/window.
 import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { ISetting, ISettingsGroup, SETTINGS_AUTHORITY, SettingValueType } from '../../../services/preferences/common/preferences.js';
+import { IPreferencesService, ISetting, ISettingsGroup, SETTINGS_AUTHORITY, SettingValueType } from '../../../services/preferences/common/preferences.js';
 import { getInvalidTypeError } from '../../../services/preferences/common/preferencesValidation.js';
 import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
 import { LANGUAGE_SETTING_TAG, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU, compareTwoNullableNumbers } from '../common/preferences.js';
@@ -1034,9 +1034,11 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		}
 
 		template.indicatorsLabel.updateScopeOverrides(element, this._onDidClickOverrideElement, this._onApplyFilter);
+		template.indicatorsLabel.updateApplicationAttributesIndicator(element);
 		template.elementDisposables.add(this._configService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(APPLY_ALL_PROFILES_SETTING)) {
 				template.indicatorsLabel.updateScopeOverrides(element, this._onDidClickOverrideElement, this._onApplyFilter);
+				template.indicatorsLabel.updateApplicationAttributesIndicator(element);
 			}
 		}));
 
@@ -2236,6 +2238,7 @@ export class SettingTreeRenderers extends Disposable {
 			this._instantiationService.createInstance(CopySettingIdAction),
 			this._instantiationService.createInstance(CopySettingAsJSONAction),
 			this._instantiationService.createInstance(CopySettingAsURLAction),
+			this._instantiationService.createInstance(EditInSettingsJsonAction),
 		];
 
 		const actionFactory = (setting: ISetting, settingTarget: SettingsTarget) => this.getActionsForSetting(setting, settingTarget);
@@ -2876,4 +2879,24 @@ class ApplySettingToAllProfilesAction extends Action {
 		}
 	}
 
+}
+
+class EditInSettingsJsonAction extends Action {
+	static readonly ID = 'settings.editInSettingsJson';
+	static readonly LABEL = localize('editInSettingsJsonLabel', "Edit in settings.json");
+
+	constructor(
+		@IPreferencesService private readonly preferencesService: IPreferencesService
+	) {
+		super(EditInSettingsJsonAction.ID, EditInSettingsJsonAction.LABEL);
+	}
+
+	override async run(context: SettingsTreeSettingElement): Promise<void> {
+		if (context) {
+			await this.preferencesService.openUserSettings({
+				jsonEditor: true,
+				revealSetting: { key: context.setting.key, edit: true }
+			});
+		}
+	}
 }


### PR DESCRIPTION
This PR addresses two issues related to the Settings Editor:

1.  **Override Indicator Visibility**: The 'Applies to all profiles' indicator was hiding other scope override indicators (e.g., language-specific overrides). This change separates the 'Applies to all profiles' indicator into its own element so that it can coexist with other indicators without obscuring them.
    *   Fixes #295100

2.  **'Edit in settings.json' Shortcut**: Adds a 'Edit in settings.json' action to the settings context menu (gear icon). This allows users to jump directly to the json configuration for a specific setting from the GUI editor.
    *   Fixes #295101

**Changes:**
*   Modified 'SettingsTreeIndicatorsLabel' in 'settingsEditorSettingIndicators.ts' to support separate indicators.
*   Added 'EditInSettingsJsonAction' in 'settingsTree.ts' and registered it in 'SettingTreeRenderers'.