### PR TITLE
Remove Restore to Last Checkpoint from chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -113,7 +113,6 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 		}
 		content.push(localize('chatEditing.helpfulCommands', 'Some helpful commands include:'));
 		content.push(localize('workbench.action.chat.undoEdits', '- Undo Edits{0}.', '<keybinding:workbench.action.chat.undoEdits>'));
-		content.push(localize('workbench.action.chat.restoreLastCheckpoint', '- Restore to Last Checkpoint{0}.', '<keybinding:workbench.action.chat.restoreLastCheckpoint>'));
 		content.push(localize('workbench.action.chat.editing.attachFiles', '- Attach Files{0}.', '<keybinding:workbench.action.chat.editing.attachFiles>'));
 		content.push(localize('chatEditing.removeFileFromWorkingSet', '- Remove File from Working Set{0}.', '<keybinding:chatEditing.removeFileFromWorkingSet>'));
 		content.push(localize('chatEditing.acceptFile', '- Keep{0} and Undo File{1}.', '<keybinding:chatEditing.acceptFile>', '<keybinding:chatEditing.discardFile>'));

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -6,7 +6,6 @@
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
-import { alert } from '../../../../../base/browser/ui/aria/aria.js';
 import { basename } from '../../../../../base/common/resources.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { isCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
@@ -596,63 +595,6 @@ registerAction2(class RestoreCheckpointAction extends Action2 {
 
 		widget?.viewModel?.model.setCheckpoint(item.id);
 		await restoreSnapshotWithConfirmation(accessor, item);
-	}
-});
-
-registerAction2(class RestoreLastCheckpoint extends Action2 {
-	constructor() {
-		super({
-			id: 'workbench.action.chat.restoreLastCheckpoint',
-			title: localize2('chat.restoreLastCheckpoint.label', "Restore to Last Checkpoint"),
-			f1: true,
-			category: CHAT_CATEGORY,
-			icon: Codicon.discard,
-			precondition: ContextKeyExpr.and(
-				ChatContextKeys.inChatSession,
-				ContextKeyExpr.equals(`config.${ChatConfiguration.CheckpointsEnabled}`, true),
-				ChatContextKeys.lockedToCodingAgent.negate()
-			),
-			menu: [
-				{
-					id: MenuId.ChatMessageFooter,
-					group: 'navigation',
-					order: 1,
-					when: ContextKeyExpr.and(ContextKeyExpr.in(ChatContextKeys.itemId.key, ChatContextKeys.lastItemId.key), ContextKeyExpr.equals(`config.${ChatConfiguration.CheckpointsEnabled}`, true), ChatContextKeys.lockedToCodingAgent.negate()),
-				}
-			]
-		});
-	}
-
-	async run(accessor: ServicesAccessor, ...args: unknown[]) {
-		let item = args[0] as ChatTreeItem | undefined;
-		const chatWidgetService = accessor.get(IChatWidgetService);
-		const chatService = accessor.get(IChatService);
-		const widget = (isChatTreeItem(item) && chatWidgetService.getWidgetBySessionResource(item.sessionResource)) || chatWidgetService.lastFocusedWidget;
-		if (!isResponseVM(item) && !isRequestVM(item)) {
-			item = widget?.getFocus();
-		}
-
-		const sessionResource = widget?.viewModel?.sessionResource ?? (isChatTreeItem(item) ? item.sessionResource : undefined);
-		if (!sessionResource) {
-			return;
-		}
-
-		const chatModel = chatService.getSession(sessionResource);
-		if (!chatModel?.editingSession) {
-			return;
-		}
-
-		const checkpointRequest = chatModel.checkpoint;
-		if (!checkpointRequest) {
-			alert(localize('chat.restoreCheckpoint.none', 'There is no checkpoint to restore.'));
-			return;
-		}
-
-		widget?.viewModel?.model.setCheckpoint(checkpointRequest.id);
-		widget?.focusInput();
-		widget?.input.setValue(checkpointRequest.message.text, false);
-
-		await restoreSnapshotWithConfirmationByRequestId(accessor, sessionResource, checkpointRequest.id);
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -210,7 +210,7 @@ const TIP_CATALOG: ITipDefinition[] = [
 				ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Edit),
 			),
 		),
-		excludeWhenCommandsExecuted: ['workbench.action.chat.restoreCheckpoint', 'workbench.action.chat.restoreLastCheckpoint'],
+		excludeWhenCommandsExecuted: ['workbench.action.chat.restoreCheckpoint'],
 	},
 	{
 		id: 'tip.customInstructions',


### PR DESCRIPTION
## Summary
- remove the `workbench.action.chat.restoreLastCheckpoint` action registration
- remove the associated chat tip and accessibility help references
- keep `workbench.action.chat.restoreCheckpoint` and checkpoint-line interaction unchanged

## Validation
- ./scripts/test.sh
- VS Code - Build watch tasks (Core - Transpile, Core - Typecheck, Ext - Build) reporting 0 errors