### PR TITLE
Fix todo list widget border radius to match chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1093,8 +1093,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	border: 1px solid var(--vscode-input-border, transparent);
 	background-color: var(--vscode-editor-background);
 	border-bottom: none;
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-large) var(--vscode-cornerRadius-large) 0 0;
 	flex-direction: column;
 	gap: 2px;
 	overflow: hidden;


### PR DESCRIPTION
The todo list widget above the chat input was using a hardcoded `4px` border radius while the chat input container and editing session container both use `var(--vscode-cornerRadius-large)`. This aligns the todo list widget to use the same CSS variable for consistency.