### PR TITLE
center align question carousel X button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -42,6 +42,7 @@
 		.chat-question-header-row {
 			display: flex;
 			justify-content: space-between;
+			align-items: center;
 			gap: 8px;
 			min-width: 0;
 			padding-bottom: 5px;


### PR DESCRIPTION
fixes #292914

Before

<img width="465" height="410" alt="Screenshot 2026-02-19 at 2 15 18 PM" src="https://github.com/user-attachments/assets/35070d79-87bb-46f1-a1bc-b31c7615c7e5" />

After

<img width="459" height="374" alt="Screenshot 2026-02-19 at 2 14 42 PM" src="https://github.com/user-attachments/assets/dec32739-57d2-4935-901e-cb80d27ef0e0" />
