### PR TITLE
Add additional schema URLs to `schemaDownload.trustedDomains`

### DIFF
--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -136,7 +136,7 @@
             "https://json.schemastore.org/": true,
             "https://json-schema.org/": true,
             "https://unpkg.com/": true,
-            "https://cdn.jsdelivr.net/": true,
+            "https://cdn.jsdelivr.net/": true
           },
           "additionalProperties": {
             "type": "boolean"

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -134,7 +134,9 @@
             "https://raw.githubusercontent.com/": true,
             "https://www.schemastore.org/": true,
             "https://json.schemastore.org/": true,
-            "https://json-schema.org/": true
+            "https://json-schema.org/": true,
+            "https://unpkg.com/": true,
+            "https://cdn.jsdelivr.net/": true,
           },
           "additionalProperties": {
             "type": "boolean"


### PR DESCRIPTION
This PR adds two more very common sources ([unpkg](https://unpkg.com/) and [jsdelivr](https://www.jsdelivr.com/)) to `schemaDownload.trustedDomains` default config introduced in #287639 (/cc @aeschli)

Since raw.githgubusercontent.com is already in defaults, it shouldn't make a difference in terms of content security.

