### PR TITLE
Add chat thinking shimmer color to 2026 Light theme

### DIFF
--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -258,6 +258,7 @@
 		"quickInputTitle.background": "#F0F0F3",
 		"chat.requestBubbleBackground": "#EEF4FB",
 		"chat.requestBubbleHoverBackground": "#E6EDFA",
+		"chat.thinkingShimmer": "#999999",
 		"editorCommentsWidget.rangeBackground": "#EEF4FB",
 		"editorCommentsWidget.rangeActiveBackground": "#E6EDFA",
 		"charts.foreground": "#202020",


### PR DESCRIPTION
Introduce a new color for the chat thinking shimmer in the 2026 Light theme. This enhances the visual feedback during chat interactions. Test by observing the shimmer effect in the chat interface.

Addresses: https://github.com/microsoft/vscode/issues/295957
