### PR TITLE
Polish actionmenu and list styles

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -53,7 +53,7 @@
 		"badge.background": "#3994BCF0",
 		"badge.foreground": "#FFFFFF",
 		"progressBar.background": "#878889",
-		"list.activeSelectionBackground": "#3994BC55",
+		"list.activeSelectionBackground": "#3994BC26",
 		"list.activeSelectionForeground": "#bfbfbf",
 		"list.inactiveSelectionBackground": "#2C2D2E",
 		"list.inactiveSelectionForeground": "#bfbfbf",

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -267,8 +267,8 @@ export class ActionList<T> extends Disposable {
 
 	private readonly _list: List<IActionListItem<T>>;
 
-	private readonly _actionLineHeight = 28;
-	private readonly _headerLineHeight = 28;
+	private readonly _actionLineHeight = 24;
+	private readonly _headerLineHeight = 24;
 	private readonly _separatorLineHeight = 8;
 
 	private readonly _allMenuItems: readonly IActionListItem<T>[];

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -56,12 +56,12 @@
 
 /** Styles for each row in the list element **/
 .action-widget .monaco-list .monaco-list-row {
-	padding: 0 4px 0 4px;
+	padding: 0 4px 0 8px;
 	white-space: nowrap;
 	cursor: pointer;
 	touch-action: none;
 	width: 100%;
-	border-radius: 3px;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
 .action-widget .monaco-list .monaco-list-row.action.focused:not(.option-disabled) {
@@ -73,8 +73,8 @@
 
 .action-widget .monaco-list-row.group-header {
 	color: var(--vscode-descriptionForeground) !important;
-	font-weight: 600;
-	font-size: 13px;
+	font-weight: 500;
+	font-size: 11px;
 }
 
 .action-widget .monaco-list-row.group-header:not(:first-of-type) {
@@ -120,8 +120,16 @@
 
 .action-widget .monaco-list-row.action {
 	display: flex;
-	gap: 4px;
+	gap: 6px;
 	align-items: center;
+}
+
+.action-widget .monaco-list-row.action .codicon {
+	font-size: 12px;
+}
+
+.action-widget .monaco-list-row.action .action-list-item-toolbar .codicon {
+	font-size: 16px;
 }
 
 .action-widget .monaco-list-row.action.option-disabled,
@@ -168,13 +176,13 @@
 }
 
 .action-widget .action-widget-action-bar .actions-container {
-	padding: 4px 8px 2px 24px;
+	padding: 2px 8px 0px 26px;
 	width: auto;
 }
 
 .action-widget-action-bar .action-label {
 	color: var(--vscode-textLink-activeForeground);
-	font-size: 13px;
+	font-size: 12px;
 	line-height: 22px;
 	padding: 0;
 	pointer-events: all;


### PR DESCRIPTION
- 24px list items (formerly 28px)
- Use 12px codicons for the leading icon in action widget list items
- Set 6px flex gap between icon and label
- Aligns actionlist and quickpick selected background colors
- Padding tweaks on list items
- Aligns header font styles with new chat sessions header styles

<img width="556" height="298" alt="CleanShot 2026-02-17 at 11 11 27@2x" src="https://github.com/user-attachments/assets/7fa4828e-27ac-4c8a-963f-b1e37e30acaa" />
<img width="546" height="402" alt="CleanShot 2026-02-17 at 11 11 23@2x" src="https://github.com/user-attachments/assets/f4be525b-79da-4b0d-8466-dfd2a3c13951" />
<img width="756" height="1394" alt="CleanShot 2026-02-17 at 11 11 32@2x" src="https://github.com/user-attachments/assets/faf389a4-fcdf-4c24-9ad1-124efbacb079" />
<img width="532" height="502" alt="CleanShot 2026-02-17 at 11 10 57@2x" src="https://github.com/user-attachments/assets/7158ee7f-5b53-4bc4-b26e-cc1c662fbff3" />

cc @mrleemurray 

