### PR TITLE
scm: allow higher diff decoration gutter widths

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
@@ -28,6 +28,16 @@ import { registerAction2, Action2, MenuId } from '../../../../platform/actions/c
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 
 export const quickDiffDecorationCount = new RawContextKey<number>('quickDiffDecorationCount', 0);
+const DEFAULT_DIFF_DECORATIONS_GUTTER_WIDTH = 3;
+const MAX_DIFF_DECORATIONS_GUTTER_WIDTH = 20;
+
+export function normalizeDiffDecorationsGutterWidth(width: number): number {
+	if (isNaN(width) || width <= 0 || width > MAX_DIFF_DECORATIONS_GUTTER_WIDTH) {
+		return DEFAULT_DIFF_DECORATIONS_GUTTER_WIDTH;
+	}
+
+	return width;
+}
 
 class QuickDiffDecorator extends Disposable {
 
@@ -272,12 +282,7 @@ export class QuickDiffWorkbenchController extends Disposable implements IWorkben
 	}
 
 	private onDidChangeDiffWidthConfiguration(): void {
-		let width = this.configurationService.getValue<number>('scm.diffDecorationsGutterWidth');
-
-		if (isNaN(width) || width <= 0 || width > 5) {
-			width = 3;
-		}
-
+		const width = normalizeDiffDecorationsGutterWidth(this.configurationService.getValue<number>('scm.diffDecorationsGutterWidth'));
 		this.setViewState({ ...this.viewState, width });
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
@@ -32,7 +32,7 @@ const DEFAULT_DIFF_DECORATIONS_GUTTER_WIDTH = 3;
 const MAX_DIFF_DECORATIONS_GUTTER_WIDTH = 20;
 
 export function normalizeDiffDecorationsGutterWidth(width: number): number {
-	if (isNaN(width) || width <= 0 || width > MAX_DIFF_DECORATIONS_GUTTER_WIDTH) {
+	if (!Number.isInteger(width) || width <= 0 || width > MAX_DIFF_DECORATIONS_GUTTER_WIDTH) {
 		return DEFAULT_DIFF_DECORATIONS_GUTTER_WIDTH;
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -197,7 +197,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('diffDecorations', "Controls diff decorations in the editor.")
 		},
 		'scm.diffDecorationsGutterWidth': {
-			type: 'number',
+			type: 'integer',
 			minimum: 1,
 			maximum: 20,
 			default: 3,

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -198,7 +198,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.diffDecorationsGutterWidth': {
 			type: 'number',
-			enum: [1, 2, 3, 4, 5],
+			minimum: 1,
+			maximum: 20,
 			default: 3,
 			description: localize('diffGutterWidth', "Controls the width(px) of diff decorations in gutter (added & modified).")
 		},

--- a/src/vs/workbench/contrib/scm/test/browser/quickDiffDecorator.test.ts
+++ b/src/vs/workbench/contrib/scm/test/browser/quickDiffDecorator.test.ts
@@ -16,6 +16,7 @@ suite('normalizeDiffDecorationsGutterWidth', () => {
 	test('falls back for invalid values', () => {
 		assert.strictEqual(normalizeDiffDecorationsGutterWidth(0), 3);
 		assert.strictEqual(normalizeDiffDecorationsGutterWidth(-1), 3);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(1.5), 3);
 		assert.strictEqual(normalizeDiffDecorationsGutterWidth(21), 3);
 		assert.strictEqual(normalizeDiffDecorationsGutterWidth(Number.NaN), 3);
 	});

--- a/src/vs/workbench/contrib/scm/test/browser/quickDiffDecorator.test.ts
+++ b/src/vs/workbench/contrib/scm/test/browser/quickDiffDecorator.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { normalizeDiffDecorationsGutterWidth } from '../../browser/quickDiffDecorator.js';
+
+suite('normalizeDiffDecorationsGutterWidth', () => {
+	test('returns input for valid values', () => {
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(1), 1);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(3), 3);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(20), 20);
+	});
+
+	test('falls back for invalid values', () => {
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(0), 3);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(-1), 3);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(21), 3);
+		assert.strictEqual(normalizeDiffDecorationsGutterWidth(Number.NaN), 3);
+	});
+});


### PR DESCRIPTION
Fixes #278083

This updates `scm.diffDecorationsGutterWidth` to allow larger values in settings while keeping runtime validation centralized.

## What changed

- Changed setting schema from a fixed enum (`1..5`) to a numeric range (`minimum: 1`, `maximum: 20`).
- Added `normalizeDiffDecorationsGutterWidth()` in quick diff logic.
- Updated the quick diff controller to use the normalization helper.
- Added unit tests for valid and invalid width values.

## Files

- `src/vs/workbench/contrib/scm/browser/scm.contribution.ts`
- `src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts`
- `src/vs/workbench/contrib/scm/test/browser/quickDiffDecorator.test.ts`