### PR TITLE
fix: selection of string literals when string contains escape characters

### DIFF
--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -175,7 +175,7 @@ export class ViewController {
 			}
 		}
 
-		// Check if current token is a string.
+		// Expand to the contiguous run of string tokens (StandardTokenType.String) around the click position.
 		const lineTokens = tokens.getLineTokens(lineNumber);
 		let startIndex = lineTokens.findTokenIndexAtOffset(column - 1);
 		let endIndex = startIndex;

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -177,14 +177,20 @@ export class ViewController {
 
 		// Check if current token is a string.
 		const lineTokens = tokens.getLineTokens(lineNumber);
-		const index = lineTokens.findTokenIndexAtOffset(column - 1);
-		if (lineTokens.getStandardTokenType(index) !== StandardTokenType.String) {
-			return undefined;
+		let startIndex = lineTokens.findTokenIndexAtOffset(column - 1);
+		let endIndex = startIndex;
+		while (startIndex > 0 &&
+			lineTokens.getStandardTokenType(startIndex - 1) === StandardTokenType.String) {
+			startIndex--;
+		}
+		while (endIndex < lineTokens.getCount() &&
+			lineTokens.getStandardTokenType(endIndex + 1) === StandardTokenType.String) {
+			endIndex++;
 		}
 
 		// Verify the click is after starting or before closing quote.
-		const tokenStart = lineTokens.getStartOffset(index);
-		const tokenEnd = lineTokens.getEndOffset(index);
+		const tokenStart = lineTokens.getStartOffset(startIndex);
+		const tokenEnd = lineTokens.getEndOffset(endIndex);
 		if (column !== tokenStart + 2 && column !== tokenEnd) {
 			return undefined;
 		}

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -183,7 +183,7 @@ export class ViewController {
 			lineTokens.getStandardTokenType(startIndex - 1) === StandardTokenType.String) {
 			startIndex--;
 		}
-		while (endIndex < lineTokens.getCount() &&
+		while (endIndex + 1 < lineTokens.getCount() &&
 			lineTokens.getStandardTokenType(endIndex + 1) === StandardTokenType.String) {
 			endIndex++;
 		}

--- a/src/vs/editor/test/browser/view/viewController.test.ts
+++ b/src/vs/editor/test/browser/view/viewController.test.ts
@@ -309,6 +309,21 @@ suite('ViewController - String content selection', () => {
 		assert.strictEqual(doubleClickAt(controller, new Position(1, 10)), 'hello');
 	});
 
+	test('Select string content containing escape characters', () => {
+		//                0123456789...
+		const text = 'var x = "hello\\"world";';
+		// Token layout: [0..8) Other  [8..22) String("hello\"world")  [22..23) Other
+		const controller = createViewControllerWithTokens(text, [
+			{ startIndex: 0, type: StandardTokenType.Other },
+			{ startIndex: 8, type: StandardTokenType.String },
+			{ startIndex: 14, type: StandardTokenType.String },
+			{ startIndex: 16, type: StandardTokenType.String },
+			{ startIndex: 22, type: StandardTokenType.Other },
+		]);
+		// Column right after opening quote: offset 9 → column 10
+		assert.strictEqual(doubleClickAt(controller, new Position(1, 10)), 'hello\\"world');
+	});
+
 	// -- Click in middle of string should NOT select the whole string --
 
 	test('Click in middle of string does not select whole string', () => {

--- a/src/vs/editor/test/browser/view/viewController.test.ts
+++ b/src/vs/editor/test/browser/view/viewController.test.ts
@@ -316,8 +316,10 @@ suite('ViewController - String content selection', () => {
 		const controller = createViewControllerWithTokens(text, [
 			{ startIndex: 0, type: StandardTokenType.Other },
 			{ startIndex: 8, type: StandardTokenType.String },
+			{ startIndex: 9, type: StandardTokenType.String },
 			{ startIndex: 14, type: StandardTokenType.String },
 			{ startIndex: 16, type: StandardTokenType.String },
+			{ startIndex: 21, type: StandardTokenType.String },
 			{ startIndex: 22, type: StandardTokenType.Other },
 		]);
 		// Column right after opening quote: offset 9 → column 10


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/292784

* https://github.com/microsoft/vscode/issues/292784

merges multiple string tokens together
because escape characters and quote characters (with certain themes on) were separate tokens

```js
"hello\"world"
```

double click after first quote `"`, before `h`

before:
<img width="206" height="52" alt="image" src="https://github.com/user-attachments/assets/d5d6ca8a-b306-4a8b-9307-d2022c0d6120" />

after:
<img width="205" height="49" alt="image" src="https://github.com/user-attachments/assets/5ae1cca4-af44-45c6-a931-7b7e9774a207" />

cc @dmitrivMS 