### PR TITLE
mcp: add resource support to gateway

### DIFF
--- a/src/vs/platform/mcp/common/mcpGateway.ts
+++ b/src/vs/platform/mcp/common/mcpGateway.ts
@@ -13,10 +13,29 @@ export const IMcpGatewayService = createDecorator<IMcpGatewayService>('IMcpGatew
 export const McpGatewayChannelName = 'mcpGateway';
 export const McpGatewayToolBrokerChannelName = 'mcpGatewayToolBroker';
 
+export interface IGatewayCallToolResult {
+	result: MCP.CallToolResult;
+	serverIndex: number;
+}
+
+export interface IGatewayServerResources {
+	serverIndex: number;
+	resources: readonly MCP.Resource[];
+}
+
+export interface IGatewayServerResourceTemplates {
+	serverIndex: number;
+	resourceTemplates: readonly MCP.ResourceTemplate[];
+}
+
 export interface IMcpGatewayToolInvoker {
 	readonly onDidChangeTools: Event<void>;
+	readonly onDidChangeResources: Event<void>;
 	listTools(): Promise<readonly MCP.Tool[]>;
-	callTool(name: string, args: Record<string, unknown>): Promise<MCP.CallToolResult>;
+	callTool(name: string, args: Record<string, unknown>): Promise<IGatewayCallToolResult>;
+	listResources(): Promise<readonly IGatewayServerResources[]>;
+	readResource(serverIndex: number, uri: string): Promise<MCP.ReadResourceResult>;
+	listResourceTemplates(): Promise<readonly IGatewayServerResourceTemplates[]>;
 }
 
 /**

--- a/src/vs/platform/mcp/node/mcpGatewayChannel.ts
+++ b/src/vs/platform/mcp/node/mcpGatewayChannel.ts
@@ -6,7 +6,7 @@
 import { Event } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { IPCServer, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
-import { IMcpGatewayService, McpGatewayToolBrokerChannelName } from '../common/mcpGateway.js';
+import { IGatewayCallToolResult, IGatewayServerResources, IGatewayServerResourceTemplates, IMcpGatewayService, McpGatewayToolBrokerChannelName } from '../common/mcpGateway.js';
 import { MCP } from '../common/modelContextProtocol.js';
 
 /**
@@ -35,8 +35,12 @@ export class McpGatewayChannel<TContext> extends Disposable implements IServerCh
 				const brokerChannel = ipcChannelForContext(this._ipcServer, ctx);
 				const result = await this.mcpGatewayService.createGateway(ctx, {
 					onDidChangeTools: brokerChannel.listen<void>('onDidChangeTools'),
+					onDidChangeResources: brokerChannel.listen<void>('onDidChangeResources'),
 					listTools: () => brokerChannel.call<readonly MCP.Tool[]>('listTools'),
-					callTool: (name, callArgs) => brokerChannel.call<MCP.CallToolResult>('callTool', { name, args: callArgs }),
+					callTool: (name, callArgs) => brokerChannel.call<IGatewayCallToolResult>('callTool', { name, args: callArgs }),
+					listResources: () => brokerChannel.call<readonly IGatewayServerResources[]>('listResources'),
+					readResource: (serverIndex, uri) => brokerChannel.call<MCP.ReadResourceResult>('readResource', { serverIndex, uri }),
+					listResourceTemplates: () => brokerChannel.call<readonly IGatewayServerResourceTemplates[]>('listResourceTemplates'),
 				});
 				return result as T;
 			}

--- a/src/vs/platform/mcp/test/node/mcpGatewaySession.test.ts
+++ b/src/vs/platform/mcp/test/node/mcpGatewaySession.test.ts
@@ -11,7 +11,7 @@ import { IJsonRpcErrorResponse, IJsonRpcSuccessResponse } from '../../../../base
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { MCP } from '../../common/modelContextProtocol.js';
-import { McpGatewaySession } from '../../node/mcpGatewaySession.js';
+import { decodeGatewayResourceUri, encodeGatewayResourceUri, McpGatewaySession } from '../../node/mcpGatewaySession.js';
 
 class TestServerResponse extends EventEmitter {
 	public statusCode: number | undefined;
@@ -48,6 +48,7 @@ suite('McpGatewaySession', () => {
 
 	function createInvoker() {
 		const onDidChangeTools = new Emitter<void>();
+		const onDidChangeResources = new Emitter<void>();
 		const tools: readonly MCP.Tool[] = [{
 			name: 'test_tool',
 			description: 'Test tool',
@@ -59,20 +60,35 @@ suite('McpGatewaySession', () => {
 			}
 		}];
 
+		const resources: readonly MCP.Resource[] = [{
+			uri: 'file:///test/resource.txt',
+			name: 'resource.txt',
+		}];
+
 		return {
 			onDidChangeTools,
+			onDidChangeResources,
 			invoker: {
 				onDidChangeTools: onDidChangeTools.event,
+				onDidChangeResources: onDidChangeResources.event,
 				listTools: async () => tools,
-				callTool: async (_name: string, args: Record<string, unknown>): Promise<MCP.CallToolResult> => ({
-					content: [{ type: 'text', text: `Hello, ${typeof args.name === 'string' ? args.name : 'World'}!` }]
-				})
+				callTool: async (_name: string, args: Record<string, unknown>) => ({
+					result: {
+						content: [{ type: 'text' as const, text: `Hello, ${typeof args.name === 'string' ? args.name : 'World'}!` }]
+					},
+					serverIndex: 0,
+				}),
+				listResources: async () => [{ serverIndex: 0, resources }],
+				readResource: async (_serverIndex: number, _uri: string) => ({
+					contents: [{ uri: 'file:///test/resource.txt', text: 'hello world', mimeType: 'text/plain' }],
+				}),
+				listResourceTemplates: async () => [{ serverIndex: 0, resourceTemplates: [{ uriTemplate: 'file:///test/{name}', name: 'Test Template' }] }],
 			}
 		};
 	}
 
 	test('returns initialize result', async () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-1', new NullLogService(), () => { }, invoker);
 
 		const responses = await session.handleIncoming({
@@ -93,10 +109,11 @@ suite('McpGatewaySession', () => {
 		assert.strictEqual((response.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
 		session.dispose();
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
 	});
 
 	test('rejects non-initialize requests before initialized notification', async () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-2', new NullLogService(), () => { }, invoker);
 
 		const responses = await session.handleIncoming({
@@ -112,10 +129,11 @@ suite('McpGatewaySession', () => {
 		assert.strictEqual(response.error.code, -32600);
 		session.dispose();
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
 	});
 
 	test('serves tools/list and tools/call after initialized notification', async () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-3', new NullLogService(), () => { }, invoker);
 
 		await session.handleIncoming({ jsonrpc: '2.0', id: 1, method: 'initialize' });
@@ -145,10 +163,11 @@ suite('McpGatewaySession', () => {
 		assert.strictEqual(text, 'Hello, VS Code!');
 		session.dispose();
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
 	});
 
 	test('broadcasts notifications to attached SSE clients', async () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-4', new NullLogService(), () => { }, invoker);
 		const response = new TestServerResponse();
 
@@ -161,12 +180,14 @@ suite('McpGatewaySession', () => {
 		assert.ok(response.writes.some(chunk => chunk.includes(': connected')));
 		assert.ok(response.writes.some(chunk => chunk.includes('event: message')));
 		assert.ok(response.writes.some(chunk => chunk.includes('notifications/tools/list_changed')));
+		assert.ok(response.writes.some(chunk => chunk.includes('notifications/resources/list_changed')));
 		session.dispose();
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
 	});
 
 	test('emits list changed on tool invoker changes', async () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-5', new NullLogService(), () => { }, invoker);
 		const response = new TestServerResponse();
 
@@ -181,10 +202,11 @@ suite('McpGatewaySession', () => {
 		assert.ok(response.writes.slice(writesBefore).some(chunk => chunk.includes('notifications/tools/list_changed')));
 		session.dispose();
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
 	});
 
 	test('disposes attached SSE clients and callback', () => {
-		const { invoker, onDidChangeTools } = createInvoker();
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		let disposed = false;
 		const session = new McpGatewaySession('session-6', new NullLogService(), () => {
 			disposed = true;
@@ -197,5 +219,145 @@ suite('McpGatewaySession', () => {
 		assert.strictEqual(response.writableEnded, true);
 		assert.strictEqual(disposed, true);
 		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('emits resources list changed on resource invoker changes', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-7', new NullLogService(), () => { }, invoker);
+		const response = new TestServerResponse();
+
+		session.attachSseClient({} as http.IncomingMessage, response as unknown as http.ServerResponse);
+		await session.handleIncoming({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+		await session.handleIncoming({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+		const writesBefore = response.writes.length;
+		onDidChangeResources.fire();
+
+		assert.ok(response.writes.length > writesBefore);
+		assert.ok(response.writes.slice(writesBefore).some(chunk => chunk.includes('notifications/resources/list_changed')));
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('serves resources/list with encoded URIs', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-8', new NullLogService(), () => { }, invoker);
+
+		await session.handleIncoming({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+		await session.handleIncoming({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+		const responses = await session.handleIncoming({ jsonrpc: '2.0', id: 2, method: 'resources/list' });
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		const resources = (response.result as { resources: Array<{ uri: string; name: string }> }).resources;
+		assert.strictEqual(resources.length, 1);
+		assert.strictEqual(resources[0].uri, 'file://-0/test/resource.txt');
+		assert.strictEqual(resources[0].name, 'resource.txt');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('serves resources/read with URI decoding and re-encoding', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-9', new NullLogService(), () => { }, invoker);
+
+		await session.handleIncoming({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+		await session.handleIncoming({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 2,
+			method: 'resources/read',
+			params: { uri: 'file://-0/test/resource.txt' },
+		});
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		const contents = (response.result as { contents: Array<{ uri: string; text: string }> }).contents;
+		assert.strictEqual(contents.length, 1);
+		assert.strictEqual(contents[0].uri, 'file://-0/test/resource.txt');
+		assert.strictEqual(contents[0].text, 'hello world');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('serves resources/templates/list with encoded URI templates', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-10', new NullLogService(), () => { }, invoker);
+
+		await session.handleIncoming({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+		await session.handleIncoming({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+		const responses = await session.handleIncoming({ jsonrpc: '2.0', id: 2, method: 'resources/templates/list' });
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		const templates = (response.result as { resourceTemplates: Array<{ uriTemplate: string; name: string }> }).resourceTemplates;
+		assert.strictEqual(templates.length, 1);
+		assert.strictEqual(templates[0].uriTemplate, 'file://-0/test/{name}');
+		assert.strictEqual(templates[0].name, 'Test Template');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+});
+
+suite('Gateway Resource URI encoding', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('encodes and decodes URI with authority', () => {
+		const encoded = encodeGatewayResourceUri('https://example.com/resource', 3);
+		assert.strictEqual(encoded, 'https://example.com-3/resource');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 3);
+		assert.strictEqual(decoded.originalUri, 'https://example.com/resource');
+	});
+
+	test('encodes and decodes URI with empty authority', () => {
+		const encoded = encodeGatewayResourceUri('file:///path/to/file', 0);
+		assert.strictEqual(encoded, 'file://-0/path/to/file');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 0);
+		assert.strictEqual(decoded.originalUri, 'file:///path/to/file');
+	});
+
+	test('encodes and decodes URI with authority containing hyphens', () => {
+		const encoded = encodeGatewayResourceUri('https://my-server.example.com/res', 12);
+		assert.strictEqual(encoded, 'https://my-server.example.com-12/res');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 12);
+		assert.strictEqual(decoded.originalUri, 'https://my-server.example.com/res');
+	});
+
+	test('encodes and decodes URI with port', () => {
+		const encoded = encodeGatewayResourceUri('http://localhost:8080/api', 5);
+		assert.strictEqual(encoded, 'http://localhost:8080-5/api');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 5);
+		assert.strictEqual(decoded.originalUri, 'http://localhost:8080/api');
+	});
+
+	test('encodes and decodes URI with query and fragment', () => {
+		const encoded = encodeGatewayResourceUri('https://example.com/resource?q=1#section', 2);
+		assert.strictEqual(encoded, 'https://example.com-2/resource?q=1#section');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 2);
+		assert.strictEqual(decoded.originalUri, 'https://example.com/resource?q=1#section');
+	});
+
+	test('encodes and decodes custom scheme URIs', () => {
+		const encoded = encodeGatewayResourceUri('custom://myhost/path', 7);
+		assert.strictEqual(encoded, 'custom://myhost-7/path');
+		const decoded = decodeGatewayResourceUri(encoded);
+		assert.strictEqual(decoded.serverIndex, 7);
+		assert.strictEqual(decoded.originalUri, 'custom://myhost/path');
+	});
+
+	test('returns URI unchanged if no scheme match', () => {
+		const encoded = encodeGatewayResourceUri('not-a-uri', 1);
+		assert.strictEqual(encoded, 'not-a-uri');
+	});
+
+	test('throws on decode of URI without server index suffix', () => {
+		assert.throws(() => decodeGatewayResourceUri('https://example.com/resource'));
 	});
 });

--- a/src/vs/workbench/contrib/mcp/common/mcpGatewayToolBrokerChannel.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpGatewayToolBrokerChannel.ts
@@ -8,8 +8,10 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IServerChannel } from '../../../../base/parts/ipc/common/ipc.js';
-import { IMcpServer, IMcpService, McpServerCacheState, McpToolVisibility } from './mcpTypes.js';
+import { IGatewayCallToolResult, IGatewayServerResources, IGatewayServerResourceTemplates } from '../../../../platform/mcp/common/mcpGateway.js';
 import { MCP } from '../../../../platform/mcp/common/modelContextProtocol.js';
+import { McpServer } from './mcpServer.js';
+import { IMcpServer, IMcpService, McpCapability, McpServerCacheState, McpToolVisibility } from './mcpTypes.js';
 import { startServerAndWaitForLiveTools } from './mcpTypesUtils.js';
 
 interface ICallToolArgs {
@@ -17,32 +19,74 @@ interface ICallToolArgs {
 	args: Record<string, unknown>;
 }
 
+interface IReadResourceArgs {
+	serverIndex: number;
+	uri: string;
+}
+
 export class McpGatewayToolBrokerChannel extends Disposable implements IServerChannel<unknown> {
 	private readonly _onDidChangeTools = this._register(new Emitter<void>());
+	private readonly _onDidChangeResources = this._register(new Emitter<void>());
+	private readonly _serverIdMap = new Map<string, number>();
+	private _nextServerIndex = 0;
 
 	constructor(
 		private readonly _mcpService: IMcpService,
 	) {
 		super();
 
-		let initialized = false;
+		let toolsInitialized = false;
 		this._register(autorun(reader => {
 			for (const server of this._mcpService.servers.read(reader)) {
 				server.tools.read(reader);
 			}
 
-			if (initialized) {
+			if (toolsInitialized) {
 				this._onDidChangeTools.fire();
 			} else {
-				initialized = true;
+				toolsInitialized = true;
 			}
 		}));
+
+		let resourcesInitialized = false;
+		this._register(autorun(reader => {
+			for (const server of this._mcpService.servers.read(reader)) {
+				server.capabilities.read(reader);
+			}
+
+			if (resourcesInitialized) {
+				this._onDidChangeResources.fire();
+			} else {
+				resourcesInitialized = true;
+			}
+		}));
+	}
+
+	private _getServerIndex(server: IMcpServer): number {
+		const defId = server.definition.id;
+		let index = this._serverIdMap.get(defId);
+		if (index === undefined) {
+			index = this._nextServerIndex++;
+			this._serverIdMap.set(defId, index);
+		}
+		return index;
+	}
+
+	private _getServerByIndex(serverIndex: number): IMcpServer | undefined {
+		for (const server of this._mcpService.servers.get()) {
+			if (this._getServerIndex(server) === serverIndex) {
+				return server;
+			}
+		}
+		return undefined;
 	}
 
 	listen<T>(_ctx: unknown, event: string): Event<T> {
 		switch (event) {
 			case 'onDidChangeTools':
 				return this._onDidChangeTools.event as Event<T>;
+			case 'onDidChangeResources':
+				return this._onDidChangeResources.event as Event<T>;
 		}
 
 		throw new Error(`Invalid listen: ${event}`);
@@ -58,6 +102,19 @@ export class McpGatewayToolBrokerChannel extends Disposable implements IServerCh
 				const { name, args } = arg as ICallToolArgs;
 				const result = await this._callTool(name, args || {}, cancellationToken);
 				return result as T;
+			}
+			case 'listResources': {
+				const resources = await this._listResources();
+				return resources as T;
+			}
+			case 'readResource': {
+				const { serverIndex, uri } = arg as IReadResourceArgs;
+				const result = await this._readResource(serverIndex, uri, cancellationToken);
+				return result as T;
+			}
+			case 'listResourceTemplates': {
+				const templates = await this._listResourceTemplates();
+				return templates as T;
 			}
 		}
 
@@ -87,18 +144,71 @@ export class McpGatewayToolBrokerChannel extends Disposable implements IServerCh
 		return mcpTools;
 	}
 
-	private async _callTool(name: string, args: Record<string, unknown>, token: CancellationToken = CancellationToken.None): Promise<MCP.CallToolResult> {
+	private async _callTool(name: string, args: Record<string, unknown>, token: CancellationToken = CancellationToken.None): Promise<IGatewayCallToolResult> {
 		for (const server of this._mcpService.servers.get()) {
 			const tool = server.tools.get().find(t =>
 				t.definition.name === name && (t.visibility & McpToolVisibility.Model)
 			);
 
 			if (tool) {
-				return tool.call(args, undefined, token);
+				const result = await tool.call(args, undefined, token);
+				return { result, serverIndex: this._getServerIndex(server) };
 			}
 		}
 
 		throw new Error(`Unknown tool: ${name}`);
+	}
+
+	private async _listResources(): Promise<readonly IGatewayServerResources[]> {
+		const results: IGatewayServerResources[] = [];
+		const servers = this._mcpService.servers.get();
+		await Promise.all(servers.map(async server => {
+			await this._ensureServerReady(server);
+
+			const capabilities = server.capabilities.get();
+			if (!capabilities || !(capabilities & McpCapability.Resources)) {
+				return;
+			}
+
+			try {
+				const resources = await McpServer.callOn(server, h => h.listResources());
+				results.push({ serverIndex: this._getServerIndex(server), resources });
+			} catch {
+				// Server failed; skip
+			}
+		}));
+
+		return results;
+	}
+
+	private async _readResource(serverIndex: number, uri: string, token: CancellationToken = CancellationToken.None): Promise<MCP.ReadResourceResult> {
+		const server = this._getServerByIndex(serverIndex);
+		if (!server) {
+			throw new Error(`Unknown server index: ${serverIndex}`);
+		}
+
+		return McpServer.callOn(server, h => h.readResource({ uri }, token), token);
+	}
+
+	private async _listResourceTemplates(): Promise<readonly IGatewayServerResourceTemplates[]> {
+		const results: IGatewayServerResourceTemplates[] = [];
+		const servers = this._mcpService.servers.get();
+
+		await Promise.all(servers.map(async server => {
+			const capabilities = server.capabilities.get();
+			if (!capabilities || !(capabilities & McpCapability.Resources)) {
+				return;
+			}
+
+			try {
+				const resourceTemplates = await McpServer.callOn(server, h => h.listResourceTemplates());
+				results.push({ serverIndex: this._getServerIndex(server), resourceTemplates });
+			} catch {
+				// Server failed; skip
+			}
+		}));
+
+		return results;
 	}
 
 	private async _ensureServerReady(server: IMcpServer): Promise<boolean> {

--- a/src/vs/workbench/contrib/mcp/common/mcpGatewayToolBrokerChannel.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpGatewayToolBrokerChannel.ts
@@ -195,6 +195,8 @@ export class McpGatewayToolBrokerChannel extends Disposable implements IServerCh
 		const servers = this._mcpService.servers.get();
 
 		await Promise.all(servers.map(async server => {
+			await this._ensureServerReady(server);
+
 			const capabilities = server.capabilities.get();
 			if (!capabilities || !(capabilities & McpCapability.Resources)) {
 				return;

--- a/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IGatewayCallToolResult } from '../../../../../platform/mcp/common/mcpGateway.js';
 import { MCP } from '../../common/modelContextProtocol.js';
 import { McpGatewayToolBrokerChannel } from '../../common/mcpGatewayToolBrokerChannel.js';
 import { IMcpIcons, IMcpServer, IMcpTool, McpConnectionState, McpServerCacheState, McpToolVisibility } from '../../common/mcpTypes.js';
@@ -60,18 +61,18 @@ suite('McpGatewayToolBrokerChannel', () => {
 
 		mcpService.servers.set([serverA, serverB], undefined);
 
-		const resultA = await channel.call<MCP.CallToolResult>(undefined, 'callTool', {
+		const resultA = await channel.call<IGatewayCallToolResult>(undefined, 'callTool', {
 			name: 'mcp_serverA_echo',
 			args: { name: 'one' },
 		});
-		const resultB = await channel.call<MCP.CallToolResult>(undefined, 'callTool', {
+		const resultB = await channel.call<IGatewayCallToolResult>(undefined, 'callTool', {
 			name: 'mcp_serverB_echo',
 			args: { name: 'two' },
 		});
 
 		assert.deepStrictEqual(invoked, ['A:one', 'B:two']);
-		assert.strictEqual((resultA.content[0] as MCP.TextContent).text, 'from A');
-		assert.strictEqual((resultB.content[0] as MCP.TextContent).text, 'from B');
+		assert.strictEqual((resultA.result.content[0] as MCP.TextContent).text, 'from A');
+		assert.strictEqual((resultB.result.content[0] as MCP.TextContent).text, 'from B');
 
 		channel.dispose();
 	});


### PR DESCRIPTION
Extends the MCP gateway to support resources alongside tools:

- Adds resource-related interfaces to IMcpGatewayToolInvoker: onDidChangeResources,
  listResources, readResource, listResourceTemplates
- Implements resource URI encoding/decoding to namespace resources from different
  MCP servers using server index suffixes (e.g., 'file:///resource-0')
- Adds handlers for resources/list, resources/read, resources/templates/list RPC methods
- Broadcasts notifications/resources/list_changed when resources change
- Updates McpGatewayToolBrokerChannel to enumerate resources from all servers and
  track server indices for resource URI namespacing
- Adds comprehensive test coverage for resource operations and URI encoding/decoding

(Commit message generated by Copilot)