### PR TITLE
chat: allow stopping agent when message is queued

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1171,9 +1171,12 @@ export class ChatService extends Disposable implements IChatService {
 		let shouldProcessPending = false;
 		const rawResponsePromise = sendRequestInternal();
 		// Note- requestId is not known at this point, assigned later
-		this._pendingRequests.set(model.sessionResource, this.instantiationService.createInstance(CancellableRequest, source, undefined));
+		const cancellableRequest = this.instantiationService.createInstance(CancellableRequest, source, undefined);
+		this._pendingRequests.set(model.sessionResource, cancellableRequest);
 		rawResponsePromise.finally(() => {
-			this._pendingRequests.deleteAndDispose(model.sessionResource);
+			if (this._pendingRequests.get(model.sessionResource) === cancellableRequest) {
+				this._pendingRequests.deleteAndDispose(model.sessionResource);
+			}
 			// Process the next pending request from the queue if any
 			if (shouldProcessPending) {
 				this.processNextPendingRequest(model);


### PR DESCRIPTION
Fixes an issue where stopping a chat session would fail to cancel the request when a message was queued. The problem occurred because queued messages could replace the pending request before the finally block attempted to delete it.

The fix stores a reference to the CancellableRequest and checks that it matches before deleting, preventing race conditions between queued messages and request cancellation.

Fixes https://github.com/microsoft/vscode/issues/295022

(Commit message generated by Copilot)