### PR TITLE
chore: update application name logic for win32 scripts

### DIFF
--- a/scripts/code-cli.bat
+++ b/scripts/code-cli.bat
@@ -8,7 +8,8 @@ pushd %~dp0..
 :: Get electron, compile, built-in extensions
 if "%VSCODE_SKIP_PRELAUNCH%"=="" node build/lib/preLaunch.ts
 
-for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
+set "NAMESHORT="
+for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do if not defined NAMESHORT set "NAMESHORT=%%~a"
 set NAMESHORT=%NAMESHORT: "=%
 set NAMESHORT=%NAMESHORT:"=%.exe
 set CODE=".build\electron\%NAMESHORT%"

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -10,7 +10,8 @@ if "%VSCODE_SKIP_PRELAUNCH%"=="" (
 	node build/lib/preLaunch.ts
 )
 
-for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
+set "NAMESHORT="
+for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do if not defined NAMESHORT set "NAMESHORT=%%~a"
 set NAMESHORT=%NAMESHORT: "=%
 set NAMESHORT=%NAMESHORT:"=%.exe
 set CODE=".build\electron\%NAMESHORT%"

--- a/scripts/node-electron.bat
+++ b/scripts/node-electron.bat
@@ -5,7 +5,8 @@ set ELECTRON_RUN_AS_NODE=1
 
 pushd %~dp0\..
 
-for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
+set "NAMESHORT="
+for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do if not defined NAMESHORT set "NAMESHORT=%%~a"
 set NAMESHORT=%NAMESHORT: "=%
 set NAMESHORT=%NAMESHORT:"=%.exe
 set CODE=".build\electron\%NAMESHORT%"

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -6,7 +6,8 @@ set ELECTRON_RUN_AS_NODE=
 pushd %~dp0\..
 
 :: Get Code.exe location
-for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do set NAMESHORT=%%~a
+set "NAMESHORT="
+for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"nameShort\":.*" product.json') do if not defined NAMESHORT set "NAMESHORT=%%~a"
 set NAMESHORT=%NAMESHORT: "=%
 set NAMESHORT=%NAMESHORT:"=%.exe
 set CODE=".build\electron\%NAMESHORT%"


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode-distro/pull/1320 scopes the `nameShort` search to first match

Refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=407780&view=logs&jobId=15ec5277-fdc6-550c-b203-acb65f44f31c&j=15ec5277-fdc6-550c-b203-acb65f44f31c&t=67c4286c-4c62-5bfd-ca8f-e1f11f6b4750