### PR TITLE
Avoid listener leak warnings

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownDecorationsRenderer.ts
@@ -260,6 +260,44 @@ export class ChatMarkdownDecorationsRenderer {
 		return container;
 	}
 
+	/**
+	 * Renders a parsed chat request as plain text DOM elements with inline decoration spans
+	 * for agents, slash commands, and other special parts. No markdown rendering is used.
+	 */
+	renderParsedRequestToPlainText(parsedRequest: IParsedChatRequest, store: DisposableStore): HTMLElement {
+		const container = dom.$('span');
+		container.style.whiteSpace = 'pre-wrap';
+		for (const part of parsedRequest.parts) {
+			if (part instanceof ChatRequestTextPart) {
+				container.appendChild(document.createTextNode(part.text));
+			} else if (part instanceof ChatRequestAgentPart) {
+				const widget = this.renderResourceWidget(`${chatAgentLeader}${part.agent.name}`, undefined, store);
+				const hover: Lazy<ChatAgentHover> = new Lazy(() => store.add(this.instantiationService.createInstance(ChatAgentHover)));
+				store.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), widget, () => {
+					hover.value.setAgent(part.agent.id);
+					return hover.value.domNode;
+				}, getChatAgentHoverOptions(() => part.agent, this.commandService)));
+				container.appendChild(widget);
+			} else {
+				const title = this.getDecorationTitle(part);
+				const widget = this.renderResourceWidget(part.text, title ? { title } : undefined, store);
+				container.appendChild(widget);
+			}
+		}
+		return container;
+	}
+
+	private getDecorationTitle(part: IParsedChatRequestPart): string | undefined {
+		const uri = part instanceof ChatRequestDynamicVariablePart && part.data instanceof URI ?
+			part.data :
+			undefined;
+		return uri ? this.labelService.getUriLabel(uri, { relative: true }) :
+			part instanceof ChatRequestSlashCommandPart ? part.slashCommand.detail :
+				part instanceof ChatRequestAgentSubcommandPart ? part.command.description :
+					part instanceof ChatRequestSlashPromptPart ? part.name :
+						part instanceof ChatRequestToolPart ? (this.toolsService.getTool(part.toolId)?.userDescription) :
+							undefined;
+	}
 
 	private injectKeybindingHint(a: HTMLAnchorElement, href: string, keybindingService: IKeybindingService): void {
 		const command = href.match(/command:([^\)]+)/)?.[1];

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart.ts
@@ -7,7 +7,7 @@ import { $, append } from '../../../../../../base/browser/dom.js';
 import { alert } from '../../../../../../base/browser/ui/aria/aria.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IRenderedMarkdown } from '../../../../../../base/browser/markdownRenderer.js';
@@ -33,6 +33,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 	private readonly showSpinner: boolean;
 	private readonly isHidden: boolean;
 	private readonly renderedMessage = this._register(new MutableDisposable<IRenderedMarkdown>());
+	private readonly _fileWidgetStore = this._register(new DisposableStore());
 	private currentContent: IMarkdownString;
 
 	constructor(
@@ -67,7 +68,7 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 		const codicon = icon ? icon : this.showSpinner ? ThemeIcon.modify(Codicon.loading, 'spin') : Codicon.check;
 		const result = this.chatContentMarkdownRenderer.render(progress.content);
 		result.element.classList.add('progress-step');
-		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
+		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._fileWidgetStore);
 
 		const tooltip: IMarkdownString | undefined = this.createApprovalMessage();
 		const progressPart = this._register(instantiationService.createInstance(ChatProgressSubPart, result.element, codicon, tooltip));
@@ -83,7 +84,8 @@ export class ChatProgressContentPart extends Disposable implements IChatContentP
 		// Render the new message
 		const result = this._register(this.chatContentMarkdownRenderer.render(content));
 		result.element.classList.add('progress-step');
-		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._store);
+		this._fileWidgetStore.clear();
+		renderFileWidgets(result.element, this.instantiationService, this.chatMarkdownAnchorService, this._fileWidgetStore);
 
 		// Replace the old message container with the new one
 		if (this.renderedMessage.value) {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -457,12 +457,14 @@
 	}
 
 	/* not ideal but I cannot query the last div with this class... */
-	.rendered-markdown:last-of-type > P > SPAN:empty {
+	.rendered-markdown:last-of-type > P > SPAN:empty,
+	.rendered-markdown:last-of-type > SPAN:empty {
 		display: inline-block;
 		width: 11px;
 	}
 
-	.rendered-markdown:last-of-type > P > SPAN:empty::after {
+	.rendered-markdown:last-of-type > P > SPAN:empty::after,
+	.rendered-markdown:last-of-type > SPAN:empty::after {
 		content: '';
 		white-space: nowrap;
 		overflow: hidden;


### PR DESCRIPTION
- Inline anchor widget- lazily create scoped CKS because this is the source of many leak warnings
- ChatProgressContentPart- avoid small possible leak
