### PR TITLE
enable question in carousel to be rendered as markdown

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -4,13 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../../../base/browser/dom.js';
+import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
 import { StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { IMarkdownString, MarkdownString, isMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { hasKey } from '../../../../../../base/common/types.js';
 import { localize } from '../../../../../../nls.js';
 import { IAccessibilityService } from '../../../../../../platform/accessibility/common/accessibility.js';
+import { IMarkdownRendererService } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultInputBoxStyles } from '../../../../../../platform/theme/browser/defaultStyles.js';
 import { Button } from '../../../../../../base/browser/ui/button/button.js';
 import { InputBox } from '../../../../../../base/browser/ui/inputbox/inputBox.js';
@@ -55,6 +58,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	private readonly _multiSelectCheckboxes: Map<string, Checkbox[]> = new Map();
 	private readonly _freeformTextareas: Map<string, HTMLTextAreaElement> = new Map();
 	private readonly _inputBoxes: DisposableStore = this._register(new DisposableStore());
+	private readonly _questionRenderStore = this._register(new MutableDisposable<DisposableStore>());
 
 	/**
 	 * Disposable store for interactive UI components (header, nav buttons, etc.)
@@ -66,6 +70,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		public readonly carousel: IChatQuestionCarousel,
 		context: IChatContentPartRenderContext,
 		private readonly _options: IChatQuestionCarouselOptions,
+		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 	) {
@@ -233,7 +238,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const question = this.carousel.questions[this._currentIndex];
 		if (question) {
 			const questionText = question.message ?? question.title;
-			const messageContent = typeof questionText === 'string' ? questionText : questionText.value;
+			const messageContent = this.getQuestionText(questionText);
 			const questionCount = this.carousel.questions.length;
 			const alertMessage = questionCount === 1
 				? messageContent
@@ -265,6 +270,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	private clearInteractiveResources(): void {
 		// Dispose interactive UI disposables (header, nav buttons, etc.)
 		this._interactiveUIStore.clear();
+		this._questionRenderStore.clear();
 		this._inputBoxes.clear();
 		this._textInputBoxes.clear();
 		this._singleSelectItems.clear();
@@ -400,7 +406,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 
 		const questionText = question.message ?? question.title;
-		const messageContent = typeof questionText === 'string' ? questionText : questionText.value;
+		const messageContent = this.getQuestionText(questionText);
 		const questionCount = this.carousel.questions.length;
 
 		if (questionCount === 1) {
@@ -429,6 +435,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			return;
 		}
 
+		const questionRenderStore = new DisposableStore();
+		this._questionRenderStore.value = questionRenderStore;
+
 		// Clear previous input boxes and stale references
 		this._inputBoxes.clear();
 		this._textInputBoxes.clear();
@@ -452,26 +461,29 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const questionText = question.message ?? question.title;
 		if (questionText) {
 			const title = dom.$('.chat-question-title');
-			const messageContent = typeof questionText === 'string'
-				? questionText
-				: questionText.value;
+			const messageContent = this.getQuestionText(questionText);
 
 			title.setAttribute('aria-label', messageContent);
 
-			// Check for subtitle in parentheses at the end
-			const parenMatch = messageContent.match(/^(.+?)\s*(\([^)]+\))\s*$/);
-			if (parenMatch) {
-				// Main title (bold)
-				const mainTitle = dom.$('span.chat-question-title-main');
-				mainTitle.textContent = parenMatch[1];
-				title.appendChild(mainTitle);
-
-				// Subtitle in parentheses (normal weight)
-				const subtitle = dom.$('span.chat-question-title-subtitle');
-				subtitle.textContent = ' ' + parenMatch[2];
-				title.appendChild(subtitle);
+			if (isMarkdownString(questionText)) {
+				const renderedTitle = questionRenderStore.add(this._markdownRendererService.render(MarkdownString.lift(questionText)));
+				title.appendChild(renderedTitle.element);
 			} else {
-				title.textContent = messageContent;
+				// Check for subtitle in parentheses at the end
+				const parenMatch = messageContent.match(/^(.+?)\s*(\([^)]+\))\s*$/);
+				if (parenMatch) {
+					// Main title (bold)
+					const mainTitle = dom.$('span.chat-question-title-main');
+					mainTitle.textContent = parenMatch[1];
+					title.appendChild(mainTitle);
+
+					// Subtitle in parentheses (normal weight)
+					const subtitle = dom.$('span.chat-question-title-subtitle');
+					subtitle.textContent = ' ' + parenMatch[2];
+					title.appendChild(subtitle);
+				} else {
+					title.textContent = messageContent;
+				}
 			}
 			headerRow.appendChild(title);
 		}
@@ -1178,6 +1190,14 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			default:
 				return String(answer);
 		}
+	}
+
+	private getQuestionText(questionText: string | IMarkdownString): string {
+		if (typeof questionText === 'string') {
+			return questionText;
+		}
+
+		return renderAsPlaintext(questionText);
 	}
 
 	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -60,6 +60,21 @@
 				font-size: var(--vscode-chat-font-size-body-s);
 				margin: 0;
 
+				.rendered-markdown {
+					a {
+						color: var(--vscode-textLink-foreground);
+					}
+
+					a:hover,
+					a:active {
+						color: var(--vscode-textLink-activeForeground);
+					}
+
+					p {
+						margin: 0;
+					}
+				}
+
 				.chat-question-title-main {
 					font-weight: 500;
 				}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
@@ -5,6 +5,7 @@
 
 import assert from 'assert';
 import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { ChatQuestionCarouselPart, IChatQuestionCarouselOptions } from '../../../../browser/widget/chatContentParts/chatQuestionCarouselPart.js';
@@ -83,6 +84,25 @@ suite('ChatQuestionCarouselPart', () => {
 			assert.ok(title, 'title element should exist when only title is provided');
 			// Title should fall back to title property when message is not provided
 			assert.ok(title?.textContent?.includes('Fallback title text'));
+		});
+
+		test('renders markdown in question message', () => {
+			const carousel = createMockCarousel([
+				{
+					id: 'q1',
+					type: 'text',
+					title: 'Question',
+					message: new MarkdownString('Please review **details** in [docs](https://example.com)')
+				}
+			]);
+			createWidget(carousel);
+
+			const title = widget.domNode.querySelector('.chat-question-title');
+			assert.ok(title, 'title element should exist');
+			assert.ok(title?.querySelector('.rendered-markdown'), 'markdown content should be rendered');
+			assert.strictEqual(title?.textContent?.includes('**details**'), false, 'markdown syntax should not be shown as raw text');
+			const link = title?.querySelector('a') as HTMLAnchorElement | null;
+			assert.ok(link, 'markdown link should render as anchor');
 		});
 
 		test('renders progress indicator correctly', () => {


### PR DESCRIPTION
fixes #295649

Before:

<img width="2302" height="862" alt="image" src="https://github.com/user-attachments/assets/041190e5-217a-443a-9fad-45401031a6c9" />

After:

<img width="352" height="321" alt="Screenshot 2026-02-17 at 3 24 33 PM" src="https://github.com/user-attachments/assets/112bb56c-2b97-4935-93e9-ed284c1a398d" />
