### PR TITLE
Reinstate bottom border from chat tip widget for improved styling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTipContent.css
@@ -67,7 +67,6 @@
 	background-color: var(--vscode-editorWidget-background);
 	border-radius: var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0 0;
 	border: 1px solid var(--vscode-editorWidget-border, var(--vscode-input-border, transparent));
-	border-bottom: none;
 	font-size: var(--vscode-chat-font-size-body-s);
 	font-family: var(--vscode-chat-font-family, inherit);
 	color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
Add back in the bottom border of the chat tip container to improve visual consistency.