### PR TITLE
add `chatTip` telemetry

### DIFF
--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -31,6 +31,8 @@ import { CreateSlashCommandsUsageTracker } from '../../browser/createSlashComman
 import { ChatRequestSlashCommandPart } from '../../common/requestParser/chatParserTypes.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { Range } from '../../../../../editor/common/core/range.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 
 class MockContextKeyServiceWithRulesMatching extends MockContextKeyService {
 	override contextMatchesRules(rules: ContextKeyExpression): boolean {
@@ -99,6 +101,7 @@ suite('ChatTipService', () => {
 		instantiationService.stub(ILanguageModelToolsService, testDisposables.add(new MockLanguageModelToolsService()));
 		instantiationService.stub(IChatEntitlementService, new TestChatEntitlementService());
 		instantiationService.stub(IChatService, new MockChatService());
+		instantiationService.stub(ITelemetryService, NullTelemetryService);
 	});
 
 	test('returns a welcome tip', () => {
@@ -923,6 +926,133 @@ suite('ChatTipService', () => {
 			assertTipNeverShown(service, tipId);
 		});
 	}
+
+	test('logs telemetry when tip is shown', () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		const shownEvents = events.filter(e => e.data.action === 'shown');
+		assert.strictEqual(shownEvents.length, 1, 'Should log exactly one shown event');
+		assert.strictEqual(shownEvents[0].eventName, 'chatTip');
+		assert.strictEqual(shownEvents[0].data.tipId, tip.id);
+	});
+
+	test('logs telemetry when tip is dismissed', () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		service.dismissTip();
+
+		const dismissEvents = events.filter(e => e.data.action === 'dismissed');
+		assert.strictEqual(dismissEvents.length, 1, 'Should log exactly one dismissed event');
+		assert.strictEqual(dismissEvents[0].data.tipId, tip.id);
+	});
+
+	test('logs telemetry when navigating tips', () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		const nextTip = service.navigateToNextTip();
+		assert.ok(nextTip);
+
+		const navigateEvents = events.filter(e => e.data.action === 'navigateNext');
+		assert.strictEqual(navigateEvents.length, 1, 'Should log one navigateNext event');
+		assert.strictEqual(navigateEvents[0].data.tipId, tip.id, 'navigateNext should log the tip being navigated away from');
+
+		const shownEvents = events.filter(e => e.data.action === 'shown');
+		assert.strictEqual(shownEvents.length, 2, 'Should log shown for initial and navigated tip');
+		assert.strictEqual(shownEvents[1].data.tipId, nextTip.id);
+	});
+
+	test('logs telemetry when tip command is clicked', () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		if (tip.enabledCommands?.length) {
+			commandExecutedEmitter.fire({ commandId: tip.enabledCommands[0], args: [] });
+
+			const clickEvents = events.filter(e => e.data.action === 'commandClicked');
+			assert.strictEqual(clickEvents.length, 1, 'Should log one commandClicked event');
+			assert.strictEqual(clickEvents[0].data.tipId, tip.id);
+			assert.strictEqual(clickEvents[0].data.commandId, tip.enabledCommands[0]);
+		}
+	});
+
+	test('logs telemetry when tip is hidden', () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		service.hideTip();
+
+		const hiddenEvents = events.filter(e => e.data.action === 'hidden');
+		assert.strictEqual(hiddenEvents.length, 1, 'Should log one hidden event');
+		assert.strictEqual(hiddenEvents[0].data.tipId, tip.id);
+	});
+
+	test('logs telemetry when tips are disabled', async () => {
+		const events: { eventName: string; data: Record<string, unknown> }[] = [];
+		instantiationService.stub(ITelemetryService, {
+			...NullTelemetryService,
+			publicLog2(eventName: string, data: Record<string, unknown>) {
+				events.push({ eventName, data });
+			},
+		} as Partial<ITelemetryService> as ITelemetryService);
+
+		const service = createService();
+		const tip = service.getWelcomeTip(contextKeyService);
+		assert.ok(tip);
+
+		await service.disableTips();
+
+		const disabledEvents = events.filter(e => e.data.action === 'disabled');
+		assert.strictEqual(disabledEvents.length, 1, 'Should log one disabled event');
+		assert.strictEqual(disabledEvents[0].data.tipId, tip.id);
+	});
 
 	test('excludeWhenSettingsChanged checks workspaceValue', () => {
 		const workspaceConfigService = new TestConfigurationService();

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -1011,6 +1011,8 @@ suite('ChatTipService', () => {
 			assert.strictEqual(clickEvents.length, 1, 'Should log one commandClicked event');
 			assert.strictEqual(clickEvents[0].data.tipId, tip.id);
 			assert.strictEqual(clickEvents[0].data.commandId, tip.enabledCommands[0]);
+		} else {
+			assert.fail('Tip has no enabled commands; cannot test command click telemetry');
 		}
 	});
 


### PR DESCRIPTION
fixes #296557

We track a `chatTip` telemetry event with the following actions:

- shown — a tip is displayed to the user
- dismissed — the user permanently dismisses a tip (it won't appear again)
- navigateNext / navigatePrevious — the user cycles to the next or previous tip
- hidden — the tip disappears due to external circumstances (e.g. chat quota exceeded), not a user action; it may reappear later
- disabled — the user disables all tips via settings
- commandClicked — the user clicks a command link within a tip (e.g. "open model picker"); 

Each includes the `commandId` to identify which tip was involved.

cc @cwebster-99 