### PR TITLE
Adjust inactive titlebar opacity for improved visibility

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -127,11 +127,6 @@
 	z-index: 10;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
-	border-radius: 0;
-	border-top: none !important;
-}
-
 .monaco-workbench.vs .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	box-shadow: inset var(--shadow-active-tab);
 	position: relative;
@@ -154,14 +149,6 @@
 /* Title Bar */
 .monaco-workbench.vs .part.titlebar {
 	box-shadow: var(--shadow-md);
-}
-
-.monaco-workbench .part.titlebar.inactive {
-	background: var(--vscode-titleBar-inactiveBackground) !important;
-
-	& > * {
-		opacity: 0.3;
-	}
 }
 
 /* Quick Input (Command Palette) */

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -146,6 +146,10 @@
 	visibility: hidden;
 }
 
+.monaco-workbench .part.titlebar.inactive > * {
+	opacity: 0.3;
+}
+
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item > .action-label,
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item.monaco-dropdown-with-primary .action-label {
 	color: var(--vscode-titleBar-activeForeground);


### PR DESCRIPTION
Enhance the visibility of the inactive titlebar by adjusting its opacity. This change aims to provide a clearer distinction between active and inactive states. Testing can be done by observing the titlebar's appearance when inactive.

