### PR TITLE
MarkerService improvement: Origins

### DIFF
--- a/src/vs/editor/common/services/markerDecorationsService.ts
+++ b/src/vs/editor/common/services/markerDecorationsService.ts
@@ -107,7 +107,7 @@ export class MarkerDecorationsService extends Disposable implements IMarkerDecor
 		if (model.uri.scheme === Schemas.inMemory
 			|| model.uri.scheme === Schemas.internal
 			|| model.uri.scheme === Schemas.vscode) {
-			this._markerService?.read({ resource: model.uri }).map(marker => marker.owner).forEach(owner => this._markerService.remove(owner, [model.uri]));
+			this._markerService?.read({ resource: model.uri }).map(marker => marker.owner).forEach(owner => this._markerService.removeOriginForOwnerResources(undefined, owner, [model.uri]));
 		}
 	}
 

--- a/src/vs/editor/contrib/codeAction/test/browser/codeActionModel.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/browser/codeActionModel.test.ts
@@ -78,7 +78,7 @@ suite('CodeActionModel', () => {
 			}));
 
 			// start here
-			markerService.changeOne('fake', uri, [{
+			markerService.changeOne(undefined, 'fake', uri, [{
 				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
 				message: 'error',
 				severity: 1,
@@ -94,7 +94,7 @@ suite('CodeActionModel', () => {
 			const reg = registry.register(languageId, testProvider);
 			store.add(reg);
 
-			markerService.changeOne('fake', uri, [{
+			markerService.changeOne(undefined, 'fake', uri, [{
 				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
 				message: 'error',
 				severity: 1,
@@ -147,7 +147,7 @@ suite('CodeActionModel', () => {
 				}, 0);
 			}, 5 /*delay*/));
 
-			markerService.changeOne('fake', uri, [{
+			markerService.changeOne(undefined, 'fake', uri, [{
 				startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
 				message: 'error',
 				severity: 1,

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -249,7 +249,7 @@ export function setModelLanguage(model: ITextModel, mimeTypeOrLanguageId: string
 export function setModelMarkers(model: ITextModel, owner: string, markers: IMarkerData[]): void {
 	if (model) {
 		const markerService = StandaloneServices.get(IMarkerService);
-		markerService.changeOne(owner, model.uri, markers);
+		markerService.changeOne(undefined, owner, model.uri, markers);
 	}
 }
 
@@ -258,7 +258,7 @@ export function setModelMarkers(model: ITextModel, owner: string, markers: IMark
  */
 export function removeAllMarkers(owner: string) {
 	const markerService = StandaloneServices.get(IMarkerService);
-	markerService.changeAll(owner, []);
+	markerService.changeAll(undefined, owner, []);
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1471,7 +1471,6 @@ declare namespace monaco.editor {
 		modelVersionId?: number;
 		relatedInformation?: IRelatedInformation[];
 		tags?: MarkerTag[];
-		origin?: string | undefined;
 	}
 
 	/**
@@ -1492,7 +1491,6 @@ declare namespace monaco.editor {
 		modelVersionId?: number;
 		relatedInformation?: IRelatedInformation[];
 		tags?: MarkerTag[];
-		origin?: string | undefined;
 	}
 
 	/**

--- a/src/vs/platform/markers/common/markerOrigin.ts
+++ b/src/vs/platform/markers/common/markerOrigin.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { IMarker } from './markers.js';
+
+export type IMarkerOrigin = string | undefined;
+
+export interface IOriginMarkers {
+	readonly origin: IMarkerOrigin;
+	markers: IMarker[];
+}
+
+/**
+ * There are two prioritization levels represented by `IMarkerOrigin`:
+ * `undefined` < `string`, strings are considered equal in priority
+ * @returns `-1` if `a` prioritized over `b`
+ */
+export function markerOriginPriorityCompare(a: IOriginMarkers, b: IOriginMarkers) {
+	if (a.origin === b.origin) { return 0; }
+	if (a.origin === undefined) { return 1; }
+	if (b.origin === undefined) { return -1; }
+	return 0;
+}
+
+export function markerOriginSelectPrioritized(ormMap: Map<IMarkerOrigin, IOriginMarkers>) {
+	if (ormMap.size === 0) {
+		return undefined;
+	}
+	const sorted = Array.from(ormMap.values()).sort(markerOriginPriorityCompare);
+	return sorted[0];
+}

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isFalsyOrEmpty, isNonEmptyArray } from '../../../base/common/arrays.js';
+import { isNonEmptyArray } from '../../../base/common/arrays.js';
 import { MicrotaskEmitter } from '../../../base/common/event.js';
 import { Iterable } from '../../../base/common/iterator.js';
 import { IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
@@ -12,6 +12,7 @@ import { Schemas } from '../../../base/common/network.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { IMarker, IMarkerData, IMarkerReadOptions, IMarkerService, IResourceMarker, MarkerSeverity, MarkerStatistics } from './markers.js';
+import { markerOriginPriorityCompare, markerOriginSelectPrioritized, IOriginMarkers, IMarkerOrigin } from './markerOrigin.js';
 
 export const unsupportedSchemas = new Set([
 	Schemas.inMemory,
@@ -157,7 +158,8 @@ export class MarkerService implements IMarkerService {
 
 	readonly onMarkerChanged = this._onMarkerChanged.event;
 
-	private readonly _data = new DoubleResourceMap<IMarker[]>();
+	private readonly _facade = new DoubleResourceMap<IOriginMarkers>();
+	private readonly _backyard = new DoubleResourceMap<Map<IMarkerOrigin, IOriginMarkers>>();
 	private readonly _stats = new MarkerStats(this);
 	private readonly _filteredResources = new ResourceMap<string[]>();
 
@@ -170,31 +172,141 @@ export class MarkerService implements IMarkerService {
 		return this._stats;
 	}
 
-	remove(owner: string, resources: URI[]): void {
+	/**
+	 * Removes origin for a given owner and resource
+	 * @returns `true` if facade markers were affected
+	 */
+	private _removeOriginForOwnerResource(origin: IMarkerOrigin, owner: string, resource: URI): boolean {
+		const backyardMarkers = this._backyard.get(resource, owner);
+		if (backyardMarkers === undefined) {
+			// No origins exist
+			return false;
+		}
+
+		backyardMarkers.delete(origin);
+		if (backyardMarkers.size === 0) {
+			this._backyard.delete(resource, owner);
+		}
+
+		const facadeMarkers = this._facade.get(resource, owner);
+		if (facadeMarkers === undefined || facadeMarkers.origin !== origin) {
+			// Removed origin is not at facade
+			return false;
+		}
+
+		// Change facade markers based on existing origins priority
+		const prioritized = markerOriginSelectPrioritized(backyardMarkers);
+		if (prioritized !== undefined) {
+			this._facade.set(resource, owner, prioritized);
+		} else {
+			this._facade.delete(resource, owner);
+		}
+		return true;
+	}
+
+	removeOriginForOwnerResources(origin: IMarkerOrigin, owner: string, resources: URI[]): void {
+		if (resources.length === 0) {
+			return;
+		}
+		const facadeAffectedUris: URI[] = [];
 		for (const resource of resources || []) {
-			this.changeOne(owner, resource, []);
+			const facadeAffected = this._removeOriginForOwnerResource(origin, owner, resource);
+			if (facadeAffected) {
+				facadeAffectedUris.push(resource);
+			}
+		}
+		if (facadeAffectedUris.length > 0) {
+			this._onMarkerChanged.fire(facadeAffectedUris);
 		}
 	}
 
-	changeOne(owner: string, resource: URI, markerData: IMarkerData[]): void {
+	/**
+	 * Removes origin from all resources for given owner
+	 * @returns list of affected facade uris
+	 */
+	private _removeOriginForOwner(origin: IMarkerOrigin, owner: string): URI[] {
+		const facadeUris: URI[] = [];
 
-		if (isFalsyOrEmpty(markerData)) {
-			// remove marker for this (owner,resource)-tuple
-			const removed = this._data.delete(resource, owner);
-			if (removed) {
-				this._onMarkerChanged.fire([resource]);
+		for (const backyardOrigins of this._backyard.values(owner)) {
+			const backyardMarkers = backyardOrigins.get(origin);
+			if (backyardMarkers === undefined) {
+				continue;
 			}
-
-		} else {
-			// insert marker for this (owner,resource)-tuple
-			const markers: IMarker[] = [];
-			for (const data of markerData) {
-				const marker = MarkerService._toMarker(owner, resource, data);
-				if (marker) {
-					markers.push(marker);
+			const first = Iterable.first(backyardMarkers.markers);
+			if (first !== undefined) {
+				const facadeAffected = this._removeOriginForOwnerResource(origin, owner, first.resource);
+				if (facadeAffected) {
+					facadeUris.push(first.resource);
 				}
 			}
-			this._data.set(resource, owner, markers);
+		}
+
+		return facadeUris;
+	}
+
+	removeOriginForOwner(origin: IMarkerOrigin, owner: string): void {
+		const facadeAffectedUris = this._removeOriginForOwner(origin, owner);
+		if (facadeAffectedUris.length > 0) {
+			this._onMarkerChanged.fire(facadeAffectedUris);
+		}
+	}
+
+	/**
+	 * Updates markers of origin for a given owner and resource
+	 * @returns `true` if facade markers were affected
+	 */
+	private _updateOriginForOwnerResource(origin: IMarkerOrigin, owner: string, resource: URI, markerData: IMarkerData[]): boolean {
+		// Sanitize incoming markers before updating
+		const markers: IMarker[] = [];
+		for (const data of markerData) {
+			const marker = MarkerService._toMarker(owner, resource, data);
+			if (marker !== undefined) {
+				markers.push(marker);
+			}
+		}
+
+		const backyardMarkers = this._backyard.get(resource, owner);
+		if (backyardMarkers === undefined) {
+			// No origins exist. Add and place on facade
+			const newOriginsMap = new Map<IMarkerOrigin, IOriginMarkers>();
+			const newMarkers: IOriginMarkers = { origin, markers };
+			newOriginsMap.set(origin, newMarkers);
+			this._backyard.set(resource, owner, newOriginsMap);
+			this._facade.set(resource, owner, newMarkers);
+			return true;
+		} else {
+			const originMarkers = backyardMarkers.get(origin);
+			const facadeMarkers = this._facade.get(resource, owner)!;
+			if (originMarkers === undefined) {
+				// New origin. Add and check if it is more prioritized to be at facade
+				const newMarkers: IOriginMarkers = { origin, markers };
+				backyardMarkers.set(origin, newMarkers);
+				if (markerOriginPriorityCompare(newMarkers, facadeMarkers) < 0) {
+					this._facade.set(resource, owner, newMarkers);
+					return true;
+				}
+			} else {
+				// Origin exists
+				originMarkers.markers = markers;
+				if (originMarkers.origin === facadeMarkers.origin) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Updates markers of origin for a given owner and resource
+	 * or removes origin from markerService if `null` is passed as markerData
+	 */
+	changeOne(origin: IMarkerOrigin, owner: string, resource: URI, markerData: IMarkerData[] | null): void {
+		const facadeAffected = markerData === null
+			? this._removeOriginForOwnerResource(origin, owner, resource)
+			: this._updateOriginForOwnerResource(origin, owner, resource, markerData);
+
+		if (facadeAffected) {
 			this._onMarkerChanged.fire([resource]);
 		}
 	}
@@ -232,7 +344,7 @@ export class MarkerService implements IMarkerService {
 			startLineNumber, startColumn, endLineNumber, endColumn,
 			relatedInformation,
 			modelVersionId,
-			tags, origin
+			tags
 		} = data;
 
 		if (!message) {
@@ -258,54 +370,39 @@ export class MarkerService implements IMarkerService {
 			endColumn,
 			relatedInformation,
 			modelVersionId,
-			tags,
-			origin
+			tags
 		};
 	}
 
-	changeAll(owner: string, data: IResourceMarker[]): void {
-		const changes: URI[] = [];
+	changeAll(origin: IMarkerOrigin, owner: string, data: IResourceMarker[]): void {
 
-		// remove old marker
-		const existing = this._data.values(owner);
-		if (existing) {
-			for (const data of existing) {
-				const first = Iterable.first(data);
-				if (first) {
-					changes.push(first.resource);
-					this._data.delete(first.resource, owner);
-				}
-			}
-		}
+		// Remove all markers of origin for owner
+		const facadeChanges = this._removeOriginForOwner(origin, owner);
 
-		// add new markers
+		// Add new markers
 		if (isNonEmptyArray(data)) {
-
-			// group by resource
-			const groups = new ResourceMap<IMarker[]>();
+			// Group by resource
+			const groups = new ResourceMap<IMarkerData[]>();
 			for (const { resource, marker: markerData } of data) {
-				const marker = MarkerService._toMarker(owner, resource, markerData);
-				if (!marker) {
-					// filter bad markers
-					continue;
-				}
 				const array = groups.get(resource);
 				if (!array) {
-					groups.set(resource, [marker]);
-					changes.push(resource);
+					groups.set(resource, [markerData]);
 				} else {
-					array.push(marker);
+					array.push(markerData);
 				}
 			}
 
-			// insert all
-			for (const [resource, value] of groups) {
-				this._data.set(resource, owner, value);
+			// Insert all
+			for (const [resource, markerData] of groups) {
+				const facadeAffected = this._updateOriginForOwnerResource(origin, owner, resource, markerData);
+				if (facadeAffected) {
+					facadeChanges.push(resource);
+				}
 			}
 		}
 
-		if (changes.length > 0) {
-			this._onMarkerChanged.fire(changes);
+		if (facadeChanges.length > 0) {
+			this._onMarkerChanged.fire(facadeChanges);
 		}
 	}
 
@@ -329,6 +426,9 @@ export class MarkerService implements IMarkerService {
 		};
 	}
 
+	/**
+	 * Returns markers from markerService facade
+	 */
 	read(filter: IMarkerReadOptions = Object.create(null)): IMarker[] {
 
 		let { owner, resource, severities, take } = filter;
@@ -345,13 +445,13 @@ export class MarkerService implements IMarkerService {
 				return [infoMarker];
 			}
 
-			const data = this._data.get(resource, owner);
+			const data = this._facade.get(resource, owner);
 			if (!data) {
 				return [];
 			}
 
 			const result: IMarker[] = [];
-			for (const marker of data) {
+			for (const marker of data.markers) {
 				if (take > 0 && result.length === take) {
 					break;
 				}
@@ -368,14 +468,14 @@ export class MarkerService implements IMarkerService {
 		} else {
 			// of one resource OR owner
 			const iterable = !owner && !resource
-				? this._data.values()
-				: this._data.values(resource ?? owner!);
+				? this._facade.values()
+				: this._facade.values(resource ?? owner!);
 
 			const result: IMarker[] = [];
 			const filtered = new ResourceSet();
 
 			for (const markers of iterable) {
-				for (const data of markers) {
+				for (const data of markers.markers) {
 					if (filtered.has(data.resource)) {
 						continue;
 					}

--- a/src/vs/platform/markers/common/markers.ts
+++ b/src/vs/platform/markers/common/markers.ts
@@ -9,6 +9,7 @@ import Severity from '../../../base/common/severity.js';
 import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
+import { IMarkerOrigin } from './markerOrigin.js';
 
 export interface IMarkerReadOptions {
 	owner?: string;
@@ -23,11 +24,13 @@ export interface IMarkerService {
 
 	getStatistics(): MarkerStatistics;
 
-	changeOne(owner: string, resource: URI, markers: IMarkerData[]): void;
+	removeOriginForOwner(origin: IMarkerOrigin, owner: string): void;
 
-	changeAll(owner: string, data: IResourceMarker[]): void;
+	changeOne(origin: IMarkerOrigin, owner: string, resource: URI, markers: IMarkerData[]): void;
 
-	remove(owner: string, resources: URI[]): void;
+	changeAll(origin: IMarkerOrigin, owner: string, data: IResourceMarker[]): void;
+
+	removeOriginForOwnerResources(origin: IMarkerOrigin, owner: string, resources: URI[]): void;
 
 	read(filter?: IMarkerReadOptions): IMarker[];
 
@@ -118,7 +121,6 @@ export interface IMarkerData {
 	modelVersionId?: number;
 	relatedInformation?: IRelatedInformation[];
 	tags?: MarkerTag[];
-	origin?: string | undefined;
 }
 
 export interface IResourceMarker {
@@ -140,7 +142,6 @@ export interface IMarker {
 	modelVersionId?: number;
 	relatedInformation?: IRelatedInformation[];
 	tags?: MarkerTag[];
-	origin?: string | undefined;
 }
 
 export interface MarkerStatistics {

--- a/src/vs/platform/markers/test/common/markerService.test.ts
+++ b/src/vs/platform/markers/test/common/markerService.test.ts
@@ -34,7 +34,7 @@ suite('Marker Service', () => {
 
 		service = new markerService.MarkerService();
 
-		service.changeAll('far', [{
+		service.changeAll(undefined, 'far', [{
 			resource: URI.parse('file:///c/test/file.cs'),
 			marker: randomMarkerData(MarkerSeverity.Error)
 		}]);
@@ -45,7 +45,7 @@ suite('Marker Service', () => {
 		assert.strictEqual(service.read({ owner: 'far', resource: URI.parse('file:///c/test/file.cs') }).length, 1);
 
 
-		service.changeAll('boo', [{
+		service.changeAll(undefined, 'boo', [{
 			resource: URI.parse('file:///c/test/file.cs'),
 			marker: randomMarkerData(MarkerSeverity.Warning)
 		}]);
@@ -65,16 +65,16 @@ suite('Marker Service', () => {
 	test('changeOne override', () => {
 
 		service = new markerService.MarkerService();
-		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
+		service.changeOne(undefined, 'far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
 		assert.strictEqual(service.read().length, 1);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 
-		service.changeOne('boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
+		service.changeOne(undefined, 'boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
 		assert.strictEqual(service.read().length, 2);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 
-		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData(), randomMarkerData()]);
+		service.changeOne(undefined, 'far', URI.parse('file:///path/only.cs'), [randomMarkerData(), randomMarkerData()]);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 2);
 		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 
@@ -83,18 +83,18 @@ suite('Marker Service', () => {
 	test('changeOne/All clears', () => {
 
 		service = new markerService.MarkerService();
-		service.changeOne('far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
-		service.changeOne('boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
+		service.changeOne(undefined, 'far', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
+		service.changeOne(undefined, 'boo', URI.parse('file:///path/only.cs'), [randomMarkerData()]);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 		assert.strictEqual(service.read().length, 2);
 
-		service.changeOne('far', URI.parse('file:///path/only.cs'), []);
+		service.changeOne(undefined, 'far', URI.parse('file:///path/only.cs'), []);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 		assert.strictEqual(service.read({ owner: 'boo' }).length, 1);
 		assert.strictEqual(service.read().length, 1);
 
-		service.changeAll('boo', []);
+		service.changeAll(undefined, 'boo', []);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 		assert.strictEqual(service.read({ owner: 'boo' }).length, 0);
 		assert.strictEqual(service.read().length, 0);
@@ -103,7 +103,7 @@ suite('Marker Service', () => {
 	test('changeAll sends event for cleared', () => {
 
 		service = new markerService.MarkerService();
-		service.changeAll('far', [{
+		service.changeAll(undefined, 'far', [{
 			resource: URI.parse('file:///d/path'),
 			marker: randomMarkerData()
 		}, {
@@ -119,7 +119,7 @@ suite('Marker Service', () => {
 			assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 		});
 
-		service.changeAll('far', []);
+		service.changeAll(undefined, 'far', []);
 
 		d.dispose();
 	});
@@ -127,7 +127,7 @@ suite('Marker Service', () => {
 	test('changeAll merges', () => {
 		service = new markerService.MarkerService();
 
-		service.changeAll('far', [{
+		service.changeAll(undefined, 'far', [{
 			resource: URI.parse('file:///c/test/file.cs'),
 			marker: randomMarkerData()
 		}, {
@@ -141,7 +141,7 @@ suite('Marker Service', () => {
 	test('changeAll must not break integrety, issue #12635', () => {
 		service = new markerService.MarkerService();
 
-		service.changeAll('far', [{
+		service.changeAll(undefined, 'far', [{
 			resource: URI.parse('scheme:path1'),
 			marker: randomMarkerData()
 		}, {
@@ -149,12 +149,12 @@ suite('Marker Service', () => {
 			marker: randomMarkerData()
 		}]);
 
-		service.changeAll('boo', [{
+		service.changeAll(undefined, 'boo', [{
 			resource: URI.parse('scheme:path1'),
 			marker: randomMarkerData()
 		}]);
 
-		service.changeAll('far', [{
+		service.changeAll(undefined, 'far', [{
 			resource: URI.parse('scheme:path1'),
 			marker: randomMarkerData()
 		}, {
@@ -172,23 +172,23 @@ suite('Marker Service', () => {
 		service = new markerService.MarkerService();
 
 		data.message = undefined!;
-		service.changeOne('far', URI.parse('some:uri/path'), [data]);
+		service.changeOne(undefined, 'far', URI.parse('some:uri/path'), [data]);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 
 		data.message = null!;
-		service.changeOne('far', URI.parse('some:uri/path'), [data]);
+		service.changeOne(undefined, 'far', URI.parse('some:uri/path'), [data]);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 0);
 
 		data.message = 'null';
-		service.changeOne('far', URI.parse('some:uri/path'), [data]);
+		service.changeOne(undefined, 'far', URI.parse('some:uri/path'), [data]);
 		assert.strictEqual(service.read({ owner: 'far' }).length, 1);
 	});
 
 	test('MapMap#remove returns bad values, https://github.com/microsoft/vscode/issues/13548', () => {
 		service = new markerService.MarkerService();
 
-		service.changeOne('o', URI.parse('some:uri/1'), [randomMarkerData()]);
-		service.changeOne('o', URI.parse('some:uri/2'), []);
+		service.changeOne(undefined, 'o', URI.parse('some:uri/1'), [randomMarkerData()]);
+		service.changeOne(undefined, 'o', URI.parse('some:uri/2'), []);
 
 	});
 
@@ -205,7 +205,7 @@ suite('Marker Service', () => {
 		};
 		service = new markerService.MarkerService();
 
-		service.changeOne('far', URI.parse('some:thing'), [data]);
+		service.changeOne(undefined, 'far', URI.parse('some:thing'), [data]);
 		const marker = service.read({ resource: URI.parse('some:thing') });
 
 		assert.strictEqual(marker.length, 1);
@@ -221,7 +221,7 @@ suite('Marker Service', () => {
 			...randomMarkerData(),
 			modelVersionId: 42
 		};
-		service.changeOne('owner', resource, [dataWithVersion]);
+		service.changeOne(undefined, 'owner', resource, [dataWithVersion]);
 
 		const markersWithVersion = service.read({ resource });
 		assert.strictEqual(markersWithVersion.length, 1);
@@ -229,7 +229,7 @@ suite('Marker Service', () => {
 
 		// Test without modelVersionId (should be undefined)
 		const dataWithoutVersion: IMarkerData = randomMarkerData();
-		service.changeOne('owner', resource, [dataWithoutVersion]);
+		service.changeOne(undefined, 'owner', resource, [dataWithoutVersion]);
 
 		const markersWithoutVersion = service.read({ resource });
 		assert.strictEqual(markersWithoutVersion.length, 1);
@@ -242,8 +242,8 @@ suite('Marker Service', () => {
 		const resource2 = URI.parse('file:///path/file2.cs');
 
 		// Add markers to both resources
-		service.changeOne('owner1', resource1, [randomMarkerData()]);
-		service.changeOne('owner1', resource2, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource1, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource2, [randomMarkerData()]);
 
 		// Verify both resources have markers
 		assert.strictEqual(service.read().length, 2);
@@ -273,8 +273,8 @@ suite('Marker Service', () => {
 		const resource2 = URI.parse('file:///path/file2.cs');
 
 		// Add markers to both resources
-		service.changeOne('owner1', resource1, [randomMarkerData()]);
-		service.changeOne('owner1', resource2, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource1, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource2, [randomMarkerData()]);
 
 		// Verify both resources have markers
 		assert.strictEqual(service.read().length, 2);
@@ -304,8 +304,8 @@ suite('Marker Service', () => {
 		service = new markerService.MarkerService();
 		const resource = URI.parse('file:///path/file.cs');
 
-		service.changeOne('owner1', resource, [randomMarkerData(MarkerSeverity.Error)]);
-		service.changeOne('owner2', resource, [randomMarkerData(MarkerSeverity.Warning)]);
+		service.changeOne(undefined, 'owner1', resource, [randomMarkerData(MarkerSeverity.Error)]);
+		service.changeOne(undefined, 'owner2', resource, [randomMarkerData(MarkerSeverity.Warning)]);
 
 		// Verify initial state
 		assert.strictEqual(service.read().length, 2);
@@ -345,7 +345,7 @@ suite('Marker Service', () => {
 		const resource = URI.parse('file:///path/file.cs');
 
 		// Add marker to resource
-		service.changeOne('owner1', resource, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource, [randomMarkerData()]);
 
 		// Verify resource has markers
 		assert.strictEqual(service.read().length, 1);
@@ -379,7 +379,7 @@ suite('Marker Service', () => {
 		const resource = URI.parse('file:///path/file.cs');
 
 		// Add error and warning to the resource
-		service.changeOne('owner1', resource, [
+		service.changeOne(undefined, 'owner1', resource, [
 			randomMarkerData(MarkerSeverity.Error),
 			randomMarkerData(MarkerSeverity.Warning)
 		]);
@@ -409,8 +409,8 @@ suite('Marker Service', () => {
 		const resource2 = URI.parse('file:///path/file2.cs');
 
 		// Add markers to both resources
-		service.changeOne('owner1', resource1, [randomMarkerData()]);
-		service.changeOne('owner1', resource2, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource1, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource2, [randomMarkerData()]);
 
 		// Verify initial state
 		assert.strictEqual(service.read().length, 2);
@@ -445,7 +445,7 @@ suite('Marker Service', () => {
 		const resource = URI.parse('file:///path/file.cs');
 
 		// Add marker to resource
-		service.changeOne('owner1', resource, [randomMarkerData()]);
+		service.changeOne(undefined, 'owner1', resource, [randomMarkerData()]);
 
 		// Verify resource has markers
 		assert.strictEqual(service.read().length, 1);

--- a/src/vs/workbench/api/browser/mainThreadDiagnostics.ts
+++ b/src/vs/workbench/api/browser/mainThreadDiagnostics.ts
@@ -47,7 +47,7 @@ export class MainThreadDiagnostics implements MainThreadDiagnosticsShape {
 			data.push([resource, allMarkerData]);
 		}
 		if (data.length > 0) {
-			this._proxy.$acceptMarkersChange(data);
+			this._proxy.$acceptMarkerServiceChange(data);
 		}
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadDiagnostics.ts
+++ b/src/vs/workbench/api/browser/mainThreadDiagnostics.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IMarkerService, IMarkerData, type IMarker } from '../../../platform/markers/common/markers.js';
+import { IMarkerService, IMarkerData } from '../../../platform/markers/common/markers.js';
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { MainThreadDiagnosticsShape, MainContext, ExtHostDiagnosticsShape, ExtHostContext } from '../common/extHost.protocol.js';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers.js';
 import { IDisposable } from '../../../base/common/lifecycle.js';
 import { IUriIdentityService } from '../../../platform/uriIdentity/common/uriIdentity.js';
-import { ResourceMap } from '../../../base/common/map.js';
 
 @extHostNamedCustomer(MainContext.MainThreadDiagnostics)
 export class MainThreadDiagnostics implements MainThreadDiagnosticsShape {
@@ -36,20 +35,7 @@ export class MainThreadDiagnostics implements MainThreadDiagnosticsShape {
 	dispose(): void {
 		this._markerListener.dispose();
 		for (const owner of this._activeOwners) {
-			const markersData: ResourceMap<IMarker[]> = new ResourceMap<IMarker[]>();
-			for (const marker of this._markerService.read({ owner })) {
-				let data = markersData.get(marker.resource);
-				if (data === undefined) {
-					data = [];
-					markersData.set(marker.resource, data);
-				}
-				if (marker.origin !== this.extHostId) {
-					data.push(marker);
-				}
-			}
-			for (const [resource, local] of markersData.entries()) {
-				this._markerService.changeOne(owner, resource, local);
-			}
+			this._markerService.removeOriginForOwner(owner, this.extHostId);
 		}
 		this._activeOwners.clear();
 	}
@@ -58,14 +44,7 @@ export class MainThreadDiagnostics implements MainThreadDiagnosticsShape {
 		const data: [UriComponents, IMarkerData[]][] = [];
 		for (const resource of resources) {
 			const allMarkerData = this._markerService.read({ resource, ignoreResourceFilters: true });
-			if (allMarkerData.length === 0) {
-				data.push([resource, []]);
-			} else {
-				const foreignMarkerData = allMarkerData.filter(marker => marker?.origin !== this.extHostId);
-				if (foreignMarkerData.length > 0) {
-					data.push([resource, foreignMarkerData]);
-				}
-			}
+			data.push([resource, allMarkerData]);
 		}
 		if (data.length > 0) {
 			this._proxy.$acceptMarkersChange(data);
@@ -85,18 +64,15 @@ export class MainThreadDiagnostics implements MainThreadDiagnosticsShape {
 					if (marker.code && typeof marker.code !== 'string') {
 						marker.code.target = URI.revive(marker.code.target);
 					}
-					if (marker.origin === undefined) {
-						marker.origin = this.extHostId;
-					}
 				}
 			}
-			this._markerService.changeOne(owner, this._uriIdentService.asCanonicalUri(URI.revive(uri)), markers);
+			this._markerService.changeOne(this.extHostId, owner, this._uriIdentService.asCanonicalUri(URI.revive(uri)), markers);
 		}
 		this._activeOwners.add(owner);
 	}
 
 	$clear(owner: string): void {
-		this._markerService.changeAll(owner, []);
+		this._markerService.removeOriginForOwner(this.extHostId, owner);
 		this._activeOwners.delete(owner);
 	}
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1971,7 +1971,7 @@ export interface ExtHostConfigurationShape {
 }
 
 export interface ExtHostDiagnosticsShape {
-	$acceptMarkersChange(data: [UriComponents, IMarkerData[]][]): void;
+	$acceptMarkerServiceChange(data: [UriComponents, IMarkerData[]][]): void;
 }
 
 export interface ExtHostDocumentContentProvidersShape {

--- a/src/vs/workbench/api/common/extHostDiagnostics.ts
+++ b/src/vs/workbench/api/common/extHostDiagnostics.ts
@@ -240,6 +240,7 @@ export class ExtHostDiagnostics implements ExtHostDiagnosticsShape {
 	private readonly _proxy: MainThreadDiagnosticsShape;
 	private readonly _collections = new Map<string, DiagnosticCollection>();
 	private readonly _onDidChangeDiagnostics = new DebounceEmitter<readonly vscode.Uri[]>({ merge: all => all.flat(), delay: 50 });
+	private readonly _markerServiceMirror: DiagnosticCollection;
 
 	static _mapper(last: readonly vscode.Uri[]): { uris: readonly vscode.Uri[] } {
 		const map = new ResourceMap<vscode.Uri>();
@@ -258,6 +259,15 @@ export class ExtHostDiagnostics implements ExtHostDiagnosticsShape {
 		private readonly _extHostDocumentsAndEditors: ExtHostDocumentsAndEditors,
 	) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadDiagnostics);
+
+		const msmName = '_markerService_mirror';
+		this._markerServiceMirror = new DiagnosticCollection(
+			msmName, msmName,
+			Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, // no limits because this collection is just a mirror of "sanitized" data
+			_uri => undefined,
+			this._fileSystemInfoService.extUri, undefined, this._onDidChangeDiagnostics
+		);
+		this._collections.set(msmName, this._markerServiceMirror);
 	}
 
 	createDiagnosticCollection(extensionId: ExtensionIdentifier, name?: string): vscode.DiagnosticCollection {
@@ -321,49 +331,31 @@ export class ExtHostDiagnostics implements ExtHostDiagnosticsShape {
 		} else {
 			const index = new Map<string, number>();
 			const res: [vscode.Uri, vscode.Diagnostic[]][] = [];
-			for (const collection of this._collections.values()) {
-				collection.forEach((uri, diagnostics) => {
-					let idx = index.get(uri.toString());
-					if (typeof idx === 'undefined') {
-						idx = res.length;
-						index.set(uri.toString(), idx);
-						res.push([uri, []]);
-					}
-					res[idx][1] = res[idx][1].concat(...diagnostics);
-				});
-			}
+
+			this._markerServiceMirror.forEach((uri, diagnostics) => {
+				let idx = index.get(uri.toString());
+				if (typeof idx === 'undefined') {
+					idx = res.length;
+					index.set(uri.toString(), idx);
+					res.push([uri, []]);
+				}
+				res[idx][1] = res[idx][1].concat(...diagnostics);
+			});
 			return res;
 		}
 	}
 
 	private _getDiagnostics(resource: vscode.Uri): ReadonlyArray<vscode.Diagnostic> {
-		let res: vscode.Diagnostic[] = [];
-		for (const collection of this._collections.values()) {
-			if (collection.has(resource)) {
-				res = res.concat(collection.get(resource));
-			}
-		}
-		return res;
+		return [...this._markerServiceMirror.get(resource)];
 	}
 
-	private _mirrorCollection: vscode.DiagnosticCollection | undefined;
-
-	$acceptMarkersChange(data: [UriComponents, IMarkerData[]][]): void {
-
-		if (!this._mirrorCollection) {
-			const name = '_generated_mirror';
-			const collection = new DiagnosticCollection(
-				name, name,
-				Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER, // no limits because this collection is just a mirror of "sanitized" data
-				_uri => undefined,
-				this._fileSystemInfoService.extUri, undefined, this._onDidChangeDiagnostics
-			);
-			this._collections.set(name, collection);
-			this._mirrorCollection = collection;
-		}
-
+	$acceptMarkerServiceChange(data: [UriComponents, IMarkerData[]][]): void {
 		for (const [uri, markers] of data) {
-			this._mirrorCollection.set(URI.revive(uri), markers.map(converter.Diagnostic.to));
+			if (markers.length === 0) {
+				this._markerServiceMirror.delete(URI.revive(uri));
+			} else {
+				this._markerServiceMirror.set(URI.revive(uri), markers.map(converter.Diagnostic.to));
+			}
 		}
 	}
 }

--- a/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostDiagnostics.test.ts
@@ -568,12 +568,12 @@ suite('ExtHostDiagnostics', () => {
 			}];
 
 			const p1 = Event.toPromise(diags.onDidChangeDiagnostics);
-			diags.$acceptMarkersChange([[uri, data]]);
+			diags.$acceptMarkerServiceChange([[uri, data]]);
 			await p1;
 			assert.strictEqual(diags.getDiagnostics(uri).length, 1);
 
 			const p2 = Event.toPromise(diags.onDidChangeDiagnostics);
-			diags.$acceptMarkersChange([[uri, []]]);
+			diags.$acceptMarkerServiceChange([[uri, []]]);
 			await p2;
 			assert.strictEqual(diags.getDiagnostics(uri).length, 0);
 		});

--- a/src/vs/workbench/api/test/browser/mainThreadDiagnostics.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadDiagnostics.test.ts
@@ -108,7 +108,7 @@ suite('MainThreadDiagnostics', function () {
 			};
 			const target = URI.file('a');
 			diag.$changeMany('foo', [[target, [{ ...markerDataStub, message: 'same_owner' }]]]);
-			markerService.changeOne('bar', target, [{ ...markerDataStub, message: 'forgein_owner' }]);
+			markerService.changeOne(undefined, 'bar', target, [{ ...markerDataStub, message: 'forgein_owner' }]);
 
 			// added one marker via the API and one via the ext host. the latter must not
 			// trigger an event to the extension host
@@ -137,7 +137,7 @@ suite('MainThreadDiagnostics', function () {
 				message: 'message'
 			};
 			const target = URI.file('a');
-			markerService.changeOne('bar', target, [markerData]);
+			markerService.changeOne(undefined, 'bar', target, [markerData]);
 
 			const changedData: [UriComponents, IMarkerData[]][][] = [];
 

--- a/src/vs/workbench/api/test/browser/mainThreadDiagnostics.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadDiagnostics.test.ts
@@ -42,7 +42,7 @@ suite('MainThreadDiagnostics', function () {
 				set(v: any): any { return null; }
 				getProxy(): any {
 					return {
-						$acceptMarkersChange() { }
+						$acceptMarkerServiceChange() { }
 					};
 				}
 				drain(): any { return null; }
@@ -84,7 +84,7 @@ suite('MainThreadDiagnostics', function () {
 					set(v: any): any { return null; }
 					getProxy(): any {
 						return {
-							$acceptMarkersChange(data: [UriComponents, IMarkerData[]][]) {
+							$acceptMarkerServiceChange(data: [UriComponents, IMarkerData[]][]) {
 								changedData.push(data);
 							}
 						};
@@ -150,7 +150,7 @@ suite('MainThreadDiagnostics', function () {
 					set(v: any): any { return null; }
 					getProxy(): any {
 						return {
-							$acceptMarkersChange(data: [UriComponents, IMarkerData[]][]) {
+							$acceptMarkerServiceChange(data: [UriComponents, IMarkerData[]][]) {
 								changedData.push(data);
 							}
 						};

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart.ts
@@ -220,12 +220,12 @@ export class ToolConfirmationSubPart extends AbstractToolConfirmationSubPart {
 						}
 					}
 
-					this.markerService.changeOne(markerOwner, model.uri, newMarker);
+					this.markerService.changeOne(undefined, markerOwner, model.uri, newMarker);
 				}, 500);
 
 				validator.schedule();
 				this._register(model.onDidChangeContent(() => validator.schedule()));
-				this._register(toDisposable(() => this.markerService.remove(markerOwner, [model.uri])));
+				this._register(toDisposable(() => this.markerService.removeOriginForOwnerResources(undefined, markerOwner, [model.uri])));
 				this._register(validator);
 
 				const editor = this._register(this.editorPool.get());

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -1063,12 +1063,12 @@ class ModelTracker extends Disposable {
 			const markers: IMarkerData[] = [];
 			const ast = this.promptsService.getParsedPromptFile(this.textModel);
 			await this.validator.validate(ast, this.promptType, m => markers.push(m));
-			this.markerService.changeOne(MARKERS_OWNER_ID, this.textModel.uri, markers);
+			this.markerService.changeOne(undefined, MARKERS_OWNER_ID, this.textModel.uri, markers);
 		});
 	}
 
 	public override dispose() {
-		this.markerService.remove(MARKERS_OWNER_ID, [this.textModel.uri]);
+		this.markerService.removeOriginForOwnerResources(undefined, MARKERS_OWNER_ID, [this.textModel.uri]);
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpLanguageFeatures.ts
@@ -82,7 +82,7 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 			tree,
 			inConfig,
 			dispose: () => {
-				this._markerService.remove(diagnosticOwner, [uri]);
+				this._markerService.removeOriginForOwnerResources(undefined, diagnosticOwner, [uri]);
 				dispose(listeners);
 			}
 		};
@@ -132,9 +132,9 @@ export class McpLanguageFeatures extends Disposable implements IWorkbenchContrib
 		});
 
 		if (diagnostics.length) {
-			this._markerService.changeOne(diagnosticOwner, tm.uri, diagnostics);
+			this._markerService.changeOne(undefined, diagnosticOwner, tm.uri, diagnostics);
 		} else {
-			this._markerService.remove(diagnosticOwner, [tm.uri]);
+			this._markerService.removeOriginForOwnerResources(undefined, diagnosticOwner, [tm.uri]);
 		}
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnosticEditorContrib.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnosticEditorContrib.ts
@@ -118,8 +118,8 @@ export class CellDiagnostics extends Disposable implements INotebookEditorContri
 			const disposables: IDisposable[] = [];
 			const errorLabel = metadata.error.name ? `${metadata.error.name}: ${metadata.error.message}` : metadata.error.message;
 			const marker = this.createMarkerData(errorLabel, metadata.error.location);
-			this.markerService.changeOne(CellDiagnostics.ID, cell.uri, [marker]);
-			disposables.push(toDisposable(() => this.markerService.changeOne(CellDiagnostics.ID, cell.uri, [])));
+			this.markerService.changeOne(undefined, CellDiagnostics.ID, cell.uri, [marker]);
+			disposables.push(toDisposable(() => this.markerService.changeOne(undefined, CellDiagnostics.ID, cell.uri, [])));
 			cell.executionErrorDiagnostic.set(metadata.error, undefined);
 			disposables.push(toDisposable(() => cell.executionErrorDiagnostic.set(undefined, undefined)));
 			disposables.push(autorun((r) => {

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookCellDiagnostics.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookCellDiagnostics.test.ts
@@ -22,6 +22,7 @@ import { ICellExecutionStateChangedEvent, IExecutionStateChangedEvent, INotebook
 import { setupInstantiationService, TestNotebookExecutionStateService, withTestNotebook } from '../testNotebookEditor.js';
 import { nullExtensionDescription } from '../../../../../services/extensions/common/extensions.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../../chat/common/constants.js';
+import { IMarkerOrigin } from '../../../../../../platform/markers/common/markerOrigin.js';
 
 
 suite('notebookCellDiagnostics', () => {
@@ -94,7 +95,7 @@ suite('notebookCellDiagnostics', () => {
 			private _onMarkersUpdated = new Emitter<void>();
 			override onMarkersUpdated = this._onMarkersUpdated.event;
 			override markers: ResourceMap<IMarkerData[]> = new ResourceMap();
-			override changeOne(owner: string, resource: URI, markers: IMarkerData[]) {
+			override changeOne(origin: IMarkerOrigin, owner: string, resource: URI, markers: IMarkerData[]) {
 				this.markers.set(resource, markers);
 				this._onMarkersUpdated.fire();
 			}

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -517,9 +517,9 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		this.codeActions.clear();
 		const markerData: IMarkerData[] = this.generateMarkerData();
 		if (markerData.length) {
-			this.markerService.changeOne('UnsupportedSettingsRenderer', this.settingsEditorModel.uri, markerData);
+			this.markerService.changeOne(undefined, 'UnsupportedSettingsRenderer', this.settingsEditorModel.uri, markerData);
 		} else {
-			this.markerService.remove('UnsupportedSettingsRenderer', [this.settingsEditorModel.uri]);
+			this.markerService.removeOriginForOwnerResources(undefined, 'UnsupportedSettingsRenderer', [this.settingsEditorModel.uri]);
 		}
 	}
 
@@ -782,7 +782,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 	}
 
 	public override dispose(): void {
-		this.markerService.remove('UnsupportedSettingsRenderer', [this.settingsEditorModel.uri]);
+		this.markerService.removeOriginForOwnerResources(undefined, 'UnsupportedSettingsRenderer', [this.settingsEditorModel.uri]);
 		this.codeActions.clear();
 		super.dispose();
 	}
@@ -814,9 +814,9 @@ class McpSettingsRenderer extends Disposable implements languages.CodeActionProv
 		this.codeActions.clear();
 		const markerData: IMarkerData[] = this.generateMarkerData();
 		if (markerData.length) {
-			this.markerService.changeOne('McpSettingsRenderer', this.settingsEditorModel.uri, markerData);
+			this.markerService.changeOne(undefined, 'McpSettingsRenderer', this.settingsEditorModel.uri, markerData);
 		} else {
-			this.markerService.remove('McpSettingsRenderer', [this.settingsEditorModel.uri]);
+			this.markerService.removeOriginForOwnerResources(undefined, 'McpSettingsRenderer', [this.settingsEditorModel.uri]);
 		}
 	}
 
@@ -902,7 +902,7 @@ class McpSettingsRenderer extends Disposable implements languages.CodeActionProv
 	}
 
 	public override dispose(): void {
-		this.markerService.remove('McpSettingsRenderer', [this.settingsEditorModel.uri]);
+		this.markerService.removeOriginForOwnerResources(undefined, 'McpSettingsRenderer', [this.settingsEditorModel.uri]);
 		this.codeActions.clear();
 		super.dispose();
 	}
@@ -945,9 +945,9 @@ class WorkspaceConfigurationRenderer extends Disposable {
 			this.decorations.set(ranges.map(range => this.createDecoration(range)));
 		}
 		if (markerData.length) {
-			this.markerService.changeOne('WorkspaceConfigurationRenderer', this.workspaceSettingsEditorModel.uri, markerData);
+			this.markerService.changeOne(undefined, 'WorkspaceConfigurationRenderer', this.workspaceSettingsEditorModel.uri, markerData);
 		} else {
-			this.markerService.remove('WorkspaceConfigurationRenderer', [this.workspaceSettingsEditorModel.uri]);
+			this.markerService.removeOriginForOwnerResources(undefined, 'WorkspaceConfigurationRenderer', [this.workspaceSettingsEditorModel.uri]);
 		}
 	}
 
@@ -965,7 +965,7 @@ class WorkspaceConfigurationRenderer extends Disposable {
 	}
 
 	override dispose(): void {
-		this.markerService.remove('WorkspaceConfigurationRenderer', [this.workspaceSettingsEditorModel.uri]);
+		this.markerService.removeOriginForOwnerResources(undefined, 'WorkspaceConfigurationRenderer', [this.workspaceSettingsEditorModel.uri]);
 		this.decorations.clear();
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IStringDictionary, INumberDictionary } from '../../../../base/common/collections.js';
+import { INumberDictionary } from '../../../../base/common/collections.js';
 import { URI } from '../../../../base/common/uri.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IDisposable, DisposableStore, Disposable } from '../../../../base/common/lifecycle.js';
 
 import { IModelService } from '../../../../editor/common/services/model.js';
 
-import { ILineMatcher, createLineMatcher, ProblemMatcher, IProblemMatch, ApplyToKind, IWatchingPattern, getResource } from './problemMatcher.js';
+import { ILineMatcher, createLineMatcher, ProblemMatcher, IProblemMatch, IWatchingPattern, getResource } from './problemMatcher.js';
 import { IMarkerService, IMarkerData, MarkerSeverity, IMarker } from '../../../../platform/markers/common/markers.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -43,12 +43,10 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 	private _maxMarkerSeverity?: MarkerSeverity;
 	private buffer: string[];
 	private bufferLength: number;
-	private openModels: IStringDictionary<boolean>;
 	protected readonly modelListeners = new DisposableStore();
 	private tail: Promise<void> | undefined;
 
-	// [owner] -> ApplyToKind
-	protected applyToByOwner: Map<string, ApplyToKind>;
+	protected readonly matchersOwners: Set<string>;
 	// [owner] -> [resource] -> URI
 	private resourcesToClean: Map<string, Map<string, URI>>;
 	// [owner] -> [resource] -> [markerkey] -> markerData
@@ -87,26 +85,13 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 		this.activeMatcher = null;
 		this._numberOfMatches = 0;
 		this._maxMarkerSeverity = undefined;
-		this.openModels = Object.create(null);
-		this.applyToByOwner = new Map<string, ApplyToKind>();
+		this.matchersOwners = new Set();
 		for (const problemMatcher of problemMatchers) {
-			const current = this.applyToByOwner.get(problemMatcher.owner);
-			if (current === undefined) {
-				this.applyToByOwner.set(problemMatcher.owner, problemMatcher.applyTo);
-			} else {
-				this.applyToByOwner.set(problemMatcher.owner, this.mergeApplyTo(current, problemMatcher.applyTo));
-			}
+			this.matchersOwners.add(problemMatcher.owner);
 		}
 		this.resourcesToClean = new Map<string, Map<string, URI>>();
 		this.markers = new Map<string, Map<string, Map<string, IMarkerData>>>();
 		this.deliveredMarkers = new Map<string, Map<string, number>>();
-		this._register(this.modelService.onModelAdded((model) => {
-			this.openModels[model.uri.toString()] = true;
-		}, this, this.modelListeners));
-		this._register(this.modelService.onModelRemoved((model) => {
-			delete this.openModels[model.uri.toString()];
-		}, this, this.modelListeners));
-		this.modelService.getModels().forEach(model => this.openModels[model.uri.toString()] = true);
 
 		this._onDidStateChange = this._register(new Emitter());
 	}
@@ -167,26 +152,6 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 			this.clearBuffer();
 		}
 		return result;
-	}
-
-	protected async shouldApplyMatch(result: IProblemMatch): Promise<boolean> {
-		switch (result.description.applyTo) {
-			case ApplyToKind.allDocuments:
-				return true;
-			case ApplyToKind.openDocuments:
-				return !!this.openModels[(await result.resource).toString()];
-			case ApplyToKind.closedDocuments:
-				return !this.openModels[(await result.resource).toString()];
-			default:
-				return true;
-		}
-	}
-
-	private mergeApplyTo(current: ApplyToKind, value: ApplyToKind): ApplyToKind {
-		if (current === value || current === ApplyToKind.allDocuments) {
-			return current;
-		}
-		return ApplyToKind.allDocuments;
 	}
 
 	private tryMatchers(): IProblemMatch | null {
@@ -263,17 +228,7 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 	}
 
 	private _cleanMarkers(owner: string, toClean: Map<string, URI>): void {
-		const uris: URI[] = [];
-		const applyTo = this.applyToByOwner.get(owner);
-		toClean.forEach((uri, uriAsString) => {
-			if (
-				applyTo === ApplyToKind.allDocuments ||
-				(applyTo === ApplyToKind.openDocuments && this.openModels[uriAsString]) ||
-				(applyTo === ApplyToKind.closedDocuments && !this.openModels[uriAsString])
-			) {
-				uris.push(uri);
-			}
-		});
+		const uris = Array.from(toClean.values());
 		this.markerService.remove(owner, uris);
 	}
 
@@ -388,16 +343,13 @@ export class StartStopProblemCollector extends AbstractProblemCollector implemen
 		const resource = await markerMatch.resource;
 		const resourceAsString = resource.toString();
 		this.removeResourceToClean(owner, resourceAsString);
-		const shouldApplyMatch = await this.shouldApplyMatch(markerMatch);
-		if (shouldApplyMatch) {
-			this.recordMarker(markerMatch.marker, owner, resourceAsString);
-			if (this.currentOwner !== owner || this.currentResource !== resourceAsString) {
-				if (this.currentOwner && this.currentResource) {
-					this.deliverMarkersPerOwnerAndResource(this.currentOwner, this.currentResource);
-				}
-				this.currentOwner = owner;
-				this.currentResource = resourceAsString;
+		this.recordMarker(markerMatch.marker, owner, resourceAsString);
+		if (this.currentOwner !== owner || this.currentResource !== resourceAsString) {
+			if (this.currentOwner && this.currentResource) {
+				this.deliverMarkersPerOwnerAndResource(this.currentOwner, this.currentResource);
 			}
+			this.currentOwner = owner;
+			this.currentResource = resourceAsString;
 		}
 	}
 }
@@ -439,38 +391,6 @@ export class WatchingProblemCollector extends AbstractProblemCollector implement
 				this.beginPatterns.push(matcher.watching.beginsPattern.regexp);
 			}
 		});
-
-		this.modelListeners.add(this.modelService.onModelRemoved(modelEvent => {
-			let markerChanged: IDisposable | undefined = Event.debounce(
-				this.markerService.onMarkerChanged,
-				(last: readonly URI[] | undefined, e: readonly URI[]) => (last ?? []).concat(e),
-				500,
-				false,
-				true
-			)(async (markerEvent: readonly URI[]) => {
-				if (markerEvent.length === 0) {
-					return;
-				}
-				const modelEventUriStr = modelEvent.uri.toString();
-				if ((!markerEvent.some(uri => uri.toString() === modelEventUriStr)) || (this.markerService.read({ resource: modelEvent.uri }).length !== 0)) {
-					return;
-				}
-				const oldLines = Array.from(this.lines);
-				for (const line of oldLines) {
-					await this.processLineInternal(line);
-				}
-			});
-
-			// Dispose the debounced listener after timeout - no need to register it since
-			// it's only used temporarily and will be disposed below
-			setTimeout(() => {
-				if (markerChanged) {
-					const _markerChanged = markerChanged;
-					markerChanged = undefined;
-					_markerChanged.dispose();
-				}
-			}, 600);
-		}));
 	}
 
 	public aboutToStart(): void {
@@ -496,14 +416,11 @@ export class WatchingProblemCollector extends AbstractProblemCollector implement
 		const owner = markerMatch.description.owner;
 		const resourceAsString = resource.toString();
 		this.removeResourceToClean(owner, resourceAsString);
-		const shouldApplyMatch = await this.shouldApplyMatch(markerMatch);
-		if (shouldApplyMatch) {
-			this.recordMarker(markerMatch.marker, owner, resourceAsString);
-			if (this.currentOwner !== owner || this.currentResource !== resourceAsString) {
-				this.reportMarkersForCurrentResource();
-				this.currentOwner = owner;
-				this.currentResource = resourceAsString;
-			}
+		this.recordMarker(markerMatch.marker, owner, resourceAsString);
+		if (this.currentOwner !== owner || this.currentResource !== resourceAsString) {
+			this.reportMarkersForCurrentResource();
+			this.currentOwner = owner;
+			this.currentResource = resourceAsString;
 		}
 	}
 
@@ -577,9 +494,9 @@ export class WatchingProblemCollector extends AbstractProblemCollector implement
 	}
 
 	public override done(): void {
-		[...this.applyToByOwner.keys()].forEach(owner => {
+		for (const owner of this.matchersOwners) {
 			this.recordResourcesToClean(owner);
-		});
+		}
 		super.done();
 	}
 

--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -229,7 +229,7 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 
 	private _cleanMarkers(owner: string, toClean: Map<string, URI>): void {
 		const uris = Array.from(toClean.values());
-		this.markerService.remove(owner, uris);
+		this.markerService.removeOriginForOwnerResources(undefined, owner, uris);
 	}
 
 	protected recordMarker(marker: IMarkerData, owner: string, resourceAsString: string): void {
@@ -280,7 +280,7 @@ export abstract class AbstractProblemCollector extends Disposable implements IDi
 		if (markers.size !== reported.get(resource)) {
 			const toSet: IMarkerData[] = [];
 			markers.forEach(value => toSet.push(value));
-			this.markerService.changeOne(owner, URI.parse(resource), toSet);
+			this.markerService.changeOne(undefined, owner, URI.parse(resource), toSet);
 			reported.set(resource, markers.size);
 		}
 	}

--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -111,31 +111,9 @@ export interface IWatchingMatcher {
 	endsPattern: IWatchingPattern;
 }
 
-export enum ApplyToKind {
-	allDocuments,
-	openDocuments,
-	closedDocuments
-}
-
-export namespace ApplyToKind {
-	export function fromString(value: string): ApplyToKind | undefined {
-		value = value.toLowerCase();
-		if (value === 'alldocuments') {
-			return ApplyToKind.allDocuments;
-		} else if (value === 'opendocuments') {
-			return ApplyToKind.openDocuments;
-		} else if (value === 'closeddocuments') {
-			return ApplyToKind.closedDocuments;
-		} else {
-			return undefined;
-		}
-	}
-}
-
 export interface ProblemMatcher {
 	owner: string;
 	source?: string;
-	applyTo: ApplyToKind;
 	fileLocation: FileLocationKind;
 	filePrefix?: string | Config.SearchFileLocationArgs;
 	pattern: Types.SingleOrMany<IProblemPattern>;
@@ -828,18 +806,6 @@ export namespace Config {
 		source?: string;
 
 		/**
-		* Specifies to which kind of documents the problems found by this
-		* matcher are applied. Valid values are:
-		*
-		*   "allDocuments": problems found in all documents are applied.
-		*   "openDocuments": problems found in documents that are open
-		*   are applied.
-		*   "closedDocuments": problems found in closed documents are
-		*   applied.
-		*/
-		applyTo?: string;
-
-		/**
 		* The severity of the VSCode problem produced by this problem matcher.
 		*
 		* Valid values are:
@@ -1255,11 +1221,6 @@ export namespace Schemas {
 				enum: ['error', 'warning', 'info'],
 				description: localize('ProblemMatcherSchema.severity', 'The default severity for captures problems. Is used if the pattern doesn\'t define a match group for severity.')
 			},
-			applyTo: {
-				type: 'string',
-				enum: ['allDocuments', 'openDocuments', 'closedDocuments'],
-				description: localize('ProblemMatcherSchema.applyTo', 'Controls if a problem reported on a text document is applied only to open, closed or all documents.')
-			},
 			pattern: PatternType,
 			fileLocation: {
 				oneOf: [
@@ -1657,10 +1618,6 @@ export class ProblemMatcherParser extends Parser {
 
 		const owner = Types.isString(description.owner) ? description.owner : UUID.generateUuid();
 		const source = Types.isString(description.source) ? description.source : undefined;
-		let applyTo = Types.isString(description.applyTo) ? ApplyToKind.fromString(description.applyTo) : ApplyToKind.allDocuments;
-		if (!applyTo) {
-			applyTo = ApplyToKind.allDocuments;
-		}
 		let fileLocation: FileLocationKind | undefined = undefined;
 		let filePrefix: string | Config.SearchFileLocationArgs | undefined = undefined;
 
@@ -1727,15 +1684,11 @@ export class ProblemMatcherParser extends Parser {
 					if (description.severity !== undefined && severity !== undefined) {
 						result.severity = severity;
 					}
-					if (description.applyTo !== undefined && applyTo !== undefined) {
-						result.applyTo = applyTo;
-					}
 				}
 			}
 		} else if (fileLocation && pattern) {
 			result = {
 				owner: owner,
-				applyTo: applyTo,
 				fileLocation: fileLocation,
 				pattern: pattern,
 			};
@@ -1933,7 +1886,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('msCompile', 'Microsoft compiler problems'),
 			owner: 'msCompile',
 			source: 'cpp',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			pattern: ProblemPatternRegistry.get('msCompile')
 		});
@@ -1944,7 +1896,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			deprecated: true,
 			owner: 'lessCompile',
 			source: 'less',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			pattern: ProblemPatternRegistry.get('lessCompile'),
 			severity: Severity.Error
@@ -1955,7 +1906,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('gulp-tsc', 'Gulp TSC Problems'),
 			owner: 'typescript',
 			source: 'ts',
-			applyTo: ApplyToKind.closedDocuments,
 			fileLocation: FileLocationKind.Relative,
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('gulp-tsc')
@@ -1966,7 +1916,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('jshint', 'JSHint problems'),
 			owner: 'jshint',
 			source: 'jshint',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			pattern: ProblemPatternRegistry.get('jshint')
 		});
@@ -1976,7 +1925,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('jshint-stylish', 'JSHint stylish problems'),
 			owner: 'jshint',
 			source: 'jshint',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			pattern: ProblemPatternRegistry.get('jshint-stylish')
 		});
@@ -1986,7 +1934,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('eslint-compact', 'ESLint compact problems'),
 			owner: 'eslint',
 			source: 'eslint',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('eslint-compact')
@@ -1997,7 +1944,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('eslint-stylish', 'ESLint stylish problems'),
 			owner: 'eslint',
 			source: 'eslint',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Absolute,
 			pattern: ProblemPatternRegistry.get('eslint-stylish')
 		});
@@ -2007,7 +1953,6 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('go', 'Go problems'),
 			owner: 'go',
 			source: 'go',
-			applyTo: ApplyToKind.allDocuments,
 			fileLocation: FileLocationKind.Relative,
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('go')

--- a/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/problemMatcher.test.ts
@@ -273,7 +273,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches lines with leading whitespace', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -288,7 +287,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches lines without diagnostic code', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -303,7 +301,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches lines without location information', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -319,7 +316,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches lines with build prefixes and fatal errors', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -335,7 +331,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches info diagnostics with codes', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -351,7 +346,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches lines with subcategory prefixes', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -367,7 +361,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('matches complex diagnostics with all qualifiers', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});
@@ -387,7 +380,6 @@ suite('ProblemPatternRegistry - msCompile', () => {
 	test('ignores diagnostics without origin', () => {
 		const matcher = matchers.createLineMatcher({
 			owner: 'msCompile',
-			applyTo: matchers.ApplyToKind.allDocuments,
 			fileLocation: matchers.FileLocationKind.Absolute,
 			pattern: matchers.ProblemPatternRegistry.get('msCompile')
 		});

--- a/src/vs/workbench/contrib/tasks/test/common/taskConfiguration.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/taskConfiguration.test.ts
@@ -10,7 +10,7 @@ import * as UUID from '../../../../../base/common/uuid.js';
 import * as Types from '../../../../../base/common/types.js';
 import * as Platform from '../../../../../base/common/platform.js';
 import { ValidationStatus } from '../../../../../base/common/parsers.js';
-import { ProblemMatcher, FileLocationKind, IProblemPattern, ApplyToKind, INamedProblemMatcher } from '../../common/problemMatcher.js';
+import { ProblemMatcher, FileLocationKind, IProblemPattern, INamedProblemMatcher } from '../../common/problemMatcher.js';
 import { WorkspaceFolder, IWorkspace } from '../../../../../platform/workspace/common/workspace.js';
 
 import * as Tasks from '../../common/tasks.js';
@@ -261,7 +261,6 @@ class ProblemMatcherBuilder {
 	constructor(public parent: CustomTaskBuilder) {
 		this.result = {
 			owner: ProblemMatcherBuilder.DEFAULT_UUID,
-			applyTo: ApplyToKind.allDocuments,
 			severity: undefined,
 			fileLocation: FileLocationKind.Relative,
 			filePrefix: '${workspaceFolder}',
@@ -271,11 +270,6 @@ class ProblemMatcherBuilder {
 
 	public owner(value: string): ProblemMatcherBuilder {
 		this.result.owner = value;
-		return this;
-	}
-
-	public applyTo(value: ApplyToKind): ProblemMatcherBuilder {
-		this.result.applyTo = value;
 		return this;
 	}
 
@@ -557,7 +551,6 @@ function assertProblemMatcher(actual: string | ProblemMatcher, expected: string 
 		} else {
 			assert.strictEqual(actual.owner, expected.owner);
 		}
-		assert.strictEqual(actual.applyTo, expected.applyTo);
 		assert.strictEqual(actual.severity, expected.severity);
 		assert.strictEqual(actual.fileLocation, expected.fileLocation);
 		assert.strictEqual(actual.filePrefix, expected.filePrefix);
@@ -1091,7 +1084,6 @@ suite('Tasks version 0.1.0', () => {
 					taskName: 'taskName',
 					problemMatcher: {
 						owner: 'myOwner',
-						applyTo: 'closedDocuments',
 						severity: 'warning',
 						fileLocation: 'absolute',
 						pattern: {
@@ -1106,7 +1098,6 @@ suite('Tasks version 0.1.0', () => {
 			command().args(['$name']).parent.
 			problemMatcher().
 			owner('myOwner').
-			applyTo(ApplyToKind.closedDocuments).
 			severity(Severity.Warning).
 			fileLocation(FileLocationKind.Absolute).
 			filePrefix(undefined!).
@@ -1826,10 +1817,9 @@ suite('Task configuration conversions', () => {
 			assert.deepEqual(result.value, [{ 'label': 'real label' }]);
 		});
 		test('returns config for a known problem matcher including applyTo', () => {
-			namedProblemMatcher.applyTo = ApplyToKind.closedDocuments;
 			const result = (ProblemMatcherConverter.from('$real', parseContext));
 			assert.strictEqual(result.errors?.length, 0);
-			assert.deepEqual(result.value, [{ 'label': 'real label', 'applyTo': ApplyToKind.closedDocuments }]);
+			assert.deepEqual(result.value, [{ 'label': 'real label' }]);
 		});
 	});
 	suite('TaskParser.from', () => {

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -22,6 +22,7 @@ import { IResourceEditorInput } from '../../../platform/editor/common/editor.js'
 import { FileChangesEvent, FileOperationEvent, FileSystemProviderCapabilities, IBaseFileStat, ICreateFileOptions, IFileContent, IFileService, IFileStat, IFileStatResult, IFileStatWithMetadata, IFileStatWithPartialMetadata, IFileStreamContent, IFileSystemProvider, IFileSystemProviderActivationEvent, IFileSystemProviderCapabilitiesChangeEvent, IFileSystemWatcher, IReadFileOptions, IReadFileStreamOptions, IResolveFileOptions, IResolveMetadataFileOptions, IWatchOptions, IWatchOptionsWithCorrelation, IWriteFileOptions } from '../../../platform/files/common/files.js';
 import { AbstractLoggerService, ILogger, LogLevel, NullLogger } from '../../../platform/log/common/log.js';
 import { IMarker, IMarkerData, IMarkerService, IResourceMarker, MarkerStatistics } from '../../../platform/markers/common/markers.js';
+import { IMarkerOrigin } from '../../../platform/markers/common/markerOrigin.js';
 import product from '../../../platform/product/common/product.js';
 import { IProgress, IProgressStep } from '../../../platform/progress/common/progress.js';
 import { InMemoryStorageService, WillSaveStateReason } from '../../../platform/storage/common/storage.js';
@@ -508,9 +509,10 @@ export class TestMarkerService implements IMarkerService {
 	onMarkerChanged = Event.None;
 
 	getStatistics(): MarkerStatistics { throw new Error('Method not implemented.'); }
-	changeOne(owner: string, resource: URI, markers: IMarkerData[]): void { }
-	changeAll(owner: string, data: IResourceMarker[]): void { }
-	remove(owner: string, resources: URI[]): void { }
+	removeOriginForOwner(origin: IMarkerOrigin, owner: string): void { }
+	changeOne(origin: IMarkerOrigin, owner: string, resource: URI, markers: IMarkerData[]): void { }
+	changeAll(origin: IMarkerOrigin, owner: string, data: IResourceMarker[]): void { }
+	removeOriginForOwnerResources(origin: IMarkerOrigin, owner: string, resources: URI[]): void { }
 	read(filter?: { owner?: string | undefined; resource?: URI | undefined; severities?: number | undefined; take?: number | undefined } | undefined): IMarker[] { return []; }
 	installResourceFilter(resource: URI, reason: string): IDisposable {
 		return { dispose: () => { /* TODO: Implement cleanup logic */ } };


### PR DESCRIPTION
This PR aims to improve `markerService` internal management by adding a third dimension, `origin`, to the existing `resource` and `owner` dimensions

###### issue, source of intention https://github.com/microsoft/vscode/issues/291739#issuecomment-3848980453

Currently, some marker providers and consumers have to use complex logic for updating/reading markers
For example, problem matchers update markers based on textModel open/close state for the given URI: [AbstractProblemCollector.shouldApplyMatch()](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/workbench/contrib/tasks/common/problemCollectors.ts#L172). When textModel is closed, `problemCollectors` [resend](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/workbench/contrib/tasks/common/problemCollectors.ts#L443) markers, assuming that markerServer storage for the given text model may have been under the control of another marker provider. This introduces false positives and more importantly may delay updates up to 3 minutes, resulting in stale diagnostics information in Problems View panel #291739

Another example is how `MainThreadDiagnostics` has to read markers and push them back filtered on [MainThreadDiagnostics.dispose()](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/workbench/api/browser/mainThreadDiagnostics.ts#L36), actually manipulating markers that do not belong to it

###### origin goals
`origin` dimension in markerService storage intends to achieve
1\. Allow marker providers to push their updates without worrying about other providers activity
2\. As a result, always up-to-date markers storage
3\. Ability to change the currently active 'origin' without delays or performance impact
4\. Give language extensions an option to switch from `onDidOpen/CloseTextDocument` events that are tied with textDocument instantiation/disposal, to `tabGroups` events, to make diagnostic information responsive based on the file editing state in UI, rather than on vs code internal text document object lifecycle
5\. Make it possible to resolve potential collisions when more than one extension declares itself a provider of same language markers

###### The following is code-related and not required reading prior to review
###### provisions of changes of [MarkerService](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/platform/markers/common/markerService.ts#L150)
`origin` dimension is added to `MarkerService._data`, which is renamed to `_backyard` and is still main storage of markers
`_facade` storage is added for maintaining an active slice of `_backyard`, a cache for `MarkerService.read` performance, and represents a visible from the outside collection of markers
'origin' property is removed from marker objects and added as argument to markerService methods
`origin` is `string | undefined`, representing two priority levels, where `undefined` is the lowest, and any `string`s are treated equally prioritized over undefined. At the moment, `string` is used only by [MainThreadDiagnostics.extHostId](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/workbench/api/browser/mainThreadDiagnostics.ts#L23). This does not resolve 'extension vs extension' yet but is sufficient for 'extension vs task problem-matcher' collision
`_facade` origins switching is automatic and based on `origins` of incoming markers. Main mechanics are concentrated in new `_updateOriginForOwnerResource()` and `_removeOriginForOwnerResource()` methods, which are good review starting points
`_onMarkerChanged` is fired for facade changes only
`problemCollectors` and `mainThreadDiagnostics` updates simplified
'applyTo' property of problem-matchers removed since the only reason for its existence seemed to be to help problem matchers avoid collisions with extensions

###### unclear points
After these changes, marker updates from extensions land in two [ExtHostDiagnostics._collections](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/src/vs/workbench/api/common/extHostDiagnostics.ts#L241), the one that belongs to the extension, and the second is `_mirrorCollection`. This results in double sets of markers given away by `getDiagnostics()`. In theory, this means that the language extension collection should not be included in `ExtHostDiagnostics._collections`, so that it doesn't participate in `getDiagnostics()` output. However, there is currently no option to filter spawned collections by this criterion. Therefore, the opposite is done — only `_mirrorCollection` is included in the output, which could be correct since, after all changes, `_mirrorCollection` became an always up-to-date reflection of `MarkerService._facade`. So this requires someone with a more knowledgeable perspective. This is either the incorrect solution, since other collections are also excluded from the `getDiagnostics()` output. Or, if the contents of these excluded collections are reflected in `markerService`, this location can be simplified even further. This would be logical, since otherwise `getDiagnostics()` output is richer than `markerService` content

###### statements
When implementing automatic switching of the active 'origin', it is necessary to ensure that marker providers are aware of the use of `MarkerService.changeOne(..., markerData: IMarkerData[] | null)`. Passing `null` removes `origin` and its markers, and this may result in another origin being placed at the facade. For example, when there is a task problem matcher is running, and a file is opened for editing, the extension origin becomes active. If the extension sends `null` when all problems are fixed, origin is removed, and markerService will place problem-matcher diagnostics to the facade. Marker providers such as language extensions should send `[]` for the case of absent problems to retain origin activity and send `null` or call `MarkerService.removeOriginForOwner` on dispose. However, such cases should be immediately visible

###### test kit
In already normal working scenarios there should be no noticeable changes except the removed delay between disappearing diagnostics on textModel removal and replacement by problem matcher diagnostics

<details>
<summary>show<br>
Check videos for the difference demonstration. Pay attention to the 'unused' problem in Problems View. When it is Error, origin is problem-matcher. When it is a Warning, origin is the extension</summary>
<br>

Before the changes, replacement is delayed on file close:
![bChanges](https://github.com/user-attachments/assets/43945209-0f90-4c36-a827-aa2e2805258f)
After the changes, replacement is instant:
![aChanges](https://github.com/user-attachments/assets/35ce3c6d-dddf-4e38-adac-75d2a8b555c1)

</details>

Looking further to leverage the results of markerService improvements, here is a branch for testing the switching of the `typescript-language-features` extension from using `workspace.onDidOpen/CloseTextDocument` events, which results in an unsynced diagnostics state in case of closing files opened by `window.openTextDocument()` (resolution of https://github.com/microsoft/vscode/issues/291739), to `window.tabGroups` events https://github.com/n-gist/vscode/tree/markerService-origins-test-typescript-extension-switchToTabGroupsEvents
Applying it over changes makes the behavior of opening .ts files from Explorer tab and by `workspace.openTextDocument` identical. Though it is not complete and sometimes updates markers after the file is closed for some reason by [DiagnosticsManager.scheduleDiagnosticsUpdate()](https://github.com/microsoft/vscode/blob/16e49a8b88457e6bd43b048933707e77bdad65ff/extensions/typescript-language-features/src/languageFeatures/diagnostics.ts#L390), but it is a subject of a different PR, just mentioning it as noticed

My test project, containing .vsix extensions to test `workspace.openTextDocument` late disposal issue and `getDiagnostics()` outputs
```
git clone https://github.com/n-gist/getDiagnostics-test.git
```