### PR TITLE
ci: add deb,rpm dependency check for batched builds

### DIFF
--- a/.github/instructions/linux-packaging.instructions.md
+++ b/.github/instructions/linux-packaging.instructions.md
@@ -1,0 +1,13 @@
+---
+description: Use when reviewing PRs that bump the Electron version or change CLI dependencies/build configuration, to remind about Linux arm64/armhf packaging validation.
+applyTo: '.npmrc,remote/.npmrc,cli/Cargo.toml,cli/Cargo.lock,build/linux/debian/install-sysroot.ts,build/checksums/vscode-sysroot.txt'
+excludeAgent: 'coding-agent'
+---
+
+# Linux Packaging Validation Reminder
+
+CI and PR builds only validate Linux x64 package dependencies. Changes to the files matched by this instruction can affect Linux arm64 and armhf packaging, which is only validated during full product builds.
+
+When reviewing a PR that modifies any of these files, leave a review comment reminding the PR author:
+
+> **Linux packaging reminder:** This change may affect Linux arm64/armhf package dependencies which are not validated in CI builds. Please trigger a full product build (including Linux arm64 and armhf) before merging to ensure packaging is not broken.

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -207,6 +207,7 @@ steps:
         npm run gulp "vscode-linux-$(VSCODE_ARCH)-check-deps"
       env:
         GITHUB_TOKEN: "$(github-distro-mixin-password)"
+        VSCODE_SYSROOT_DIR: "$(Build.SourcesDirectory)/.build/sysroots/glibc-2.28-gcc-10.5.0"
       displayName: Check package dependencies
 
   - script: |

--- a/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
+++ b/build/azure-pipelines/linux/steps/product-build-linux-compile.yml
@@ -186,21 +186,28 @@ steps:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Build client
 
-  - ${{ if ne(parameters.VSCODE_CIBUILD, true) }}:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifact: $(ARTIFACT_PREFIX)vscode_cli_linux_$(VSCODE_ARCH)_cli
-        patterns: "**"
-        path: $(Build.ArtifactStagingDirectory)/cli
-      displayName: Download VS Code CLI
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: $(ARTIFACT_PREFIX)vscode_cli_linux_$(VSCODE_ARCH)_cli
+      patterns: "**"
+      path: $(Build.ArtifactStagingDirectory)/cli
+    displayName: Download VS Code CLI
 
+  - script: |
+      set -e
+      tar -xzvf $(Build.ArtifactStagingDirectory)/cli/*.tar.gz -C $(Build.ArtifactStagingDirectory)/cli
+      CLI_APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").tunnelApplicationName")
+      APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").applicationName")
+      mv $(Build.ArtifactStagingDirectory)/cli/$APP_NAME $(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/bin/$CLI_APP_NAME
+    displayName: Mix in CLI
+
+  - ${{ if eq(parameters.VSCODE_CIBUILD, true) }}:
     - script: |
         set -e
-        tar -xzvf $(Build.ArtifactStagingDirectory)/cli/*.tar.gz -C $(Build.ArtifactStagingDirectory)/cli
-        CLI_APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").tunnelApplicationName")
-        APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").applicationName")
-        mv $(Build.ArtifactStagingDirectory)/cli/$APP_NAME $(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/bin/$CLI_APP_NAME
-      displayName: Mix in CLI
+        npm run gulp "vscode-linux-$(VSCODE_ARCH)-check-deps"
+      env:
+        GITHUB_TOKEN: "$(github-distro-mixin-password)"
+      displayName: Check package dependencies
 
   - script: |
       set -e

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -229,7 +229,6 @@ extends:
               - template: build/azure-pipelines/linux/product-build-linux-cli.yml@self
                 parameters:
                   VSCODE_ARCH: x64
-                  VSCODE_CHECK_ONLY: ${{ variables.VSCODE_CIBUILD }}
                   VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
 
             - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX_ARM64, true)) }}:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -98,6 +98,10 @@ parameters:
     displayName: "Skip tests"
     type: boolean
     default: false
+  - name: VSCODE_CIBUILD
+    displayName: "Build as CI (skip packaging, only build and test)"
+    type: boolean
+    default: false
 
 variables:
   - name: VSCODE_PRIVATE_BUILD
@@ -119,7 +123,7 @@ variables:
   - name: VSCODE_BUILD_STAGE_WEB
     value: ${{ eq(parameters.VSCODE_BUILD_WEB, true) }}
   - name: VSCODE_CIBUILD
-    value: ${{ in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI') }}
+    value: ${{ or(eq(parameters.VSCODE_CIBUILD, true), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI')) }}
   - name: VSCODE_PUBLISH
     value: ${{ and(eq(parameters.VSCODE_PUBLISH, true), eq(variables.VSCODE_CIBUILD, false), eq(parameters.VSCODE_COMPILE_ONLY, false)) }}
   - name: VSCODE_SCHEDULEDBUILD

--- a/build/gulpfile.vscode.linux.ts
+++ b/build/gulpfile.vscode.linux.ts
@@ -280,6 +280,17 @@ function buildSnapPackage(arch: string) {
 	return () => exec('snapcraft', { cwd });
 }
 
+function checkPackageDependencies(arch: string) {
+	const binaryDir = '../VSCode-linux-' + arch;
+	const debArch = getDebPackageArch(arch);
+	const rpmArch = getRpmPackageArch(arch);
+
+	return async function () {
+		await getDependencies('deb', binaryDir, product.applicationName, debArch);
+		await getDependencies('rpm', binaryDir, product.applicationName, rpmArch);
+	};
+}
+
 const BUILD_TARGETS = [
 	{ arch: 'x64' },
 	{ arch: 'armhf' },
@@ -303,4 +314,7 @@ BUILD_TARGETS.forEach(({ arch }) => {
 	gulp.task(prepareSnapTask);
 	const buildSnapTask = task.define(`vscode-linux-${arch}-build-snap`, task.series(prepareSnapTask, buildSnapPackage(arch)));
 	gulp.task(buildSnapTask);
+
+	const checkDepsTask = task.define(`vscode-linux-${arch}-check-deps`, checkPackageDependencies(arch));
+	gulp.task(checkDepsTask);
 });


### PR DESCRIPTION
Followup to https://github.com/microsoft/vscode/pull/295539

To allow catching dependency failures early on in the product cycle this PR does the following,

1) Enable dependency checks of deb and rpm for `VSCODE_CIBUILD`, this will only capture linux x64
2) For armhf and arm64, enable CCR leave a comment to trigger full build if any of the files specified have a possibility to affect the dependency.