### PR TITLE
Update codicons version and add 'openInWindow' icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-6",
+        "@vscode/codicons": "^0.0.45-7",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -2947,9 +2947,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-6",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-6.tgz",
-      "integrity": "sha512-HjJmIxw6anUPk/yiQTyF60ERjARNfc/A11kKoiO7jg2bzNeaCexunu4oUo/W8lHGr/dvHxYcruM1V3ZoGxyFNQ==",
+      "version": "0.0.45-7",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-7.tgz",
+      "integrity": "sha512-z7B3hI6LfrFY8uo0PrAHkZ0K0XQbKTshIHlDe5qyf0j6sjM2vNlzdj2FA8HgasYKBQ3zzpZzD/GK8on2A1AKRA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/deviceid": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-6",
+    "@vscode/codicons": "^0.0.45-7",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-6",
+        "@vscode/codicons": "^0.0.45-7",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-6",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-6.tgz",
-      "integrity": "sha512-HjJmIxw6anUPk/yiQTyF60ERjARNfc/A11kKoiO7jg2bzNeaCexunu4oUo/W8lHGr/dvHxYcruM1V3ZoGxyFNQ==",
+      "version": "0.0.45-7",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-7.tgz",
+      "integrity": "sha512-z7B3hI6LfrFY8uo0PrAHkZ0K0XQbKTshIHlDe5qyf0j6sjM2vNlzdj2FA8HgasYKBQ3zzpZzD/GK8on2A1AKRA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-6",
+    "@vscode/codicons": "^0.0.45-7",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -654,4 +654,5 @@ export const codiconsLibrary = {
 	ask: register('ask', 0xec80),
 	openai: register('openai', 0xec81),
 	claude: register('claude', 0xec82),
+	openInWindow: register('open-in-window', 0xec83),
 } as const;


### PR DESCRIPTION
Update the codicons package to version 0.0.45-7 and introduce a new icon named 'openInWindow'. This enhances the icon library available for use. Testing can be done by verifying the presence of the new icon in the codicons set.

