### PR TITLE
sessions - more predictable sessions sorting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -170,5 +170,5 @@ export const AGENT_SESSION_RENAME_ACTION_ID = 'agentSession.rename';
 export const AGENT_SESSION_DELETE_ACTION_ID = 'agentSession.delete';
 
 export function getAgentSessionTime(timing: IChatSessionTiming): number {
-	return timing.lastRequestEnded ?? timing.lastRequestStarted ?? timing.created;
+	return timing.lastRequestStarted ?? timing.created;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -20,16 +20,16 @@ suite('getAgentSessionTime', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('returns lastRequestEnded when available', () => {
+	test('returns lastRequestStarted when available', () => {
 		const timing: IChatSessionTiming = {
 			created: 1000,
 			lastRequestStarted: 2000,
 			lastRequestEnded: 3000,
 		};
-		assert.strictEqual(getAgentSessionTime(timing), 3000);
+		assert.strictEqual(getAgentSessionTime(timing), 2000);
 	});
 
-	test('returns lastRequestStarted when lastRequestEnded is undefined', () => {
+	test('returns lastRequestStarted even when lastRequestEnded is undefined', () => {
 		const timing: IChatSessionTiming = {
 			created: 1000,
 			lastRequestStarted: 2000,
@@ -38,7 +38,7 @@ suite('getAgentSessionTime', () => {
 		assert.strictEqual(getAgentSessionTime(timing), 2000);
 	});
 
-	test('returns created when both lastRequestEnded and lastRequestStarted are undefined', () => {
+	test('returns created when lastRequestStarted is undefined', () => {
 		const timing: IChatSessionTiming = {
 			created: 1000,
 			lastRequestStarted: undefined,


### PR DESCRIPTION
Remove the sorting by last response time to prevent hectic sorting updates when multiple sessions run.