### PR TITLE
Remove Keep/Undo buttons from chat editing UI

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditor/style.css
+++ b/src/vs/editor/browser/widget/multiDiffEditor/style.css
@@ -31,6 +31,7 @@
 			display: grid;
 			place-items: center;
 			place-content: center;
+			color: var(--vscode-descriptionForeground);
 		}
 	}
 

--- a/src/vs/editor/common/standaloneStrings.ts
+++ b/src/vs/editor/common/standaloneStrings.ts
@@ -43,7 +43,7 @@ export namespace AccessibilityHelpNLS {
 	export const debugExecuteSelection = nls.localize('debugConsole.executeSelection', "The Debug: Execute Selection command{0} will execute the selected text in the debug console.", '<keybinding:editor.debug.action.selectionToRepl>');
 	export const chatEditorModification = nls.localize('chatEditorModification', "The editor contains pending modifications that have been made by chat.");
 	export const chatEditorRequestInProgress = nls.localize('chatEditorRequestInProgress', "The editor is currently waiting for modifications to be made by chat.");
-	export const chatEditActions = nls.localize('chatEditing.navigation', 'Navigate between edits in the editor with navigate previous{0} and next{1} and accept{2}, reject{3} or view the diff{4} for the current change. Accept edits across all files{5}.', '<keybinding:chatEditor.action.navigatePrevious>', '<keybinding:chatEditor.action.navigateNext>', '<keybinding:chatEditor.action.acceptHunk>', '<keybinding:chatEditor.action.undoHunk>', '<keybinding:chatEditor.action.toggleDiff>', '<keybinding:chatEditor.action.acceptAllEdits>');
+	export const chatEditActions = nls.localize('chatEditing.navigation', 'Navigate between edits in the editor with navigate previous{0} and next{1} or view the diff{2} for the current change.', '<keybinding:chatEditor.action.navigatePrevious>', '<keybinding:chatEditor.action.navigateNext>', '<keybinding:chatEditor.action.toggleDiff>');
 }
 
 export namespace InspectTokensNLS {

--- a/src/vs/sessions/contrib/changesView/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changesView/browser/changesView.ts
@@ -48,7 +48,7 @@ import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browse
 import { AgentSessionProviders } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
 import { isIChatSessionFileChange2 } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { chatEditingWidgetFileStateContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, ModifiedFileEntryState } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
+import { chatEditingWidgetFileStateContextKey, hasAppliedChatEditsContextKey, IChatEditingService, ModifiedFileEntryState } from '../../../../workbench/contrib/chat/common/editing/chatEditingService.js';
 import { getChatSessionType } from '../../../../workbench/contrib/chat/common/model/chatUri.js';
 import { createFileIconThemableTreeContainerScope } from '../../../../workbench/contrib/files/browser/views/explorerView.js';
 import { IActivityService, NumberBadge } from '../../../../workbench/services/activity/common/activity.js';
@@ -519,15 +519,6 @@ export class ChangesViewPane extends ViewPane {
 			}));
 
 			// Bind required context keys for the menu buttons
-			this.renderDisposables.add(bindContextKey(hasUndecidedChatEditingResourceContextKey, scopedContextKeyService, r => {
-				const session = activeEditingSessionObs.read(r);
-				if (!session) {
-					return false;
-				}
-				const entries = session.entries.read(r);
-				return entries.some(entry => entry.state.read(r) === ModifiedFileEntryState.Modified);
-			}));
-
 			this.renderDisposables.add(bindContextKey(hasAppliedChatEditsContextKey, scopedContextKeyService, r => {
 				const session = activeEditingSessionObs.read(r);
 				if (!session) {
@@ -555,7 +546,10 @@ export class ChangesViewPane extends ViewPane {
 							? { args: [sessionResource, this.agentSessionsService.getSession(sessionResource)?.metadata] }
 							: { shouldForwardArgs: true },
 						buttonConfigProvider: (action) => {
-							if (action.id === 'chatEditing.viewChanges' || action.id === 'chatEditing.viewPreviousEdits' || action.id === 'chatEditing.viewAllSessionChanges' || action.id === 'chat.openSessionWorktreeInVSCode') {
+							if (action.id === 'chatEditing.viewChanges') {
+								return { showIcon: false, showLabel: true, isSecondary: true };
+							}
+							if (action.id === 'chatEditing.viewPreviousEdits' || action.id === 'chatEditing.viewAllSessionChanges' || action.id === 'chat.openSessionWorktreeInVSCode') {
 								const diffStatsLabel = new MarkdownString(
 									`<span class="working-set-lines-added">+${added}</span>&nbsp;<span class="working-set-lines-removed">-${removed}</span>`,
 									{ supportHtml: true }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -101,8 +101,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 		content.push(localize('chatEditing.expectation', 'When a request is made, a progress indicator will play while the edits are being applied.'));
 		content.push(localize('chatEditing.review', 'Once the edits are applied, a sound will play to indicate the document has been opened and is ready for review. The sound can be disabled with accessibility.signals.chatEditModifiedFile.'));
 		content.push(localize('chatEditing.sections', 'Navigate between edits in the editor with navigate previous{0} and next{1}', '<keybinding:chatEditor.action.navigatePrevious>', '<keybinding:chatEditor.action.navigateNext>'));
-		content.push(localize('chatEditing.acceptHunk', 'In the editor, Keep{0}, Undo{1}, or Toggle the Diff{2} for the current Change.', '<keybinding:chatEditor.action.acceptHunk>', '<keybinding:chatEditor.action.undoHunk>', '<keybinding:chatEditor.action.toggleDiff>'));
-		content.push(localize('chatEditing.undoKeepSounds', 'Sounds will play when a change is accepted or undone. The sounds can be disabled with accessibility.signals.editsKept and accessibility.signals.editsUndone.'));
+		content.push(localize('chatEditing.toggleDiff', 'Toggle the Diff{0} for the current change.', '<keybinding:chatEditor.action.toggleDiff>'));
 		if (type === 'agentView') {
 			content.push(localize('chatAgent.userActionRequired', 'An alert will indicate when user action is required. For example, if the agent wants to run something in the terminal, you will hear Action Required: Run Command in Terminal.'));
 			content.push(localize('chatAgent.runCommand', 'To take the action, use the accept tool command{0}.', '<keybinding:workbench.action.chat.acceptTool>'));
@@ -116,10 +115,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'age
 		content.push(localize('workbench.action.chat.restoreLastCheckpoint', '- Restore to Last Checkpoint{0}.', '<keybinding:workbench.action.chat.restoreLastCheckpoint>'));
 		content.push(localize('workbench.action.chat.editing.attachFiles', '- Attach Files{0}.', '<keybinding:workbench.action.chat.editing.attachFiles>'));
 		content.push(localize('chatEditing.removeFileFromWorkingSet', '- Remove File from Working Set{0}.', '<keybinding:chatEditing.removeFileFromWorkingSet>'));
-		content.push(localize('chatEditing.acceptFile', '- Keep{0} and Undo File{1}.', '<keybinding:chatEditing.acceptFile>', '<keybinding:chatEditing.discardFile>'));
 		content.push(localize('chatEditing.saveAllFiles', '- Save All Files{0}.', '<keybinding:chatEditing.saveAllFiles>'));
-		content.push(localize('chatEditing.acceptAllFiles', '- Keep All Edits{0}.', '<keybinding:chatEditing.acceptAllFiles>'));
-		content.push(localize('chatEditing.discardAllFiles', '- Undo All Edits{0}.', '<keybinding:chatEditing.discardAllFiles>'));
 		content.push(localize('chatEditing.openFileInDiff', '- Open File in Diff{0}.', '<keybinding:chatEditing.openFileInDiff>'));
 		content.push(`- ${ChatEditingShowChangesAction.LABEL}<keybinding:chatEditing.viewChanges>`);
 		content.push(`- ${ViewPreviousEditsAction.Label}<keybinding:chatEditing.viewPreviousEdits>`);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -82,7 +82,6 @@ class AcceptToolConfirmation extends ToolConfirmationAction {
 			keybinding: {
 				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, ChatContextKeys.Editing.hasToolConfirmation),
 				primary: KeyMod.CtrlCmd | KeyCode.Enter,
-				// Override chatEditor.action.accept
 				weight: KeybindingWeight.WorkbenchContrib + 1,
 			},
 		});
@@ -103,7 +102,6 @@ class SkipToolConfirmation extends ToolConfirmationAction {
 			keybinding: {
 				when: ContextKeyExpr.and(ChatContextKeys.inChatSession, ChatContextKeys.Editing.hasToolConfirmation),
 				primary: KeyMod.CtrlCmd | KeyCode.Enter | KeyMod.Alt,
-				// Override chatEditor.action.accept
 				weight: KeybindingWeight.WorkbenchContrib + 1,
 			},
 		});

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -479,7 +479,7 @@ configurationRegistry.registerConfiguration({
 		'chat.checkpoints.showFileChanges': {
 			type: 'boolean',
 			description: nls.localize('chat.checkpoints.showFileChanges', "Controls whether to show chat checkpoint file changes."),
-			default: false
+			default: true
 		},
 		[mcpAccessConfig]: {
 			type: 'string',

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -30,7 +30,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { isChatViewTitleActionContext } from '../../common/actions/chatActions.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { applyingChatEditsFailedContextKey, CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME, chatEditingResourceContextKey, chatEditingWidgetFileStateContextKey, decidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../../common/editing/chatEditingService.js';
+import { applyingChatEditsFailedContextKey, chatEditingWidgetFileStateContextKey, hasAppliedChatEditsContextKey, IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../../common/editing/chatEditingService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { isChatTreeItem, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';
@@ -114,12 +114,6 @@ registerAction2(class OpenFileInDiffAction extends WorkingSetAction {
 			id: 'chatEditing.openFileInDiff',
 			title: localize2('open.fileInDiff', 'Open Changes in Diff Editor'),
 			icon: Codicon.diffSingle,
-			menu: [{
-				id: MenuId.ChatEditingWidgetModifiedFilesToolbar,
-				when: ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified),
-				order: 2,
-				group: 'navigation'
-			}],
 		});
 	}
 
@@ -144,118 +138,7 @@ registerAction2(class OpenFileInDiffAction extends WorkingSetAction {
 	}
 });
 
-registerAction2(class AcceptAction extends WorkingSetAction {
-	constructor() {
-		super({
-			id: 'chatEditing.acceptFile',
-			title: localize2('accept.file', 'Keep'),
-			icon: Codicon.check,
-			menu: [{
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key)),
-				id: MenuId.MultiDiffEditorFileToolbar,
-				order: 0,
-				group: 'navigation',
-			}, {
-				id: MenuId.ChatEditingWidgetModifiedFilesToolbar,
-				when: ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified),
-				order: 0,
-				group: 'navigation'
-			}],
-		});
-	}
 
-	async runWorkingSetAction(accessor: ServicesAccessor, currentEditingSession: IChatEditingSession, chatWidget: IChatWidget, ...uris: URI[]): Promise<void> {
-		await currentEditingSession.accept(...uris);
-	}
-});
-
-registerAction2(class DiscardAction extends WorkingSetAction {
-	constructor() {
-		super({
-			id: 'chatEditing.discardFile',
-			title: localize2('discard.file', 'Undo'),
-			icon: Codicon.discard,
-			menu: [{
-				when: ContextKeyExpr.and(ContextKeyExpr.equals('resourceScheme', CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME), ContextKeyExpr.notIn(chatEditingResourceContextKey.key, decidedChatEditingResourceContextKey.key)),
-				id: MenuId.MultiDiffEditorFileToolbar,
-				order: 2,
-				group: 'navigation',
-			}, {
-				id: MenuId.ChatEditingWidgetModifiedFilesToolbar,
-				when: ContextKeyExpr.equals(chatEditingWidgetFileStateContextKey.key, ModifiedFileEntryState.Modified),
-				order: 1,
-				group: 'navigation'
-			}],
-		});
-	}
-
-	async runWorkingSetAction(accessor: ServicesAccessor, currentEditingSession: IChatEditingSession, chatWidget: IChatWidget, ...uris: URI[]): Promise<void> {
-		await currentEditingSession.reject(...uris);
-	}
-});
-
-export class ChatEditingAcceptAllAction extends EditingSessionAction {
-
-	constructor() {
-		super({
-			id: 'chatEditing.acceptAllFiles',
-			title: localize('accept', 'Keep'),
-			icon: Codicon.check,
-			tooltip: localize('acceptAllEdits', 'Keep All Edits'),
-			precondition: hasUndecidedChatEditingResourceContextKey,
-			keybinding: {
-				primary: KeyMod.CtrlCmd | KeyCode.Enter,
-				when: ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey, ChatContextKeys.inChatInput),
-				weight: KeybindingWeight.WorkbenchContrib,
-			},
-			menu: [
-
-				{
-					id: MenuId.ChatEditingWidgetToolbar,
-					group: 'navigation',
-					order: 0,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey))
-				}
-			]
-		});
-	}
-
-	override async runEditingSessionAction(accessor: ServicesAccessor, editingSession: IChatEditingSession, chatWidget: IChatWidget, ...args: unknown[]) {
-		await editingSession.accept();
-	}
-}
-registerAction2(ChatEditingAcceptAllAction);
-
-export class ChatEditingDiscardAllAction extends EditingSessionAction {
-
-	constructor() {
-		super({
-			id: 'chatEditing.discardAllFiles',
-			title: localize('discard', 'Undo'),
-			icon: Codicon.discard,
-			tooltip: localize('discardAllEdits', 'Undo All Edits'),
-			precondition: hasUndecidedChatEditingResourceContextKey,
-			menu: [
-				{
-					id: MenuId.ChatEditingWidgetToolbar,
-					group: 'navigation',
-					order: 1,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), hasUndecidedChatEditingResourceContextKey)
-				}
-			],
-			keybinding: {
-				when: ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey, ChatContextKeys.inChatInput, ChatContextKeys.inputHasText.negate()),
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.Backspace,
-			},
-		});
-	}
-
-	override async runEditingSessionAction(accessor: ServicesAccessor, editingSession: IChatEditingSession, chatWidget: IChatWidget, ...args: unknown[]) {
-		await discardAllEditsWithConfirmation(accessor, editingSession);
-	}
-}
-registerAction2(ChatEditingDiscardAllAction);
 
 export class ToggleExplanationWidgetAction extends EditingSessionAction {
 
@@ -266,13 +149,13 @@ export class ToggleExplanationWidgetAction extends EditingSessionAction {
 			id: ToggleExplanationWidgetAction.ID,
 			title: localize('explainButton', 'Explain'),
 			tooltip: localize('toggleExplanationTooltip', 'Toggle Change Explanations'),
-			precondition: hasUndecidedChatEditingResourceContextKey,
+			precondition: hasAppliedChatEditsContextKey,
 			menu: [
 				{
 					id: MenuId.ChatEditingWidgetToolbar,
 					group: 'navigation',
 					order: 2,
-					when: ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey, ContextKeyExpr.has(`config.${ChatConfiguration.ExplainChangesEnabled}`))
+					when: ContextKeyExpr.and(hasAppliedChatEditsContextKey, ContextKeyExpr.has(`config.${ChatConfiguration.ExplainChangesEnabled}`))
 				}
 			],
 		});
@@ -288,48 +171,24 @@ export class ToggleExplanationWidgetAction extends EditingSessionAction {
 }
 registerAction2(ToggleExplanationWidgetAction);
 
-export async function discardAllEditsWithConfirmation(accessor: ServicesAccessor, currentEditingSession: IChatEditingSession): Promise<boolean> {
-
-	const dialogService = accessor.get(IDialogService);
-
-	// Ask for confirmation if there are any edits
-	const entries = currentEditingSession.entries.get().filter(e => e.state.get() === ModifiedFileEntryState.Modified);
-	if (entries.length > 0) {
-		const confirmation = await dialogService.confirm({
-			title: localize('chat.editing.discardAll.confirmation.title', "Undo all edits?"),
-			message: entries.length === 1
-				? localize('chat.editing.discardAll.confirmation.oneFile', "This will undo changes made in {0}. Do you want to proceed?", basename(entries[0].modifiedURI))
-				: localize('chat.editing.discardAll.confirmation.manyFiles', "This will undo changes made in {0} files. Do you want to proceed?", entries.length),
-			primaryButton: localize('chat.editing.discardAll.confirmation.primaryButton', "Yes"),
-			type: 'info'
-		});
-		if (!confirmation.confirmed) {
-			return false;
-		}
-	}
-
-	await currentEditingSession.reject();
-	return true;
-}
-
 export class ChatEditingShowChangesAction extends EditingSessionAction {
 	static readonly ID = 'chatEditing.viewChanges';
-	static readonly LABEL = localize('chatEditing.viewChanges', 'View All Edits');
+	static readonly LABEL = localize('chatEditing.viewChanges', 'Review');
 
 	constructor() {
 		super({
 			id: ChatEditingShowChangesAction.ID,
-			title: { value: ChatEditingShowChangesAction.LABEL, original: ChatEditingShowChangesAction.LABEL },
-			tooltip: ChatEditingShowChangesAction.LABEL,
+			title: { value: ChatEditingShowChangesAction.LABEL, original: 'Review' },
+			tooltip: localize('chatEditing.viewChangesTooltip', 'Review All Edits'),
 			f1: true,
 			icon: Codicon.diffMultiple,
-			precondition: hasUndecidedChatEditingResourceContextKey,
+			precondition: hasAppliedChatEditsContextKey,
 			menu: [
 				{
 					id: MenuId.ChatEditingWidgetToolbar,
 					group: 'navigation',
 					order: 4,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), ContextKeyExpr.and(hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey))
+					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), hasAppliedChatEditsContextKey)
 				}
 			],
 		});
@@ -862,15 +721,7 @@ export class ViewPreviousEditsAction extends EditingSessionAction {
 			tooltip: ViewPreviousEditsAction.Label,
 			f1: true,
 			icon: Codicon.diffMultiple,
-			precondition: ContextKeyExpr.and(ChatContextKeys.enabled, hasUndecidedChatEditingResourceContextKey.negate()),
-			menu: [
-				{
-					id: MenuId.ChatEditingWidgetToolbar,
-					group: 'navigation',
-					order: 4,
-					when: ContextKeyExpr.and(applyingChatEditsFailedContextKey.negate(), ContextKeyExpr.and(hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey.negate()))
-				}
-			],
+			precondition: hasAppliedChatEditsContextKey,
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -30,7 +30,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js';
 import { isChatViewTitleActionContext } from '../../common/actions/chatActions.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { applyingChatEditsFailedContextKey, chatEditingWidgetFileStateContextKey, hasAppliedChatEditsContextKey, IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../../common/editing/chatEditingService.js';
+import { applyingChatEditsFailedContextKey, hasAppliedChatEditsContextKey, IChatEditingService, IChatEditingSession } from '../../common/editing/chatEditingService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { isChatTreeItem, isRequestVM, isResponseVM } from '../../common/model/chatViewModel.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../../common/constants.js';

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingCodeEditorIntegration.ts
@@ -766,17 +766,10 @@ class DiffHunkWidget implements IOverlayWidget, IModifiedFileEntryChangeHunk {
 				arg: this,
 			},
 			actionViewItemProvider: (action, options) => {
-				const isPrimary = action.id === 'chatEditor.action.acceptHunk';
 				if (!action.class) {
 					return new class extends ActionViewItem {
 						constructor() {
 							super(undefined, action, { ...options, keybindingNotRenderedWithLabel: true /* hide keybinding for actions without icon */, icon: false, label: true });
-						}
-						override render(container: HTMLElement): void {
-							super.render(container);
-							if (isPrimary) {
-								this.element?.classList.add('primary');
-							}
 						}
 					};
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts
@@ -446,9 +446,12 @@ export class ChatEditingSession extends Disposable implements IChatEditingSessio
 				return;
 			}
 		}
+		const entryCount = this._entriesObs.get().length;
 		const input = MultiDiffEditorInput.fromResourceMultiDiffEditorInput({
 			multiDiffSource: getMultiDiffSourceUri(this, previousChanges),
-			label: localize('multiDiffEditorInput.name', "Suggested Edits")
+			label: entryCount === 1
+				? localize('multiDiffEditorInput.name.one', "Review Edits (1 file)")
+				: localize('multiDiffEditorInput.name.many', "Review Edits ({0} files)", entryCount)
 		}, this._instantiationService);
 
 		this._editorPane = await this._editorGroupsService.activeGroup.openEditor(input, { pinned: true, activation: EditorActivation.ACTIVATE }) as MultiDiffEditor | undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -51,7 +51,7 @@ import { ILifecycleService } from '../../../../services/lifecycle/common/lifecyc
 import { checkModeOption } from '../../common/chat.js';
 import { IChatAgentAttachmentCapabilities, IChatAgentCommand, IChatAgentData, IChatAgentService } from '../../common/participants/chatAgents.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
-import { applyingChatEditsFailedContextKey, decidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey, hasUndecidedChatEditingResourceContextKey, IChatEditingService, IChatEditingSession, inChatEditingSessionContextKey, ModifiedFileEntryState } from '../../common/editing/chatEditingService.js';
+import { applyingChatEditsFailedContextKey, hasAppliedChatEditsContextKey, IChatEditingService, IChatEditingSession, inChatEditingSessionContextKey } from '../../common/editing/chatEditingService.js';
 import { IChatLayoutService } from '../../common/widget/chatLayoutService.js';
 import { IChatModel, IChatModelInputState, IChatResponseModel } from '../../common/model/chatModel.js';
 import { ChatMode, IChatModeService } from '../../common/chatModes.js';
@@ -439,21 +439,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 		}));
 
-		this._register(bindContextKey(decidedChatEditingResourceContextKey, contextKeyService, (reader) => {
-			const currentSession = this._editingSession.read(reader);
-			if (!currentSession) {
-				return;
-			}
-			const entries = currentSession.entries.read(reader);
-			const decidedEntries = entries.filter(entry => entry.state.read(reader) !== ModifiedFileEntryState.Modified);
-			return decidedEntries.map(entry => entry.entryId);
-		}));
-		this._register(bindContextKey(hasUndecidedChatEditingResourceContextKey, contextKeyService, (reader) => {
-			const currentSession = this._editingSession.read(reader);
-			const entries = currentSession?.entries.read(reader) ?? []; // using currentSession here
-			const decidedEntries = entries.filter(entry => entry.state.read(reader) === ModifiedFileEntryState.Modified);
-			return decidedEntries.length > 0;
-		}));
 		this._register(bindContextKey(hasAppliedChatEditsContextKey, contextKeyService, (reader) => {
 			const currentSession = this._editingSession.read(reader);
 			if (!currentSession) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2865,7 +2865,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				}) : undefined,
 				disableWhileRunning: isSessionMenu,
 				buttonConfigProvider: (action) => {
-					if (action.id === ChatEditingShowChangesAction.ID || action.id === ViewPreviousEditsAction.Id || action.id === ViewAllSessionChangesAction.ID) {
+					if (action.id === ChatEditingShowChangesAction.ID) {
+						return { showIcon: false, showLabel: true, isSecondary: true };
+					}
+					if (action.id === ViewPreviousEditsAction.Id || action.id === ViewAllSessionChangesAction.ID) {
 						return { showIcon: true, showLabel: false, isSecondary: true };
 					}
 					return undefined;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -329,7 +329,8 @@
 	border-right: none;
 }
 
-.interactive-item-container .value .rendered-markdown table tbody tr:last-child td {
+.interactive-item-container .value .rendered-markdown table tr:last-child td,
+.interactive-item-container .value .rendered-markdown table tr:last-child th {
 	border-bottom: none;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -329,8 +329,7 @@
 	border-right: none;
 }
 
-.interactive-item-container .value .rendered-markdown table tr:last-child td,
-.interactive-item-container .value .rendered-markdown table tr:last-child th {
+.interactive-item-container .value .rendered-markdown table tbody tr:last-child td {
 	border-bottom: none;
 }
 
@@ -865,7 +864,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .monaco-scrollable-element .monaco-list-rows .monaco-list-row {
-	border-radius: 2px;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-container.show-file-icons .chat-editing-session-list .monaco-scrollable-element:has(.visible.scrollbar.vertical) .monaco-list-row .monaco-icon-label {
@@ -2003,7 +2002,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-direction: column;
 	flex-wrap: wrap;
 	align-items: center;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 	border: 1px solid var(--vscode-chat-requestBorder);
 
 	.chat-view-changes-icon {
@@ -2020,11 +2019,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	.insertions-and-deletions {
 		display: flex;
 		margin-right: 5px;
-		font-size: 12px;
+		font-size: 11px;
 	}
 
 	.checkpoint-file-changes-summary-header {
-		padding: 3px 3px 3px 3px;
+		padding: 2px 3px;
 		width: 100%;
 		display: flex;
 		box-sizing: border-box;
@@ -2045,16 +2044,21 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button {
 		width: 100%;
+		background-color: transparent !important;
+		color: var(--vscode-descriptionForeground);
+		padding: 0;
+		gap: 2px;
 	}
 
 	.checkpoint-file-changes-summary-header .chat-file-changes-label .monaco-button .codicon {
 		font-size: 16px;
+		color: var(--vscode-descriptionForeground);
 	}
 
 	.chat-summary-list {
 		width: 100%;
 		max-width: 100%;
-		padding: 0px;
+		padding: 2px;
 		margin-bottom: 0px;
 		border-bottom: 0px;
 		border-left: 0px;
@@ -2065,6 +2069,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.chat-summary-list .monaco-icon-label {
 		display: flex;
+		padding: 0px 3px;
 	}
 
 	.chat-summary-list .monaco-scrollable-element {
@@ -2073,14 +2078,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	.insertions {
 		color: var(--vscode-chat-linesAddedForeground);
-		font-weight: bold;
 		padding-left: 5px;
 		padding-right: 5px;
 	}
 
 	.deletions {
 		color: var(--vscode-chat-linesRemovedForeground);
-		font-weight: bold;
 	}
 }
 
@@ -2139,7 +2142,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .chat-summary-list .monaco-list .monaco-list-row {
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-small);
 }
 
 .interactive-session .chat-summary-list .monaco-list .monaco-list-row:hover {

--- a/src/vs/workbench/contrib/chat/common/editing/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/common/editing/chatEditingService.ts
@@ -429,10 +429,8 @@ export const CHAT_EDITING_MULTI_DIFF_SOURCE_RESOLVER_SCHEME = 'chat-editing-mult
 
 export const chatEditingWidgetFileStateContextKey = new RawContextKey<ModifiedFileEntryState>('chatEditingWidgetFileState', undefined, localize('chatEditingWidgetFileState', "The current state of the file in the chat editing widget"));
 export const chatEditingAgentSupportsReadonlyReferencesContextKey = new RawContextKey<boolean>('chatEditingAgentSupportsReadonlyReferences', undefined, localize('chatEditingAgentSupportsReadonlyReferences', "Whether the chat editing agent supports readonly references (temporary)"));
-export const decidedChatEditingResourceContextKey = new RawContextKey<string[]>('decidedChatEditingResource', []);
 export const chatEditingResourceContextKey = new RawContextKey<string | undefined>('chatEditingResource', undefined);
 export const inChatEditingSessionContextKey = new RawContextKey<boolean | undefined>('inChatEditingSession', undefined);
-export const hasUndecidedChatEditingResourceContextKey = new RawContextKey<boolean | undefined>('hasUndecidedChatEditingResource', false);
 export const hasAppliedChatEditsContextKey = new RawContextKey<boolean | undefined>('hasAppliedChatEdits', false);
 export const applyingChatEditsFailedContextKey = new RawContextKey<boolean | undefined>('applyingChatEditsFailed', false);
 


### PR DESCRIPTION
## Summary

Removes the Keep/Undo paradigm from the chat editing UI. Edits from chat are applied directly — there is no longer an accept/reject decision for the user to make.

## What changed

**Removed UI elements:**
- "Keep" and "Undo" buttons from the chat input widget toolbar (the top-level Keep All / Undo All)
- "Keep" and "Undo" per-file buttons from the modified files list
- "Keep" and "Undo" from the editor overlay toolbar (the floating bar at bottom-right of edited files)
- Per-hunk "Keep" and "Undo" buttons from inline change widgets in the editor
- "Keep All Edits" / "Undo All Edits" from the multi-diff editor title bar
- Per-file diff icon button from the modified files list (redundant with clicking the file name)

**Added/changed UI:**
- "Review" label button replaces the diff icon in the "N files changed" toolbar — opens the multi-file diff view
- Multi-file diff editor tab renamed from "Suggested Edits" to "Review Edits (N files)"
- `chat.checkpoints.showFileChanges` now defaults to `true` (was `false`)

**Style polish:**
- Checkpoint file changes list: matched padding, font size (11px), and font weight to the main "N files changed" working set list
- Checkpoint toggle button: uses `descriptionForeground`, no hover background, zero left/right padding, 2px gap
- List item border-radius uses `cornerRadius-small` in both file lists
- Multi-diff editor empty state placeholder uses `descriptionForeground`

**Infrastructure cleanup:**
- Removed `decidedChatEditingResourceContextKey` and `hasUndecidedChatEditingResourceContextKey` (no longer meaningful without Keep/Undo)
- Re-gated remaining toolbar actions (Explain, View Changes) on `hasAppliedChatEditsContextKey`
- Updated accessibility help text to remove Keep/Undo references
- Updated standalone strings for editor accessibility

## What's preserved

- The internal `accept()`/`reject()` methods and `ModifiedFileEntryState` enum — still used by checkpoint/restore, session disposal, and snapshot infrastructure
- Undo/Redo chat interaction actions (undo an entire chat turn)
- Checkpoint and restore actions
- Review mode and change navigation (prev/next)
- Inline chat's own Keep/Undo (separate feature, separate actions)
- All internal AI vs user edit tracking