### PR TITLE
Hide ChatModelStore.acquire()

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModelStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModelStore.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from '../../../../../base/common/event.js';
-import { DisposableStore, IDisposable, IReference, ReferenceCollection } from '../../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, IReference, ReferenceCollection } from '../../../../../base/common/lifecycle.js';
 import { ObservableMap } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
@@ -27,17 +27,17 @@ export interface ChatModelStoreDelegate {
 	willDisposeModel: (model: ChatModel) => Promise<void>;
 }
 
-export class ChatModelStore extends ReferenceCollection<ChatModel> implements IDisposable {
-	private readonly _store = new DisposableStore();
+export class ChatModelStore extends Disposable implements IDisposable {
+	private readonly _refCollection: ReferenceCollection<ChatModel>;
 
 	private readonly _models = new ObservableMap<string, ChatModel>();
 	private readonly _modelsToDispose = new Set<string>();
 	private readonly _pendingDisposals = new Set<Promise<void>>();
 
-	private readonly _onDidDisposeModel = this._store.add(new Emitter<ChatModel>());
+	private readonly _onDidDisposeModel = this._register(new Emitter<ChatModel>());
 	public readonly onDidDisposeModel = this._onDidDisposeModel.event;
 
-	private readonly _onDidCreateModel = this._store.add(new Emitter<ChatModel>());
+	private readonly _onDidCreateModel = this._register(new Emitter<ChatModel>());
 	public readonly onDidCreateModel = this._onDidCreateModel.event;
 
 	constructor(
@@ -45,6 +45,16 @@ export class ChatModelStore extends ReferenceCollection<ChatModel> implements ID
 		@ILogService private readonly logService: ILogService,
 	) {
 		super();
+
+		const self = this;
+		this._refCollection = new class extends ReferenceCollection<ChatModel> {
+			protected createReferencedObject(key: string, props?: IStartSessionProps): ChatModel {
+				return self.createReferencedObject(key, props);
+			}
+			protected destroyReferencedObject(key: string, object: ChatModel): void {
+				return self.destroyReferencedObject(key, object);
+			}
+		}();
 	}
 
 	public get observable() {
@@ -71,14 +81,14 @@ export class ChatModelStore extends ReferenceCollection<ChatModel> implements ID
 		if (!this._models.has(key)) {
 			return undefined;
 		}
-		return this.acquire(key);
+		return this._refCollection.acquire(key);
 	}
 
 	public acquireOrCreate(props: IStartSessionProps): IReference<ChatModel> {
-		return this.acquire(this.toKey(props.sessionResource), props);
+		return this._refCollection.acquire(this.toKey(props.sessionResource), props);
 	}
 
-	protected createReferencedObject(key: string, props?: IStartSessionProps): ChatModel {
+	private createReferencedObject(key: string, props?: IStartSessionProps): ChatModel {
 		this._modelsToDispose.delete(key);
 		const existingModel = this._models.get(key);
 		if (existingModel) {
@@ -99,7 +109,7 @@ export class ChatModelStore extends ReferenceCollection<ChatModel> implements ID
 		return model;
 	}
 
-	protected destroyReferencedObject(key: string, object: ChatModel): void {
+	private destroyReferencedObject(key: string, object: ChatModel): void {
 		this._modelsToDispose.add(key);
 		const promise = this.doDestroyReferencedObject(key, object);
 		this._pendingDisposals.add(promise);
@@ -135,8 +145,8 @@ export class ChatModelStore extends ReferenceCollection<ChatModel> implements ID
 		return uri.toString();
 	}
 
-	dispose(): void {
-		this._store.dispose();
+	override dispose(): void {
+		super.dispose();
 		this._models.forEach(model => model.dispose());
 	}
 }


### PR DESCRIPTION
We don't want outside callers to use `acquire` directly. Instead they should use `get` or `acquireExisting` or `acquireOrCreate`
