### PR TITLE
Revert toolbar icons and labels to use regular foreground color

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1400,12 +1400,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	padding: 3px 0px 3px 6px;
 	display: flex;
 	align-items: center;
-	color: var(--vscode-descriptionForeground);
+	color: var(--vscode-foreground);
 }
 
 .monaco-workbench .interactive-session .chat-input-toolbars .monaco-action-bar .action-item .codicon.codicon,
 .monaco-workbench .interactive-session .chat-input-toolbars .action-label .codicon.codicon {
-	color: var(--vscode-descriptionForeground) !important;
+	color: var(--vscode-foreground) !important;
 }
 
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1403,11 +1403,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-foreground);
 }
 
-.monaco-workbench .interactive-session .chat-input-toolbars .monaco-action-bar .action-item .codicon.codicon,
-.monaco-workbench .interactive-session .chat-input-toolbars .action-label .codicon.codicon {
-	color: var(--vscode-foreground) !important;
-}
-
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
 .monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
 	font-size: 12px;


### PR DESCRIPTION
Reverts the chat input toolbar icon and label colors from `descriptionForeground` back to `foreground`.

Fixes https://github.com/microsoft/vscode/issues/295885