### PR TITLE
Revert "Raise keybinding precedence for chat question carousel and confirmation focus actions"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions.ts
@@ -31,7 +31,7 @@ class AnnounceChatConfirmationAction extends Action2 {
 			precondition: ChatContextKeys.enabled,
 			f1: true,
 			keybinding: {
-				weight: KeybindingWeight.ExternalExtension + 1,
+				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyA | KeyMod.Shift,
 				when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, ChatContextKeys.Editing.hasQuestionCarousel.negate())
 			}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -894,7 +894,7 @@ export function registerChatActions() {
 				f1: true,
 				precondition: ChatContextKeys.inChatSession,
 				keybinding: [{
-					weight: KeybindingWeight.ExternalExtension + 1,
+					weight: KeybindingWeight.WorkbenchContrib,
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
 					when: ContextKeyExpr.and(ChatContextKeys.inChatSession, ChatContextKeys.Editing.hasQuestionCarousel),
 				}]


### PR DESCRIPTION
Reverts microsoft/vscode#296616

