### PR TITLE
Fix git warning messages incorrectly styled as errors

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5650,9 +5650,19 @@ export class CommandCenter {
 							.split(/[\r\n]/)
 							.filter((line: string) => !!line);
 
-						message = hintLines.length > 0
-							? l10n.t('Git: {0}', err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
-							: l10n.t('Git error');
+						const hint = hintLines.length > 0
+							? (err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
+							: undefined;
+
+						if (hint && /^warning: /i.test(hint)) {
+							type = 'warning';
+							options.modal = false;
+							message = l10n.t('Git: {0}', hint.replace(/^warning: /i, ''));
+						} else {
+							message = hint
+								? l10n.t('Git: {0}', hint)
+								: l10n.t('Git error');
+						}
 
 						break;
 					}


### PR DESCRIPTION
## Summary
- Git/SSH warning messages (e.g. `warning: permanently added 'host' to the list of known hosts`) were displayed with error-level styling (red icon) instead of warning styling (yellow icon)
- When the first line of stderr starts with `warning:`, the notification is now classified as a warning (yellow, non-modal) instead of an error (red, modal), and the `warning:` prefix is stripped for a cleaner message

## Test plan
- [ ] Connect to a Git remote via SSH for the first time and verify the "permanently added to known hosts" message appears with warning (yellow) styling, not error (red) styling
- [ ] Trigger an actual git error (e.g. authentication failure) and verify it still shows with error (red) styling
- [ ] Trigger a git warning with mixed-case `Warning:` prefix and verify it's correctly classified as a warning

Fixes #280834