### PR TITLE
Fix build task matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,7 +54,7 @@
 					"message": 3
 				},
 				"background": {
-					"beginsPattern": "Starting compilation...",
+					"beginsPattern": "Starting compilation\\.\\.\\.",
 					"endsPattern": "Finished compilation with"
 				}
 			}


### PR DESCRIPTION
This is a pattern so we need to escape special regex chars like `.` if we literally want to match `.`
