### PR TITLE
Respect explicit editor.accessibilitySupport setting in accessibility mode resolution

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibilityService.ts
+++ b/src/vs/platform/accessibility/browser/accessibilityService.ts
@@ -146,11 +146,11 @@ export class AccessibilityService extends Disposable implements IAccessibilitySe
 
 		// Resolve the setting explicitly in scope precedence order to avoid relying on
 		// resource-dependent resolution in this global service.
-		return inspectedValue.workspaceFolderValue
+		return inspectedValue.policyValue
+			?? inspectedValue.memoryValue
+			?? inspectedValue.workspaceFolderValue
 			?? inspectedValue.workspaceValue
 			?? inspectedValue.userValue
-			?? inspectedValue.userLocalValue
-			?? inspectedValue.userRemoteValue
 			?? inspectedValue.applicationValue
 			?? inspectedValue.defaultValue
 			?? 'auto';

--- a/src/vs/platform/accessibility/browser/accessibilityService.ts
+++ b/src/vs/platform/accessibility/browser/accessibilityService.ts
@@ -137,8 +137,23 @@ export class AccessibilityService extends Disposable implements IAccessibilitySe
 	}
 
 	isScreenReaderOptimized(): boolean {
-		const config = this._configurationService.getValue('editor.accessibilitySupport');
+		const config = this.getAccessibilitySupportConfigurationValue();
 		return config === 'on' || (config === 'auto' && this._accessibilitySupport === AccessibilitySupport.Enabled);
+	}
+
+	private getAccessibilitySupportConfigurationValue(): 'auto' | 'off' | 'on' {
+		const inspectedValue = this._configurationService.inspect<'auto' | 'off' | 'on'>('editor.accessibilitySupport');
+
+		// Resolve the setting explicitly in scope precedence order to avoid relying on
+		// resource-dependent resolution in this global service.
+		return inspectedValue.workspaceFolderValue
+			?? inspectedValue.workspaceValue
+			?? inspectedValue.userValue
+			?? inspectedValue.userLocalValue
+			?? inspectedValue.userRemoteValue
+			?? inspectedValue.applicationValue
+			?? inspectedValue.defaultValue
+			?? 'auto';
 	}
 
 	get onDidChangeReducedMotion(): Event<void> {


### PR DESCRIPTION
fixes #282290

Changed accessibility mode config lookup to use inspect-based explicit scope precedence instead of getValue in AccessibilityService, so explicit off/on settings are respected consistently (not accidentally treated like auto when OS screen reader state changes). 