### PR TITLE
perf: defer expensive repo diff capture to export time

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatRepoInfo.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatRepoInfo.ts
@@ -23,7 +23,6 @@ import * as nls from '../../../../nls.js';
 
 const MAX_CHANGES = 100;
 const MAX_DIFFS_SIZE_BYTES = 900 * 1024;
-const MAX_SESSIONS_WITH_FULL_DIFFS = 5;
 const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB per file
 /**
  * Regex to match `url = <remote-url>` lines in git config.
@@ -374,7 +373,76 @@ function computeDiffHunks(
 }
 
 /**
- * Captures repository state from the first available SCM repository.
+ * Captures lightweight repository metadata (branch, commit, remote) from SCM providers.
+ * No file I/O or diff computation - reads only from already-loaded SCM observables.
+ * Used on chat message submission to record the point-in-time commit state.
+ */
+export function captureRepoMetadata(scmService: ISCMService): IExportableRepoData | undefined {
+	const repositories = [...scmService.repositories];
+	if (repositories.length === 0) {
+		return undefined;
+	}
+
+	const repository = repositories[0];
+	const rootUri = repository.provider.rootUri;
+	if (!rootUri) {
+		return undefined;
+	}
+
+	let localBranch: string | undefined;
+	let localHeadCommit: string | undefined;
+	let remoteTrackingBranch: string | undefined;
+	let remoteHeadCommit: string | undefined;
+	let remoteBaseBranch: string | undefined;
+
+	const historyProvider = repository.provider.historyProvider?.get();
+	if (historyProvider) {
+		const historyItemRef = historyProvider.historyItemRef.get();
+		localBranch = historyItemRef?.name;
+		localHeadCommit = historyItemRef?.revision;
+
+		const historyItemRemoteRef = historyProvider.historyItemRemoteRef.get();
+		if (historyItemRemoteRef) {
+			remoteTrackingBranch = historyItemRemoteRef.name;
+			remoteHeadCommit = historyItemRemoteRef.revision;
+		}
+
+		const historyItemBaseRef = historyProvider.historyItemBaseRef.get();
+		if (historyItemBaseRef) {
+			remoteBaseBranch = historyItemBaseRef.name;
+		}
+	}
+
+	// Determine sync status without file I/O.
+	// Note: workspaceType is always 'remote-git' here because we cannot distinguish
+	// plain-folder or local-git without reading .git or .git/config (which requires I/O).
+	// The full captureRepoInfo at export time will produce accurate classification.
+	const workspaceType: IExportableRepoData['workspaceType'] = 'remote-git';
+	let syncStatus: IExportableRepoData['syncStatus'];
+
+	if (!remoteTrackingBranch) {
+		syncStatus = 'unpublished';
+	} else if (localHeadCommit === remoteHeadCommit) {
+		syncStatus = 'synced';
+	} else {
+		syncStatus = 'unpushed';
+	}
+
+	return {
+		workspaceType,
+		syncStatus,
+		localBranch,
+		remoteTrackingBranch,
+		remoteBaseBranch,
+		localHeadCommit,
+		remoteHeadCommit,
+		diffsStatus: 'notCaptured',
+	};
+}
+
+/**
+ * Captures full repository state including working tree diffs.
+ * Performs file I/O and diff computation - should only be called on explicit user action (e.g., export).
  */
 export async function captureRepoInfo(scmService: ISCMService, fileService: IFileService): Promise<IExportableRepoData | undefined> {
 	const repositories = [...scmService.repositories];
@@ -564,7 +632,9 @@ export async function captureRepoInfo(scmService: ISCMService, fileService: IFil
 }
 
 /**
- * Captures repository information for chat sessions on creation and first message.
+ * Captures lightweight repository metadata for chat sessions on first message.
+ * Only reads from already-loaded SCM provider observables, no file I/O.
+ * Full diff capture is deferred to export time (see chatExportZip.ts).
  */
 export class ChatRepoInfoContribution extends Disposable implements IWorkbenchContribution {
 
@@ -576,7 +646,6 @@ export class ChatRepoInfoContribution extends Disposable implements IWorkbenchCo
 		@IChatService private readonly chatService: IChatService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 		@ISCMService private readonly scmService: ISCMService,
-		@IFileService private readonly fileService: IFileService,
 		@ILogService private readonly logService: ILogService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
@@ -586,12 +655,12 @@ export class ChatRepoInfoContribution extends Disposable implements IWorkbenchCo
 			this.registerConfigurationIfInternal();
 		}));
 
-		this._register(this.chatService.onDidSubmitRequest(async ({ chatSessionResource }) => {
+		this._register(this.chatService.onDidSubmitRequest(({ chatSessionResource }) => {
 			const model = this.chatService.getSession(chatSessionResource);
 			if (!model) {
 				return;
 			}
-			await this.captureAndSetRepoData(model);
+			this.captureAndSetRepoMetadata(model);
 		}));
 	}
 
@@ -612,7 +681,7 @@ export class ChatRepoInfoContribution extends Disposable implements IWorkbenchCo
 			properties: {
 				[ChatConfiguration.RepoInfoEnabled]: {
 					type: 'boolean',
-					description: nls.localize('chat.repoInfo.enabled', "Controls whether repository information (branch, commit, working tree diffs) is captured at the start of chat sessions for internal diagnostics."),
+					description: nls.localize('chat.repoInfo.enabled', "Controls whether repository information (branch, commit, working tree diffs) is captured for chat sessions for internal diagnostics."),
 					default: false,
 				}
 			}
@@ -622,12 +691,15 @@ export class ChatRepoInfoContribution extends Disposable implements IWorkbenchCo
 		this.logService.debug('[ChatRepoInfo] Configuration registered for internal user');
 	}
 
-	private async captureAndSetRepoData(model: IChatModel): Promise<void> {
+	/**
+	 * Captures lightweight metadata (branch, commit, remote refs) on first message.
+	 * Synchronous, no file I/O. Reads only from SCM provider observables.
+	 */
+	private captureAndSetRepoMetadata(model: IChatModel): void {
 		if (!this.chatEntitlementService.isInternal) {
 			return;
 		}
 
-		// Check if repo info capture is enabled via configuration
 		if (!this.configurationService.getValue<boolean>(ChatConfiguration.RepoInfoEnabled)) {
 			return;
 		}
@@ -637,55 +709,17 @@ export class ChatRepoInfoContribution extends Disposable implements IWorkbenchCo
 		}
 
 		try {
-			const repoData = await captureRepoInfo(this.scmService, this.fileService);
-			if (repoData) {
-				model.setRepoData(repoData);
-				if (!repoData.localHeadCommit && repoData.workspaceType !== 'plain-folder') {
-					this.logService.warn('[ChatRepoInfo] Captured repo data without commit hash - git history may not be ready');
+			const metadata = captureRepoMetadata(this.scmService);
+			if (metadata) {
+				model.setRepoData(metadata);
+				if (!metadata.localHeadCommit) {
+					this.logService.warn('[ChatRepoInfo] Captured repo metadata without commit hash - git history may not be ready');
 				}
-
-				// Trim diffs from older sessions to manage storage
-				this.trimOldSessionDiffs();
 			} else {
 				this.logService.debug('[ChatRepoInfo] No SCM repository available for chat session');
 			}
 		} catch (error) {
-			this.logService.warn('[ChatRepoInfo] Failed to capture repo info:', error);
-		}
-	}
-
-	/**
-	 * Trims diffs from older sessions, keeping full diffs only for the most recent sessions.
-	 */
-	private trimOldSessionDiffs(): void {
-		try {
-			// Get all sessions with repoData that has diffs
-			const sessionsWithDiffs: { model: IChatModel; timestamp: number }[] = [];
-
-			for (const model of this.chatService.chatModels.get()) {
-				if (model.repoData?.diffs && model.repoData.diffs.length > 0 && model.repoData.diffsStatus === 'included') {
-					sessionsWithDiffs.push({ model, timestamp: model.timestamp });
-				}
-			}
-
-			// Sort by timestamp descending (most recent first)
-			sessionsWithDiffs.sort((a, b) => b.timestamp - a.timestamp);
-
-			// Trim diffs from sessions beyond the limit
-			for (let i = MAX_SESSIONS_WITH_FULL_DIFFS; i < sessionsWithDiffs.length; i++) {
-				const { model } = sessionsWithDiffs[i];
-				if (model.repoData) {
-					const trimmedRepoData: IExportableRepoData = {
-						...model.repoData,
-						diffs: undefined,
-						diffsStatus: 'trimmedForStorage'
-					};
-					model.setRepoData(trimmedRepoData);
-					this.logService.trace(`[ChatRepoInfo] Trimmed diffs from older session: ${model.sessionResource.toString()}`);
-				}
-			}
-		} catch (error) {
-			this.logService.warn('[ChatRepoInfo] Failed to trim old session diffs:', error);
+			this.logService.warn('[ChatRepoInfo] Failed to capture repo metadata:', error);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -2652,7 +2652,6 @@ export class ChatModel extends Disposable implements IChatModel {
 			creationDate: this._timestamp,
 			customTitle: this._customTitle,
 			inputState: this.inputModel.toJSON(),
-			repoData: this._repoData,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/chatExportZip.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/chatExportZip.ts
@@ -7,7 +7,6 @@ import { joinPath } from '../../../../../base/common/resources.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -19,7 +18,6 @@ import { IChatWidgetService } from '../../browser/chat.js';
 import { captureRepoInfo } from '../../browser/chatRepoInfo.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatService } from '../../common/chatService/chatService.js';
-import { ChatConfiguration } from '../../common/constants.js';
 import { ISCMService } from '../../../scm/common/scm.js';
 
 export function registerChatExportZipAction() {
@@ -42,9 +40,6 @@ export function registerChatExportZipAction() {
 			const notificationService = accessor.get(INotificationService);
 			const scmService = accessor.get(ISCMService);
 			const fileService = accessor.get(IFileService);
-			const configurationService = accessor.get(IConfigurationService);
-
-			const repoInfoEnabled = configurationService.getValue<boolean>(ChatConfiguration.RepoInfoEnabled) ?? false;
 
 			const widget = widgetService.lastFocusedWidget;
 			if (!widget || !widget.viewModel) {
@@ -83,36 +78,32 @@ export function registerChatExportZipAction() {
 					});
 				}
 
-				if (repoInfoEnabled) {
-					const currentRepoData = await captureRepoInfo(scmService, fileService);
-					if (currentRepoData) {
-						files.push({
-							path: 'chat.repo.end.json',
-							contents: JSON.stringify(currentRepoData, undefined, 2)
-						});
-					}
+				const currentRepoData = await captureRepoInfo(scmService, fileService);
+				if (currentRepoData) {
+					files.push({
+						path: 'chat.repo.end.json',
+						contents: JSON.stringify(currentRepoData, undefined, 2)
+					});
+				}
 
-					if (!model.repoData && !currentRepoData) {
-						notificationService.notify({
-							severity: Severity.Warning,
-							message: localize('chatExportZip.noRepoData', "Exported chat without repository context. No Git repository was detected.")
-						});
-					}
+				if (!model.repoData && !currentRepoData) {
+					notificationService.notify({
+						severity: Severity.Warning,
+						message: localize('chatExportZip.noRepoData', "Exported chat without repository context. No Git repository was detected.")
+					});
 				}
 			} else {
-				if (repoInfoEnabled) {
-					const currentRepoData = await captureRepoInfo(scmService, fileService);
-					if (currentRepoData) {
-						files.push({
-							path: 'chat.repo.begin.json',
-							contents: JSON.stringify(currentRepoData, undefined, 2)
-						});
-					} else {
-						notificationService.notify({
-							severity: Severity.Warning,
-							message: localize('chatExportZip.noRepoData', "Exported chat without repository context. No Git repository was detected.")
-						});
-					}
+				const currentRepoData = await captureRepoInfo(scmService, fileService);
+				if (currentRepoData) {
+					files.push({
+						path: 'chat.repo.begin.json',
+						contents: JSON.stringify(currentRepoData, undefined, 2)
+					});
+				} else {
+					notificationService.notify({
+						severity: Severity.Warning,
+						message: localize('chatExportZip.noRepoData', "Exported chat without repository context. No Git repository was detected.")
+					});
 				}
 			}
 


### PR DESCRIPTION
Split repo info capture into lightweight metadata (on first message) and full diffs (at export time only).

**On first message** — `captureRepoMetadata()` reads branch/commit/remote refs from already-loaded SCM observables. Synchronous, zero file I/O.

**At export time** — `captureRepoInfo()` performs full file reads and diff generation, only when user triggers "Export Chat as Zip".

Also:
- Remove `repoData` from `toJSON()` — no need to persist across restarts
- Remove `trimOldSessionDiffs()` — diffs are never stored on the model
- Remove `IFileService` dependency from `ChatRepoInfoContribution`
- Export action always captures diffs on-demand (no longer gated on `chat.repoInfo.enabled`)

Addresses https://github.com/microsoft/vscode/pull/286812#issuecomment-3915462189