### PR TITLE
add tips toolbar

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -274,6 +274,7 @@ export class MenuId {
 	static readonly ChatTitleBarMenu = new MenuId('ChatTitleBarMenu');
 	static readonly ChatAttachmentsContext = new MenuId('ChatAttachmentsContext');
 	static readonly ChatTipContext = new MenuId('ChatTipContext');
+	static readonly ChatTipToolbar = new MenuId('ChatTipToolbar');
 	static readonly ChatToolOutputResourceToolbar = new MenuId('ChatToolOutputResourceToolbar');
 	static readonly ChatTextEditorMenu = new MenuId('ChatTextEditorMenu');
 	static readonly ChatToolOutputResourceContext = new MenuId('ChatToolOutputResourceContext');

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -796,20 +796,10 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		}
 
 		const dismissedIds = new Set(this._getDismissedTipIds());
-		const totalTips = TIP_CATALOG.length;
-
-		// Pass 1: consider only non-dismissed and eligible tips
-		// Pass 2: consider any non-dismissed tips, regardless of eligibility
-		for (let pass = 0; pass < 2; pass++) {
-			for (let i = 1; i < totalTips; i++) {
-				const idx = ((currentIndex + direction * i) % totalTips + totalTips) % totalTips;
-				const candidate = TIP_CATALOG[idx];
-				if (dismissedIds.has(candidate.id)) {
-					continue;
-				}
-				if (pass === 0 && !this._isEligible(candidate, contextKeyService)) {
-					continue;
-				}
+		for (let i = 1; i < TIP_CATALOG.length; i++) {
+			const idx = ((currentIndex + direction * i) % TIP_CATALOG.length + TIP_CATALOG.length) % TIP_CATALOG.length;
+			const candidate = TIP_CATALOG[idx];
+			if (!dismissedIds.has(candidate.id) && this._isEligible(candidate, contextKeyService)) {
 				this._shownTip = candidate;
 				this._storageService.store(ChatTipService._LAST_TIP_ID_KEY, candidate.id, StorageScope.PROFILE, StorageTarget.USER);
 				const tip = this._createTip(candidate);

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -796,10 +796,20 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		}
 
 		const dismissedIds = new Set(this._getDismissedTipIds());
-		for (let i = 1; i < TIP_CATALOG.length; i++) {
-			const idx = ((currentIndex + direction * i) % TIP_CATALOG.length + TIP_CATALOG.length) % TIP_CATALOG.length;
-			const candidate = TIP_CATALOG[idx];
-			if (!dismissedIds.has(candidate.id) && this._isEligible(candidate, contextKeyService)) {
+		const totalTips = TIP_CATALOG.length;
+
+		// Pass 1: consider only non-dismissed and eligible tips
+		// Pass 2: consider any non-dismissed tips, regardless of eligibility
+		for (let pass = 0; pass < 2; pass++) {
+			for (let i = 1; i < totalTips; i++) {
+				const idx = ((currentIndex + direction * i) % totalTips + totalTips) % totalTips;
+				const candidate = TIP_CATALOG[idx];
+				if (dismissedIds.has(candidate.id)) {
+					continue;
+				}
+				if (pass === 0 && !this._isEligible(candidate, contextKeyService)) {
+					continue;
+				}
 				this._shownTip = candidate;
 				this._storageService.store(ChatTipService._LAST_TIP_ID_KEY, candidate.id, StorageScope.PROFILE, StorageTarget.USER);
 				const tip = this._createTip(candidate);

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -43,6 +43,11 @@ export interface IChatTipService {
 	readonly onDidNavigateTip: Event<IChatTip>;
 
 	/**
+	 * Fired when the tip widget is hidden without dismissing the tip.
+	 */
+	readonly onDidHideTip: Event<void>;
+
+	/**
 	 * Fired when tips are disabled.
 	 */
 	readonly onDidDisableTips: Event<void>;
@@ -76,6 +81,12 @@ export interface IChatTipService {
 	 * The dismissed tip will not be shown again in this profile.
 	 */
 	dismissTip(): void;
+
+	/**
+	 * Hides the tip widget without permanently dismissing the tip.
+	 * The tip may be shown again in a future session.
+	 */
+	hideTip(): void;
 
 	/**
 	 * Disables tips permanently by setting the `chat.tips.enabled` configuration to false.
@@ -571,6 +582,9 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	private readonly _onDidNavigateTip = this._register(new Emitter<IChatTip>());
 	readonly onDidNavigateTip = this._onDidNavigateTip.event;
 
+	private readonly _onDidHideTip = this._register(new Emitter<void>());
+	readonly onDidHideTip = this._onDidHideTip.event;
+
 	private readonly _onDidDisableTips = this._register(new Emitter<void>());
 	readonly onDidDisableTips = this._onDidDisableTips.event;
 
@@ -654,6 +668,13 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		} catch {
 			return [];
 		}
+	}
+
+	hideTip(): void {
+		this._hasShownRequestTip = false;
+		this._shownTip = undefined;
+		this._tipRequestId = undefined;
+		this._onDidHideTip.fire();
 	}
 
 	async disableTips(): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -13,10 +13,11 @@ import { Emitter } from '../../../../../../base/common/event.js';
 import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../../../nls.js';
 import { getFlatContextMenuActions } from '../../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { MenuWorkbenchToolBar } from '../../../../../../platform/actions/browser/toolbar.js';
 import { Action2, IMenuService, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
-import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IInstantiationService, ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { ChatContextKeys } from '../../../common/actions/chatContextKeys.js';
 import { IChatTip, IChatTipService } from '../../chatTipService.js';
@@ -30,6 +31,9 @@ export class ChatTipContentPart extends Disposable {
 	public readonly onDidHide = this._onDidHide.event;
 
 	private readonly _renderedContent = this._register(new MutableDisposable());
+	private readonly _toolbar = this._register(new MutableDisposable<MenuWorkbenchToolBar>());
+
+	private _suppressNextDismissHandler = false;
 
 	private readonly _inChatTipContextKey: IContextKey<boolean>;
 
@@ -41,6 +45,7 @@ export class ChatTipContentPart extends Disposable {
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IMenuService private readonly _menuService: IMenuService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
@@ -58,6 +63,10 @@ export class ChatTipContentPart extends Disposable {
 		this._renderTip(tip);
 
 		this._register(this._chatTipService.onDidDismissTip(() => {
+			if (this._suppressNextDismissHandler) {
+				this._suppressNextDismissHandler = false;
+				return;
+			}
 			const nextTip = this._getNextTip();
 			if (nextTip) {
 				this._renderTip(nextTip);
@@ -93,10 +102,22 @@ export class ChatTipContentPart extends Disposable {
 
 	private _renderTip(tip: IChatTip): void {
 		dom.clearNode(this.domNode);
+		this._toolbar.clear();
+
 		this.domNode.appendChild(renderIcon(Codicon.lightbulb));
 		const markdownContent = this._renderer.render(tip.content);
 		this._renderedContent.value = markdownContent;
 		this.domNode.appendChild(markdownContent.element);
+
+		// Toolbar with previous, next, and dismiss actions via MenuWorkbenchToolBar
+		const toolbarContainer = $('.chat-tip-toolbar');
+		this._toolbar.value = this._instantiationService.createInstance(MenuWorkbenchToolBar, toolbarContainer, MenuId.ChatTipToolbar, {
+			menuOptions: {
+				shouldForwardArgs: true,
+			},
+		});
+		this.domNode.appendChild(toolbarContainer);
+
 		const textContent = markdownContent.element.textContent ?? localize('chatTip', "Chat tip");
 		const hasLink = /\[.*?\]\(.*?\)/.test(tip.content.value);
 		const ariaLabel = hasLink
@@ -106,6 +127,74 @@ export class ChatTipContentPart extends Disposable {
 		status(ariaLabel);
 	}
 }
+
+//#region Tip toolbar actions
+
+registerAction2(class PreviousTipAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.previousTip',
+			title: localize2('chatTip.previous', "Previous Tip"),
+			icon: Codicon.chevronLeft,
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipToolbar,
+				group: 'navigation',
+				order: 1,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const chatTipService = accessor.get(IChatTipService);
+		const contextKeyService = accessor.get(IContextKeyService);
+		chatTipService.navigateToPreviousTip(contextKeyService);
+	}
+});
+
+registerAction2(class NextTipAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.nextTip',
+			title: localize2('chatTip.next', "Next Tip"),
+			icon: Codicon.chevronRight,
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipToolbar,
+				group: 'navigation',
+				order: 2,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const chatTipService = accessor.get(IChatTipService);
+		const contextKeyService = accessor.get(IContextKeyService);
+		chatTipService.navigateToNextTip(contextKeyService);
+	}
+});
+
+registerAction2(class DismissTipToolbarAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.dismissTipToolbar',
+			title: localize2('chatTip.dismissButton', "Dismiss Tip"),
+			icon: Codicon.check,
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipToolbar,
+				group: 'navigation',
+				order: 3,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IChatTipService).dismissTip();
+	}
+});
+
+//#endregion
 
 //#region Tip context menu actions
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -200,7 +200,7 @@ registerAction2(class CloseTipToolbarAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.chat.closeTip',
-			title: localize2('chatTip.close', "Close Tip"),
+			title: localize2('chatTip.close', "Close Tips"),
 			icon: Codicon.close,
 			f1: false,
 			menu: [{

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -73,6 +73,10 @@ export class ChatTipContentPart extends Disposable {
 			this._renderTip(tip);
 		}));
 
+		this._register(this._chatTipService.onDidHideTip(() => {
+			this._onDidHide.fire();
+		}));
+
 		this._register(this._chatTipService.onDidDisableTips(() => {
 			this._onDidHide.fire();
 		}));
@@ -189,6 +193,26 @@ registerAction2(class DismissTipToolbarAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		accessor.get(IChatTipService).dismissTip();
+	}
+});
+
+registerAction2(class CloseTipToolbarAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.closeTip',
+			title: localize2('chatTip.close', "Close Tip"),
+			icon: Codicon.close,
+			f1: false,
+			menu: [{
+				id: MenuId.ChatTipToolbar,
+				group: 'navigation',
+				order: 4,
+			}]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IChatTipService).hideTip();
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -33,8 +33,6 @@ export class ChatTipContentPart extends Disposable {
 	private readonly _renderedContent = this._register(new MutableDisposable());
 	private readonly _toolbar = this._register(new MutableDisposable<MenuWorkbenchToolBar>());
 
-	private _suppressNextDismissHandler = false;
-
 	private readonly _inChatTipContextKey: IContextKey<boolean>;
 
 	constructor(
@@ -63,16 +61,16 @@ export class ChatTipContentPart extends Disposable {
 		this._renderTip(tip);
 
 		this._register(this._chatTipService.onDidDismissTip(() => {
-			if (this._suppressNextDismissHandler) {
-				this._suppressNextDismissHandler = false;
-				return;
-			}
 			const nextTip = this._getNextTip();
 			if (nextTip) {
 				this._renderTip(nextTip);
 			} else {
 				this._onDidHide.fire();
 			}
+		}));
+
+		this._register(this._chatTipService.onDidNavigateTip(tip => {
+			this._renderTip(tip);
 		}));
 
 		this._register(this._chatTipService.onDidDisableTips(() => {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -37,6 +37,36 @@
 	margin: 0;
 }
 
+.interactive-item-container .chat-tip-widget .chat-tip-toolbar,
+.chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar {
+	display: flex;
+	align-items: center;
+	margin-left: auto;
+	flex-shrink: 0;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+}
+
+.interactive-item-container .chat-tip-widget:hover .chat-tip-toolbar,
+.interactive-item-container .chat-tip-widget:focus-within .chat-tip-toolbar,
+.chat-getting-started-tip-container .chat-tip-widget:hover .chat-tip-toolbar,
+.chat-getting-started-tip-container .chat-tip-widget:focus-within .chat-tip-toolbar {
+	opacity: 1;
+}
+
+.interactive-item-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label,
+.chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label {
+	width: 20px;
+	height: 20px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.interactive-item-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label:hover,
+.chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+	color: var(--vscode-foreground);
+}
+
 .chat-getting-started-tip-container {
 	margin-bottom: -4px; /* Counter the flex gap */
 	width: 100%;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -16,7 +16,6 @@
 	font-family: var(--vscode-chat-font-family, inherit);
 	color: var(--vscode-descriptionForeground);
 	position: relative;
-	overflow: hidden;
 }
 
 .interactive-item-container .chat-tip-widget .codicon-lightbulb {
@@ -46,8 +45,8 @@
 .interactive-item-container .chat-tip-widget .chat-tip-toolbar > .monaco-toolbar,
 .chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar > .monaco-toolbar {
 	position: absolute;
-	top: 2px;
-	right: 4px;
+	top: -15px;
+	right: 10px;
 	height: 26px;
 	line-height: 26px;
 	background-color: var(--vscode-editorWidget-background);
@@ -104,7 +103,6 @@
 	font-family: var(--vscode-chat-font-family, inherit);
 	color: var(--vscode-descriptionForeground);
 	position: relative;
-	overflow: hidden;
 }
 
 .chat-getting-started-tip-container .chat-tip-widget a {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -39,11 +39,21 @@
 
 .interactive-item-container .chat-tip-widget .chat-tip-toolbar,
 .chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar {
-	display: flex;
-	align-items: center;
-	margin-left: auto;
-	flex-shrink: 0;
 	opacity: 0;
+	pointer-events: none;
+}
+
+.interactive-item-container .chat-tip-widget .chat-tip-toolbar > .monaco-toolbar,
+.chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar > .monaco-toolbar {
+	position: absolute;
+	top: 2px;
+	right: 4px;
+	height: 26px;
+	line-height: 26px;
+	background-color: var(--vscode-editorWidget-background);
+	border: 1px solid var(--vscode-chat-requestBorder);
+	border-radius: var(--vscode-cornerRadius-medium);
+	z-index: 100;
 	transition: opacity 0.1s ease-in-out;
 }
 
@@ -52,12 +62,18 @@
 .chat-getting-started-tip-container .chat-tip-widget:hover .chat-tip-toolbar,
 .chat-getting-started-tip-container .chat-tip-widget:focus-within .chat-tip-toolbar {
 	opacity: 1;
+	pointer-events: auto;
+}
+
+.interactive-item-container .chat-tip-widget .chat-tip-toolbar .action-item,
+.chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar .action-item {
+	height: 24px;
+	width: 24px;
+	margin: 1px 2px;
 }
 
 .interactive-item-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label,
 .chat-getting-started-tip-container .chat-tip-widget .chat-tip-toolbar .action-item .action-label {
-	width: 20px;
-	height: 20px;
 	color: var(--vscode-descriptionForeground);
 }
 
@@ -87,6 +103,7 @@
 	font-size: var(--vscode-chat-font-size-body-s);
 	font-family: var(--vscode-chat-font-family, inherit);
 	color: var(--vscode-descriptionForeground);
+	position: relative;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
fix #295172

To do:
- move tip toolbar up so still overlap but not with text
- add disable tips action
- add keybindings for these actions with `when` tips container focused for screen reader users

https://github.com/user-attachments/assets/f393beec-616c-48a9-8034-853186fc4da5


