### PR TITLE
Port #295253 - Skip binary/large files in chat repo info capture and disable by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatRepoInfo.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatRepoInfo.ts
@@ -24,7 +24,7 @@ import * as nls from '../../../../nls.js';
 const MAX_CHANGES = 100;
 const MAX_DIFFS_SIZE_BYTES = 900 * 1024;
 const MAX_SESSIONS_WITH_FULL_DIFFS = 5;
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB per file
+const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1 MB per file
 /**
  * Regex to match `url = <remote-url>` lines in git config.
  */

--- a/src/vs/workbench/contrib/chat/electron-browser/actions/chatExportZip.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/actions/chatExportZip.ts
@@ -44,7 +44,7 @@ export function registerChatExportZipAction() {
 			const fileService = accessor.get(IFileService);
 			const configurationService = accessor.get(IConfigurationService);
 
-			const repoInfoEnabled = configurationService.getValue<boolean>(ChatConfiguration.RepoInfoEnabled) ?? true;
+			const repoInfoEnabled = configurationService.getValue<boolean>(ChatConfiguration.RepoInfoEnabled) ?? false;
 
 			const widget = widgetService.lastFocusedWidget;
 			if (!widget || !widget.viewModel) {


### PR DESCRIPTION
Copilot-authored message: Cherry-pick of #295253 to `release/1.109`.

Adjusts file size limits to 1 MB and changes the default setting for repository information capture to `false`.

Fixes https://github.com/microsoft/vscode/issues/294863