### PR TITLE
Add directional editor resize commands

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -34,7 +34,7 @@ import { IKeybindingService } from '../../../platform/keybinding/common/keybindi
 import { MenuSettings, TitlebarStyle } from '../../../platform/window/common/window.js';
 import { IPreferencesService } from '../../services/preferences/common/preferences.js';
 import { QuickInputAlignmentContextKey } from '../../../platform/quickinput/browser/quickInput.js';
-import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
+import { GroupDirection, IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
 
 // Register Icons
 const menubarIcon = registerIcon('menuBar', Codicon.layoutMenubar, localize('menuBarIcon', "Represents the menu bar"));
@@ -1214,6 +1214,23 @@ abstract class BaseResizeViewAction extends Action2 {
 	}
 }
 
+export function resizeEditorGroupInDirection(editorGroupService: IEditorGroupsService, direction: GroupDirection, increment: number): boolean {
+	const activeGroup = editorGroupService.mainPart.activeGroup;
+	const adjacentGroup = editorGroupService.mainPart.findGroup({ direction }, activeGroup);
+	if (!adjacentGroup || adjacentGroup === activeGroup) {
+		return false;
+	}
+
+	const adjacentSize = editorGroupService.mainPart.getSize(adjacentGroup);
+	if (direction === GroupDirection.LEFT || direction === GroupDirection.RIGHT) {
+		editorGroupService.mainPart.setSize(adjacentGroup, { width: adjacentSize.width - increment, height: adjacentSize.height });
+	} else {
+		editorGroupService.mainPart.setSize(adjacentGroup, { width: adjacentSize.width, height: adjacentSize.height - increment });
+	}
+
+	return true;
+}
+
 class IncreaseViewSizeAction extends BaseResizeViewAction {
 
 	constructor() {
@@ -1309,6 +1326,70 @@ class DecreaseViewHeightAction extends BaseResizeViewAction {
 	}
 }
 
+class ResizeEditorLeftAction extends BaseResizeViewAction {
+
+	constructor() {
+		super({
+			id: 'workbench.action.resizeEditorLeft',
+			title: localize2('resizeEditorLeft', 'Resize Editor Left'),
+			f1: true,
+			precondition: IsAuxiliaryWindowFocusedContext.toNegated()
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		resizeEditorGroupInDirection(accessor.get(IEditorGroupsService), GroupDirection.LEFT, BaseResizeViewAction.RESIZE_INCREMENT);
+	}
+}
+
+class ResizeEditorRightAction extends BaseResizeViewAction {
+
+	constructor() {
+		super({
+			id: 'workbench.action.resizeEditorRight',
+			title: localize2('resizeEditorRight', 'Resize Editor Right'),
+			f1: true,
+			precondition: IsAuxiliaryWindowFocusedContext.toNegated()
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		resizeEditorGroupInDirection(accessor.get(IEditorGroupsService), GroupDirection.RIGHT, BaseResizeViewAction.RESIZE_INCREMENT);
+	}
+}
+
+class ResizeEditorUpAction extends BaseResizeViewAction {
+
+	constructor() {
+		super({
+			id: 'workbench.action.resizeEditorUp',
+			title: localize2('resizeEditorUp', 'Resize Editor Up'),
+			f1: true,
+			precondition: IsAuxiliaryWindowFocusedContext.toNegated()
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		resizeEditorGroupInDirection(accessor.get(IEditorGroupsService), GroupDirection.UP, BaseResizeViewAction.RESIZE_INCREMENT);
+	}
+}
+
+class ResizeEditorDownAction extends BaseResizeViewAction {
+
+	constructor() {
+		super({
+			id: 'workbench.action.resizeEditorDown',
+			title: localize2('resizeEditorDown', 'Resize Editor Down'),
+			f1: true,
+			precondition: IsAuxiliaryWindowFocusedContext.toNegated()
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		resizeEditorGroupInDirection(accessor.get(IEditorGroupsService), GroupDirection.DOWN, BaseResizeViewAction.RESIZE_INCREMENT);
+	}
+}
+
 registerAction2(IncreaseViewSizeAction);
 registerAction2(IncreaseViewWidthAction);
 registerAction2(IncreaseViewHeightAction);
@@ -1316,6 +1397,10 @@ registerAction2(IncreaseViewHeightAction);
 registerAction2(DecreaseViewSizeAction);
 registerAction2(DecreaseViewWidthAction);
 registerAction2(DecreaseViewHeightAction);
+registerAction2(ResizeEditorLeftAction);
+registerAction2(ResizeEditorRightAction);
+registerAction2(ResizeEditorUpAction);
+registerAction2(ResizeEditorDownAction);
 
 //#region Quick Input Alignment Actions
 

--- a/src/vs/workbench/test/browser/layoutActions.test.ts
+++ b/src/vs/workbench/test/browser/layoutActions.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/common/utils.js';
+import { resizeEditorGroupInDirection } from '../../browser/actions/layoutActions.js';
+import { GroupDirection } from '../../services/editor/common/editorGroupsService.js';
+import { createEditorPart, workbenchInstantiationService } from './workbenchTestServices.js';
+
+suite('Layout Actions', () => {
+	const disposables = new DisposableStore();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	test('resizes active editor group to the left by shrinking the left adjacent group', async () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const part = await createEditorPart(instantiationService, disposables);
+
+		const leftGroup = part.activeGroup;
+		const middleGroup = part.addGroup(leftGroup, GroupDirection.RIGHT);
+		const rightGroup = part.addGroup(middleGroup, GroupDirection.RIGHT);
+
+		part.activateGroup(middleGroup);
+
+		const leftBefore = part.getSize(leftGroup);
+		const middleBefore = part.getSize(middleGroup);
+		const rightBefore = part.getSize(rightGroup);
+
+		const didResize = resizeEditorGroupInDirection(part, GroupDirection.LEFT, 60);
+		assert.strictEqual(didResize, true);
+
+		const leftAfter = part.getSize(leftGroup);
+		const middleAfter = part.getSize(middleGroup);
+		const rightAfter = part.getSize(rightGroup);
+
+		assert.ok(leftAfter.width < leftBefore.width);
+		assert.ok(middleAfter.width > middleBefore.width);
+		assert.ok(Math.abs(rightAfter.width - rightBefore.width) <= 1);
+	});
+
+	test('resizes active editor group to the right by shrinking the right adjacent group', async () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const part = await createEditorPart(instantiationService, disposables);
+
+		const leftGroup = part.activeGroup;
+		const middleGroup = part.addGroup(leftGroup, GroupDirection.RIGHT);
+		const rightGroup = part.addGroup(middleGroup, GroupDirection.RIGHT);
+
+		part.activateGroup(middleGroup);
+
+		const leftBefore = part.getSize(leftGroup);
+		const middleBefore = part.getSize(middleGroup);
+		const rightBefore = part.getSize(rightGroup);
+
+		const didResize = resizeEditorGroupInDirection(part, GroupDirection.RIGHT, 60);
+		assert.strictEqual(didResize, true);
+
+		const leftAfter = part.getSize(leftGroup);
+		const middleAfter = part.getSize(middleGroup);
+		const rightAfter = part.getSize(rightGroup);
+
+		assert.ok(rightAfter.width < rightBefore.width);
+		assert.ok(middleAfter.width > middleBefore.width);
+		assert.ok(Math.abs(leftAfter.width - leftBefore.width) <= 1);
+	});
+
+	test('resizes active editor group upwards by shrinking the upper adjacent group', async () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const part = await createEditorPart(instantiationService, disposables);
+
+		const topGroup = part.activeGroup;
+		const middleGroup = part.addGroup(topGroup, GroupDirection.DOWN);
+		const bottomGroup = part.addGroup(middleGroup, GroupDirection.DOWN);
+
+		part.activateGroup(middleGroup);
+
+		const topBefore = part.getSize(topGroup);
+		const middleBefore = part.getSize(middleGroup);
+		const bottomBefore = part.getSize(bottomGroup);
+
+		const didResize = resizeEditorGroupInDirection(part, GroupDirection.UP, 60);
+		assert.strictEqual(didResize, true);
+
+		const topAfter = part.getSize(topGroup);
+		const middleAfter = part.getSize(middleGroup);
+		const bottomAfter = part.getSize(bottomGroup);
+
+		assert.ok(topAfter.height < topBefore.height);
+		assert.ok(middleAfter.height > middleBefore.height);
+		assert.ok(Math.abs(bottomAfter.height - bottomBefore.height) <= 1);
+	});
+
+	test('does not resize when there is no adjacent editor group in that direction', async () => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		const part = await createEditorPart(instantiationService, disposables);
+
+		const activeBefore = part.getSize(part.activeGroup);
+
+		const didResize = resizeEditorGroupInDirection(part, GroupDirection.LEFT, 60);
+		assert.strictEqual(didResize, false);
+
+		const activeAfter = part.getSize(part.activeGroup);
+		assert.deepStrictEqual(activeAfter, activeBefore);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
## Summary
- add new editor resize commands for directional control: `workbench.action.resizeEditorLeft`, `workbench.action.resizeEditorRight`, `workbench.action.resizeEditorUp`, `workbench.action.resizeEditorDown`
- implement directional resizing by shrinking the adjacent group in the requested direction so the active group grows toward that edge
- add browser workbench tests for left/right/up behavior and no-op behavior when no adjacent group exists

## Testing
- `npm run compile-check-ts-native`

Refs #145890
