### PR TITLE
Fix memory leak in SCM artifact provider

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -437,6 +437,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 			const artifactProvider = new MainThreadSCMArtifactProvider(this.proxy, this.handle);
 			this._artifactProvider.set(artifactProvider, undefined);
 		} else if (features.hasArtifactProvider === false && this.artifactProvider.get()) {
+			this._artifactProvider.get()?.dispose();
 			this._artifactProvider.set(undefined, undefined);
 		}
 
@@ -595,6 +596,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 	}
 
 	dispose(): void {
+		this._artifactProvider.get()?.dispose();
 		this._stagedQuickDiff?.dispose();
 		this._quickDiff?.dispose();
 	}


### PR DESCRIPTION
[LEAKED DISPOSABLE] Error: CREATED via:
lifecycle.ts:52
    at GCBasedDisposableTracker.trackDisposable (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/base/common/lifecycle.js:16:19)
lifecycle.ts:52
    at trackDisposable (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/base/common/lifecycle.js:192:22)
lifecycle.ts:52
    at new DisposableStore (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/base/common/lifecycle.js:277:5)
lifecycle.ts:52
    at new MainThreadSCMArtifactProvider (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/workbench/api/browser/mainThreadSCM.js:157:25)
lifecycle.ts:52
    at MainThreadSCMProvider.$updateSourceControl (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/workbench/api/browser/mainThreadSCM.js:401:32)
lifecycle.ts:52
    at MainThreadSCM.$updateSourceControl (vscode-file://vscode-app/c:/Users/dmitriv/repos/vscode/out/vs/workbench/api/browser/mainThreadSCM.js:584:14)
lifecycle.ts:52