### PR TITLE
Move session type picker and context indicator underneath chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -205,9 +205,7 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 
 		const labelElements = [];
 		labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
-		if (!this.pickerOptions.onlyShowIconsForDefaultActions.get()) {
-			labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
-		}
+		labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
 		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...labelElements);

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -804,11 +804,89 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	position: relative;
 }
 
+/* Below-input toolbar — session picker on the left, context usage on the right */
+.interactive-session .chat-input-below-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 4px;
+	padding: 0 5px 0 7px;
+}
+
+.interactive-session .chat-input-below-toolbar:empty {
+	display: none;
+}
+
+/* Replicate .monaco-action-bar and .chat-input-toolbar base styles for the below-input picker */
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker {
+	cursor: pointer;
+	position: relative;
+	min-width: 0;
+	overflow: hidden;
+	color: var(--vscode-icon-foreground);
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker .dropdown-label {
+	justify-content: flex-start;
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker .action-label {
+	height: 16px;
+	padding: 3px 0px 3px 6px;
+	display: flex;
+	align-items: center;
+	font-size: 11px;
+	border-radius: 5px;
+	color: var(--vscode-icon-foreground);
+	min-width: 0;
+	overflow: hidden;
+	position: relative;
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker .action-label > .codicon {
+	display: flex;
+	align-items: center;
+	width: 16px;
+	height: 16px;
+	font-size: 12px;
+	flex-shrink: 0;
+	color: var(--vscode-icon-foreground);
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker .action-label > .chat-input-picker-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-left: 2px;
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker .action-label > .codicon-chevron-down {
+	font-size: 12px;
+	margin-left: 2px;
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker.disabled {
+	cursor: default;
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker.disabled .action-label {
+	color: var(--vscode-disabledForeground);
+}
+
+.interactive-session .chat-input-below-toolbar .chat-below-input-session-picker.disabled .action-label .codicon {
+	color: var(--vscode-disabledForeground) !important;
+}
+
 /* Context usage widget container - positioned in the bottom toolbar */
-.interactive-session .chat-input-toolbars .chat-context-usage-container {
+.interactive-session .chat-input-toolbars .chat-context-usage-container,
+.interactive-session .chat-input-below-toolbar .chat-context-usage-container {
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	margin-left: auto;
+}
+
+/* When context usage is inside the toolbars (compact mode), keep the ordering */
+.interactive-session .chat-input-toolbars .chat-context-usage-container {
 	order: 1;
 }
 
@@ -1597,7 +1675,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part {
 	margin: 0px 12px;
-	padding: 4px 0 12px 0px;
+	padding: 4px 0 6px 0px;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatContextUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatContextUsageWidget.ts
@@ -92,6 +92,7 @@ export class ChatContextUsageWidget extends Disposable {
 	readonly domNode: HTMLElement;
 
 	private readonly progressIndicator: CircularProgressIndicator;
+	private readonly percentageLabel: HTMLElement;
 
 	private readonly _isVisible = observableValue<boolean>(this, false);
 	get isVisible(): IObservable<boolean> { return this._isVisible; }
@@ -129,6 +130,9 @@ export class ChatContextUsageWidget extends Disposable {
 		const iconContainer = this.domNode.appendChild($('.icon-container'));
 		this.progressIndicator = new CircularProgressIndicator();
 		iconContainer.appendChild(this.progressIndicator.domNode);
+
+		// Percentage label
+		this.percentageLabel = this.domNode.appendChild($('.percentage-label'));
 
 		// Track context usage opened state
 		this._contextUsageOpenedKey = ChatContextKeys.contextUsageHasBeenOpened.bindTo(this.contextKeyService);
@@ -285,6 +289,9 @@ export class ChatContextUsageWidget extends Disposable {
 
 		// Update pie chart progress
 		this.progressIndicator.setProgress(percentage);
+
+		// Update percentage label
+		this.percentageLabel.textContent = `${Math.round(percentage)}%`;
 
 		// Update color based on usage level
 		this.domNode.classList.remove('warning', 'error');

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatContextUsageWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/media/chatContextUsageWidget.css
@@ -6,9 +6,7 @@
 .chat-context-usage-widget {
 	display: flex;
 	align-items: center;
-	justify-content: center;
-	height: 22px;
-	width: 22px;
+	gap: 4px;
 	flex-shrink: 0;
 	cursor: pointer;
 	padding: 3px;
@@ -20,8 +18,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 14px;
-	height: 14px;
+	width: 12px;
+	height: 12px;
 	flex-shrink: 0;
 }
 
@@ -55,7 +53,7 @@
 
 .chat-context-usage-widget .progress-arc {
 	fill: none;
-	stroke: var(--vscode-descriptionForeground);
+	stroke: var(--vscode-icon-foreground);
 	stroke-width: 4;
 	stroke-linecap: round;
 	transform: rotate(-90deg);
@@ -69,4 +67,21 @@
 
 .chat-context-usage-widget.error .progress-arc {
 	stroke: var(--vscode-editorError-foreground);
+}
+
+.chat-context-usage-widget .percentage-label {
+	font-size: 11px;
+	line-height: 1;
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+	max-width: 0;
+	opacity: 0;
+	overflow: hidden;
+	transition: max-width 0.1s cubic-bezier(0.33, 0, 0.67, 1), opacity 0.1s cubic-bezier(0.33, 0, 0.67, 1);
+}
+
+.chat-context-usage-widget:hover .percentage-label,
+.chat-context-usage-widget:focus .percentage-label {
+	max-width: 4em;
+	opacity: 1;
 }


### PR DESCRIPTION
Small layout refinements to the chat input area:

- Always show label on the Local/session target picker (no responsive hiding)
- Reduce bottom padding on chat input part (12px → 6px)
- Add `0px 6px` padding to the below-input toolbar
- Make context usage donut indicator 2px smaller in diameter, use `icon-foreground` for the filled arc
- Show percentage label next to the context usage donut on hover/focus with a 0.1s cubic-bezier transition