### PR TITLE
fix tip dismissal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -584,6 +584,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		this._storageService.remove(ChatTipService._DISMISSED_TIP_KEY, StorageScope.PROFILE);
 		this._shownTip = undefined;
 		this._tipRequestId = undefined;
+		this._contextKeyService = undefined;
 		this._onDidDismissTip.fire();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -40,7 +40,6 @@ export class ChatTipContentPart extends Disposable {
 	constructor(
 		tip: IChatTip,
 		private readonly _renderer: IMarkdownRenderer,
-		private readonly _getNextTip: () => IChatTip | undefined,
 		@IChatTipService private readonly _chatTipService: IChatTipService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IMenuService private readonly _menuService: IMenuService,
@@ -63,7 +62,7 @@ export class ChatTipContentPart extends Disposable {
 		this._renderTip(tip);
 
 		this._register(this._chatTipService.onDidDismissTip(() => {
-			const nextTip = this._getNextTip();
+			const nextTip = this._chatTipService.navigateToNextTip();
 			if (nextTip) {
 				this._renderTip(nextTip);
 				dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(this.domNode), () => this.focus());
@@ -152,8 +151,7 @@ registerAction2(class PreviousTipAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const chatTipService = accessor.get(IChatTipService);
-		const contextKeyService = accessor.get(IContextKeyService);
-		chatTipService.navigateToPreviousTip(contextKeyService);
+		chatTipService.navigateToPreviousTip();
 	}
 });
 
@@ -174,8 +172,7 @@ registerAction2(class NextTipAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const chatTipService = accessor.get(IChatTipService);
-		const contextKeyService = accessor.get(IContextKeyService);
-		chatTipService.navigateToNextTip(contextKeyService);
+		chatTipService.navigateToNextTip();
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -275,4 +275,19 @@ registerAction2(class DisableTipsAction extends Action2 {
 	}
 });
 
+registerAction2(class ResetDismissedTipsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.chat.resetDismissedTips',
+			title: localize2('chatTip.resetDismissedTips', "Reset Dismissed Tips"),
+			f1: true,
+			precondition: ChatContextKeys.enabled,
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IChatTipService).clearDismissedTips();
+	}
+});
+
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1006,7 +1006,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		const tipPart = store.add(this.instantiationService.createInstance(ChatTipContentPart,
 			tip,
 			renderer,
-			() => this.chatTipService.getWelcomeTip(this.contextKeyService),
 		));
 		tipContainer.appendChild(tipPart.domNode);
 		this._gettingStartedTipPartRef = tipPart;

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -296,6 +296,11 @@ suite('ChatTipService', () => {
 	test('dismissed tips stay dismissed after disabling and re-enabling tips', async () => {
 		const service = createService();
 
+		// Flush microtask queue so async file-check exclusions resolve before
+		// we start dismissing tips (otherwise excludeUntilChecked tips are
+		// temporarily excluded and never get dismissed in the loop below).
+		await new Promise<void>(r => queueMicrotask(r));
+
 		for (let i = 0; i < 100; i++) {
 			const tip = service.getWelcomeTip(contextKeyService);
 			if (!tip) {

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -279,6 +279,26 @@ suite('ChatTipService', () => {
 		assert.ok(tip2, 'Should return a tip after disabling and re-enabling');
 	});
 
+	test('dismissed tips stay dismissed after disabling and re-enabling tips', async () => {
+		const service = createService();
+
+		for (let i = 0; i < 100; i++) {
+			const tip = service.getWelcomeTip(contextKeyService);
+			if (!tip) {
+				break;
+			}
+
+			service.dismissTip();
+		}
+
+		assert.strictEqual(service.getWelcomeTip(contextKeyService), undefined, 'No tip should remain once all tips are dismissed');
+
+		await service.disableTips();
+		configurationService.setUserConfiguration('chat.tips.enabled', true);
+
+		assert.strictEqual(service.getWelcomeTip(contextKeyService), undefined, 'Dismissed tips should remain dismissed after re-enabling tips');
+	});
+
 	function createMockPromptsService(
 		agentInstructions: IResolvedAgentFile[] = [],
 		promptInstructions: IPromptPath[] = [],

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -227,6 +227,20 @@ suite('ChatTipService', () => {
 		}
 	});
 
+	test('dismissTip keeps navigation context for next tip traversal', () => {
+		const service = createService();
+
+		const tip1 = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip1);
+
+		service.dismissTip();
+
+		const tip2 = service.navigateToNextTip();
+		if (tip2) {
+			assert.notStrictEqual(tip1.id, tip2.id, 'Dismissed tip should not be returned by next navigation');
+		}
+	});
+
 	test('dismissTip fires onDidDismissTip event', () => {
 		const service = createService();
 
@@ -318,6 +332,18 @@ suite('ChatTipService', () => {
 		assert.ok(service.getWelcomeTip(contextKeyService), 'A tip should be visible again after clearing dismissed tips');
 	});
 
+	test('migrates dismissed tips from profile to application storage', () => {
+		storageService.store('chat.tip.dismissed', JSON.stringify(['tip.switchToAuto']), StorageScope.PROFILE, StorageTarget.MACHINE);
+		const service = createService();
+		contextKeyService.createKey(ChatContextKeys.chatModelId.key, 'gpt-4.1');
+
+		const tip = service.getWelcomeTip(contextKeyService);
+
+		assert.ok(tip);
+		assert.notStrictEqual(tip.id, 'tip.switchToAuto', 'Should honor profile-stored dismissed tip id');
+		assert.ok(storageService.get('chat.tip.dismissed', StorageScope.APPLICATION), 'Expected dismissed tips to migrate to application storage');
+	});
+
 	function createMockPromptsService(
 		agentInstructions: IResolvedAgentFile[] = [],
 		promptInstructions: IPromptPath[] = [],
@@ -378,6 +404,28 @@ suite('ChatTipService', () => {
 		assert.ok(storageService.get('chat.tips.executedCommands', StorageScope.APPLICATION), 'Expected executed command exclusions in application storage');
 		assert.strictEqual(storageService.get('chat.tips.executedCommands', StorageScope.PROFILE), undefined, 'Did not expect executed command exclusions in profile storage');
 		assert.strictEqual(storageService.get('chat.tips.executedCommands', StorageScope.WORKSPACE), undefined, 'Did not expect executed command exclusions in workspace storage');
+	});
+
+	test('migrates executed command exclusions from profile to application storage', () => {
+		const tip: ITipDefinition = {
+			id: 'tip.undoChanges',
+			message: 'test',
+			excludeWhenCommandsExecuted: ['workbench.action.chat.restoreCheckpoint'],
+		};
+
+		storageService.store('chat.tips.executedCommands', JSON.stringify(['workbench.action.chat.restoreCheckpoint']), StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		const tracker = testDisposables.add(new TipEligibilityTracker(
+			[tip],
+			{ onDidExecuteCommand: commandExecutedEmitter.event, onWillExecuteCommand: Event.None } as Partial<ICommandService> as ICommandService,
+			storageService,
+			createMockPromptsService() as IPromptsService,
+			createMockToolsService(),
+			new NullLogService(),
+		));
+
+		assert.strictEqual(tracker.isExcluded(tip), true, 'Should honor profile-stored exclusions');
+		assert.ok(storageService.get('chat.tips.executedCommands', StorageScope.APPLICATION), 'Expected migrated exclusion data in application storage');
 	});
 
 	test('excludes tip.customInstructions when copilot-instructions.md exists in workspace', async () => {


### PR DESCRIPTION
fixes #296057

Dismissed tips were stored as a plain array, so duplicate IDs built up. A recovery check then treated “too many dismissed” as “none dismissed,” and a fallback always picked a tip, so previously dismissed tips could reappear after re-enabling tips.

We now dedupe persisted dismissals, only keep valid tip IDs, remove the reset-to-empty behavior, and return no tip when all are dismissed. That keeps dismissals persistent across disable/re-enable, and we added a regression test to lock this behavior.