### PR TITLE
Add `accessibility.chat.showCheckmarks` setting

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -36,7 +36,8 @@ export const enum AccessibilityWorkbenchSettingId {
 	DimUnfocusedOpacity = 'accessibility.dimUnfocused.opacity',
 	HideAccessibleView = 'accessibility.hideAccessibleView',
 	AccessibleViewCloseOnKeyPress = 'accessibility.accessibleView.closeOnKeyPress',
-	VerboseChatProgressUpdates = 'accessibility.verboseChatProgressUpdates'
+	VerboseChatProgressUpdates = 'accessibility.verboseChatProgressUpdates',
+	ShowChatCheckmarks = 'accessibility.chat.showCheckmarks'
 }
 
 export const enum ViewDimUnfocusedOpacityProperties {
@@ -863,6 +864,12 @@ export function registerAccessibilityConfiguration() {
 				'type': 'boolean',
 				'default': true,
 				'markdownDescription': localize('accessibility.verboseChatProgressUpdates', "Controls whether verbose progress announcements should be made when a chat request is in progress, including information like searched text for <search term> with X results, created file <file_name>, or read file <file path>.")
+			},
+			[AccessibilityWorkbenchSettingId.ShowChatCheckmarks]: {
+				'type': 'boolean',
+				'default': false,
+				'tags': ['accessibility'],
+				'markdownDescription': localize('accessibility.chat.showCheckmarks', "Controls whether checkmark icons are shown on completed tool calls and other collapsible items in chat responses.")
 			}
 		}
 	});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -6,7 +6,6 @@
 import { $ } from '../../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
 import { HoverStyle } from '../../../../../../base/browser/ui/hover/hover.js';
-import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableValue } from '../../../../../../base/common/observable.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleContentPart.ts
@@ -10,7 +10,10 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IMarkdownString, MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { observableConfigValue } from '../../../../../../platform/observable/common/platformObservableUtils.js';
+import { AccessibilityWorkbenchSettingId } from '../../../../accessibility/browser/accessibilityConfiguration.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
@@ -32,6 +35,7 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 	protected _collapseButton: ButtonWithIcon | undefined;
 
 	private readonly _overrideIcon = observableValue<ThemeIcon | undefined>(this, undefined);
+	protected readonly _showCheckmarks: IObservable<boolean>;
 	private _contentElement?: HTMLElement;
 	private _contentInitialized = false;
 
@@ -50,10 +54,12 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		context: IChatContentPartRenderContext,
 		private readonly hoverMessage: IMarkdownString | undefined,
 		@IHoverService protected readonly hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
 		this.element = context.element;
 		this.hasFollowingContent = context.contentIndex + 1 < context.content.length;
+		this._showCheckmarks = observableConfigValue(AccessibilityWorkbenchSettingId.ShowChatCheckmarks, false, configurationService);
 	}
 
 	get domNode(): HTMLElement {
@@ -103,15 +109,13 @@ export abstract class ChatCollapsibleContentPart extends Disposable implements I
 		this._register(autorun(r => {
 			const expanded = this._isExpanded.read(r);
 			const overrideIcon = this._overrideIcon.read(r);
-			const isErrorIcon = overrideIcon?.id === Codicon.error.id || overrideIcon?.id === Codicon.warning.id;
+			const showCheckmarks = this._showCheckmarks.read(r);
 
-			if (isErrorIcon && overrideIcon) {
+			if (overrideIcon) {
 				collapseButton.icon = overrideIcon;
-				collapseButton.iconElement.style.display = '';
-			} else {
-				collapseButton.icon = Codicon.blank;
-				collapseButton.iconElement.style.display = 'none';
 			}
+
+			this._domNode?.classList.toggle('show-checkmarks', showCheckmarks);
 
 			// Update hover chevron direction
 			hoverChevron.classList.toggle('codicon-chevron-right', !expanded);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCollapsibleMarkdownContentPart.ts
@@ -8,6 +8,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { ChatTreeItem } from '../../chat.js';
 import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
@@ -27,8 +28,9 @@ export class ChatCollapsibleMarkdownContentPart extends ChatCollapsibleContentPa
 		context: IChatContentPartRenderContext,
 		private readonly chatContentMarkdownRenderer: IMarkdownRenderer,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(title, context, undefined, hoverService);
+		super(title, context, undefined, hoverService, configurationService);
 		this.icon = Codicon.check;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatHookContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatHookContentPart.ts
@@ -7,6 +7,7 @@ import { $ } from '../../../../../../base/browser/dom.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { localize } from '../../../../../../nls.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IChatHookPart } from '../../../common/chatService/chatService.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { HookType, HOOK_TYPES, HookTypeValue } from '../../../common/promptSyntax/hookSchema.js';
@@ -25,6 +26,7 @@ export class ChatHookContentPart extends ChatCollapsibleContentPart implements I
 		private readonly hookPart: IChatHookPart,
 		context: IChatContentPartRenderContext,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		const hookTypeLabel = getHookTypeLabel(hookPart.hookType);
 		const isStopped = !!hookPart.stopReason;
@@ -38,7 +40,7 @@ export class ChatHookContentPart extends ChatCollapsibleContentPart implements I
 				? localize('hook.title.warningWithTool', "Warning for {0} - {1} hook", toolName, hookTypeLabel)
 				: localize('hook.title.warning', "Warning from {0} hook", hookTypeLabel));
 
-		super(title, context, undefined, hoverService);
+		super(title, context, undefined, hoverService, configurationService);
 
 		this.icon = isStopped ? Codicon.error : isWarning ? Codicon.warning : Codicon.check;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -510,6 +510,15 @@ export class CollapsedCodeBlock extends Disposable {
 		this.element.appendChild(this.statusIndicatorContainer);
 		this.element.appendChild(this.pillElement);
 
+		// Toggle show-checkmarks class for the accessibility setting
+		const updateCheckmarks = () => this.element.classList.toggle('show-checkmarks', !!this.configurationService.getValue<boolean>(AccessibilityWorkbenchSettingId.ShowChatCheckmarks));
+		updateCheckmarks();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.ShowChatCheckmarks)) {
+				updateCheckmarks();
+			}
+		}));
+
 		this.registerListeners();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -79,6 +79,7 @@ export class ChatCollapsibleListContentPart extends ChatCollapsibleContentPart {
 			localize('usedReferencesPlural', "Used {0} references", data.length) :
 			localize('usedReferencesSingular', "Used {0} reference", 1)), context, hoverMessage,
 			hoverService, configurationService);
+		this.icon = Codicon.check;
 	}
 
 	protected override initContent(): HTMLElement {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart.ts
@@ -47,6 +47,7 @@ import { ChatCollapsibleContentPart } from './chatCollapsibleContentPart.js';
 import { IDisposableReference, ResourcePool } from './chatCollections.js';
 import { IChatContentPartRenderContext } from './chatContentParts.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 
 const $ = dom.$;
 
@@ -72,11 +73,12 @@ export class ChatCollapsibleListContentPart extends ChatCollapsibleContentPart {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super(labelOverride ?? (data.length > 1 ?
 			localize('usedReferencesPlural', "Used {0} references", data.length) :
 			localize('usedReferencesSingular', "Used {0} reference", 1)), context, hoverMessage,
-			hoverService);
+			hoverService, configurationService);
 	}
 
 	protected override initContent(): HTMLElement {
@@ -160,8 +162,9 @@ export class ChatUsedReferencesListContentPart extends ChatCollapsibleListConten
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
-		super(data, labelOverride, context, contentReferencesListPool, undefined, openerService, menuService, instantiationService, contextMenuService, hoverService);
+		super(data, labelOverride, context, contentReferencesListPool, undefined, openerService, menuService, instantiationService, contextMenuService, hoverService, configurationService);
 		if (data.length === 0) {
 			dom.hide(this.domNode);
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
@@ -15,6 +15,7 @@ import { rcut } from '../../../../../../base/common/strings.js';
 import { localize } from '../../../../../../nls.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IMarkdownRenderer } from '../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IChatHookPart, IChatMarkdownContent, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../common/chatService/chatService.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
@@ -162,6 +163,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatMarkdownAnchorService private readonly chatMarkdownAnchorService: IChatMarkdownAnchorService,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		// Extract description, agentName, and prompt from toolInvocation
 		const { description, agentName, prompt, modelName } = ChatSubagentContentPart.extractSubagentInfo(toolInvocation);
@@ -169,7 +171,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 		// Build title: "AgentName: description" or "Subagent: description"
 		const prefix = agentName || localize('chat.subagent.prefix', 'Subagent');
 		const initialTitle = `${prefix}: ${description}`;
-		super(initialTitle, context, undefined, hoverService);
+		super(initialTitle, context, undefined, hoverService, configurationService);
 
 		this.description = description;
 		this.agentName = agentName;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -240,7 +240,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		const extractedTitle = extractTitleFromThinkingContent(initialText)
 			?? 'Working';
 
-		super(extractedTitle, context, undefined, hoverService);
+		super(extractedTitle, context, undefined, hoverService, configurationService);
 
 		this.id = content.id;
 		this.content = content;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -16,10 +16,13 @@ import { ILanguageService } from '../../../../../../editor/common/languages/lang
 import { IModelService } from '../../../../../../editor/common/services/model.js';
 import { localize } from '../../../../../../nls.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { observableConfigValue } from '../../../../../../platform/observable/common/platformObservableUtils.js';
 import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IChatRendererContent } from '../../../common/model/chatViewModel.js';
 import { LanguageModelPartAudience } from '../../../common/languageModels.js';
+import { AccessibilityWorkbenchSettingId } from '../../../../accessibility/browser/accessibilityConfiguration.js';
 import { ChatTreeItem, IChatCodeBlockInfo } from '../../chat.js';
 import { CodeBlockPart, ICodeBlockData, ICodeBlockRenderOptions } from './codeBlockPart.js';
 import { IDisposableReference } from './chatCollections.js';
@@ -100,6 +103,7 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IChatMarkdownAnchorService private readonly chatMarkdownAnchorService: IChatMarkdownAnchorService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -142,18 +146,24 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 			}));
 		}
 
-		// Only show leading icon for errors
-		if (isError) {
-			btn.icon = Codicon.error;
-		} else {
-			btn.icon = Codicon.blank;
-			btn.iconElement.style.display = 'none';
-		}
+		// Only show leading icon for errors, or for checkmarks/loading when the accessibility setting is on
+		const showCheckmarks = observableConfigValue(AccessibilityWorkbenchSettingId.ShowChatCheckmarks, false, this.configurationService);
 
 		const expanded = this._expanded = observableValue(this, initiallyExpanded);
 		this._register(autorun(r => {
 			const value = expanded.read(r);
+			const checkmarksEnabled = showCheckmarks.read(r);
 			elements.root.classList.toggle('collapsed', !value);
+
+			if (isError) {
+				btn.icon = Codicon.error;
+			} else {
+				btn.icon = output
+					? Codicon.check
+					: ThemeIcon.modify(Codicon.loading, 'spin');
+			}
+
+			container.root.classList.toggle('show-checkmarks', checkmarksEnabled);
 
 			// Update hover chevron direction
 			hoverChevron.classList.toggle('codicon-chevron-right', !value);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatToolInputOutputContentPart.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../../../../base/browser/dom.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
-import { HoverStyle } from '../../../../../../base/browser/ui/hover/hover.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
@@ -131,20 +130,6 @@ export class ChatCollapsibleInputOutputContentPart extends Disposable {
 		const hoverChevron = dom.$('span.chat-collapsible-hover-chevron.codicon.codicon-chevron-right');
 		hoverChevron.setAttribute('aria-hidden', 'true');
 		btn.element.appendChild(hoverChevron);
-
-		const check = dom.h(isError
-			? ThemeIcon.asCSSSelector(Codicon.error)
-			: output
-				? ThemeIcon.asCSSSelector(Codicon.check)
-				: ThemeIcon.asCSSSelector(ThemeIcon.modify(Codicon.loading, 'spin'))
-		);
-
-		if (progressTooltip) {
-			this._register(hoverService.setupDelayedHover(check.root, {
-				content: progressTooltip,
-				style: HoverStyle.Pointer,
-			}));
-		}
 
 		// Only show leading icon for errors, or for checkmarks/loading when the accessibility setting is on
 		const showCheckmarks = observableConfigValue(AccessibilityWorkbenchSettingId.ShowChatCheckmarks, false, this.configurationService);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
@@ -37,6 +37,10 @@
 			display: none;
 		}
 
+		.show-checkmarks & .codicon.codicon-check {
+			display: inline-flex;
+		}
+
 		.status-label {
 			color: var(--vscode-descriptionForeground);
 			white-space: nowrap;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -342,4 +342,17 @@
 		}
 	}
 
+	/* Hide the leading icon by default; show-checkmarks restores it */
+	.chat-confirmation-widget-container .chat-confirmation-widget .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron):not(.codicon-error):not(.codicon-warning) {
+		display: none;
+	}
+
+	.show-checkmarks .chat-confirmation-widget .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
+		display: inline-block;
+	}
+
+	.show-checkmarks .chat-confirmation-widget .chat-confirmation-widget-title {
+		padding-left: 2px;
+	}
+
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -342,8 +342,7 @@
 		}
 	}
 
-	/* Hide the leading icon by default; show-checkmarks restores it */
-	.chat-confirmation-widget-container .chat-confirmation-widget .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron):not(.codicon-error):not(.codicon-warning) {
+	.chat-confirmation-widget .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
 		display: none;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -148,6 +148,10 @@
 				display: inline-block;
 			}
 
+			.show-checkmarks .progress-container > .codicon.codicon-check {
+				display: inline-flex;
+			}
+
 			.chat-used-context.chat-hook-outcome-blocked,
 			.chat-used-context.chat-hook-outcome-warning {
 					padding: 4px 12px 4px 20px;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -140,6 +140,14 @@
 					display: inline-flex;
 				}
 
+			.chat-used-context.show-checkmarks .chat-used-context-label .monaco-icon-button > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
+				display: inline-block;
+			}
+
+			.show-checkmarks .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
+				display: inline-block;
+			}
+
 			.chat-used-context.chat-hook-outcome-blocked,
 			.chat-used-context.chat-hook-outcome-warning {
 					padding: 4px 12px 4px 20px;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -185,6 +185,10 @@
 				display: none;
 			}
 
+			.show-checkmarks .status-icon.codicon-check {
+				display: inline-flex;
+			}
+
 			.code:has(.chat-codeblock-pill-container) {
 				margin-bottom: 0px;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1483,9 +1483,10 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 		initialExpanded: boolean,
 		isComplete: boolean,
 		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		const title = isComplete ? `Ran \`${commandText}\`` : `Running \`${commandText}\``;
-		super(title, context, undefined, hoverService);
+		super(title, context, undefined, hoverService, configurationService);
 
 		this._terminalContentElement = contentElement;
 		this._commandText = commandText;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1494,6 +1494,10 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 
 		this.domNode.classList.add('chat-terminal-thinking-collapsible');
 
+		if (isComplete) {
+			this.icon = Codicon.check;
+		}
+
 		this._setCodeFormattedTitle();
 		this.setExpanded(initialExpanded);
 	}
@@ -1522,6 +1526,7 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 			return;
 		}
 		this._isComplete = true;
+		this.icon = Codicon.check;
 		this._setCodeFormattedTitle();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -41,7 +41,7 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { stripIcons } from '../../../../../../../base/common/iconLabels.js';
 import { IAccessibleViewService } from '../../../../../../../platform/accessibility/browser/accessibleView.js';
 import { IContextKey, IContextKeyService } from '../../../../../../../platform/contextkey/common/contextkey.js';
-import { AccessibilityVerbositySettingId } from '../../../../../accessibility/browser/accessibilityConfiguration.js';
+import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId } from '../../../../../accessibility/browser/accessibilityConfiguration.js';
 import { ChatContextKeys } from '../../../../common/actions/chatContextKeys.js';
 import { EditorPool } from '../chatContentCodePools.js';
 import { IKeybindingService } from '../../../../../../../platform/keybinding/common/keybinding.js';
@@ -372,6 +372,14 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			this.domNode = this._createCollapsibleWrapper(progressPart.domNode, displayCommand, toolInvocation, context);
 		} else {
 			this.domNode = progressPart.domNode;
+			// Toggle show-checkmarks class on the progress container for accessibility setting
+			const updateCheckmarks = () => this.domNode.classList.toggle('show-checkmarks', !!this._configurationService.getValue<boolean>(AccessibilityWorkbenchSettingId.ShowChatCheckmarks));
+			updateCheckmarks();
+			this._register(this._configurationService.onDidChangeConfiguration(e => {
+				if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.ShowChatCheckmarks)) {
+					updateCheckmarks();
+				}
+			}));
 		}
 
 		// Only auto-expand in thinking containers if there's actual output to show

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolProgressPart.ts
@@ -35,6 +35,15 @@ export class ChatToolProgressSubPart extends BaseChatToolInvocationSubPart {
 		super(toolInvocation);
 
 		this.domNode = this.createProgressPart();
+
+		// Toggle show-checkmarks class for the accessibility setting
+		const updateCheckmarks = () => this.domNode.classList.toggle('show-checkmarks', !!this.configurationService.getValue<boolean>(AccessibilityWorkbenchSettingId.ShowChatCheckmarks));
+		updateCheckmarks();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.ShowChatCheckmarks)) {
+				updateCheckmarks();
+			}
+		}));
 	}
 
 	private createProgressPart(): HTMLElement {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2306,7 +2306,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.show-checkmarks .progress-container > .codicon.codicon-check {
+.show-checkmarks .progress-container > .codicon.codicon-check,
+.progress-container.show-checkmarks > .codicon.codicon-check {
 	display: inline-flex;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2306,6 +2306,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
+.show-checkmarks .progress-container > .codicon.codicon-check {
+	display: inline-flex;
+}
+
 .interactive-item-container .chat-command-button {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2176,6 +2176,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	line-height: unset;
 }
 
+.interactive-session .chat-used-context.show-checkmarks .chat-used-context-label .monaco-button {
+	gap: 4px;
+	margin-left: 0;
+}
+
 .interactive-session .chat-file-changes-label .monaco-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
@@ -2199,6 +2204,15 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-used-context-label .monaco-button .codicon {
 	font-size: 12px;
 	color: var(--vscode-icon-foreground) !important;
+}
+
+/* Hide the leading icon on collapsible parts by default; show-checkmarks restores it */
+.interactive-session .chat-used-context-label .monaco-icon-button > .codicon:first-child:not(.chat-collapsible-hover-chevron):not(.codicon-error):not(.codicon-warning) {
+	display: none;
+}
+
+.interactive-session .chat-used-context.show-checkmarks .chat-used-context-label .monaco-icon-button > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
+	display: inline-block;
 }
 
 /* Hover chevron indicator for collapsible parts */

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatSubagentContentPart.test.ts
@@ -22,6 +22,9 @@ import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js
 import { CodeBlockModelCollection } from '../../../../common/widget/codeBlockModelCollection.js';
 import { EditorPool, DiffEditorPool } from '../../../../browser/widget/chatContentParts/chatContentCodePools.js';
 import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { AccessibilityWorkbenchSettingId } from '../../../../../accessibility/browser/accessibilityConfiguration.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 import { RunSubagentTool } from '../../../../common/tools/builtinTools/runSubagentTool.js';
 import { CollapsibleListPool } from '../../../../browser/widget/chatContentParts/chatReferencesContentPart.js';
@@ -412,6 +415,10 @@ suite('ChatSubagentContentPart', () => {
 		});
 
 		test('finalizeTitle should update button icon to check', () => {
+			// Enable the showCheckmarks setting so the check icon is visible
+			const configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+			configService.setUserConfiguration(AccessibilityWorkbenchSettingId.ShowChatCheckmarks, true);
+
 			const toolInvocation = createMockToolInvocation();
 			const context = createMockRenderContext(false);
 


### PR DESCRIPTION
Add a boolean accessibility setting `accessibility.chat.showCheckmarks` that restores the checkmark icons removed in #296621 on completed tool calls and other collapsible items in chat responses.

Fixes https://github.com/microsoft/vscode/issues/297114

## Behavior

- **Default (`false`)**: Checkmarks are hidden — matches current behavior from #296621
- **Enabled (`true`)**: Checkmark and loading spinner icons are shown as the leading icon on collapsible content parts, tool input/output parts, and inside thinking/subagent boxes

The setting is **reactive** — toggling it immediately updates all existing chat parts without needing a window reload.

https://github.com/user-attachments/assets/08b7666a-41a1-489c-8f43-7de39ac153f8

## Implementation

- New `AccessibilityWorkbenchSettingId.ShowChatCheckmarks` enum value and setting registration in `accessibilityConfiguration.ts`
- `ChatCollapsibleContentPart` base class creates an `observableConfigValue` for the setting and toggles a `.show-checkmarks` CSS class on the container
- `ChatCollapsibleInputOutputContentPart` does the same via its own `autorun`
- CSS rules in `chat.css`, `chatConfirmationWidget.css`, and `chatThinkingContent.css` hide the leading icon by default and show it when `.show-checkmarks` is present
- Error/warning icons are always visible regardless of the setting
- All 5 subclasses (`ChatCollapsibleMarkdownContentPart`, `ChatCollapsibleListContentPart`, `ChatThinkingContentPart`, `ChatSubagentContentPart`, `ChatHookContentPart`) forward `IConfigurationService` to the base class
- Updated `chatSubagentContentPart.test.ts` to configure the setting for the icon assertion test