### PR TITLE
Fix welcome view sessions grid layout after item height change

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
@@ -168,31 +168,31 @@
  * Each pair forms a visual row.
  * Left column items need to move up by floor((index-1)/2) rows
  * Right column items need to move right and up by (index/2) rows
- * Row height is 44px.
+ * Row height is 54px (must match AgentSessionsListDelegate.ITEM_HEIGHT).
  */
 
 /* Left column items (odd positions): move up to form 2-column layout */
 /* Item 3: move up 1 row */
 .agentSessionsWelcome-sessionsGrid .monaco-list-row:nth-child(3) {
-	transform: translateY(-44px);
+	transform: translateY(-54px);
 }
 /* Item 5: move up 2 rows */
 .agentSessionsWelcome-sessionsGrid .monaco-list-row:nth-child(5) {
-	transform: translateY(-88px);
+	transform: translateY(-108px);
 }
 
 /* Right column items (even positions): move right and up */
 /* Item 2: move right, up 1 row */
 .agentSessionsWelcome-sessionsGrid .monaco-list-row:nth-child(2) {
-	transform: translateX(100%) translateY(-44px);
+	transform: translateX(100%) translateY(-54px);
 }
 /* Item 4: move right, up 2 rows */
 .agentSessionsWelcome-sessionsGrid .monaco-list-row:nth-child(4) {
-	transform: translateX(100%) translateY(-88px);
+	transform: translateX(100%) translateY(-108px);
 }
 /* Item 6: move right, up 3 rows */
 .agentSessionsWelcome-sessionsGrid .monaco-list-row:nth-child(6) {
-	transform: translateX(100%) translateY(-132px);
+	transform: translateX(100%) translateY(-162px);
 }
 
 /* Style individual session items in the welcome page */


### PR DESCRIPTION
The 2-column grid CSS transforms in the welcome page used hardcoded `44px` row heights for positioning session items, but `ITEM_HEIGHT` was changed to `54px` in #296560. This caused items to overlap or have gaps in the welcome view's session list.

Updated all transform values to match the new height:
- `-44px` → `-54px`
- `-88px` → `-108px` (2 × 54)
- `-132px` → `-162px` (3 × 54)