### PR TITLE
Fix hidden `+` button in inline chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -476,10 +476,7 @@ export class AttachContextAction extends Action2 {
 			menu: [{
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inQuickChat.negate(),
-					ContextKeyExpr.or(
-						ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
-						ContextKeyExpr.and(ChatContextKeys.location.isEqualTo(ChatAgentLocation.EditorInline), CTX_INLINE_CHAT_V2_ENABLED)
-					),
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 					ContextKeyExpr.or(
 						ChatContextKeys.lockedToCodingAgent.negate(),
 						ChatContextKeys.agentSupportsAttachments
@@ -488,6 +485,19 @@ export class AttachContextAction extends Action2 {
 				id: MenuId.ChatInput,
 				group: 'navigation',
 				order: 101
+			}, {
+				when: ContextKeyExpr.and(
+					ChatContextKeys.inQuickChat.negate(),
+					ChatContextKeys.location.isEqualTo(ChatAgentLocation.EditorInline),
+					CTX_INLINE_CHAT_V2_ENABLED,
+					ContextKeyExpr.or(
+						ChatContextKeys.lockedToCodingAgent.negate(),
+						ChatContextKeys.agentSupportsAttachments
+					)
+				),
+				id: MenuId.ChatInput,
+				group: 'navigation',
+				order: 2
 			}, {
 				when: ContextKeyExpr.and(
 					ChatContextKeys.inQuickChat,


### PR DESCRIPTION
The `+` (Add Context) button in inline chat was being pushed into the overflow `...` menu because it shared `order: 101` with the sidebar chat registration. Since the inline chat toolbar is narrow and uses responsive behavior that hides items from the right, the `+` button — being the highest-ordered item — was hidden first.

**Fix:** Split the `AttachContextAction` menu registration into separate entries for Chat sidebar (`order: 101`, unchanged) and EditorInline (`order: 2`), so the `+` button appears before the model picker and tools actions in inline chat and stays visible.

Fixes https://github.com/microsoft/vscode/issues/297051