### PR TITLE
Revert to old non-agentic ask behavior when agent is disabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -214,11 +214,11 @@ export class ModePickerActionItem extends ChatInputPickerActionViewItem {
 				const agentMode = modes.builtin.find(mode => mode.id === ChatMode.Agent.id);
 
 				const otherBuiltinModes = modes.builtin.filter(mode => {
-					return mode.id !== ChatMode.Agent.id && shouldShowBuiltInMode(mode, assignments.get());
+					return mode.id !== ChatMode.Agent.id && shouldShowBuiltInMode(mode, assignments.get(), agentModeDisabledViaPolicy);
 				});
 				const filteredCustomModes = modes.custom.filter(mode => {
 					if (isModeConsideredBuiltIn(mode, this._productService)) {
-						return shouldShowBuiltInMode(mode, assignments.get());
+						return shouldShowBuiltInMode(mode, assignments.get(), agentModeDisabledViaPolicy);
 					}
 					return true;
 				});
@@ -335,19 +335,22 @@ function isModeConsideredBuiltIn(mode: IChatMode, productService: IProductServic
 	return !isOrganizationPromptFile(modeUri, mode.source.extensionId, productService);
 }
 
-function shouldShowBuiltInMode(mode: IChatMode, assignments: { showOldAskMode: boolean }): boolean {
-	// The built-in "Edit" mode is deprecated, but still supported for older conversations.
-	if (mode.id === ChatMode.Edit.id) {
-		return false;
+function shouldShowBuiltInMode(mode: IChatMode, assignments: { showOldAskMode: boolean }, agentModeDisabledViaPolicy: boolean): boolean {
+	// The built-in "Edit" mode is deprecated, but still supported for older conversations and agent disablement.
+	if (mode.id === ChatMode.Edit.id || mode.name.get().toLowerCase() === 'edit') {
+		if (mode.id === ChatMode.Edit.id) {
+			return agentModeDisabledViaPolicy;
+		}
+		return true;
 	}
 
-	// The "Ask" mode is a special case - we want to show either the old or new version based on the assignment, but not both
+	// The "Ask" mode is a special case - we want to show either the old or new version based on the assignment or agent disablement, but not both
 	// We still support the old "Ask" mode for conversations that already use it.
-	if (mode.id === ChatMode.Ask.id) {
-		return assignments.showOldAskMode;
-	}
-	if (mode.name.get().toLowerCase() === 'ask') {
-		return !assignments.showOldAskMode;
+	if (mode.id === ChatMode.Ask.id || mode.name.get().toLowerCase() === 'ask') {
+		if (mode.id === ChatMode.Ask.id) {
+			return assignments.showOldAskMode || agentModeDisabledViaPolicy;
+		}
+		return true;
 	}
 
 	return true;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem.ts
@@ -340,8 +340,9 @@ function shouldShowBuiltInMode(mode: IChatMode, assignments: { showOldAskMode: b
 	if (mode.id === ChatMode.Edit.id || mode.name.get().toLowerCase() === 'edit') {
 		if (mode.id === ChatMode.Edit.id) {
 			return agentModeDisabledViaPolicy;
+		} else {
+			return !agentModeDisabledViaPolicy;
 		}
-		return true;
 	}
 
 	// The "Ask" mode is a special case - we want to show either the old or new version based on the assignment or agent disablement, but not both
@@ -349,8 +350,9 @@ function shouldShowBuiltInMode(mode: IChatMode, assignments: { showOldAskMode: b
 	if (mode.id === ChatMode.Ask.id || mode.name.get().toLowerCase() === 'ask') {
 		if (mode.id === ChatMode.Ask.id) {
 			return assignments.showOldAskMode || agentModeDisabledViaPolicy;
+		} else {
+			return !(assignments.showOldAskMode || agentModeDisabledViaPolicy);
 		}
-		return true;
 	}
 
 	return true;


### PR DESCRIPTION
```Copilot Generated Description:``` Update the mode display logic to revert to the previous behavior for the "Ask" mode when the agent is disabled. Adjustments ensure that the old or new version of the "Ask" mode is shown based on the assignment and agent disablement.

Fixes microsoft/vscode#296232

