### PR TITLE
show checkpoint on response hover

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -750,6 +750,22 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		templateData.checkpointContainer.classList.toggle('hidden', isResponseVM(element) || isPendingRequest || !(checkpointEnabled));
 
+		// show checkpoint on response monaco-list row hover as well
+		if (isResponseVM(element) && checkpointEnabled) {
+			templateData.elementDisposables.add(dom.addDisposableListener(templateData.rowContainer, dom.EventType.MOUSE_ENTER, () => {
+				const requestTemplateData = this.templateDataByRequestId.get(element.requestId);
+				if (requestTemplateData) {
+					requestTemplateData.checkpointContainer.classList.add('response-hovered');
+				}
+			}));
+			templateData.elementDisposables.add(dom.addDisposableListener(templateData.rowContainer, dom.EventType.MOUSE_LEAVE, () => {
+				const requestTemplateData = this.templateDataByRequestId.get(element.requestId);
+				if (requestTemplateData) {
+					requestTemplateData.checkpointContainer.classList.remove('response-hovered');
+				}
+			}));
+		}
+
 		// Only show restore container when we have a checkpoint and not editing, and not a pending request
 		const shouldShowRestore = this.viewModel?.model.checkpoint && !this.viewModel?.editing && (index === this.delegate.getListLength() - 1) && !isPendingRequest;
 		templateData.checkpointRestoreContainer.classList.toggle('hidden', !(shouldShowRestore && checkpointEnabled));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -764,6 +764,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 					requestTemplateData.checkpointContainer.classList.remove('response-hovered');
 				}
 			}));
+			// Ensure 'response-hovered' is cleared if the response row is disposed while hovered
+			templateData.elementDisposables.add(toDisposable(() => {
+				const requestTemplateData = this.templateDataByRequestId.get(element.requestId);
+				if (requestTemplateData) {
+					requestTemplateData.checkpointContainer.classList.remove('response-hovered');
+				}
+			}));
 		}
 
 		// Only show restore container when we have a checkpoint and not editing, and not a pending request

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2849,6 +2849,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 
 	.checkpoint-container:focus-within,
+	.checkpoint-container.response-hovered,
 	.interactive-item-container.interactive-request:not(.editing):hover .checkpoint-container {
 		opacity: 1;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

shows checkpoint on not only request hover, but it's corresponding response hover as well

<img width="400" height="400" alt="551-Sandile" src="https://github.com/user-attachments/assets/c44f561d-57e4-45ac-ac38-a6ce4ba2bdc9" />
