### PR TITLE
#296641 Removing required timeout property as it's optional

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -247,7 +247,6 @@ export async function createRunInTerminalToolData(
 				'explanation',
 				'goal',
 				'isBackground',
-				'timeout',
 			]
 		}
 	};


### PR DESCRIPTION
This PR fixes an issue where timeout property in runInTerminalTool was considering required but it's not (https://github.com/microsoft/vscode/issues/296641).

Changes:

Updated the inputSchema in the returned object of createRunInTerminalToolData()