### PR TITLE
don't eval task output with llm unless the task lacks problem matchers

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -258,7 +258,8 @@ export async function collectTerminalResults(
 			}
 		}
 
-		const outputMonitor = disposableStore.add(instantiationService.createInstance(OutputMonitor, execution, taskProblemPollFn, invocationContext, token, task._label));
+		const hasProblemMatchers = terminalTask.configurationProperties.problemMatchers && terminalTask.configurationProperties.problemMatchers.length > 0;
+		const outputMonitor = disposableStore.add(instantiationService.createInstance(OutputMonitor, execution, hasProblemMatchers ? taskProblemPollFn : undefined, invocationContext, token, task._label));
 		await Promise.race([
 			Event.toPromise(outputMonitor.onDidFinishCommand),
 			Event.toPromise(token.onCancellationRequested as Event<unknown>)

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -355,9 +355,6 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const custom = await this._pollFn?.(this._execution, token, this._taskService);
 		this._logService.trace(`OutputMonitor: Custom poller result: ${custom ? 'provided' : 'none'}`);
 		const resources = custom?.resources;
-		// Only assess output for errors via LLM when there is no custom poller. Custom pollers
-		// (e.g. taskProblemPollFn) already provide structured error information in their output,
-		// so running the LLM assessment would be redundant and slow (~10s).
 		const modelOutputEvalResponse = this._pollFn ? undefined : await this._assessOutputForErrors(this._execution.getOutput(), token);
 		return { resources, modelOutputEvalResponse, shouldContinuePollling: false, output: custom?.output ?? output };
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -355,7 +355,10 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const custom = await this._pollFn?.(this._execution, token, this._taskService);
 		this._logService.trace(`OutputMonitor: Custom poller result: ${custom ? 'provided' : 'none'}`);
 		const resources = custom?.resources;
-		const modelOutputEvalResponse = await this._assessOutputForErrors(this._execution.getOutput(), token);
+		// Only assess output for errors via LLM when there is no custom poller. Custom pollers
+		// (e.g. taskProblemPollFn) already provide structured error information in their output,
+		// so running the LLM assessment would be redundant and slow (~10s).
+		const modelOutputEvalResponse = this._pollFn ? undefined : await this._assessOutputForErrors(this._execution.getOutput(), token);
 		return { resources, modelOutputEvalResponse, shouldContinuePollling: false, output: custom?.output ?? output };
 	}
 


### PR DESCRIPTION
fix #266292

Skip the redundant ~10s LLM error assessment `_assessOutputForErrors` for tasks that have problem matchers. 

Only pass `taskProblemPollFn` when the task has problem matchers; pass `undefined` otherwise. Skip `_assessOutputForErrors` when a `_pollFn` is provided, since it already supplies structured error info.

Tasks with problem matchers get fast structured errors. Tasks without problem matchers now correctly fall through to the LLM assessment instead of throwing.