### PR TITLE
Preserve question carousel across change of view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -1082,7 +1082,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	private renderSummary(): void {
 		// If no answers, show skipped message
 		if (this._answers.size === 0) {
-			this.renderSkippedMessage();
+			if (this.carousel.isUsed) {
+				this.renderSkippedMessage();
+			}
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2103,6 +2103,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const inputPartHasCarousel = widget?.input.questionCarousel !== undefined;
 
 		if (carousel.isUsed || responseIsComplete) {
+			if (responseIsComplete && !carousel.isUsed && isResponseVM(context.element) && carousel.resolveId && carousel.data === undefined) {
+				carousel.data = {};
+				this.chatService.notifyQuestionCarouselAnswer(context.element.requestId, carousel.resolveId, undefined);
+				this.pendingQuestionCarousels.get(context.element.sessionResource)?.clear();
+			}
+
 			// Clear the carousel from input part when response completes (stopped/canceled)
 			// Only clear if this response's carousel is currently displayed (pass responseId)
 			if (responseIsComplete && inputPartHasCarousel && responseId) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -2105,6 +2105,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		if (carousel.isUsed || responseIsComplete) {
 			if (responseIsComplete && !carousel.isUsed && isResponseVM(context.element) && carousel.resolveId && carousel.data === undefined) {
 				carousel.data = {};
+				carousel.isUsed = true;
 				this.chatService.notifyQuestionCarouselAnswer(context.element.requestId, carousel.resolveId, undefined);
 				this.pendingQuestionCarousels.get(context.element.sessionResource)?.clear();
 			}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1991,17 +1991,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.container.setAttribute('data-session-id', model.sessionId);
 		this.viewModel = this.instantiationService.createInstance(ChatViewModel, model, this._codeBlockModelCollection, undefined);
 
-		// mark any question carousels as used on reload
-		for (const request of model.getRequests()) {
-			if (request.response) {
-				for (const part of request.response.entireResponse.value) {
-					if (part.kind === 'questionCarousel' && !part.isUsed) {
-						part.isUsed = true;
-					}
-				}
-			}
-		}
-
 		// Pass input model reference to input part for state syncing
 		this.inputPart.setInputModel(model.inputModel, model.getRequests().length === 0);
 		this.listWidget.setViewModel(this.viewModel);
@@ -2263,18 +2252,23 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
-		const responseId = this.input.questionCarouselResponseId;
+		const inputPart = this.inputPartDisposable.value;
+		if (!inputPart) {
+			return;
+		}
+
+		const responseId = inputPart.questionCarouselResponseId;
 		if (!responseId || this.viewModel.model.lastRequest?.id !== responseId) {
 			return;
 		}
 
-		const carouselPart = this.input.questionCarousel;
+		const carouselPart = inputPart.questionCarousel;
 		if (!carouselPart) {
 			return;
 		}
 
 		carouselPart.ignore();
-		this.input.clearQuestionCarousel(responseId);
+		inputPart.clearQuestionCarousel(responseId);
 	}
 
 	private async _acceptInput(query: { query: string } | undefined, options: IChatAcceptInputOptions = {}): Promise<IChatResponseModel | undefined> {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1905,7 +1905,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this.refreshChatSessionPickers();
 			this.tryUpdateWidgetController();
 			this.updateContextUsageWidget();
-			if (this._currentQuestionCarouselSessionResource && e.currentSessionResource && !isEqual(this._currentQuestionCarouselSessionResource, e.currentSessionResource)) {
+			if (this._currentQuestionCarouselSessionResource && (!e.currentSessionResource || !isEqual(this._currentQuestionCarouselSessionResource, e.currentSessionResource))) {
 				this.clearQuestionCarousel();
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -103,7 +103,7 @@ import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
 import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 import { ChatImplicitContexts } from '../../attachments/chatImplicitContext.js';
 import { ImplicitContextAttachmentWidget } from '../../attachments/implicitContextAttachment.js';
-import { IChatWidget, ISessionTypePickerDelegate, isIChatResourceViewContext, isIChatViewViewContext, IWorkspacePickerDelegate } from '../../chat.js';
+import { IChatWidget, IChatWidgetViewModelChangeEvent, ISessionTypePickerDelegate, isIChatResourceViewContext, isIChatViewViewContext, IWorkspacePickerDelegate } from '../../chat.js';
 import { ChatEditingShowChangesAction, ViewAllSessionChangesAction, ViewPreviousEditsAction } from '../../chatEditing/chatEditingActions.js';
 import { resizeImage } from '../../chatImageUtils.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../chatSessions/chatSessionPickerActionItem.js';
@@ -209,6 +209,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _chatQuestionCarouselWidget = this._register(new MutableDisposable<ChatQuestionCarouselPart>());
 	private readonly _chatQuestionCarouselDisposables = this._register(new DisposableStore());
 	private _currentQuestionCarouselResponseId: string | undefined;
+	private _currentQuestionCarouselSessionResource: URI | undefined;
 	private _hasQuestionCarouselContextKey: IContextKey<boolean> | undefined;
 	private readonly _chatEditingTodosDisposables = this._register(new DisposableStore());
 	private _lastEditingSessionResource: URI | undefined;
@@ -1897,14 +1898,16 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 		}
 
-		this._register(widget.onDidChangeViewModel(() => {
+		this._register(widget.onDidChangeViewModel((e: IChatWidgetViewModelChangeEvent) => {
 			this._pendingDelegationTarget = undefined;
 			// Update agentSessionType when view model changes
 			this.updateAgentSessionTypeContextKey();
 			this.refreshChatSessionPickers();
 			this.tryUpdateWidgetController();
 			this.updateContextUsageWidget();
-			this.clearQuestionCarousel();
+			if (this._currentQuestionCarouselSessionResource && e.currentSessionResource && !isEqual(this._currentQuestionCarouselSessionResource, e.currentSessionResource)) {
+				this.clearQuestionCarousel();
+			}
 
 			// Track the current session type and re-initialize model selection
 			// when the session type changes (different session types may have
@@ -2611,6 +2614,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		// track the response id and session
 		this._currentQuestionCarouselResponseId = isResponseVM(context.element) ? context.element.requestId : undefined;
+		this._currentQuestionCarouselSessionResource = isResponseVM(context.element) ? context.element.sessionResource : undefined;
 
 		const part = this._chatQuestionCarouselDisposables.add(
 			this.instantiationService.createInstance(ChatQuestionCarouselPart, carousel, context, options)
@@ -2631,6 +2635,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._chatQuestionCarouselDisposables.clear();
 		this._chatQuestionCarouselWidget.clear();
 		this._currentQuestionCarouselResponseId = undefined;
+		this._currentQuestionCarouselSessionResource = undefined;
 		this._hasQuestionCarouselContextKey?.set(false);
 		dom.clearNode(this.chatQuestionCarouselContainer);
 	}


### PR DESCRIPTION
fixes #295472

- Carousel questions are now kept across the same sesssion view/editor switches, and only cleared when session actually changes
- Removed forced used mutation on model reattach that caused false "Skipped" rendering after navigation
- Added safe auto-resolution when a response completes with unanswered carousel
- "Skipped" text now renders only for explicit used with no answers cases, not for auto-finalized unanswered carousels
- Carousels still not rendered and are marked "skipped" on window reload

Before:

https://github.com/user-attachments/assets/2c59ba29-852a-4a01-bc5c-4048d1b4cf4e

After:

https://github.com/user-attachments/assets/add8be26-1a70-440f-8c82-d23b5f2cc4f0

cc @justschen 