### PR TITLE
fix(git): warn when publishing a shallow repository

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4318,6 +4318,19 @@ export class CommandCenter {
 
 	@command('git.publish', { repository: true })
 	async publish(repository: Repository): Promise<void> {
+		if (await repository.isShallow) {
+			const proceed = l10n.t('Continue');
+			const result = await window.showWarningMessage(
+				l10n.t('The repository "{0}" is a shallow clone. Publishing it may result in a partial history on the remote.', path.basename(repository.root)),
+				{ modal: true },
+				proceed
+			);
+
+			if (result !== proceed) {
+				return;
+			}
+		}
+
 		const branchName = repository.HEAD && repository.HEAD.name || '';
 		const remotes = repository.remotes;
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1480,6 +1480,15 @@ export class Repository {
 		return parseGitCommits(result.stdout);
 	}
 
+	async isShallow(cancellationToken?: CancellationToken): Promise<boolean> {
+		try {
+			const result = await this.exec(['rev-parse', '--is-shallow-repository'], { cancellationToken });
+			return result.stdout.trim() === 'true';
+		} catch (e) {
+			return false;
+		}
+	}
+
 	async logFile(uri: Uri, options?: LogFileOptions, cancellationToken?: CancellationToken): Promise<Commit[]> {
 		const args = ['log', `--format=${COMMIT_FORMAT}`, '-z'];
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -884,6 +884,10 @@ export class Repository implements Disposable {
 	private _isHidden: boolean;
 	get isHidden(): boolean { return this._isHidden; }
 
+	get isShallow(): Promise<boolean> {
+		return this.repository.isShallow();
+	}
+
 	private isRepositoryHuge: false | { limit: number } = false;
 	private didWarnAboutLimit = false;
 


### PR DESCRIPTION
Fixes #180317. This PR adds a warning when attempting to publish a branch from a shallow clone, which can result in incomplete history on the remote.