### PR TITLE
fix: preserve special characters when dropping files into terminal

### DIFF
--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -7,9 +7,9 @@ import { OperatingSystem, OS } from '../../../base/common/platform.js';
 import { IShellLaunchConfig, TerminalShellType, PosixShellType, WindowsShellType, GeneralShellType } from './terminal.js';
 
 /**
- * Aggressively escape non-windows paths to prepare for being sent to a shell. This will do some
- * escaping inaccurately to be careful about possible script injection via the file path. For
- * example, we're trying to prevent this sort of attack: `/foo/file$(echo evil)`.
+ * Escape non-windows paths to prepare for being sent to a shell. Paths are wrapped in
+ * single quotes to prevent shell expansion. Special characters are preserved literally
+ * within the quotes. When a path contains both quote types, shell-specific escaping is used.
  */
 export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType): string {
 	let newPath = path;
@@ -41,7 +41,7 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			break;
 		case PosixShellType.Fish:
 			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '\\"')}"`,
+				bothQuotes: (path) => `"${path.replace(/"/g, '\\"').replace(/\$/g, '\\$')}"`,
 				singleQuotes: (path) => `'${path.replace(/'/g, '\\\'')}'`,
 				noSingleQuotes: (path) => `'${path}'`
 			};
@@ -50,7 +50,7 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			// PowerShell should be handled separately in preparePathForShell
 			// but if we get here, use PowerShell escaping
 			escapeConfig = {
-				bothQuotes: (path) => `"${path.replace(/"/g, '`"')}"`,
+				bothQuotes: (path) => '"' + path.replace(/`/g, '``').replace(/"/g, '`"').replace(/\$/g, '`$') + '"',
 				singleQuotes: (path) => `'${path.replace(/'/g, '\'\'')}'`,
 				noSingleQuotes: (path) => `'${path}'`
 			};
@@ -64,10 +64,6 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			};
 			break;
 	}
-
-	// Remove dangerous characters except single and double quotes, which we'll escape properly
-	const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
-	newPath = newPath.replace(bannedChars, '');
 
 	// Apply shell-specific escaping based on quote content
 	if (newPath.includes('\'') && newPath.includes('"')) {

--- a/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
@@ -91,9 +91,32 @@ suite('terminalEnvironment', () => {
 			strictEqual(escapeNonWindowsPath('/foo/bar\'baz'), '\'/foo/bar\\\'baz\'');
 		});
 
-		test('should remove dangerous characters', () => {
-			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar(echo evil)\'');
-			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/barwhoami\'');
+		test('should preserve special characters within quotes', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar~v1', PosixShellType.Bash), '\'/foo/bar~v1\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar$var', PosixShellType.Bash), '\'/foo/bar$var\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar`cmd`', PosixShellType.Bash), '\'/foo/bar`cmd`\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar|baz', PosixShellType.Bash), '\'/foo/bar|baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar&baz', PosixShellType.Bash), '\'/foo/bar&baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar>baz', PosixShellType.Bash), '\'/foo/bar>baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar#baz', PosixShellType.Bash), '\'/foo/bar#baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar!baz', PosixShellType.Bash), '\'/foo/bar!baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar^baz', PosixShellType.Bash), '\'/foo/bar^baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar*baz', PosixShellType.Bash), '\'/foo/bar*baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar;baz', PosixShellType.Bash), '\'/foo/bar;baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar<baz', PosixShellType.Bash), '\'/foo/bar<baz\'');
+		});
+
+		test('should safely quote injection patterns', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar$(echo evil)\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/bar`whoami`\'');
+		});
+
+		test('should escape $ in fish double-quoted paths', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar\'$"baz', PosixShellType.Fish), '"/foo/bar\'\\$\\"baz"');
+		});
+
+		test('should escape $ and ` in PowerShell double-quoted paths', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar\'$"baz', GeneralShellType.PowerShell), '"/foo/bar\'`$`"baz"');
 		});
 	});
 });

--- a/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
@@ -117,6 +117,7 @@ suite('terminalEnvironment', () => {
 
 		test('should escape $ and ` in PowerShell double-quoted paths', () => {
 			strictEqual(escapeNonWindowsPath('/foo/bar\'$"baz', GeneralShellType.PowerShell), '"/foo/bar\'`$`"baz"');
+			strictEqual(escapeNonWindowsPath('/foo/bar\'`$"baz', GeneralShellType.PowerShell), '"/foo/bar\'```$`"baz"');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalEnvironment.test.ts
@@ -247,7 +247,7 @@ suite('Workbench - TerminalEnvironment', () => {
 			test('Git Bash', async () => {
 				strictEqual(await preparePathForShell('c:\\foo\\bar', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, true), `'c:/foo/bar'`);
 				strictEqual(await preparePathForShell('c:\\foo\\bar\'baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, true), `'c:/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('c:\\foo\\bar$(echo evil)baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, true), `'c:/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('c:\\foo\\bar$(echo evil)baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, true), `'c:/foo/bar$(echo evil)baz'`);
 			});
 			test('WSL', async () => {
 				strictEqual(await preparePathForShell('c:\\foo\\bar', 'bash', 'bash', WindowsShellType.Wsl, wslPathBackend, OperatingSystem.Windows, true), '/mnt/c/foo/bar');
@@ -257,17 +257,17 @@ suite('Workbench - TerminalEnvironment', () => {
 			test('Bash', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar$(echo evil)baz'`);
 			});
 			test('Zsh', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar$(echo evil)baz'`);
 			});
 			test('Fish', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, true), `'/foo/bar$(echo evil)baz'`);
 			});
 		});
 		suite('Linux frontend, Windows backend', () => {
@@ -284,7 +284,7 @@ suite('Workbench - TerminalEnvironment', () => {
 			test('Git Bash', async () => {
 				strictEqual(await preparePathForShell('c:\\foo\\bar', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, false), `'c:/foo/bar'`);
 				strictEqual(await preparePathForShell('c:\\foo\\bar\'baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, false), `'c:/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('c:\\foo\\bar$(echo evil)baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, false), `'c:/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('c:\\foo\\bar$(echo evil)baz', 'bash', 'bash', WindowsShellType.GitBash, wslPathBackend, OperatingSystem.Windows, false), `'c:/foo/bar$(echo evil)baz'`);
 			});
 			test('WSL', async () => {
 				strictEqual(await preparePathForShell('c:\\foo\\bar', 'bash', 'bash', WindowsShellType.Wsl, wslPathBackend, OperatingSystem.Windows, false), '/mnt/c/foo/bar');
@@ -294,17 +294,17 @@ suite('Workbench - TerminalEnvironment', () => {
 			test('Bash', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'bash', 'bash', PosixShellType.Bash, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar$(echo evil)baz'`);
 			});
 			test('Zsh', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'zsh', 'zsh', PosixShellType.Zsh, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar$(echo evil)baz'`);
 			});
 			test('Fish', async () => {
 				strictEqual(await preparePathForShell('/foo/bar', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar'`);
 				strictEqual(await preparePathForShell('/foo/bar\'baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar\\'baz'`);
-				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar(echo evil)baz'`);
+				strictEqual(await preparePathForShell('/foo/bar$(echo evil)baz', 'fish', 'fish', PosixShellType.Fish, wslPathBackend, OperatingSystem.Linux, false), `'/foo/bar$(echo evil)baz'`);
 			});
 		});
 	});


### PR DESCRIPTION
Fixes #276999

## Problem

Dragging a file with special characters (`~`, `` ` ``, `!`, `#`, `$`, `^`, `&`, `*`, `|`, `;`, `<`, `>`) in its name from the Explorer into the Terminal silently strips those characters from the path. This corrupts file paths and can cause users to unknowingly reference the wrong file.

**Example:** `/home/user/file~v1.sh` becomes `'/home/user/filev1.sh'` (tilde lost).

## Root cause

`escapeNonWindowsPath()` contains a `bannedChars` regex that **removes** special characters from the path before quoting. Since the function already wraps paths in single quotes - where all characters are literal in POSIX shells (bash, zsh, sh, fish) and PowerShell - the stripping is unnecessary and actively harmful.

## Fix

- **Remove the `bannedChars` regex** - single-quote wrapping already neutralizes all special characters
- **Fix Fish `bothQuotes` handler** - escape `$` inside double-quoted paths (for the rare case where a path contains both `'` and `"`)
- **Fix PowerShell `bothQuotes` handler** - escape `` ` `` and `$` inside double-quoted paths

## Test plan

- [x] Updated unit tests: replaced "should remove dangerous characters" with tests verifying all 12 special characters are **preserved**
- [x] Added tests for injection patterns (`$(echo evil)`, `` `whoami` ``) confirming they are safely quoted
- [x] Added tests for Fish and PowerShell `bothQuotes` `$`-escaping
- [x] Updated 8 integration test expectations across all shell/platform combinations