### PR TITLE
Move mode badge and timestamp to bottom row in session list items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -112,10 +112,6 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 				h('div.agent-session-main-col', [
 					h('div.agent-session-title-row', [
 						h('div.agent-session-title@title'),
-						h('div.agent-session-status@statusContainer', [
-							h('span.agent-session-status-provider-icon@statusProviderIcon'),
-							h('span.agent-session-status-time@statusTime')
-						]),
 						h('div.agent-session-title-toolbar@titleToolbar'),
 					]),
 					h('div.agent-session-details-row', [
@@ -124,9 +120,15 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 								h('span.agent-session-diff-added@addedSpan'),
 								h('span.agent-session-diff-removed@removedSpan')
 							]),
-						h('div.agent-session-badge@badge'),
-						h('span.agent-session-separator@separator'),
 						h('div.agent-session-description@description'),
+						h('div.agent-session-details-right', [
+							h('div.agent-session-badge@badge'),
+							h('span.agent-session-separator@separator'),
+							h('div.agent-session-status@statusContainer', [
+								h('span.agent-session-status-provider-icon@statusProviderIcon'),
+								h('span.agent-session-status-time@statusTime')
+							]),
+						]),
 					])
 				])
 			]
@@ -219,9 +221,8 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			this.renderDescription(session, template, hasBadge);
 		}
 
-		// Separator (dot between badge and description)
-		const hasDescription = template.description.textContent !== '';
-		template.separator.classList.toggle('has-separator', hasBadge && hasDescription);
+		// Separator (dot between badge and timestamp)
+		template.separator.classList.toggle('has-separator', hasBadge);
 
 		// Status
 		this.renderStatus(session, template);
@@ -508,7 +509,7 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 
 export class AgentSessionsListDelegate implements IListVirtualDelegate<AgentSessionListItem> {
 
-	static readonly ITEM_HEIGHT = 48;
+	static readonly ITEM_HEIGHT = 54;
 	static readonly SECTION_HEIGHT = 26;
 
 	getHeight(element: AgentSessionListItem): number {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -44,10 +44,6 @@
 		color: unset;
 	}
 
-	.monaco-list-row.selected .agent-session-status {
-		color: unset;
-	}
-
 	.monaco-list:not(:focus) .monaco-list-row.selected .agent-session-details-row {
 		color: var(--vscode-descriptionForeground);
 	}
@@ -66,7 +62,7 @@
 		}
 	}
 
-	/* On hover or keyboard focus: show toolbar, hide status */
+	/* On hover or keyboard focus: show toolbar */
 	.monaco-list-row:hover,
 	.monaco-list-row.focused {
 
@@ -74,15 +70,15 @@
 			display: block;
 		}
 
-		.agent-session-status {
-			display: none;
+		.agent-session-title {
+			margin-right: 8px;
 		}
 	}
 
 	.agent-session-item {
 		display: flex;
 		flex-direction: row;
-		padding: 6px 6px;
+		padding: 8px 6px;
 
 		&.archived {
 			color: var(--vscode-descriptionForeground);
@@ -143,7 +139,7 @@
 
 		.agent-session-title-row {
 			line-height: 17px;
-			padding-bottom: 4px;
+			padding-bottom: 6px;
 		}
 
 		.agent-session-details-row {
@@ -227,21 +223,25 @@
 			flex: 1;
 			overflow: hidden;
 			white-space: nowrap;
-			margin-right: 16px;
-			mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
-			-webkit-mask-image: linear-gradient(to right, black calc(100% - 32px), transparent);
 		}
 
 		.agent-session-title {
 			font-size: 13px;
 		}
 
+		.agent-session-details-right {
+			display: flex;
+			align-items: center;
+			gap: 4px;
+			margin-left: auto;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+
 		.agent-session-status {
 			display: flex;
 			align-items: center;
 			font-variant-numeric: tabular-nums;
-			font-size: 12px;
-			color: var(--vscode-descriptionForeground);
 			white-space: nowrap;
 
 			.agent-session-status-provider-icon {


### PR DESCRIPTION
Move the mode badge and timestamp from the top row to the bottom row (right-aligned) in agent session list items. The session title now spans the full width of the top row.

### Changes
- Move status container (provider icon + timestamp) from title row to details row
- Move badge and separator into a right-aligned wrapper in the details row
- Let session title span full width of the top row
- Increase list item height from 48 to 54px
- Add more padding between title and details rows
- Only show title margin-right on hover when toolbar is visible
- Remove mask fade from title and description