### PR TITLE
Add foreground color for italic markup in theme files

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -156,7 +156,8 @@
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"fontStyle": "italic"
+				"fontStyle": "italic",
+				"foreground": "#C586C0"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/hc_light.json
+++ b/extensions/theme-defaults/themes/hc_light.json
@@ -122,7 +122,8 @@
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"fontStyle": "italic"
+				"fontStyle": "italic",
+				"foreground": "#800080"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -159,7 +159,8 @@
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"fontStyle": "italic"
+				"fontStyle": "italic",
+				"foreground": "#800080"
 			}
 		},
 		{

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
@@ -1809,42 +1809,42 @@
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
+			"dark_plus": "markup.italic: #C586C0",
+			"light_plus": "markup.italic: #800080",
+			"dark_vs": "markup.italic: #C586C0",
+			"light_vs": "markup.italic: #800080",
 			"hc_black": "default: #FFFFFF",
-			"dark_modern": "default: #CCCCCC",
-			"hc_light": "default: #292929",
-			"light_modern": "default: #3B3B3B"
+			"dark_modern": "markup.italic: #C586C0",
+			"hc_light": "markup.italic: #800080",
+			"light_modern": "markup.italic: #800080"
 		}
 	},
 	{
 		"c": "italics",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
+			"dark_plus": "markup.italic: #C586C0",
+			"light_plus": "markup.italic: #800080",
+			"dark_vs": "markup.italic: #C586C0",
+			"light_vs": "markup.italic: #800080",
 			"hc_black": "default: #FFFFFF",
-			"dark_modern": "default: #CCCCCC",
-			"hc_light": "default: #292929",
-			"light_modern": "default: #3B3B3B"
+			"dark_modern": "markup.italic: #C586C0",
+			"hc_light": "markup.italic: #800080",
+			"light_modern": "markup.italic: #800080"
 		}
 	},
 	{
 		"c": "_",
 		"t": "text.html.markdown meta.paragraph.markdown markup.italic.markdown punctuation.definition.italic.markdown",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
+			"dark_plus": "markup.italic: #C586C0",
+			"light_plus": "markup.italic: #800080",
+			"dark_vs": "markup.italic: #C586C0",
+			"light_vs": "markup.italic: #800080",
 			"hc_black": "default: #FFFFFF",
-			"dark_modern": "default: #CCCCCC",
-			"hc_light": "default: #292929",
-			"light_modern": "default: #3B3B3B"
+			"dark_modern": "markup.italic: #C586C0",
+			"hc_light": "markup.italic: #800080",
+			"light_modern": "markup.italic: #800080"
 		}
 	},
 	{

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_rst.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_rst.json
@@ -3,14 +3,14 @@
 		"c": "*italics*",
 		"t": "source.rst markup.italic",
 		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
+			"dark_plus": "markup.italic: #C586C0",
+			"light_plus": "markup.italic: #800080",
+			"dark_vs": "markup.italic: #C586C0",
+			"light_vs": "markup.italic: #800080",
 			"hc_black": "default: #FFFFFF",
-			"dark_modern": "default: #CCCCCC",
-			"hc_light": "default: #292929",
-			"light_modern": "default: #3B3B3B"
+			"dark_modern": "markup.italic: #C586C0",
+			"hc_light": "markup.italic: #800080",
+			"light_modern": "markup.italic: #800080"
 		}
 	},
 	{


### PR DESCRIPTION
Introduce foreground colors for italic markup in theme files to enhance visibility and aesthetics. Test by applying the updated theme and verifying the italic text color in the editor.

Addresses: https://github.com/microsoft/vscode/issues/294508
