### PR TITLE
add tip for /create*

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -21,6 +21,8 @@ import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
 import { localChatSessionType } from '../common/chatSessionsService.js';
+import { IChatService } from '../common/chatService/chatService.js';
+import { CreateSlashCommandsUsageTracker } from './createSlashCommandsUsageTracker.js';
 
 export const IChatTipService = createDecorator<IChatTipService>('chatTipService');
 
@@ -152,6 +154,26 @@ const TIP_CATALOG: ITipDefinition[] = [
 		message: localize('tip.switchToAuto', "Tip: Using gpt-4.1? Try switching to [Auto](command:workbench.action.chat.openModelPicker) in the model picker for better coding performance."),
 		enabledCommands: ['workbench.action.chat.openModelPicker'],
 		onlyWhenModelIds: ['gpt-4.1'],
+	},
+	{
+		id: 'tip.createSlashCommands',
+		message: localize(
+			'tip.createSlashCommands',
+			"Tip: Use [/create-instruction](command:workbench.action.chat.generateInstruction), [/create-prompt](command:workbench.action.chat.generatePrompt), [/create-agent](command:workbench.action.chat.generateAgent), or [/create-skill](command:workbench.action.chat.generateSkill) to generate reusable agent customization files."
+		),
+		when: ChatContextKeys.hasUsedCreateSlashCommands.negate(),
+		enabledCommands: [
+			'workbench.action.chat.generateInstruction',
+			'workbench.action.chat.generatePrompt',
+			'workbench.action.chat.generateAgent',
+			'workbench.action.chat.generateSkill',
+		],
+		excludeWhenCommandsExecuted: [
+			'workbench.action.chat.generateInstruction',
+			'workbench.action.chat.generatePrompt',
+			'workbench.action.chat.generateAgent',
+			'workbench.action.chat.generateSkill',
+		],
 	},
 	{
 		id: 'tip.agentMode',
@@ -538,16 +560,19 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	private static readonly _DISMISSED_TIP_KEY = 'chat.tip.dismissed';
 	private static readonly _LAST_TIP_ID_KEY = 'chat.tip.lastTipId';
 	private readonly _tracker: TipEligibilityTracker;
+	private readonly _createSlashCommandsUsageTracker: CreateSlashCommandsUsageTracker;
 
 	constructor(
 		@IProductService private readonly _productService: IProductService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@IChatService private readonly _chatService: IChatService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 		this._tracker = this._register(instantiationService.createInstance(TipEligibilityTracker, TIP_CATALOG));
+		this._createSlashCommandsUsageTracker = this._register(new CreateSlashCommandsUsageTracker(this._chatService, this._storageService, () => this._contextKeyService));
 	}
 
 	resetSession(): void {
@@ -617,6 +642,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	getWelcomeTip(contextKeyService: IContextKeyService): IChatTip | undefined {
+		this._createSlashCommandsUsageTracker.syncContextKey(contextKeyService);
 		// Check if tips are enabled
 		if (!this._configurationService.getValue<boolean>('chat.tips.enabled')) {
 			return undefined;
@@ -661,6 +687,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	private _findNextEligibleTip(currentTipId: string, contextKeyService: IContextKeyService): ITipDefinition | undefined {
+		this._createSlashCommandsUsageTracker.syncContextKey(contextKeyService);
 		const currentIndex = TIP_CATALOG.findIndex(tip => tip.id === currentTipId);
 		if (currentIndex === -1) {
 			return undefined;
@@ -679,6 +706,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	private _pickTip(sourceId: string, contextKeyService: IContextKeyService): IChatTip | undefined {
+		this._createSlashCommandsUsageTracker.syncContextKey(contextKeyService);
 		// Record the current mode for future eligibility decisions.
 		this._tracker.recordCurrentMode(contextKeyService);
 
@@ -730,6 +758,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	private _navigateTip(direction: 1 | -1, contextKeyService: IContextKeyService): IChatTip | undefined {
+		this._createSlashCommandsUsageTracker.syncContextKey(contextKeyService);
 		if (!this._shownTip) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/chat/browser/createSlashCommandsUsageTracker.ts
+++ b/src/vs/workbench/contrib/chat/browser/createSlashCommandsUsageTracker.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IChatService } from '../common/chatService/chatService.js';
+import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
+import { ChatRequestSlashCommandPart } from '../common/requestParser/chatParserTypes.js';
+
+export class CreateSlashCommandsUsageTracker extends Disposable {
+	private static readonly _USED_CREATE_SLASH_COMMANDS_KEY = 'chat.tips.usedCreateSlashCommands';
+
+	constructor(
+		private readonly _chatService: IChatService,
+		private readonly _storageService: IStorageService,
+		private readonly _getActiveContextKeyService: () => IContextKeyService | undefined,
+	) {
+		super();
+
+		this._register(this._chatService.onDidSubmitRequest(e => {
+			const model = this._chatService.getSession(e.chatSessionResource);
+			const lastRequest = model?.lastRequest;
+			if (!lastRequest) {
+				return;
+			}
+
+			for (const part of lastRequest.message.parts) {
+				if (part.kind === ChatRequestSlashCommandPart.Kind) {
+					const slash = part as ChatRequestSlashCommandPart;
+					if (CreateSlashCommandsUsageTracker._isCreateSlashCommand(slash.slashCommand.command)) {
+						this._markUsed();
+						return;
+					}
+				}
+			}
+
+			// Fallback when parsing doesn't produce a slash command part.
+			const trimmed = lastRequest.message.text.trimStart();
+			const match = /^\/(create-(?:instruction|prompt|agent|skill))(?:\s|$)/.exec(trimmed);
+			if (match && CreateSlashCommandsUsageTracker._isCreateSlashCommand(match[1])) {
+				this._markUsed();
+			}
+		}));
+	}
+
+	syncContextKey(contextKeyService: IContextKeyService): void {
+		const used = this._storageService.getBoolean(CreateSlashCommandsUsageTracker._USED_CREATE_SLASH_COMMANDS_KEY, StorageScope.APPLICATION, false);
+		ChatContextKeys.hasUsedCreateSlashCommands.bindTo(contextKeyService).set(used);
+	}
+
+	private _markUsed(): void {
+		if (this._storageService.getBoolean(CreateSlashCommandsUsageTracker._USED_CREATE_SLASH_COMMANDS_KEY, StorageScope.APPLICATION, false)) {
+			return;
+		}
+
+		this._storageService.store(CreateSlashCommandsUsageTracker._USED_CREATE_SLASH_COMMANDS_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const contextKeyService = this._getActiveContextKeyService();
+		if (contextKeyService) {
+			ChatContextKeys.hasUsedCreateSlashCommands.bindTo(contextKeyService).set(true);
+		}
+	}
+
+	private static _isCreateSlashCommand(command: string): boolean {
+		switch (command) {
+			case 'create-instruction':
+			case 'create-prompt':
+			case 'create-agent':
+			case 'create-skill':
+				return true;
+			default:
+				return false;
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -130,6 +130,12 @@ export namespace ChatContextKeys {
 
 	export const isKatexMathElement = new RawContextKey<boolean>('chatIsKatexMathElement', false, { type: 'boolean', description: localize('chatIsKatexMathElement', "True when focusing a KaTeX math element.") });
 
+	/**
+	 * True when the user has submitted a chat request using any of the `/create-*` slash commands.
+	 * This is persisted in application storage and used to suppress onboarding tips once discovered.
+	 */
+	export const hasUsedCreateSlashCommands = new RawContextKey<boolean>('chatHasUsedCreateSlashCommands', false, { type: 'boolean', description: localize('chatHasUsedCreateSlashCommands', "True when the user has used any of the /create-* slash commands.") });
+
 	export const contextUsageHasBeenOpened = new RawContextKey<boolean>('chatContextUsageHasBeenOpened', false, { type: 'boolean', description: localize('chatContextUsageHasBeenOpened', "True when the user has opened the context window usage details.") });
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -25,6 +25,12 @@ import { ILanguageModelToolsService } from '../../common/tools/languageModelTool
 import { MockLanguageModelToolsService } from '../common/tools/mockLanguageModelToolsService.js';
 import { IChatEntitlementService } from '../../../../services/chat/common/chatEntitlementService.js';
 import { TestChatEntitlementService } from '../../../../test/common/workbenchTestServices.js';
+import { IChatService } from '../../common/chatService/chatService.js';
+import { MockChatService } from '../common/chatService/mockChatService.js';
+import { CreateSlashCommandsUsageTracker } from '../../browser/createSlashCommandsUsageTracker.js';
+import { ChatRequestSlashCommandPart } from '../../common/requestParser/chatParserTypes.js';
+import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
+import { Range } from '../../../../../editor/common/core/range.js';
 
 class MockContextKeyServiceWithRulesMatching extends MockContextKeyService {
 	override contextMatchesRules(): boolean {
@@ -92,6 +98,7 @@ suite('ChatTipService', () => {
 		} as Partial<IPromptsService> as IPromptsService);
 		instantiationService.stub(ILanguageModelToolsService, testDisposables.add(new MockLanguageModelToolsService()));
 		instantiationService.stub(IChatEntitlementService, new TestChatEntitlementService());
+		instantiationService.stub(IChatService, new MockChatService());
 	});
 
 	test('returns a welcome tip', () => {
@@ -756,6 +763,41 @@ suite('ChatTipService', () => {
 		assert.strictEqual(tracker.isExcluded(tip), false, 'Should not be excluded when no skill files exist');
 	});
 
+	test('shows tip.createSlashCommands when context key is false', () => {
+		const service = createService();
+		contextKeyService.createKey(ChatContextKeys.hasUsedCreateSlashCommands.key, false);
+
+		// Dismiss tips until we find createSlashCommands or run out
+		let found = false;
+		for (let i = 0; i < 100; i++) {
+			const tip = service.getWelcomeTip(contextKeyService);
+			if (!tip) {
+				break;
+			}
+			if (tip.id === 'tip.createSlashCommands') {
+				found = true;
+				break;
+			}
+			service.dismissTip();
+		}
+
+		assert.ok(found, 'Should eventually show tip.createSlashCommands when context key is false');
+	});
+
+	test('does not show tip.createSlashCommands when context key is true', () => {
+		contextKeyService.createKey(ChatContextKeys.hasUsedCreateSlashCommands.key, true);
+		const service = createService();
+
+		for (let i = 0; i < 100; i++) {
+			const tip = service.getWelcomeTip(contextKeyService);
+			if (!tip) {
+				break;
+			}
+			assert.notStrictEqual(tip.id, 'tip.createSlashCommands', 'Should not show tip.createSlashCommands when context key is true');
+			service.dismissTip();
+		}
+	});
+
 	test('re-checks agent file exclusion when onDidChangeCustomAgents fires', async () => {
 		const agentChangeEmitter = testDisposables.add(new Emitter<void>());
 		let agentFiles: IPromptPath[] = [];
@@ -788,5 +830,191 @@ suite('ChatTipService', () => {
 		await new Promise(r => setTimeout(r, 0));
 
 		assert.strictEqual(tracker.isExcluded(tip), true, 'Should be excluded after onDidChangeCustomAgents fires and agent files exist');
+	});
+});
+
+suite('CreateSlashCommandsUsageTracker', () => {
+	const testDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let storageService: InMemoryStorageService;
+	let contextKeyService: MockContextKeyService;
+	let submitRequestEmitter: Emitter<{ readonly chatSessionResource: URI }>;
+	let sessions: Map<string, { lastRequest: { message: { text: string; parts: readonly { kind: string }[] } } | undefined }>;
+
+	setup(() => {
+		storageService = testDisposables.add(new InMemoryStorageService());
+		contextKeyService = new MockContextKeyService();
+		submitRequestEmitter = testDisposables.add(new Emitter<{ readonly chatSessionResource: URI }>());
+		sessions = new Map();
+	});
+
+	function createMockChatServiceForTracker(): IChatService {
+		return {
+			onDidSubmitRequest: submitRequestEmitter.event,
+			getSession: (resource: URI) => sessions.get(resource.toString()),
+		} as Partial<IChatService> as IChatService;
+	}
+
+	function createTracker(chatService?: IChatService): CreateSlashCommandsUsageTracker {
+		return testDisposables.add(new CreateSlashCommandsUsageTracker(
+			chatService ?? createMockChatServiceForTracker(),
+			storageService,
+			() => contextKeyService,
+		));
+	}
+
+	test('syncContextKey sets context key to false when storage is empty', () => {
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		const value = contextKeyService.getContextKeyValue(ChatContextKeys.hasUsedCreateSlashCommands.key);
+		assert.strictEqual(value, false, 'Context key should be false when no create commands have been used');
+	});
+
+	test('syncContextKey sets context key to true when storage has recorded usage', () => {
+		storageService.store('chat.tips.usedCreateSlashCommands', true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		const value = contextKeyService.getContextKeyValue(ChatContextKeys.hasUsedCreateSlashCommands.key);
+		assert.strictEqual(value, true, 'Context key should be true when create commands have been used');
+	});
+
+	test('detects create-instruction slash command via text fallback', () => {
+		const sessionResource = URI.parse('chat:session1');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: {
+					text: '/create-instruction test',
+					parts: [],
+				},
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+
+		const value = contextKeyService.getContextKeyValue(ChatContextKeys.hasUsedCreateSlashCommands.key);
+		assert.strictEqual(value, true, 'Context key should be true after /create-instruction is used');
+		assert.strictEqual(
+			storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false),
+			true,
+			'Storage should persist the create slash command usage',
+		);
+	});
+
+	test('detects create-prompt slash command via text fallback', () => {
+		const sessionResource = URI.parse('chat:session2');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: {
+					text: '/create-prompt my-prompt',
+					parts: [],
+				},
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+
+		assert.strictEqual(
+			storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false),
+			true,
+			'Storage should persist the create-prompt usage',
+		);
+	});
+
+	test('detects create-agent slash command via parsed part', () => {
+		const sessionResource = URI.parse('chat:session3');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: {
+					text: '/create-agent test',
+					parts: [
+						new ChatRequestSlashCommandPart(
+							new OffsetRange(0, 13),
+							new Range(1, 1, 1, 14),
+							{ command: 'create-agent', detail: '', locations: [] },
+						),
+					],
+				},
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+
+		assert.strictEqual(
+			storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false),
+			true,
+			'Storage should persist when create-agent slash command part is detected',
+		);
+	});
+
+	test('does not mark used for non-create slash commands', () => {
+		const sessionResource = URI.parse('chat:session4');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: {
+					text: '/help test',
+					parts: [],
+				},
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+
+		const value = contextKeyService.getContextKeyValue(ChatContextKeys.hasUsedCreateSlashCommands.key);
+		assert.strictEqual(value, false, 'Context key should remain false for non-create slash commands');
+	});
+
+	test('does not mark used when session has no last request', () => {
+		const sessionResource = URI.parse('chat:session5');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), { lastRequest: undefined });
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+
+		assert.strictEqual(
+			storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false),
+			false,
+			'Should not mark used when there is no last request',
+		);
+	});
+
+	test('only marks used once even with multiple create commands', () => {
+		const sessionResource = URI.parse('chat:session6');
+		const tracker = createTracker();
+		tracker.syncContextKey(contextKeyService);
+
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: { text: '/create-skill test', parts: [] },
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+		assert.strictEqual(storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false), true);
+
+		// Fire again — should be a no-op
+		sessions.set(sessionResource.toString(), {
+			lastRequest: {
+				message: { text: '/create-prompt test', parts: [] },
+			},
+		});
+
+		submitRequestEmitter.fire({ chatSessionResource: sessionResource });
+		assert.strictEqual(storageService.getBoolean('chat.tips.usedCreateSlashCommands', StorageScope.APPLICATION, false), true);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { ICommandEvent, ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpression, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { ILogService, NullLogService } from '../../../../../platform/log/common/log.js';
@@ -33,8 +33,8 @@ import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRang
 import { Range } from '../../../../../editor/common/core/range.js';
 
 class MockContextKeyServiceWithRulesMatching extends MockContextKeyService {
-	override contextMatchesRules(): boolean {
-		return true;
+	override contextMatchesRules(rules: ContextKeyExpression): boolean {
+		return rules.evaluate({ getValue: (key: string) => this.getContextKeyValue(key) });
 	}
 }
 
@@ -785,7 +785,7 @@ suite('ChatTipService', () => {
 	});
 
 	test('does not show tip.createSlashCommands when context key is true', () => {
-		contextKeyService.createKey(ChatContextKeys.hasUsedCreateSlashCommands.key, true);
+		storageService.store('chat.tips.usedCreateSlashCommands', true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		const service = createService();
 
 		for (let i = 0; i < 100; i++) {


### PR DESCRIPTION
fixes #296110

Adds a new “create slash commands” onboarding tip that appears until the user has used any of `/create-instruction`, `/create-prompt`, `/create-agent`, or `/create-skill`.

https://github.com/user-attachments/assets/03a328ea-a64c-47c5-a65c-eddc26e18b93

