### PR TITLE
Add queue management options in chat handling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -322,6 +322,11 @@ export interface IChatAcceptInputOptions {
 	 * If Steering, also sets yieldRequested on any active request to signal it should wrap up.
 	 */
 	queue?: ChatRequestQueueKind;
+	/**
+	 * When true, always queues the request regardless of whether a request is currently in progress.
+	 * The request stays in the pending queue until explicitly processed.
+	 */
+	alwaysQueue?: boolean;
 }
 
 export interface IChatWidgetViewModelChangeEvent {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2330,6 +2330,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// discard them or need a prompt (as in `confirmPendingRequestsBeforeSend`)
 		// which could be a surprising behavior if the user finishes typing a steering
 		// request just as confirmation is triggered.
+		if (options.alwaysQueue) {
+			options.queue ??= ChatRequestQueueKind.Queued;
+		}
 		if (model.requestNeedsInput.get() && !model.getPendingRequests().length) {
 			this.chatService.cancelCurrentRequestForSession(this.viewModel.sessionResource);
 			options.queue ??= ChatRequestQueueKind.Queued;
@@ -2337,7 +2340,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		if (requestInProgress) {
 			options.queue ??= ChatRequestQueueKind.Queued;
 		}
-		if (!requestInProgress && !isEditing && !(await this.confirmPendingRequestsBeforeSend(model, options))) {
+		if (!options.alwaysQueue && !requestInProgress && !isEditing && !(await this.confirmPendingRequestsBeforeSend(model, options))) {
 			return;
 		}
 
@@ -2408,6 +2411,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			modeInfo: this.input.currentModeInfo,
 			agentIdSilent: this._lockedAgent?.id,
 			queue: options?.queue,
+			pauseQueue: options?.alwaysQueue,
 		});
 
 		if (this.viewModel.sessionResource && !options.queue && ChatSendResult.isRejected(result)) {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1329,6 +1329,12 @@ export interface IChatSendRequestOptions {
 	 */
 	queue?: ChatRequestQueueKind;
 
+	/**
+	 * When true, the queued request will not be processed immediately even if no request is active.
+	 * The request stays in the queue until `processPendingRequests` is called explicitly.
+	 */
+	pauseQueue?: boolean;
+
 }
 
 export type IChatModelReference = IReference<IChatModel>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -794,7 +794,9 @@ export class ChatService extends Disposable implements IChatService {
 
 		if (options?.queue) {
 			const queued = this.queuePendingRequest(model, sessionResource, request, options);
-			this.processPendingRequests(sessionResource);
+			if (!options.pauseQueue) {
+				this.processPendingRequests(sessionResource);
+			}
 			return queued;
 		} else if (hasPendingRequest) {
 			this.trace('sendRequest', `Session ${sessionResource} already has a pending request`);

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -92,8 +92,7 @@ registerAction2(InlineChatActions.StartSessionAction);
 registerAction2(InlineChatActions.AskInChatAction);
 registerAction2(InlineChatActions.FocusInlineChat);
 registerAction2(InlineChatActions.SubmitInlineChatInputAction);
-registerAction2(InlineChatActions.SubmitToChatAction);
-registerAction2(InlineChatActions.AttachToChatAction);
+registerAction2(InlineChatActions.QueueInChatAction);
 registerAction2(InlineChatActions.HideInlineChatInputAction);
 
 


### PR DESCRIPTION
Introduce options for always queuing requests and pausing the queue in chat request handling. Replace the existing SubmitToChatAction with a new QueueInChatAction to streamline the chat input process.

