### PR TITLE
Increase max-width of extension editor to 95%

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -9,7 +9,7 @@
 	display: flex;
 	flex-direction: column;
 	margin: 0px auto;
-	max-width: 90%;
+	max-width: 95%;
 }
 
 .extension-editor .clickable {


### PR DESCRIPTION
Adjust the maximum width of the extension editor to enhance the layout and user experience. Test by opening the extension editor and verifying the new width.

