### PR TITLE
feat(chat): support pasting images in chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatDragAndDrop.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatDragAndDrop.ts
@@ -309,7 +309,7 @@ export class ChatDragAndDrop extends Themable {
 		return undefined;
 	}
 
-	private async resolveHTMLAttachContext(e: DragEvent): Promise<IChatRequestVariableEntry[]> {
+	public async resolveFilesAndImages(dataTransfer: DataTransfer): Promise<IChatRequestVariableEntry[]> {
 		const existingAttachmentNames = new Set<string>(this.attachmentModel.attachments.map(attachment => attachment.name));
 		const createDisplayName = (): string => {
 			const baseName = localize('dragAndDroppedImageName', 'Image from URL');
@@ -355,20 +355,27 @@ export class ChatDragAndDrop extends Themable {
 		const imageTransferData: ImageTransferData[] = [];
 
 		// Image Web File Drag and Drop
-		const imageFiles = extractImageFilesFromDragEvent(e);
+		const imageFiles = extractImageFilesFromDataTransfer(dataTransfer);
 		if (imageFiles.length) {
 			const imageTransferDataFromFiles = await Promise.all(imageFiles.map(file => getImageTransferDataFromFile(file)));
 			imageTransferData.push(...imageTransferDataFromFiles.filter(data => !!data));
 		}
 
 		// Image Web URL Drag and Drop
-		const imageUrls = extractUrlsFromDragEvent(e);
+		const imageUrls = extractUrlsFromDataTransfer(dataTransfer, this.logService);
 		if (imageUrls.length) {
 			const imageTransferDataFromUrl = await Promise.all(imageUrls.map(getImageTransferDataFromUrl));
 			imageTransferData.push(...imageTransferDataFromUrl.filter(data => !!data));
 		}
 
 		return await this.chatAttachmentResolveService.resolveImageAttachContext(imageTransferData);
+	}
+
+	private async resolveHTMLAttachContext(e: DragEvent): Promise<IChatRequestVariableEntry[]> {
+		if (e.dataTransfer) {
+			return this.resolveFilesAndImages(e.dataTransfer);
+		}
+		return [];
 	}
 
 	private setOverlay(target: HTMLElement, type: ChatDragAndDropType | undefined): void {
@@ -433,8 +440,8 @@ function containsImageDragType(e: DragEvent): boolean {
 	return false;
 }
 
-function extractUrlsFromDragEvent(e: DragEvent, logService?: ILogService): string[] {
-	const textUrl = e.dataTransfer?.getData('text/uri-list');
+function extractUrlsFromDataTransfer(dataTransfer: DataTransfer, logService?: ILogService): string[] {
+	const textUrl = dataTransfer.getData('text/uri-list');
 	if (textUrl) {
 		try {
 			const urls = UriList.parse(textUrl);
@@ -450,11 +457,12 @@ function extractUrlsFromDragEvent(e: DragEvent, logService?: ILogService): strin
 	return [];
 }
 
-function extractImageFilesFromDragEvent(e: DragEvent): File[] {
-	const files = e.dataTransfer?.files;
+function extractImageFilesFromDataTransfer(dataTransfer: DataTransfer): File[] {
+	const files = dataTransfer.files;
 	if (!files) {
 		return [];
 	}
 
 	return Array.from(files).filter(file => file.type.startsWith('image/'));
 }
+

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1929,6 +1929,24 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 		}));
 
+		this._register(dom.addDisposableListener(this._inputEditorElement, 'paste', async (e: ClipboardEvent) => {
+			if (!e.clipboardData) {
+				return;
+			}
+
+			// We need to check if there are images in the clipboard to prevent default behavior
+			// If we don't prevent default, the editor will try to paste the image as text (e.g. file path or binary)
+			const hasImages = Array.from(e.clipboardData.files).some(file => file.type.startsWith('image/'));
+			if (hasImages) {
+				e.preventDefault();
+			}
+
+			const attachments = await this.dnd.resolveFilesAndImages(e.clipboardData);
+			if (attachments.length > 0) {
+				this._attachmentModel.addContext(...attachments);
+			}
+		}));
+
 		this._register(this._inputEditor.onDidChangeModelContent(() => {
 			const currentHeight = Math.min(this._inputEditor.getContentHeight(), this.inputEditorMaxHeight);
 			if (currentHeight !== this.inputEditorHeight) {


### PR DESCRIPTION
Fixes #295322. Allows users to paste images from clipboard into Copilot Chat input box.