### PR TITLE
Fix some jumping on scrolling up

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -120,11 +120,6 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 		const element = context.element;
 		const inUndoStop = (findLast(context.content, e => e.kind === 'undoStop', context.contentIndex) as IChatUndoStop | undefined)?.id;
 
-		// We release editors in order so that it's more likely that the same editor will
-		// be assigned if this element is re-rendered right away, like it often is during
-		// progressive rendering
-		const orderedDisposablesList: IDisposable[] = [];
-
 		// Need to track the index of the codeblock within the response so it can have a unique ID,
 		// and within this part to find it within the codeblocks array
 		let globalCodeBlockIndexStart = codeBlockStartIndex;
@@ -141,10 +136,27 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 
 		const enableMath = configurationService.getValue<boolean>(ChatConfiguration.EnableMath);
 
+		const renderStore = this._register(new MutableDisposable<DisposableStore>());
+
 		const doRenderMarkdown = () => {
 			if (this._store.isDisposed) {
 				return;
 			}
+
+			// Dispose previous render and reset state for re-render
+			const store = new DisposableStore();
+			renderStore.value = store;
+			dom.clearNode(this.domNode);
+			this.allRefs.length = 0;
+			this._codeblocks.length = 0;
+			this.mathLayoutParticipants.clear();
+			globalCodeBlockIndexStart = codeBlockStartIndex;
+			thisPartCodeBlockIndexStart = 0;
+
+			// We release editors in order so that it's more likely that the same editor will
+			// be assigned if this element is re-rendered right away, like it often is during
+			// progressive rendering
+			const orderedDisposablesList: IDisposable[] = [];
 
 			// TODO: Move katex support into chatMarkdownRenderer
 			const markedExtensions = enableMath
@@ -160,7 +172,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 				breaks: true,
 			};
 
-			const result = this._register(renderer.render(markdown.content, {
+			const result = store.add(renderer.render(markdown.content, {
 				sanitizerConfig: MarkedKatexSupport.getSanitizerOptions({
 					allowedTags: allowedChatMarkdownHtmlTags,
 					allowedAttributes: allowedMarkdownHtmlAttributes,
@@ -201,7 +213,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 						}
 					}
 					if (languageId === 'vscode-extensions') {
-						const chatExtensions = this._register(instantiationService.createInstance(ChatExtensionsContentPart, { kind: 'extensions', extensions: text.split(',') }));
+						const chatExtensions = store.add(instantiationService.createInstance(ChatExtensionsContentPart, { kind: 'extensions', extensions: text.split(',') }));
 						return chatExtensions.domNode;
 					}
 					const globalIndex = globalCodeBlockIndexStart++;
@@ -330,12 +342,12 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 			}
 
 			const markdownDecorationsRenderer = instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
-			this._register(markdownDecorationsRenderer.walkTreeAndAnnotateReferenceLinks(markdown, result.element));
+			store.add(markdownDecorationsRenderer.walkTreeAndAnnotateReferenceLinks(markdown, result.element));
 
 			const layoutParticipants = new Lazy(() => {
 				const observer = new ResizeObserver(() => this.mathLayoutParticipants.forEach(layout => layout()));
 				observer.observe(this.domNode);
-				this._register(toDisposable(() => observer.disconnect()));
+				store.add(toDisposable(() => observer.disconnect()));
 				return this.mathLayoutParticipants;
 			});
 
@@ -357,19 +369,21 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 				scrollable.scanDomNode();
 			}
 
-			orderedDisposablesList.reverse().forEach(d => this._register(d));
+			orderedDisposablesList.reverse().forEach(d => store.add(d));
 		};
 
+		// Always render immediately
+		doRenderMarkdown();
+
 		if (enableMath && !MarkedKatexSupport.getExtension(dom.getWindow(context.container))) {
-			// Need to load async
+			// KaTeX not yet loaded - load it and re-render when ready
 			MarkedKatexSupport.loadExtension(dom.getWindow(context.container))
+				.then(() => {
+					doRenderMarkdown();
+				})
 				.catch(e => {
 					console.error('Failed to load MarkedKatexSupport extension:', e);
-				}).finally(() => {
-					doRenderMarkdown();
 				});
-		} else {
-			doRenderMarkdown();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -228,8 +228,8 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 							range = parsedBody.range && Range.lift(parsedBody.range);
 							const modelRefPromise = this.textModelService.createModelReference(parsedBody.uri);
 							textModel = modelRefPromise.then(ref => {
-								if (!this._store.isDisposed) {
-									this._register(ref);
+								if (!store.isDisposed) {
+									store.add(ref);
 								}
 								return ref.object.textEditorModel;
 							});


### PR DESCRIPTION
- Chat session loads, katex has not yet been loaded
- ListView really wants to render from the top down so it checks the heights of some elements at the top
- Katex not loaded, so we don't render markdown at all
- Measured element height is very wrong
- But we initialize scroll all the way down so those elements don't get a chance to fix their height
- When scrolling up, we render an element and it is resized massively from the previous estimate, content shifts down

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

SO we try to fix this by always rendering then re-rendering after katex loads