### PR TITLE
Pass `--no-ext-diff` to git diff invocations in git extension

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1447,6 +1447,7 @@ export class Repository {
 
 		if (options?.shortStats) {
 			args.push('--shortstat');
+			args.push('--no-ext-diff');
 
 			if (this._git.compareGitVersionTo('2.31') !== -1) {
 				args.push('--diff-merges=first-parent');
@@ -1527,6 +1528,7 @@ export class Repository {
 
 		if (options?.shortStats) {
 			args.push('--shortstat');
+			args.push('--no-ext-diff');
 		}
 
 		if (options?.sortByAuthorDate) {
@@ -1735,7 +1737,7 @@ export class Repository {
 	}
 
 	async diff(cached = false): Promise<string> {
-		const args = ['diff'];
+		const args = ['diff', '--no-ext-diff'];
 
 		if (cached) {
 			args.push('--cached');
@@ -1753,7 +1755,7 @@ export class Repository {
 			return await this.diffFiles(undefined, { cached: false });
 		}
 
-		const args = ['diff', '--', this.sanitizeRelativePath(path)];
+		const args = ['diff', '--no-ext-diff', '--', this.sanitizeRelativePath(path)];
 		const result = await this.exec(args);
 		return result.stdout;
 	}
@@ -1770,7 +1772,7 @@ export class Repository {
 			return await this.diffFiles(ref, { cached: false });
 		}
 
-		const args = ['diff', ref, '--', this.sanitizeRelativePath(path)];
+		const args = ['diff', '--no-ext-diff', ref, '--', this.sanitizeRelativePath(path)];
 		const result = await this.exec(args);
 		return result.stdout;
 	}
@@ -1783,7 +1785,7 @@ export class Repository {
 			return await this.diffFiles(undefined, { cached: true });
 		}
 
-		const args = ['diff', '--cached', '--', this.sanitizeRelativePath(path)];
+		const args = ['diff', '--no-ext-diff', '--cached', '--', this.sanitizeRelativePath(path)];
 		const result = await this.exec(args);
 		return result.stdout;
 	}
@@ -1800,13 +1802,13 @@ export class Repository {
 			return await this.diffFiles(ref, { cached: true });
 		}
 
-		const args = ['diff', '--cached', ref, '--', this.sanitizeRelativePath(path)];
+		const args = ['diff', '--no-ext-diff', '--cached', ref, '--', this.sanitizeRelativePath(path)];
 		const result = await this.exec(args);
 		return result.stdout;
 	}
 
 	async diffBlobs(object1: string, object2: string): Promise<string> {
-		const args = ['diff', object1, object2];
+		const args = ['diff', '--no-ext-diff', object1, object2];
 		const result = await this.exec(args);
 		return result.stdout;
 	}
@@ -1820,14 +1822,14 @@ export class Repository {
 			return await this.diffFiles(range, { cached: false });
 		}
 
-		const args = ['diff', range, '--', this.sanitizeRelativePath(path)];
+		const args = ['diff', '--no-ext-diff', range, '--', this.sanitizeRelativePath(path)];
 		const result = await this.exec(args);
 
 		return result.stdout.trim();
 	}
 
 	async diffBetweenPatch(ref: string, options: { path?: string }): Promise<string> {
-		const args = ['diff', ref, '--'];
+		const args = ['diff', '--no-ext-diff', ref, '--'];
 
 		if (options.path) {
 			args.push(this.sanitizeRelativePath(options.path));
@@ -1838,7 +1840,7 @@ export class Repository {
 	}
 
 	async diffBetweenWithStats(ref: string, options: { path?: string; similarityThreshold?: number }): Promise<DiffChange[]> {
-		const args = ['diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z',];
+		const args = ['diff', '--no-ext-diff', '--raw', '--numstat', '--diff-filter=ADMR', '-z',];
 
 		if (options.similarityThreshold) {
 			args.push(`--find-renames=${options.similarityThreshold}%`);
@@ -1858,7 +1860,7 @@ export class Repository {
 	}
 
 	private async diffFiles(ref: string | undefined, options: { cached: boolean; similarityThreshold?: number }): Promise<Change[]> {
-		const args = ['diff', '--name-status', '-z', '--diff-filter=ADMR'];
+		const args = ['diff', '--no-ext-diff', '--name-status', '-z', '--diff-filter=ADMR'];
 
 		if (options.cached) {
 			args.push('--cached');
@@ -1883,7 +1885,7 @@ export class Repository {
 	}
 
 	private async diffFilesShortStat(ref: string | undefined, options: { cached: boolean; path?: string }): Promise<CommitShortStat> {
-		const args = ['diff', '--shortstat'];
+		const args = ['diff', '--no-ext-diff', '--shortstat'];
 
 		if (options.cached) {
 			args.push('--cached');
@@ -1909,7 +1911,7 @@ export class Repository {
 
 
 	async diffTrees(treeish1: string, treeish2?: string, options?: { similarityThreshold?: number }): Promise<DiffChange[]> {
-		const args = ['diff-tree', '-r', '--raw', '--numstat', '--diff-filter=ADMR', '-z'];
+		const args = ['diff-tree', '--no-ext-diff', '-r', '--raw', '--numstat', '--diff-filter=ADMR', '-z'];
 
 		if (options?.similarityThreshold) {
 			args.push(`--find-renames=${options.similarityThreshold}%`);
@@ -3313,7 +3315,7 @@ export class Repository {
 
 	async showChanges(ref: string): Promise<string> {
 		try {
-			const result = await this.exec(['log', '-p', '-n1', ref, '--']);
+			const result = await this.exec(['log', '--no-ext-diff', '-p', '-n1', ref, '--']);
 			return result.stdout.trim();
 		} catch (err) {
 			if (/^fatal: bad revision '.+'/.test(err.stderr || '')) {
@@ -3326,7 +3328,7 @@ export class Repository {
 
 	async showChangesBetween(ref1: string, ref2: string, path?: string): Promise<string> {
 		try {
-			const args = ['log', '-p', `${ref1}..${ref2}`, '--'];
+			const args = ['log', '--no-ext-diff', '-p', `${ref1}..${ref2}`, '--'];
 			if (path) {
 				args.push(this.sanitizeRelativePath(path));
 			}


### PR DESCRIPTION
Fixes #295057

When a user has an external diff tool configured via `diff.external` (e.g. difftastic), git hands off diff output to that tool. Since the git extension parses diff output programmatically, this breaks features like "Generate Commit Message" and SCM change detection.

This adds `--no-ext-diff` to every `git diff`, `git diff-tree`, and `git log -p`/`--shortstat` invocation in `extensions/git/src/git.ts`. The flag tells git to use its built-in diff engine regardless of user configuration. None of these callsites want custom diff formatting.

**How to test:**

1. Configure an external diff tool: `git config --global diff.external difft`
2. Make a change in a tracked file
3. Verify SCM changes display correctly and "Generate Commit Message" works
4. `git config --global --unset diff.external` to clean up