### PR TITLE
markdown-language-features: enhance document link handling with improved URI parsing and selection

### DIFF
--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -28,7 +28,20 @@ export class MdLinkOpener {
 			return;
 		}
 
-		const uri = vscode.Uri.from(resolved.uri);
+		let uri = vscode.Uri.from(resolved.uri);
+		let rangeSelection: vscode.Range | undefined;
+		if (resolved.kind === 'file' && !resolved.position) {
+			if (uri.fragment) {
+				rangeSelection = getSelectionFromLocationFragment(uri.fragment);
+			} else {
+				const locationFragment = getLocationFragmentFromLinkText(linkText);
+				if (locationFragment) {
+					uri = uri.with({ fragment: locationFragment });
+					rangeSelection = getSelectionFromLocationFragment(locationFragment);
+				}
+			}
+		}
+
 		switch (resolved.kind) {
 			case 'external':
 				return vscode.commands.executeCommand('vscode.open', uri);
@@ -50,12 +63,55 @@ export class MdLinkOpener {
 				}
 
 				return vscode.commands.executeCommand('vscode.open', uri, {
-					selection: resolved.position ? new vscode.Range(resolved.position.line, resolved.position.character, resolved.position.line, resolved.position.character) : undefined,
+					selection: resolved.position
+						? new vscode.Range(resolved.position.line, resolved.position.character, resolved.position.line, resolved.position.character)
+						: rangeSelection,
 					viewColumn: viewColumn ?? getViewColumn(fromResource),
 				} satisfies vscode.TextDocumentShowOptions);
 			}
 		}
 	}
+}
+
+function getSelectionFromLocationFragment(fragment: string): vscode.Range | undefined {
+	const match = /^L?(\d+)(?:,(\d+))?(?:-L?(\d+)(?:,(\d+))?)?$/i.exec(fragment);
+	if (!match) {
+		return undefined;
+	}
+
+	const startLineNumber = parseInt(match[1], 10);
+	if (isNaN(startLineNumber)) {
+		return undefined;
+	}
+
+	const startColumn = match[2] ? parseInt(match[2], 10) : 1;
+	const endLineNumber = match[3] ? parseInt(match[3], 10) : undefined;
+	const endColumn = match[3] ? (match[4] ? parseInt(match[4], 10) : 1) : undefined;
+
+	const start = new vscode.Position(startLineNumber - 1, Math.max(0, startColumn - 1));
+	const end = endLineNumber
+		? new vscode.Position(endLineNumber - 1, Math.max(0, (endColumn ?? 1) - 1))
+		: start;
+
+	return new vscode.Range(start, end);
+}
+
+function getLocationFragmentFromLinkText(linkText: string): string | undefined {
+	const fragmentStart = linkText.indexOf('#');
+	if (fragmentStart < 0) {
+		return undefined;
+	}
+
+	const fragment = decodeURIComponent(linkText.slice(fragmentStart + 1));
+	if (!fragment) {
+		return undefined;
+	}
+
+	if (/^L?\d+(?:,\d+)?(?:-L?\d+(?:,\d+)?)?$/i.test(fragment)) {
+		return fragment;
+	}
+
+	return undefined;
 }
 
 function getViewColumn(resource: vscode.Uri): vscode.ViewColumn {

--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -80,12 +80,16 @@ function getSelectionFromLocationFragment(fragment: string): vscode.Range | unde
 	}
 
 	const startLineNumber = parseInt(match[1], 10);
-	if (isNaN(startLineNumber)) {
+	if (isNaN(startLineNumber) || startLineNumber <= 0) {
 		return undefined;
 	}
 
 	const startColumn = match[2] ? parseInt(match[2], 10) : 1;
-	const endLineNumber = match[3] ? parseInt(match[3], 10) : undefined;
+	const endLineNumberRaw = match[3] ? parseInt(match[3], 10) : undefined;
+	if (typeof endLineNumberRaw !== 'undefined' && endLineNumberRaw <= 0) {
+		return undefined;
+	}
+	const endLineNumber = endLineNumberRaw;
 	const endColumn = match[3] ? (match[4] ? parseInt(match[4], 10) : 1) : undefined;
 
 	const start = new vscode.Position(startLineNumber - 1, Math.max(0, startColumn - 1));

--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -106,7 +106,12 @@ function getLocationFragmentFromLinkText(linkText: string): string | undefined {
 		return undefined;
 	}
 
-	const fragment = decodeURIComponent(linkText.slice(fragmentStart + 1));
+	let fragment: string;
+	try {
+		fragment = decodeURIComponent(linkText.slice(fragmentStart + 1));
+	} catch {
+		return undefined;
+	}
 	if (!fragment) {
 		return undefined;
 	}

--- a/extensions/markdown-language-features/src/util/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/util/openDocumentLink.ts
@@ -92,9 +92,25 @@ function getSelectionFromLocationFragment(fragment: string): vscode.Range | unde
 	const endLineNumber = endLineNumberRaw;
 	const endColumn = match[3] ? (match[4] ? parseInt(match[4], 10) : 1) : undefined;
 
-	const start = new vscode.Position(startLineNumber - 1, Math.max(0, startColumn - 1));
-	const end = endLineNumber
-		? new vscode.Position(endLineNumber - 1, Math.max(0, (endColumn ?? 1) - 1))
+	let normalizedStartLine = startLineNumber;
+	let normalizedStartColumn = startColumn;
+	let normalizedEndLine = endLineNumber;
+	let normalizedEndColumn = endColumn ?? 1;
+
+	if (typeof normalizedEndLine === 'number') {
+		if (normalizedEndLine < normalizedStartLine || (normalizedEndLine === normalizedStartLine && normalizedEndColumn < normalizedStartColumn)) {
+			const tmpLine = normalizedStartLine;
+			const tmpColumn = normalizedStartColumn;
+			normalizedStartLine = normalizedEndLine;
+			normalizedStartColumn = normalizedEndColumn;
+			normalizedEndLine = tmpLine;
+			normalizedEndColumn = tmpColumn;
+		}
+	}
+
+	const start = new vscode.Position(normalizedStartLine - 1, Math.max(0, normalizedStartColumn - 1));
+	const end = typeof normalizedEndLine === 'number'
+		? new vscode.Position(normalizedEndLine - 1, Math.max(0, normalizedEndColumn - 1))
 		: start;
 
 	return new vscode.Range(start, end);


### PR DESCRIPTION
markdown-language-features: enhance document link handling with improved URI parsing and selection. Fix #288317

Added support for `./src/main.ts#L100-L110` style links. Since LSP  does not appear to support ranges, this needs to be handled on the VS Code side, not on vscode-markdown-languageservice.

This style links are now universal since we tell LLMs to write such links in markdown files.
