### PR TITLE
Normalize end of line cursor move operation

### DIFF
--- a/src/vs/editor/common/cursor/cursorMoveOperations.ts
+++ b/src/vs/editor/common/cursor/cursorMoveOperations.ts
@@ -114,7 +114,7 @@ export class MoveOperations {
 			lineNumber = lineNumber + 1;
 			column = model.getLineMinColumn(lineNumber);
 		}
-		return new Position(lineNumber, column);
+		return model.normalizePosition(new Position(lineNumber, column), PositionAffinity.Right);
 	}
 
 	public static rightPositionAtomicSoftTabs(model: ICursorSimpleModel, lineNumber: number, column: number, tabSize: number, indentSize: number): Position {


### PR DESCRIPTION
When a line is wrapped, there are two view model positions that represent the same text model position. To illustrate, say we have the line `text edit`. We can represent it like this, where `|` represents the cursor position.

```
   0 1 2 3 4 5 6 7 8 9
1.  t e x t ·|e d i t
```

If we break it in the view model, it looks like this:

```
   0 1 2 3 4 5 6 7 8 9
1.  t e x t ·|
2. |e d i t
```

Both positions 1.5 and 2.0 represent the same text position. I did some testing on cursor behaviour, and found inconsistent behaviour across several editors:
- Some editors split words if necessary, others only split on whitespace.
- Some editors render the space on which the line is split, others don’t.
- When pressing <kbd>End</kbd> from position 0.0, some editors move the cursor to 1.4, others to 1.5.

However, one specific thing is consistent across all editors I tried: If the cursor is at position 1.4, and you press the right arrow key, all editors move the cursor to position 2.0. I found this behaviour regardless of whether the line is split on whitespace or something else. Only Monaco moves the cursor to position 1.5.

This change makes Monaco behaviour consistent with other editors. I recorded two videos, one before, and one after, where I move the cursor to a line, and slowly keep pressing the right arrow key.

Before:

[simplescreenrecorder-2026-02-21_11.08.11.webm](https://github.com/user-attachments/assets/3267bde8-2c09-420c-a0aa-b6f8b89ee020)

After:

[simplescreenrecorder-2026-02-21_11.07.26.webm](https://github.com/user-attachments/assets/4611bbb3-9151-47ad-a5f8-c19a445fbcf1)
