### PR TITLE
Remove workaround for Microsoft/TypeScript#59831

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { homedir } from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ServiceConfigurationProvider, SyntaxServerConfiguration, TsServerLogLevel, TypeScriptServiceConfiguration, areServiceConfigurationsEqual } from './configuration/configuration';
@@ -1041,11 +1040,6 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 			case EventName.createDirectoryWatcher: {
 				const fpath = (event.body as Proto.CreateDirectoryWatcherEventBody).path;
 				if (fpath.startsWith(inMemoryResourcePrefix)) {
-					return;
-				}
-				if (process.platform === 'darwin' && fpath === path.join(homedir(), 'Library')) {
-					// ignore directory watch requests on ~/Library
-					// until microsoft/TypeScript#59831 is resolved
 					return;
 				}
 


### PR DESCRIPTION
This has been fixed for a while. We want to avoid having to shim out `os` for browser builds

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
