### PR TITLE
style(focus): avoid two spaces with "Focus on {view} View" when no view name is specified

### DIFF
--- a/src/vs/workbench/services/views/browser/viewsService.ts
+++ b/src/vs/workbench/services/views/browser/viewsService.ts
@@ -557,7 +557,9 @@ export class ViewsService extends Disposable implements IViewsService {
 	private registerFocusViewAction(viewDescriptor: IViewDescriptor, category?: string | ILocalizedString): IDisposable {
 		return registerAction2(class FocusViewAction extends Action2 {
 			constructor() {
-				const title = localize2({ key: 'focus view', comment: ['{0} indicates the name of the view to be focused.'] }, "Focus on {0} View", viewDescriptor.name.value);
+				const title = viewDescriptor.name.value ?
+					localize2({ key: 'focus view', comment: ['{0} indicates the name of the view to be focused.'] }, "Focus on {0} View", viewDescriptor.name.value) :
+					localize2({ key: 'focus view', comment: [] }, "Focus on View");
 				super({
 					id: viewDescriptor.focusCommand ? viewDescriptor.focusCommand.id : `${viewDescriptor.id}.focus`,
 					title,


### PR DESCRIPTION
Hi Team 👋

A small pull request to not have two spaces when a viewDescriptor doesn't have a name. Might happen with extensions when the view "namespace" itself is self-sufficient (and to avoid duplication):

`<Namespace>: Focus on <Namespace> View`.

Some examples (it's not bad but some extensions might choose to avoid this duplication):

`Ports: Focus on Ports View`.
`Chat: Focus on Chat View`.
`Output: Focus on Output View`.
`Problems: Focus on Problems View`.
