### PR TITLE
Polish chat confirmation widget styling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -265,7 +265,7 @@
 
 .chat-confirmation-message-terminal .chat-confirmation-message-terminal-disclaimer p:last-child {
 	margin-bottom: 0 !important;
-	padding: 4px 8px 0 9px;
+	padding: 4px 8px 0 8px;
 }
 
 .chat-confirmation-widget-container.hideButtons .chat-confirmation-widget-buttons,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -202,12 +202,12 @@
 .chat-confirmation-widget2 {
 	margin-bottom: 8px;
 	border: 1px solid var(--vscode-chat-requestBorder);
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 }
 
 .chat-confirmation-widget2 .chat-confirmation-widget-title {
 	border-bottom: 1px solid var(--vscode-chat-requestBorder);
-	padding: 5px 9px;
+	padding: 4px 8px;
 	display: flex;
 	justify-content: space-between;
 	column-gap: 10px;
@@ -217,6 +217,10 @@
 
 		p {
 			margin: 0 !important;
+		}
+
+		.codicon {
+			margin-right: 4px;
 		}
 	}
 
@@ -261,7 +265,7 @@
 
 .chat-confirmation-message-terminal .chat-confirmation-message-terminal-disclaimer p:last-child {
 	margin-bottom: 0 !important;
-	padding: 5px 9px 0 9px;
+	padding: 4px 8px 0 9px;
 }
 
 .chat-confirmation-widget-container.hideButtons .chat-confirmation-widget-buttons,
@@ -271,7 +275,7 @@
 
 .chat-confirmation-widget2 .chat-confirmation-widget-buttons {
 	display: flex;
-	padding: 5px 9px;
+	padding: 4px 8px;
 
 	.chat-buttons {
 		display: flex;
@@ -282,6 +286,14 @@
 			overflow-wrap: break-word;
 			width: inherit;
 		}
+	}
+
+	.monaco-button-dropdown > .monaco-button.monaco-dropdown-button {
+		padding: 0px 4px 0 3px;
+	}
+
+	.monaco-button-dropdown > .monaco-button.monaco-dropdown-button.codicon[class*='codicon-'] {
+		font-size: 12px;
 	}
 }
 


### PR DESCRIPTION
- Add 4px gap between icon and title in confirmation widget title rendered markdown
- Add padding/gap and 12px font-size for dropdown button chevron
- Use `var(--vscode-cornerRadius-medium)` for confirmation widget border-radius to match code blocks and markdown tables