### PR TITLE
fix: correct typos in code comments across multiple files

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -391,7 +391,7 @@ export function compareSubstringIgnoreCase(a: string, b: string, aStart: number 
 			return compareSubstring(a.toLowerCase(), b.toLowerCase(), aStart, aEnd, bStart, bEnd);
 		}
 
-		// mapper lower-case ascii letter onto upper-case varinats
+		// mapper lower-case ascii letter onto upper-case variants
 		// [97-122] (lower ascii) --> [65-90] (upper ascii)
 		if (isLowerAsciiLetter(codeA)) {
 			codeA -= 32;

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,13 +170,13 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 
-	// Reduce likelyhood of spam from file events via throttling.
+	// Reduce likelihood of spam from file events via throttling.
 	// (https://github.com/microsoft/vscode/issues/124723)
 	private readonly throttledFileChangesEmitter = this._register(new ThrottledWorker<IFileChange>(
 		{

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -585,7 +585,7 @@ const enum AdjustCommandStartMarkerConstants {
 
 /**
  * An object that integrated with and decorates the command detection capability to add heuristics
- * that adjust various markers to work better with Windows and ConPTY. This isn't depended upon the
+ * that adjust various markers to work better with Windows and ConPTY. This isn't dependent upon the
  * frontend OS, or even the backend OS, but the `IsWindows` property which technically a non-Windows
  * client can emit (for example in tests).
  */

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3118,7 +3118,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,11 +1686,11 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {
-					return true; // Can not move anything onto itself excpet for root folders
+					return true; // Can not move anything onto itself except for root folders
 				}
 
 				if (!isCopy && this.uriIdentityService.extUri.isEqual(dirname(source.resource), target.resource)) {


### PR DESCRIPTION
## Fix Typos in Code Comments

Corrects spelling and grammar errors across 5 source files. All changes are limited to code comments — no functional changes.

### Changes

| File | Typo | Fix |
|------|------|-----|
| `strings.ts` | `varinats` | `variants` |
| `parcelWatcher.ts` | `occured` | `occurred` |
| `parcelWatcher.ts` | `coleasing` | `coalescing` |
| `parcelWatcher.ts` | `likelyhood` | `likelihood` |
| `extHostTypes.ts` | `seperate` | `separate` |
| `explorerViewer.ts` | `seperately` | `separately` |
| `explorerViewer.ts` | `excpet` | `except` |
| `commandDetectionCapability.ts` | `depended` | `dependent` |
