### PR TITLE
Increase agent session list item height to 48px

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -503,7 +503,7 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 
 export class AgentSessionsListDelegate implements IListVirtualDelegate<AgentSessionListItem> {
 
-	static readonly ITEM_HEIGHT = 44;
+	static readonly ITEM_HEIGHT = 48;
 	static readonly SECTION_HEIGHT = 26;
 
 	getHeight(element: AgentSessionListItem): number {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -82,7 +82,7 @@
 	.agent-session-item {
 		display: flex;
 		flex-direction: row;
-		padding: 4px 6px;
+		padding: 6px 6px;
 
 		&.archived {
 			color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
Adds 2px top/bottom padding to agent session list items, increasing the row height from 44px to 48px.