### PR TITLE
Ask mode assignment and refetch trigger

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -73,7 +73,7 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		@IOpenerService openerService: IOpenerService,
 		@IWorkbenchAssignmentService assignmentService: IWorkbenchAssignmentService,
 	) {
-		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false }, { equalsFn: (a, b) => a.showOldAskMode === b.showOldAskMode });
+		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false });
 
 		// Get custom agent target (if filtering is enabled)
 		const customAgentTarget = delegate.customAgentTarget?.() ?? Target.Undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -73,7 +73,7 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 		@IOpenerService openerService: IOpenerService,
 		@IWorkbenchAssignmentService assignmentService: IWorkbenchAssignmentService,
 	) {
-		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false });
+		const assignments = observableValue<{ showOldAskMode: boolean }>('modePickerAssignments', { showOldAskMode: false }, { equalsFn: (a, b) => a.showOldAskMode === b.showOldAskMode });
 
 		// Get custom agent target (if filtering is enabled)
 		const customAgentTarget = delegate.customAgentTarget?.() ?? Target.Undefined;

--- a/src/vs/workbench/services/assignment/common/assignmentService.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentService.ts
@@ -178,6 +178,11 @@ export class WorkbenchAssignmentService extends Disposable implements IAssignmen
 
 		this.telemetry = this._register(new WorkbenchAssignmentServiceTelemetry(telemetryService, productService));
 		this._register(this.telemetry.onDidUpdateAssignmentContext(() => this._onDidRefetchAssignments.fire()));
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('experiments.override')) {
+				this._onDidRefetchAssignments.fire();
+			}
+		}));
 
 		this.keyValueStorage = new MementoKeyValueStorage(new Memento<Record<string, unknown>>('experiment.service.memento', storageService));
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a mechanism to manage the visibility of the old and new "Ask" modes based on user assignments. Implement a refetch trigger for assignments when configuration changes occur.

