### PR TITLE
Fix diff editor gutter selection for pure deletions

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -39,6 +39,7 @@ export class DiffEditorEditors extends Disposable {
 	public readonly modifiedSelections;
 	public readonly modifiedCursor;
 
+	public readonly originalSelections;
 	public readonly originalCursor;
 
 	public readonly isOriginalFocused;
@@ -67,6 +68,7 @@ export class DiffEditorEditors extends Disposable {
 		this.modifiedModel = this.modifiedObs.model;
 		this.modifiedSelections = observableFromEvent(this, this.modified.onDidChangeCursorSelection, () => this.modified.getSelections() ?? []);
 		this.modifiedCursor = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.modifiedSelections.read(reader)[0]?.getPosition() ?? new Position(1, 1));
+		this.originalSelections = observableFromEvent(this, this.original.onDidChangeCursorSelection, () => this.original.getSelections() ?? []);
 		this.originalCursor = observableFromEvent(this, this.original.onDidChangeCursorPosition, () => this.original.getPosition() ?? new Position(1, 1));
 		this.isOriginalFocused = observableCodeEditor(this.original).isFocused;
 		this.isModifiedFocused = observableCodeEditor(this.modified).isFocused;

--- a/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
@@ -21,7 +21,7 @@ import { LineRange, LineRangeSet } from '../../../../common/core/ranges/lineRang
 import { OffsetRange } from '../../../../common/core/ranges/offsetRange.js';
 import { Range } from '../../../../common/core/range.js';
 import { TextEdit } from '../../../../common/core/edits/textEdit.js';
-import { DetailedLineRangeMapping } from '../../../../common/diff/rangeMapping.js';
+import { DetailedLineRangeMapping, RangeMapping } from '../../../../common/diff/rangeMapping.js';
 import { TextModelText } from '../../../../common/model/textModelText.js';
 import { ActionRunnerWithContext } from '../../multiDiffEditor/utils.js';
 import { DiffEditorEditors } from '../components/diffEditorEditors.js';
@@ -81,20 +81,50 @@ export class DiffEditorGutter extends Disposable {
 			// Return `emptyArr` because it is a constant. [] is always a new array and would trigger a change.
 			if (!diff) { return emptyArr; }
 
-			const selections = this._editors.modifiedSelections.read(reader);
-			if (selections.every(s => s.isEmpty())) { return emptyArr; }
+			const modifiedSelections = this._editors.modifiedSelections.read(reader);
+			const originalSelections = this._editors.originalSelections.read(reader);
+			const hasModifiedSelection = !modifiedSelections.every(s => s.isEmpty());
+			const hasOriginalSelection = !originalSelections.every(s => s.isEmpty());
+			if (!hasModifiedSelection && !hasOriginalSelection) { return emptyArr; }
 
-			const selectedLineNumbers = new LineRangeSet(selections.map(s => LineRange.fromRangeInclusive(s)));
+			const selectedModifiedLineNumbers = hasModifiedSelection
+				? new LineRangeSet(modifiedSelections.map(s => LineRange.fromRangeInclusive(s)))
+				: undefined;
+			const selectedOriginalLineNumbers = hasOriginalSelection
+				? new LineRangeSet(originalSelections.map(s => LineRange.fromRangeInclusive(s)))
+				: undefined;
 
-			const selectedMappings = diff.mappings.filter(m =>
-				m.lineRangeMapping.innerChanges && selectedLineNumbers.intersects(m.lineRangeMapping.modified)
-			);
-			const result = selectedMappings.map(mapping => ({
-				mapping,
-				rangeMappings: mapping.lineRangeMapping.innerChanges!.filter(
-					c => selections.some(s => Range.areIntersecting(c.modifiedRange, s))
-				)
-			}));
+			const selectedMappings = diff.mappings.filter(m => {
+				if (!m.lineRangeMapping.innerChanges) { return false; }
+				// Pure deletions have an empty modified range — match them
+				// via the original (left) editor where the deleted text lives.
+				if (m.lineRangeMapping.modified.isEmpty && selectedOriginalLineNumbers) {
+					return selectedOriginalLineNumbers.intersects(m.lineRangeMapping.original);
+				}
+				if (selectedModifiedLineNumbers) {
+					return selectedModifiedLineNumbers.intersects(m.lineRangeMapping.modified);
+				}
+				return false;
+			});
+			const result = selectedMappings.map(mapping => {
+				const isPureDeletion = mapping.lineRangeMapping.modified.isEmpty;
+				let rangeMappings: RangeMapping[];
+				if (isPureDeletion) {
+					// For pure deletions, clip each inner change's originalRange
+					// to the selection so only selected deleted lines are staged.
+					rangeMappings = mapping.lineRangeMapping.innerChanges!.flatMap(c => {
+						const clipped = originalSelections
+							.map(s => Range.intersectRanges(c.originalRange, s))
+							.filter((r): r is Range => r !== null && !r.isEmpty());
+						return clipped.map(r => new RangeMapping(r, c.modifiedRange));
+					});
+				} else {
+					rangeMappings = mapping.lineRangeMapping.innerChanges!.filter(
+						c => modifiedSelections.some(s => Range.areIntersecting(c.modifiedRange, s))
+					);
+				}
+				return { mapping, rangeMappings };
+			});
 			if (result.length === 0 || result.every(r => r.rangeMappings.length === 0)) { return emptyArr; }
 			return result;
 		});

--- a/src/vs/editor/test/browser/widget/diffEditorGutterSelection.test.ts
+++ b/src/vs/editor/test/browser/widget/diffEditorGutterSelection.test.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { Range } from '../../../common/core/range.js';
+import { StringText } from '../../../common/core/text/abstractText.js';
+import { TextEdit } from '../../../common/core/edits/textEdit.js';
+import { DetailedLineRangeMapping, RangeMapping } from '../../../common/diff/rangeMapping.js';
+import { LineRange } from '../../../common/core/ranges/lineRange.js';
+
+suite('DiffEditorGutterSelection', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('Partial staging of pure deletions', () => {
+		/**
+		 * Simulates what computeStagedValue does:
+		 * applies the inner changes (as text edits) from modified onto original.
+		 */
+		function computeStagedValue(innerChanges: RangeMapping[], original: StringText, modified: StringText): string {
+			const edit = new TextEdit(innerChanges.map(c => c.toTextEdit(modified)));
+			return edit.apply(original);
+		}
+
+		/**
+		 * Simulates the clipping logic from gutterFeature._selectedDiffs:
+		 * clips inner changes' originalRange to the selection.
+		 */
+		function clipRangeMappings(innerChanges: RangeMapping[], selection: Range): RangeMapping[] {
+			return innerChanges.flatMap(c => {
+				const clipped = Range.intersectRanges(c.originalRange, selection);
+				if (!clipped || clipped.isEmpty()) { return []; }
+				return [new RangeMapping(clipped, c.modifiedRange)];
+			});
+		}
+
+		test('Full deletion staged completely', () => {
+			// Original has 5 lines, modified has 0 (pure deletion of lines 2-4)
+			const original = new StringText('line1\nline2\nline3\nline4\nline5');
+			const modified = new StringText('line1\nline5');
+
+			// A pure deletion: original lines 2-4 deleted, modified range is empty
+			const innerChange = new RangeMapping(
+				new Range(2, 1, 5, 1),  // original: lines 2-4 (up to start of line 5)
+				new Range(2, 1, 2, 1),  // modified: empty range at line 2
+			);
+
+			// Select all deleted lines
+			const selection = new Range(2, 1, 5, 1);
+			const clipped = clipRangeMappings([innerChange], selection);
+
+			assert.deepStrictEqual(
+				computeStagedValue(clipped, original, modified),
+				'line1\nline5',
+			);
+		});
+
+		test('Partial deletion — select first two of three deleted lines', () => {
+			const original = new StringText('line1\nline2\nline3\nline4\nline5');
+			const modified = new StringText('line1\nline5');
+
+			const innerChange = new RangeMapping(
+				new Range(2, 1, 5, 1),
+				new Range(2, 1, 2, 1),
+			);
+
+			// Select only lines 2-3 (not line 4)
+			const selection = new Range(2, 1, 4, 1);
+			const clipped = clipRangeMappings([innerChange], selection);
+
+			assert.deepStrictEqual(
+				computeStagedValue(clipped, original, modified),
+				'line1\nline4\nline5',
+			);
+		});
+
+		test('Partial deletion — select last line of three deleted lines', () => {
+			const original = new StringText('line1\nline2\nline3\nline4\nline5');
+			const modified = new StringText('line1\nline5');
+
+			const innerChange = new RangeMapping(
+				new Range(2, 1, 5, 1),
+				new Range(2, 1, 2, 1),
+			);
+
+			// Select only line 4
+			const selection = new Range(4, 1, 5, 1);
+			const clipped = clipRangeMappings([innerChange], selection);
+
+			assert.deepStrictEqual(
+				computeStagedValue(clipped, original, modified),
+				'line1\nline2\nline3\nline5',
+			);
+		});
+
+		test('Selection does not intersect deletion — no changes applied', () => {
+			const original = new StringText('line1\nline2\nline3\nline4\nline5');
+			const modified = new StringText('line1\nline5');
+
+			const innerChange = new RangeMapping(
+				new Range(2, 1, 5, 1),
+				new Range(2, 1, 2, 1),
+			);
+
+			// Select line 1 (outside the deletion)
+			const selection = new Range(1, 1, 2, 1);
+			const clipped = clipRangeMappings([innerChange], selection);
+
+			assert.strictEqual(clipped.length, 0);
+		});
+
+		test('fromRangeMappings produces correct DetailedLineRangeMapping from clipped range', () => {
+			const innerChange = new RangeMapping(
+				new Range(2, 1, 5, 1),
+				new Range(2, 1, 2, 1),
+			);
+
+			// Clip to lines 3-4
+			const selection = new Range(3, 1, 5, 1);
+			const clipped = clipRangeMappings([innerChange], selection);
+
+			const mapping = DetailedLineRangeMapping.fromRangeMappings(clipped);
+			assert.deepStrictEqual(mapping.original, new LineRange(3, 6));
+			assert.deepStrictEqual(mapping.modified, new LineRange(2, 3));
+			assert.strictEqual(mapping.innerChanges!.length, 1);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #9475

## Summary
- Pure deletions (lines removed with nothing added) have an empty modified line range in the diff editor. Selecting text in the modified (right) editor could never match them, making it impossible to partially stage deletions via the gutter.
- Adds `originalSelections` observable to `DiffEditorEditors` and updates `_selectedDiffs` in `gutterFeature.ts` to read selections from both editors.
- Pure deletions are now matched via the original (left) editor's line ranges, and inner changes are clipped to the selection so only selected deleted lines are staged.

## Test plan
- [ ] Open a side-by-side diff with pure deletions (lines only in the left editor)
- [ ] Select a subset of the deleted lines on the left side
- [ ] Verify the "Stage Selection" button appears in the gutter
- [ ] Click it and verify only the selected lines are staged, not the entire deletion block
- [ ] Verify existing behavior: selecting modified lines on the right side still works as before