### PR TITLE
Add additional markdown extensions

### DIFF
--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -18,14 +18,17 @@
           "markdown"
         ],
         "extensions": [
+          ".litcoffee",
           ".md",
           ".mkd",
+          ".mkdn",
           ".mdwn",
           ".mdown",
           ".markdown",
           ".markdn",
           ".mdtxt",
           ".mdtext",
+          ".ron",
           ".workbook"
         ],
         "filenamePatterns": [

--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -29,6 +29,7 @@
           ".mdtxt",
           ".mdtext",
           ".ron",
+          ".ronn",
           ".workbook"
         ],
         "filenamePatterns": [


### PR DESCRIPTION
This marks the `.litcoffee` file extension as markdown. This is a markdown format, where indented code blocks can be interpreted as CoffeeScript.

This also adds the `.mkdn` and `.ron` extensions, which are taken from https://github.com/sindresorhus/markdown-extensions/blob/main/index.js.