### PR TITLE
Clean up chat tool button and code block pill styling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -81,6 +81,10 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
 
+		// Add hover chevron indicator on the right
+		const hoverChevron = $('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
+		collapseButton.element.appendChild(hoverChevron);
+
 		if (this.hoverMessage) {
 			this._register(this.hoverService.setupDelayedHover(collapseButton.iconElement, {
 				content: this.hoverMessage,
@@ -98,7 +102,21 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 
 		this._register(autorun(r => {
 			const expanded = this._isExpanded.read(r);
-			collapseButton.icon = this._overrideIcon.read(r) ?? (expanded ? Codicon.chevronDown : Codicon.chevronRight);
+			const overrideIcon = this._overrideIcon.read(r);
+			const isErrorIcon = overrideIcon?.id === Codicon.error.id || overrideIcon?.id === Codicon.warning.id;
+
+			if (isErrorIcon && overrideIcon) {
+				collapseButton.icon = overrideIcon;
+				collapseButton.iconElement.style.display = '';
+			} else {
+				collapseButton.icon = Codicon.blank;
+				collapseButton.iconElement.style.display = 'none';
+			}
+
+			// Update hover chevron direction
+			hoverChevron.classList.toggle('codicon-chevron-right', !expanded);
+			hoverChevron.classList.toggle('codicon-chevron-down', expanded);
+
 			this._domNode?.classList.toggle('chat-used-context-collapsed', !expanded);
 			this.updateAriaLabel(collapseButton.element, typeof referencesLabel === 'string' ? referencesLabel : referencesLabel.value, expanded);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -591,6 +591,7 @@ export class CollapsedCodeBlock extends Disposable {
 			statusIconEl.classList.remove(...statusIconClasses);
 			iconEl.classList.remove(...pillIconClasses);
 			if (isStreaming.read(r)) {
+				statusIconEl.style.display = '';
 				const codicon = ThemeIcon.modify(Codicon.loading, 'spin');
 				statusIconClasses = ThemeIcon.asClassNameArray(codicon);
 				statusIconEl.classList.add(...statusIconClasses);
@@ -609,9 +610,7 @@ export class CollapsedCodeBlock extends Disposable {
 					labelDetail.textContent = rwRatio === 0 || !rwRatio ? localize('chat.codeblock.generating', "Generating edits...") : localize('chat.codeblock.applyingPercentage', "({0}%)...", rwRatio);
 				}
 			} else {
-				const statusCodeicon = Codicon.check;
-				statusIconClasses = ThemeIcon.asClassNameArray(statusCodeicon);
-				statusIconEl.classList.add(...statusIconClasses);
+				statusIconEl.style.display = 'none';
 				statusLabelEl.textContent = localize('chat.codeblock.edited', 'Edited');
 				const fileKind = uri.path.endsWith('/') ? FileKind.FOLDER : FileKind.FILE;
 				pillIconClasses = getIconClasses(this.modelService, this.languageService, uri, fileKind);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
@@ -11,7 +11,7 @@
 	display: flex;
 	align-items: center;
 	gap: 5px;
-	margin: 0 0 6px 4px;
+	margin: 0 0 10px 0;
 	font-size: var(--vscode-chat-font-size-body-s);
 	color: var(--vscode-descriptionForeground);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -83,10 +83,6 @@
 }
 
 .chat-confirmation-widget .chat-confirmation-widget-title.monaco-button {
-	&:hover {
-		background: var(--vscode-toolbar-hoverBackground);
-	}
-
 	&:active {
 		background: var(--vscode-toolbar-activeBackground);
 	}
@@ -96,6 +92,21 @@
 		width: 100%;
 		text-align: left;
 		align-items: center;
+	}
+
+	.chat-collapsible-hover-chevron {
+		font-size: 12px;
+		opacity: 0;
+		transition: opacity 0.1s ease-in-out;
+		color: var(--vscode-descriptionForeground);
+	}
+
+	.chat-collapsible-hover-chevron.codicon-chevron-down {
+		opacity: 1;
+	}
+
+	&:hover .chat-collapsible-hover-chevron {
+		opacity: 1;
 	}
 }
 
@@ -313,15 +324,11 @@
 
 			width: fit-content;
 			outline: none;
-			gap: 4px;
+			gap: 0;
 		}
 
 		.codicon {
 			font-size: 12px;
-		}
-
-		&:hover {
-			background: var(--vscode-list-hoverBackground);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -933,7 +933,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-editing-session .working-set-title {
 
 	.monaco-button {
-		padding: 4px 6px 4px 0px;
+		padding: 4px 6px 0 0;
 		border-radius: 2px;
 		border: none;
 		background-color: unset;
@@ -2161,7 +2161,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: fit-content;
 	border: none;
 	border-radius: 4px;
-	gap: 4px;
+	gap: 0;
 	text-align: initial;
 	justify-content: initial;
 }
@@ -2177,6 +2177,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .chat-used-context-label .monaco-button {
 	padding: 2px 6px 2px 2px;
+	margin-left: -2px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	line-height: unset;
 }
@@ -2185,10 +2186,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
+.interactive-session .chat-used-context:not(.chat-used-context-collapsed) .chat-used-context-label .monaco-button,
 .interactive-session .chat-used-context-label .monaco-button:hover {
-	background-color: var(--vscode-list-hoverBackground);
 	color: var(--vscode-foreground);
-
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus,
@@ -2205,6 +2205,27 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-used-context-label .monaco-button .codicon {
 	font-size: 12px;
 	color: var(--vscode-icon-foreground) !important;
+}
+
+/* Hover chevron indicator for collapsible parts */
+.chat-collapsible-hover-chevron {
+	font-size: 12px;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+	color: var(--vscode-descriptionForeground);
+}
+
+.chat-collapsible-hover-chevron.codicon-chevron-down {
+	opacity: 1;
+}
+
+.interactive-session .chat-used-context-label .monaco-button:hover .chat-collapsible-hover-chevron {
+	opacity: 1;
+}
+
+/* Hide completion checkmark icon on tool invocation progress lines */
+.chat-tool-invocation-part .progress-container > .codicon-check {
+	display: none;
 }
 
 .interactive-item-container .progress-container {


### PR DESCRIPTION
- Hide left icons on collapsible tool buttons, show hover chevron on right to indicate expand/collapse state
- Hide checkmark icon on code block pills (status-indicator-container)
- Remove left margin and adjust bottom margin on code block pill container
- Add hover/expanded state styling for collapsible parts
- Hide completion checkmark on tool invocation progress lines