### PR TITLE
Remove checkmarks from chat-used-context-label, add hover chevron

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -81,8 +81,8 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
 
-		// Add hover chevron indicator on the right
-		const hoverChevron = $('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
+		// Add hover chevron indicator on the right (decorative, hide from screen readers)
+		const hoverChevron = $('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right', { 'aria-hidden': 'true' });
 		collapseButton.element.appendChild(hoverChevron);
 
 		if (this.hoverMessage) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -81,6 +81,10 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
 
+		// Add hover chevron indicator on the right
+		const hoverChevron = $('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
+		collapseButton.element.appendChild(hoverChevron);
+
 		if (this.hoverMessage) {
 			this._register(this.hoverService.setupDelayedHover(collapseButton.iconElement, {
 				content: this.hoverMessage,
@@ -98,7 +102,21 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 
 		this._register(autorun(r => {
 			const expanded = this._isExpanded.read(r);
-			collapseButton.icon = this._overrideIcon.read(r) ?? (expanded ? Codicon.chevronDown : Codicon.chevronRight);
+			const overrideIcon = this._overrideIcon.read(r);
+			const isErrorIcon = overrideIcon?.id === Codicon.error.id || overrideIcon?.id === Codicon.warning.id;
+
+			if (isErrorIcon && overrideIcon) {
+				collapseButton.icon = overrideIcon;
+				collapseButton.iconElement.style.display = '';
+			} else {
+				collapseButton.icon = Codicon.blank;
+				collapseButton.iconElement.style.display = 'none';
+			}
+
+			// Update hover chevron direction
+			hoverChevron.classList.toggle('codicon-chevron-right', !expanded);
+			hoverChevron.classList.toggle('codicon-chevron-down', expanded);
+
 			this._domNode?.classList.toggle('chat-used-context-collapsed', !expanded);
 			this.updateAriaLabel(collapseButton.element, typeof referencesLabel === 'string' ? referencesLabel : referencesLabel.value, expanded);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -123,6 +123,10 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		btn.element.classList.add('chat-confirmation-widget-title', 'monaco-text-button');
 		btn.labelElement.append(titleEl.root);
 
+		// Add hover chevron indicator on the right
+		const hoverChevron = dom.$('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
+		btn.element.appendChild(hoverChevron);
+
 		const check = dom.h(isError
 			? ThemeIcon.asCSSSelector(Codicon.error)
 			: output
@@ -137,15 +141,22 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			}));
 		}
 
+		// Only show leading icon for errors
+		if (isError) {
+			btn.icon = Codicon.error;
+		} else {
+			btn.icon = Codicon.blank;
+			btn.iconElement.style.display = 'none';
+		}
+
 		const expanded = this._expanded = observableValue(this, initiallyExpanded);
 		this._register(autorun(r => {
 			const value = expanded.read(r);
-			btn.icon = isError
-				? Codicon.error
-				: output
-					? Codicon.check
-					: ThemeIcon.modify(Codicon.loading, 'spin');
 			elements.root.classList.toggle('collapsed', !value);
+
+			// Update hover chevron direction
+			hoverChevron.classList.toggle('codicon-chevron-right', !value);
+			hoverChevron.classList.toggle('codicon-chevron-down', value);
 
 			// Lazy initialization: render content only when expanded for the first time
 			if (value && !this._contentInitialized) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -123,8 +123,9 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		btn.element.classList.add('chat-confirmation-widget-title', 'monaco-text-button');
 		btn.labelElement.append(titleEl.root);
 
-		// Add hover chevron indicator on the right
+		// Add hover chevron indicator on the right (decorative, hide from screen readers)
 		const hoverChevron = dom.$('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
+		hoverChevron.setAttribute('aria-hidden', 'true');
 		btn.element.appendChild(hoverChevron);
 
 		const check = dom.h(isError

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
@@ -11,7 +11,7 @@
 	display: flex;
 	align-items: center;
 	gap: 5px;
-	margin: 0 0 6px 4px;
+	margin: 0 0 6px 0px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	color: var(--vscode-descriptionForeground);
 
@@ -31,6 +31,10 @@
 			&::before {
 				font-size: var(--vscode-chat-font-size-body-s);
 			}
+		}
+
+		.codicon.codicon-check {
+			display: none;
 		}
 
 		.status-label {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -83,13 +83,6 @@
 }
 
 .chat-confirmation-widget .chat-confirmation-widget-title.monaco-button {
-	&:hover {
-		background: var(--vscode-toolbar-hoverBackground);
-	}
-
-	&:active {
-		background: var(--vscode-toolbar-activeBackground);
-	}
 
 	.monaco-button-mdlabel {
 		display: flex;
@@ -319,7 +312,7 @@
 	}
 
 	.chat-confirmation-widget-container .chat-confirmation-widget .chat-confirmation-widget-title {
-		padding: 2px 6px 2px 2px;
+		padding: 2px 6px 2px 0px;
 
 		&.monaco-button {
 
@@ -332,8 +325,20 @@
 			font-size: 12px;
 		}
 
-		&:hover {
-			background: var(--vscode-list-hoverBackground);
+		&:hover  {
+			p, .rendered-markdown {
+				color: var(--vscode-foreground);
+			}
+
+			.chat-collapsible-hover-chevron {
+				opacity: 1;
+			}
+		}
+	}
+
+	.chat-confirmation-widget:not(.collapsed) .chat-confirmation-widget-title {
+		p, .rendered-markdown {
+			color: var(--vscode-foreground);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatHookContentPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatHookContentPart.css
@@ -7,12 +7,6 @@
 	color: var(--vscode-notificationsWarningIcon-foreground) !important;
 }
 
-.chat-thinking-box .chat-used-context.chat-hook-outcome-blocked,
-.chat-thinking-box .chat-used-context.chat-hook-outcome-warning {
-	padding: 4px 12px 4px 22px;
-	margin-bottom: 0;
-}
-
 .chat-thinking-box .chat-used-context.chat-hook-outcome-blocked > .chat-used-context-label .codicon,
 .chat-thinking-box .chat-used-context.chat-hook-outcome-warning > .chat-used-context-label .codicon {
 	display: none;
@@ -41,4 +35,8 @@
 	border-top: 1px solid var(--vscode-chat-requestBorder, var(--vscode-editorWidget-border));
 	margin-top: 2px;
 	padding-top: 6px;
+}
+
+.chat-used-context.chat-hook-outcome-warning .chat-used-context-label .monaco-button {
+	gap: 4px;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -101,8 +101,28 @@
 
 			.chat-used-context {
 				margin-bottom: 0px;
-				margin-left: 2px;
+				margin-left: 4px;
 				padding-left: 2px;
+			}
+
+			.chat-used-context {
+				.monaco-button.monaco-text-button {
+					color: var(--vscode-descriptionForeground);
+
+					:hover {
+						color: var(--vscode-foreground);
+					}
+
+					.monaco-button:hover .chat-collapsible-hover-chevron {
+						opacity: 1;
+					}
+				}
+			}
+
+			.chat-used-context:not(.chat-used-context-collapsed) {
+				.monaco-button.monaco-text-button {
+					color: var(--vscode-foreground);
+				}
 			}
 
 			.progress-container,
@@ -112,6 +132,10 @@
 
 			.codicon:not(.chat-thinking-icon) {
 				display: none;
+			}
+
+			.chat-collapsible-hover-chevron.codicon {
+				display: inline-flex;
 			}
 
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -98,46 +98,53 @@
 		.chat-tool-invocation-part {
 			padding: 4px 12px 4px 18px;
 			position: relative;
+		}
 
+		.chat-thinking-tool-wrapper {
 			.chat-used-context {
-				margin-bottom: 0px;
-				margin-left: 4px;
-				padding-left: 2px;
-			}
+					margin-bottom: 0px;
+					margin-left: 4px;
+					padding-left: 2px;
+				}
 
-			.chat-used-context {
-				.monaco-button.monaco-text-button {
-					color: var(--vscode-descriptionForeground);
+				.chat-used-context {
+					.monaco-button.monaco-text-button {
+						color: var(--vscode-descriptionForeground);
 
-					:hover {
+						:hover {
+							color: var(--vscode-foreground);
+						}
+
+						.monaco-button:hover .chat-collapsible-hover-chevron {
+							opacity: 1;
+						}
+					}
+				}
+
+				.chat-used-context:not(.chat-used-context-collapsed) {
+					.monaco-button.monaco-text-button {
 						color: var(--vscode-foreground);
 					}
-
-					.monaco-button:hover .chat-collapsible-hover-chevron {
-						opacity: 1;
-					}
 				}
-			}
 
-			.chat-used-context:not(.chat-used-context-collapsed) {
-				.monaco-button.monaco-text-button {
-					color: var(--vscode-foreground);
+				.progress-container,
+				.chat-confirmation-widget-container {
+					margin: 0 0 2px 6px;
 				}
-			}
 
-			.progress-container,
-			.chat-confirmation-widget-container {
-				margin: 0 0 2px 6px;
-			}
+				.codicon:not(.chat-thinking-icon) {
+					display: none;
+				}
 
-			.codicon:not(.chat-thinking-icon) {
-				display: none;
-			}
+				.chat-collapsible-hover-chevron.codicon {
+					display: inline-flex;
+				}
 
-			.chat-collapsible-hover-chevron.codicon {
-				display: inline-flex;
-			}
-
+			.chat-used-context.chat-hook-outcome-blocked,
+			.chat-used-context.chat-hook-outcome-warning {
+					padding: 4px 12px 4px 20px;
+					margin-bottom: 0;
+				}
 		}
 
 		.chat-thinking-item.markdown-content {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2154,7 +2154,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: fit-content;
 	border: none;
 	border-radius: 4px;
-	gap: 4px;
+	gap: 0;
 	text-align: initial;
 	justify-content: initial;
 }
@@ -2170,6 +2170,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .chat-used-context-label .monaco-button {
 	padding: 2px 6px 2px 2px;
+	margin-left: -2px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	line-height: unset;
 }
@@ -2178,10 +2179,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
+.interactive-session .chat-used-context:not(.chat-used-context-collapsed) .chat-used-context-label .monaco-button,
 .interactive-session .chat-used-context-label .monaco-button:hover {
-	background-color: var(--vscode-list-hoverBackground);
 	color: var(--vscode-foreground);
-
 }
 
 .interactive-session .chat-file-changes-label .monaco-text-button:focus,
@@ -2198,6 +2198,22 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-used-context-label .monaco-button .codicon {
 	font-size: 12px;
 	color: var(--vscode-icon-foreground) !important;
+}
+
+/* Hover chevron indicator for collapsible parts */
+.chat-collapsible-hover-chevron {
+	font-size: 12px;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+	color: var(--vscode-descriptionForeground);
+}
+
+.chat-collapsible-hover-chevron.codicon-chevron-down {
+	opacity: 1;
+}
+
+.interactive-session .chat-used-context-label .monaco-button:hover .chat-collapsible-hover-chevron {
+	opacity: 1;
 }
 
 .interactive-item-container .progress-container {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2220,7 +2220,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: flex;
 	align-items: center;
 	gap: 4px;
-	margin: 0 0 6px 2px;
+	margin: 0 0 6px 0;
 	font-size: 13px;
 
 	/* Tool calls transition from a progress to a collapsible list part, which needs to have this top padding.

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2235,6 +2235,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 		}
 	}
 
+	> .codicon.codicon-check {
+		display: none;
+	}
+
 	.codicon {
 		/* Very aggressive list styles try to apply focus colors to every codicon in a list row. */
 		color: var(--vscode-icon-foreground) !important;

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
@@ -274,7 +274,7 @@ suite('ChatSubagentContentPart', () => {
 	}
 
 	function getCollapseButtonLabel(button: HTMLElement): HTMLElement | undefined {
-		const label = button.lastElementChild;
+		const label = button.querySelector('.monaco-button-mdlabel');
 		return isHTMLElement(label) ? label : undefined;
 	}
 


### PR DESCRIPTION
Remove checkmark icons from `chat-used-context-label` elements and replace with a hover chevron indicator that points down when expanded.

Changes:
- **chatCollapsibleContentPart.ts**: Hide leading icon unless it's an error/warning; add hover chevron element that toggles direction on expand/collapse
- **chatToolInputOutputContentPart.ts**: Same treatment — only show error icon, hide checkmark/loading; add hover chevron
- **chat.css**: Adjust `gap` to 0, add `margin-left: -2px` to compensate for removed icon, update hover styles, add `.chat-collapsible-hover-chevron` CSS rules (hidden by default, visible on hover or when expanded)