### PR TITLE
Tree shake extensions

### DIFF
--- a/extensions/esbuild-extension-common.mts
+++ b/extensions/esbuild-extension-common.mts
@@ -44,6 +44,7 @@ function resolveOptions(config: RunConfig, outdir: string): BuildOptions {
 		platform: config.platform,
 		bundle: true,
 		minify: true,
+		treeShaking: true,
 		sourcemap: true,
 		target: ['es2024'],
 		external: ['vscode'],


### PR DESCRIPTION
Reduces the built extension  size back to what we have with web pack (or even slightly smaller)