### PR TITLE
Fix missing border beneath markdown table header row

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -329,8 +329,7 @@
 	border-right: none;
 }
 
-.interactive-item-container .value .rendered-markdown table tr:last-child td,
-.interactive-item-container .value .rendered-markdown table tr:last-child th {
+.interactive-item-container .value .rendered-markdown table tbody tr:last-child td {
 	border-bottom: none;
 }
 


### PR DESCRIPTION
The `tr:last-child` rule introduced in #294275 was removing the bottom border from `thead th` cells, since the header row is always the last (and only) child of `thead`. This scopes the rule to `tbody` only so the header border is preserved.