### PR TITLE
Align expanded chat entry border-radius with cornerRadius-medium

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -5,7 +5,7 @@
 
 .chat-confirmation-widget {
 	border: none;
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
@@ -124,7 +124,7 @@
 
 .chat-confirmation-widget .chat-confirmation-widget-message-container {
 	border: 1px solid var(--vscode-chat-requestBorder);
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 	font-size: var(--vscode-chat-font-size-body-s);
 }
 
@@ -305,7 +305,7 @@
 		.chat-confirmation-widget-message {
 			margin: 2px 0 0 0;
 			border: 1px solid var(--vscode-chat-requestBorder);
-			border-radius: 4px;
+			border-radius: var(--vscode-cornerRadius-medium);
 			font-size: var(--vscode-chat-font-size-body-s);
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatTerminalToolProgressPart.css
@@ -10,7 +10,7 @@
 
 .chat-terminal-content-part .chat-terminal-content-title {
 	border: 1px solid var(--vscode-chat-requestBorder);
-	border-radius: 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 	padding: 0px 9px 0px 5px;
 	max-width: 100%;
 	box-sizing: border-box;
@@ -135,8 +135,8 @@
 .chat-terminal-output-container.collapsed { display: none; }
 .chat-terminal-output-container {
 	border: 1px solid var(--vscode-chat-requestBorder);
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
+	border-bottom-left-radius: var(--vscode-cornerRadius-medium);
+	border-bottom-right-radius: var(--vscode-cornerRadius-medium);
 	max-height: 300px;
 	box-sizing: border-box;
 	overflow: hidden;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -90,7 +90,7 @@
 
 	.chat-used-context-list.chat-thinking-collapsible {
 		border: 1px solid var(--vscode-chat-requestBorder);
-		border-radius: 4px;
+		border-radius: var(--vscode-cornerRadius-medium);
 		margin-bottom: 0;
 		position: relative;
 		overflow: hidden;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -558,7 +558,7 @@
 
 	.tool-output-part {
 		border: 1px solid var(--vscode-widget-border);
-		border-radius: 6px;
+		border-radius: var(--vscode-cornerRadius-medium);
 		background: var(--vscode-editor-background);
 		margin: 4px 0;
 		overflow: hidden;


### PR DESCRIPTION
Replace hardcoded `4px`/`6px` border-radius values in expanded chat entries with `var(--vscode-cornerRadius-medium)` to align with codeblocks, markdown tables, and `chat-confirmation-widget2`.

### Changes

| Component | File | Before | After |
|---|---|---|---|
| Thinking collapsible list | `chatThinkingContent.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Terminal content title | `chatTerminalToolProgressPart.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Terminal output container | `chatTerminalToolProgressPart.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Confirmation widget | `chatConfirmationWidget.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Confirmation message container | `chatConfirmationWidget.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Confirmation message (tool invocation) | `chatConfirmationWidget.css` | `4px` | `var(--vscode-cornerRadius-medium)` |
| Tool output part | `chat.css` | `6px` | `var(--vscode-cornerRadius-medium)` |