### PR TITLE
Don't show `Used n references` when opening an old session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1777,8 +1777,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			} else if (content.kind === 'markdownContent') {
 				return this.renderMarkdown(content, templateData, context);
 			} else if (content.kind === 'references') {
-				if (isResponseVM(context.element) && context.element.model.request?.modeInfo?.modeId === ChatModeKind.Agent) {
-					return this.renderNoContent(other => other.kind === content.kind);
+				if (isResponseVM(context.element)) {
+					const isAgent = context.element.model.request?.modeInfo
+						? context.element.model.request.modeInfo.modeId === ChatModeKind.Agent
+						: this.delegate.currentChatMode() === ChatModeKind.Agent;
+					if (isAgent) {
+						return this.renderNoContent(other => other.kind === content.kind);
+					}
 				}
 				return this.renderContentReferencesListData(content, undefined, context, templateData);
 			} else if (content.kind === 'codeCitations') {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1778,9 +1778,15 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				return this.renderMarkdown(content, templateData, context);
 			} else if (content.kind === 'references') {
 				if (isResponseVM(context.element)) {
-					const isAgent = context.element.model.request?.modeInfo
-						? context.element.model.request.modeInfo.modeId === ChatModeKind.Agent
-						: this.delegate.currentChatMode() === ChatModeKind.Agent;
+					const request = context.element.model.request;
+					let isAgent = false;
+					if (request) {
+						if (request.modeInfo) {
+							isAgent = request.modeInfo.modeId === ChatModeKind.Agent;
+						} else {
+							isAgent = this.delegate.currentChatMode() === ChatModeKind.Agent;
+						}
+					}
 					if (isAgent) {
 						return this.renderNoContent(other => other.kind === content.kind);
 					}

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1446,6 +1446,7 @@ export interface ISerializableChatRequestData extends ISerializableChatResponseD
 	confirmation?: string;
 	editedFileEvents?: IChatAgentEditedFileEvent[];
 	modelId?: string;
+	modeInfo?: IChatRequestModeInfo;
 }
 
 export interface ISerializableMarkdownInfo {
@@ -2297,6 +2298,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			confirmation: raw.confirmation,
 			editedFileEvents: raw.editedFileEvents,
 			modelId: raw.modelId,
+			modeInfo: raw.modeInfo,
 		});
 		request.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any, local/code-no-any-casts
@@ -2639,6 +2641,7 @@ export class ChatModel extends Disposable implements IChatModel {
 					confirmation: r.confirmation,
 					editedFileEvents: r.editedFileEvents,
 					modelId: r.modelId,
+					modeInfo: r.modeInfo,
 					...r.response?.toJSON(),
 				};
 			}),

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1446,7 +1446,17 @@ export interface ISerializableChatRequestData extends ISerializableChatResponseD
 	confirmation?: string;
 	editedFileEvents?: IChatAgentEditedFileEvent[];
 	modelId?: string;
-	modeInfo?: IChatRequestModeInfo;
+	modeInfo?: ISerializableModeInfo;
+}
+
+/**
+ * Reduced shape of {@link IChatRequestModeInfo} for serialization.
+ * Only persists fields needed for UI decisions, avoiding large modeInstructions content.
+ */
+export interface ISerializableModeInfo {
+	modeId: IChatRequestModeInfo['modeId'];
+	kind: ChatModeKind | undefined;
+	isBuiltin: boolean;
 }
 
 export interface ISerializableMarkdownInfo {
@@ -2298,7 +2308,13 @@ export class ChatModel extends Disposable implements IChatModel {
 			confirmation: raw.confirmation,
 			editedFileEvents: raw.editedFileEvents,
 			modelId: raw.modelId,
-			modeInfo: raw.modeInfo,
+			modeInfo: raw.modeInfo ? {
+				modeId: raw.modeInfo.modeId,
+				kind: raw.modeInfo.kind,
+				isBuiltin: raw.modeInfo.isBuiltin,
+				modeInstructions: undefined,
+				applyCodeBlockSuggestionId: undefined,
+			} : undefined,
 		});
 		request.shouldBeRemovedOnSend = raw.isHidden ? { requestId: raw.requestId } : raw.shouldBeRemovedOnSend;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any, local/code-no-any-casts
@@ -2641,7 +2657,11 @@ export class ChatModel extends Disposable implements IChatModel {
 					confirmation: r.confirmation,
 					editedFileEvents: r.editedFileEvents,
 					modelId: r.modelId,
-					modeInfo: r.modeInfo,
+					modeInfo: r.modeInfo ? {
+						modeId: r.modeInfo.modeId,
+						kind: r.modeInfo.kind,
+						isBuiltin: r.modeInfo.isBuiltin,
+					} : undefined,
 					...r.response?.toJSON(),
 				};
 			}),

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -126,6 +126,7 @@ const requestSchema = Adapt.object<IChatRequestModel, ISerializableChatRequestDa
 	shouldBeRemovedOnSend: Adapt.v(m => m.shouldBeRemovedOnSend, objectsEqual),
 	agent: Adapt.v(m => m.response?.agent, (a, b) => a?.id === b?.id),
 	modelId: Adapt.v(m => m.modelId),
+	modeInfo: Adapt.v(m => m.modeInfo, objectsEqual),
 	editedFileEvents: Adapt.t(m => m.editedFileEvents, Adapt.array(agentEditedFileEventSchema)),
 	variableData: Adapt.t(m => m.variableData, chatVariableSchema),
 	isHidden: Adapt.v(() => undefined), // deprecated, always undefined for new data

--- a/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts
@@ -126,7 +126,7 @@ const requestSchema = Adapt.object<IChatRequestModel, ISerializableChatRequestDa
 	shouldBeRemovedOnSend: Adapt.v(m => m.shouldBeRemovedOnSend, objectsEqual),
 	agent: Adapt.v(m => m.response?.agent, (a, b) => a?.id === b?.id),
 	modelId: Adapt.v(m => m.modelId),
-	modeInfo: Adapt.v(m => m.modeInfo, objectsEqual),
+	modeInfo: Adapt.v(m => m.modeInfo ? { modeId: m.modeInfo.modeId, kind: m.modeInfo.kind, isBuiltin: m.modeInfo.isBuiltin } : undefined, objectsEqual),
 	editedFileEvents: Adapt.t(m => m.editedFileEvents, Adapt.array(agentEditedFileEventSchema)),
 	variableData: Adapt.t(m => m.variableData, chatVariableSchema),
 	isHidden: Adapt.v(() => undefined), // deprecated, always undefined for new data


### PR DESCRIPTION
Fixes "Used n references" buttons appearing on restored agent-mode chats.

## Problem

`modeInfo` was never serialized when saving chat sessions. When restoring old chats, `modeInfo` was always `undefined`, so the check `modeInfo?.modeId === ChatModeKind.Agent` in `chatListRenderer.ts` always evaluated to `false`, causing the "Used n references" button to show even for agent-mode sessions.

## Fix

1. **Persist `modeInfo`** — Added `modeInfo` to `ISerializableChatRequestData`, `toExport()`, `_deserializeRequest()`, and the operation log schema so it survives across save/restore cycles.

2. **Fallback for old sessions** — For sessions saved before this change (no `modeInfo` on the request), fall back to the session-level `delegate.currentChatMode()` which reflects the persisted `inputModel.mode`.