### PR TITLE
Fix welcome sessions list scrolling and archived session flicker

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -554,6 +554,7 @@ export class AgentSessionsWelcomePage extends EditorPane {
 			}),
 			filter: this.sessionsControlDisposables.add(this.instantiationService.createInstance(AgentSessionsFilter, {
 				limitResults: () => MAX_SESSIONS,
+				overrideExclude: (session) => session.isArchived() ? true : undefined,
 			})),
 			getHoverPosition: () => HoverPosition.BELOW,
 			trackActiveEditorSession: () => false,


### PR DESCRIPTION
## Problem
The welcome view sessions list allows scrolling even when there are only 1-2 items, and archived sessions flicker in when scrolling.

## Root Cause
The container height in `layoutSessionsControl()` is calculated based on non-archived sessions, but the `AgentSessionsFilter` doesn't exclude archived sessions from the tree data source (it only does so when `groupResults` is set to `Capped`, which the welcome view doesn't use). This mismatch means the tree renders more items than the container is sized for, causing unwanted scrolling and archived session flicker.

## Fix
Add `overrideExclude` to the filter options to exclude archived sessions from the tree data, matching the height calculation.