### PR TITLE
add bottom border to chat tip

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -59,7 +59,7 @@
 	background-color: var(--vscode-editorWidget-background);
 	border-radius: 4px 4px 0 0;
 	border: 1px solid var(--vscode-editorWidget-border, var(--vscode-input-border, transparent));
-	border-bottom: none; /* Seamless attachment to input below */
+	border-bottom: 1px solid var(--vscode-editorWidget-border, var(--vscode-input-border, transparent));
 	font-size: var(--vscode-chat-font-size-body-s);
 	font-family: var(--vscode-chat-font-family, inherit);
 	color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
fix #295793

Before:

<img width="626" height="454" alt="image" src="https://github.com/user-attachments/assets/f250d728-badf-497f-bd70-0038b73cda1b" />

After:

<img width="626" height="454" alt="image" src="https://github.com/user-attachments/assets/8f6dff2f-78ff-4494-8528-12e4f9d4e957" />
