### PR TITLE
Fix typos in comments

### DIFF
--- a/src/vs/editor/contrib/message/browser/messageController.ts
+++ b/src/vs/editor/contrib/message/browser/messageController.ts
@@ -107,7 +107,7 @@ export class MessageController implements IEditorContribution {
 			}
 
 			if (!bounds) {
-				// define bounding box around position and first mouse occurance
+				// define bounding box around position and first mouse occurrence
 				bounds = new Range(position.lineNumber - 3, 1, e.target.position.lineNumber + 3, 1);
 			} else if (!bounds.containsPosition(e.target.position)) {
 				// check if position is still in bounds

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,9 +170,9 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3116,7 +3116,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedDocumentEntry.ts
@@ -264,7 +264,7 @@ export class ChatEditingModifiedDocumentEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (!config.autoSave || !this._textFileService.isDirty(this.modifiedURI)) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			try {
 				await this._textFileService.save(this.modifiedURI, {
 					reason: SaveReason.EXPLICIT,

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingModifiedNotebookEntry.ts
@@ -421,7 +421,7 @@ export class ChatEditingModifiedNotebookEntry extends AbstractChatEditingModifie
 		const config = this._fileConfigService.getAutoSaveConfiguration(this.modifiedURI);
 		if (this.modifiedModel.uri.scheme !== Schemas.untitled && (!config.autoSave || !this.notebookResolver.isDirty(this.modifiedURI))) {
 			// SAVE after accept for manual-savers, for auto-savers
-			// trigger explict save to get save participants going
+			// trigger explicit save to get save participants going
 			await this._applyEdits(async () => {
 				try {
 					await this.modifiedResourceRef.object.save({

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,7 +1686,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -47,7 +47,7 @@ class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemP
 			if (registeredId) {
 				displayLanguage = this._languageService.getLanguageName(displayLanguage) ?? displayLanguage;
 			} else {
-				// add unregistered lanugage warning item
+				// add unregistered language warning item
 				const searchTooltip = localize('notebook.cell.status.searchLanguageExtensions', "Unknown cell language. Click to search for '{0}' extensions", cell.language);
 				statusBarItems.push({
 					text: `$(dialog-warning)`,

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -174,7 +174,7 @@ export class NotebookEditor extends EditorPane implements INotebookEditorPane, I
 		if (!visible) {
 			this._saveEditorViewState(this.input);
 			if (this.input && this._widget.value) {
-				// the widget is not transfered to other editor inputs
+				// the widget is not transferred to other editor inputs
 				this._widget.value.onWillHide();
 			}
 		}

--- a/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
+++ b/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
@@ -139,7 +139,7 @@ export class OutputLinkComputer implements IWebWorkerServerRequestHandler {
 						resourceString = resource.toString();
 					}
 				} catch (error) {
-					continue; // we might find an invalid URI and then we dont want to loose all other links
+					continue; // we might find an invalid URI and then we dont want to lose all other links
 				}
 
 				// Append line/col information to URI if matching

--- a/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTelemetry.ts
@@ -168,7 +168,7 @@ const enum AllowedShellType {
 	Termux = 'termux',
 	Xonsh = 'xonsh',
 
-	// Lanugage REPLs
+	// Language REPLs
 	// These are expected to be very low since they are not typically the default shell
 	Clojure = 'clj',
 	CommonLispSbcl = 'sbcl',
@@ -230,7 +230,7 @@ const shellTypeExecutableAllowList: Set<string> = new Set([
 	AllowedShellType.Termux,
 	AllowedShellType.Xonsh,
 
-	// Lanugage REPLs
+	// Language REPLs
 	AllowedShellType.Clojure,
 	AllowedShellType.CommonLispSbcl,
 	AllowedShellType.Crystal,

--- a/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
@@ -227,7 +227,7 @@ suite('RPCProtocol', () => {
 		});
 	});
 
-	test('SerializableObjectWithBuffers is correctly transfered', function (done) {
+	test('SerializableObjectWithBuffers is correctly transferred', function (done) {
 		delegate = (a1: SerializableObjectWithBuffers<{ string: string; buff: VSBuffer }>, a2: number) => {
 			return new SerializableObjectWithBuffers({ string: a1.value.string + ' world', buff: a1.value.buff });
 		};


### PR DESCRIPTION
Fix several spelling typos in comments across the codebase:

- `explict` → `explicit` (chatEditingModifiedDocumentEntry.ts, chatEditingModifiedNotebookEntry.ts)
- `seperate` / `seperately` → `separate` / `separately` (extHostTypes.ts, explorerViewer.ts)
- `transfered` → `transferred` (notebookEditor.ts, rpcProtocol.test.ts)
- `occured` / `occurance` → `occurred` / `occurrence` (parcelWatcher.ts, messageController.ts)
- `coleasing` → `coalescing` (parcelWatcher.ts)
- `lanugage` → `language` (statusBarProviders.ts, terminalTelemetry.ts)
- `loose` → `lose` (outputLinkComputer.ts)

No functional changes.