### PR TITLE
feat(chat): add tooltip for line counts in editing session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -11,7 +11,7 @@ import { hasModifierKeys, StandardKeyboardEvent } from '../../../../../../base/b
 import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../../../base/browser/ui/aria/aria.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
-import { createInstantHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { createInstantHoverDelegate, getDefaultHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 import { renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IAction } from '../../../../../../base/common/actions.js';
@@ -67,6 +67,7 @@ import { WorkbenchList } from '../../../../../../platform/list/browser/listServi
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { ObservableMemento, observableMemento } from '../../../../../../platform/observable/common/observableMemento.js';
 import { bindContextKey } from '../../../../../../platform/observable/common/platformObservableUtils.js';
+import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
 import { ISharedWebContentExtractorService } from '../../../../../../platform/webContentExtractor/common/webContentExtractor.js';
@@ -496,6 +497,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		@IFileService private readonly fileService: IFileService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IThemeService private readonly themeService: IThemeService,
+		@IHoverService private readonly hoverService: IHoverService,
 		@ITextModelService private readonly textModelResolverService: ITextModelService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IChatAgentService private readonly agentService: IChatAgentService,
@@ -2877,6 +2879,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		button.element.appendChild(countsContainer);
 		countsContainer.appendChild(this._workingSetLinesAddedSpan.value);
 		countsContainer.appendChild(this._workingSetLinesRemovedSpan.value);
+		const countsHover = store.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), countsContainer, ''));
 
 		store.add(autorun(reader => {
 			const { files, added, removed, shouldShowEditingSession } = topLevelStats.read(reader);
@@ -2891,7 +2894,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._workingSetLinesAddedSpan.value.textContent = `+${added}`;
 			this._workingSetLinesRemovedSpan.value.textContent = `-${removed}`;
 
-			countsContainer.title = localize('chatEditingSession.lineCountsTooltip', '{0}, {1} lines added, {2} lines removed', buttonLabel, added, removed);
+			countsHover.update(localize('chatEditingSession.lineCountsTooltip', '{0}, {1} lines added, {2} lines removed', buttonLabel, added, removed));
 
 			dom.setVisibility(shouldShowEditingSession, this.chatEditingSessionWidgetContainer);
 		}));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2873,6 +2873,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}));
 		}));
 
+		const countsContainer = dom.$('.working-set-line-counts');
+		button.element.appendChild(countsContainer);
+		countsContainer.appendChild(this._workingSetLinesAddedSpan.value);
+		countsContainer.appendChild(this._workingSetLinesRemovedSpan.value);
+
 		store.add(autorun(reader => {
 			const { files, added, removed, shouldShowEditingSession } = topLevelStats.read(reader);
 
@@ -2886,13 +2891,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._workingSetLinesAddedSpan.value.textContent = `+${added}`;
 			this._workingSetLinesRemovedSpan.value.textContent = `-${removed}`;
 
+			countsContainer.title = localize('chatEditingSession.lineCountsTooltip', '{0}, {1} lines added, {2} lines removed', buttonLabel, added, removed);
+
 			dom.setVisibility(shouldShowEditingSession, this.chatEditingSessionWidgetContainer);
 		}));
-
-		const countsContainer = dom.$('.working-set-line-counts');
-		button.element.appendChild(countsContainer);
-		countsContainer.appendChild(this._workingSetLinesAddedSpan.value);
-		countsContainer.appendChild(this._workingSetLinesRemovedSpan.value);
 
 		const toggleWorkingSet = () => {
 			this._workingSetCollapsed.set(!this._workingSetCollapsed.get(), undefined);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/296348

## What Changed
- Added a tooltip on the Chat Editing Session line counts container.
- Tooltip now includes:
  - file changed
  - added lines
  - removed lines
- Kept the change scoped to the chat input working set UI.

## How to Test
1. Open Chat with an editing session.
2. Make edits so `+` and `-` line counts are visible.
3. Hover the line counts.
4. Verify the tooltip shows label + added/removed counts.

<img width="1444" height="1000" alt="image" src="https://github.com/user-attachments/assets/2d45bf8a-b290-4e89-8eac-55cf5f1d0e80" />


## Notes
- More context on https://github.com/microsoft/vscode/issues/296348