### PR TITLE
Add diagnostics support to inline chat and related actions

### DIFF
--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -93,4 +93,5 @@ export namespace EditorContextKeys {
 	export const hasMultipleDocumentFormattingProvider = new RawContextKey<boolean>('editorHasMultipleDocumentFormattingProvider', false, nls.localize('editorHasMultipleDocumentFormattingProvider', "Whether the editor has multiple document formatting providers"));
 	export const hasMultipleDocumentSelectionFormattingProvider = new RawContextKey<boolean>('editorHasMultipleDocumentSelectionFormattingProvider', false, nls.localize('editorHasMultipleDocumentSelectionFormattingProvider', "Whether the editor has multiple document selection formatting providers"));
 
+	export const selectionHasDiagnostics = new RawContextKey<boolean>('editorSelectionHasDiagnostics', false, nls.localize('editorSelectionHasDiagnostics', "Whether any diagnostic is present in the current editor selection"));
 }

--- a/src/vs/editor/contrib/gotoError/browser/markerSelectionStatus.ts
+++ b/src/vs/editor/contrib/gotoError/browser/markerSelectionStatus.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { ICodeEditor } from '../../../browser/editorBrowser.js';
+import { EditorContributionInstantiation, registerEditorContribution } from '../../../browser/editorExtensions.js';
+import { Range } from '../../../common/core/range.js';
+import { IEditorContribution } from '../../../common/editorCommon.js';
+import { EditorContextKeys } from '../../../common/editorContextKeys.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IMarkerService, MarkerSeverity } from '../../../../platform/markers/common/markers.js';
+
+class MarkerSelectionStatus extends Disposable implements IEditorContribution {
+
+	static readonly ID = 'editor.contrib.markerSelectionStatus';
+
+	private readonly _ctxHasDiagnostics: IContextKey<boolean>;
+
+	constructor(
+		private readonly _editor: ICodeEditor,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IMarkerService private readonly _markerService: IMarkerService,
+	) {
+		super();
+
+		this._ctxHasDiagnostics = EditorContextKeys.selectionHasDiagnostics.bindTo(contextKeyService);
+
+		this._store.add(this._editor.onDidChangeCursorSelection(() => this._update()));
+		this._store.add(this._editor.onDidChangeModel(() => this._update()));
+		this._store.add(this._markerService.onMarkerChanged(e => {
+			const model = this._editor.getModel();
+			if (model && e.some(uri => isEqual(uri, model.uri))) {
+				this._update();
+			}
+		}));
+
+		this._update();
+	}
+
+	override dispose(): void {
+		this._ctxHasDiagnostics.reset();
+		super.dispose();
+	}
+
+	private _update(): void {
+		const model = this._editor.getModel();
+		const selection = this._editor.getSelection();
+		if (!model || !selection) {
+			this._ctxHasDiagnostics.reset();
+			return;
+		}
+
+		const markers = this._markerService.read({
+			resource: model.uri,
+			severities: MarkerSeverity.Error | MarkerSeverity.Warning | MarkerSeverity.Info
+		});
+
+		const hasIntersecting = markers.some(marker => Range.areIntersecting(
+			{ startLineNumber: marker.startLineNumber, startColumn: marker.startColumn, endLineNumber: marker.endLineNumber, endColumn: marker.endColumn },
+			selection
+		));
+
+		this._ctxHasDiagnostics.set(hasIntersecting);
+	}
+}
+
+registerEditorContribution(MarkerSelectionStatus.ID, MarkerSelectionStatus, EditorContributionInstantiation.AfterFirstRender);

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -30,6 +30,7 @@ import './contrib/inlineProgress/browser/inlineProgress.js';
 import './contrib/gotoSymbol/browser/goToCommands.js';
 import './contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.js';
 import './contrib/gotoError/browser/gotoError.js';
+import './contrib/gotoError/browser/markerSelectionStatus.js';
 import './contrib/gpu/browser/gpuActions.js';
 import './contrib/hover/browser/hoverContribution.js';
 import './contrib/indentation/browser/indentation.js';
@@ -70,4 +71,3 @@ import './contrib/floatingMenu/browser/floatingMenu.contribution.js';
 import './common/standaloneStrings.js';
 
 import '../base/browser/ui/codicons/codiconStyles.js'; // The codicons are defined here and must be loaded
-

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -94,6 +94,7 @@ registerAction2(InlineChatActions.FocusInlineChat);
 registerAction2(InlineChatActions.SubmitInlineChatInputAction);
 registerAction2(InlineChatActions.QueueInChatAction);
 registerAction2(InlineChatActions.HideInlineChatInputAction);
+registerAction2(InlineChatActions.FixDiagnosticsAction);
 
 
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatEditorAffordance.ts
@@ -173,7 +173,7 @@ export class InlineChatEditorAffordance extends Disposable implements IContentWi
 				if (action instanceof MenuItemAction && action.id === quickFixCommandId) {
 					return instantiationService.createInstance(QuickFixActionViewItem, action, this._editor);
 				}
-				if (action instanceof MenuItemAction && (action.id === ACTION_START || action.id === ACTION_ASK_IN_CHAT)) {
+				if (action instanceof MenuItemAction && (action.id === ACTION_START || action.id === ACTION_ASK_IN_CHAT || action.id === 'inlineChat.fixDiagnostics')) {
 					return instantiationService.createInstance(LabelWithKeybindingActionViewItem, action);
 				}
 				return undefined;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
@@ -225,9 +225,14 @@ export class InlineChatInputWidget extends Disposable {
 		}));
 
 		// ArrowUp on first action bar item moves focus back to input editor
+		// Escape on action bar hides the widget
 		this._store.add(dom.addDisposableListener(actionBar.domNode, 'keydown', (e: KeyboardEvent) => {
 			const event = new StandardKeyboardEvent(e);
-			if (event.keyCode === KeyCode.UpArrow) {
+			if (event.keyCode === KeyCode.Escape) {
+				event.preventDefault();
+				event.stopPropagation();
+				this.hide();
+			} else if (event.keyCode === KeyCode.UpArrow) {
 				const firstItem = actionBar.viewItems[0] as BaseActionViewItem | undefined;
 				if (firstItem?.element && dom.isAncestorOfActiveElement(firstItem.element)) {
 					event.preventDefault();

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -22,6 +22,7 @@ export const enum InlineChatConfigKeys {
 	DefaultModel = 'inlineChat.defaultModel',
 	Affordance = 'inlineChat.affordance',
 	RenderMode = 'inlineChat.renderMode',
+	FixDiagnostics = 'inlineChat.fixDiagnostics',
 }
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
@@ -83,6 +84,15 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				mode: 'auto'
 			},
 			tags: ['experimental']
+		},
+		[InlineChatConfigKeys.FixDiagnostics]: {
+			description: localize('fixDiagnostics', "Controls whether the Fix action is shown for diagnostics in the editor."),
+			default: false,
+			type: 'boolean',
+			experiment: {
+				mode: 'auto'
+			},
+			tags: ['experimental']
 		}
 	}
 });
@@ -130,6 +140,7 @@ export const CTX_INLINE_CHAT_V2_ENABLED = ContextKeyExpr.or(
 );
 
 export const CTX_HOVER_MODE = ContextKeyExpr.equals('config.inlineChat.renderMode', 'hover');
+export const CTX_FIX_DIAGNOSTICS_ENABLED = ContextKeyExpr.equals('config.inlineChat.fixDiagnostics', true);
 
 // --- (selected) action identifier
 


### PR DESCRIPTION
- Introduce `selectionHasDiagnostics` context key to track diagnostics in the editor selection.
- Implement `FixDiagnosticsAction` to allow users to fix diagnostics directly from inline chat.
- Enhance `InlineChatController` to optionally attach diagnostics to chat requests.
- Update inline chat configuration to include `FixDiagnostics` setting.
- Register new action in the inline chat affordance for fixing diagnostics.