### PR TITLE
Fix sessions list: show description with badge, remove bold, add ellipsis

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -293,20 +293,18 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		return Codicon.circleSmallFilled;
 	}
 
-	private renderDescription(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): boolean {
+	private renderDescription(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): void {
 		const description = session.element.description;
 		if (description) {
 			this.renderMarkdownOrText(description, template.description, template.elementDisposable);
-			return true;
+			return;
 		}
 
 		// Fallback to state label
 		if (session.element.status === AgentSessionStatus.InProgress) {
 			template.description.textContent = localize('chat.session.status.inProgress', "Working...");
-			return true;
 		} else if (session.element.status === AgentSessionStatus.NeedsInput) {
 			template.description.textContent = localize('chat.session.status.needsInput', "Input needed.");
-			return true;
 		} else if (
 			session.element.timing.lastRequestEnded &&
 			session.element.timing.lastRequestStarted &&
@@ -317,12 +315,10 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
 				localize('chat.session.status.failedAfter', "Failed after {0}", duration) :
 				localize('chat.session.status.completedAfter', "Completed in {0}", duration);
-			return true;
 		} else {
 			template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
 				localize('chat.session.status.failed', "Failed") :
 				localize('chat.session.status.completed', "Completed");
-			return true;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -218,7 +218,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 
 		// Description (unless diff is shown)
 		if (!hasDiff) {
-			this.renderDescription(session, template, hasBadge);
+			this.renderDescription(session, template);
 		}
 
 		// Separator (dot between badge and timestamp)
@@ -293,35 +293,36 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		return Codicon.circleSmallFilled;
 	}
 
-	private renderDescription(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate, hasBadge: boolean): void {
+	private renderDescription(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): boolean {
 		const description = session.element.description;
 		if (description) {
 			this.renderMarkdownOrText(description, template.description, template.elementDisposable);
+			return true;
 		}
 
 		// Fallback to state label
-		else {
-			if (session.element.status === AgentSessionStatus.InProgress) {
-				template.description.textContent = localize('chat.session.status.inProgress', "Working...");
-			} else if (session.element.status === AgentSessionStatus.NeedsInput) {
-				template.description.textContent = localize('chat.session.status.needsInput', "Input needed.");
-			} else if (hasBadge && session.element.status === AgentSessionStatus.Completed) {
-				template.description.textContent = ''; // no description if completed and has badge
-			} else if (
-				session.element.timing.lastRequestEnded &&
-				session.element.timing.lastRequestStarted &&
-				session.element.timing.lastRequestEnded > session.element.timing.lastRequestStarted
-			) {
-				const duration = this.toDuration(session.element.timing.lastRequestStarted, session.element.timing.lastRequestEnded, false, true);
+		if (session.element.status === AgentSessionStatus.InProgress) {
+			template.description.textContent = localize('chat.session.status.inProgress', "Working...");
+			return true;
+		} else if (session.element.status === AgentSessionStatus.NeedsInput) {
+			template.description.textContent = localize('chat.session.status.needsInput', "Input needed.");
+			return true;
+		} else if (
+			session.element.timing.lastRequestEnded &&
+			session.element.timing.lastRequestStarted &&
+			session.element.timing.lastRequestEnded > session.element.timing.lastRequestStarted
+		) {
+			const duration = this.toDuration(session.element.timing.lastRequestStarted, session.element.timing.lastRequestEnded, false, true);
 
-				template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
-					localize('chat.session.status.failedAfter', "Failed after {0}", duration) :
-					localize('chat.session.status.completedAfter', "Completed in {0}", duration);
-			} else {
-				template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
-					localize('chat.session.status.failed', "Failed") :
-					localize('chat.session.status.completed', "Completed");
-			}
+			template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
+				localize('chat.session.status.failedAfter', "Failed after {0}", duration) :
+				localize('chat.session.status.completedAfter', "Completed in {0}", duration);
+			return true;
+		} else {
+			template.description.textContent = session.element.status === AgentSessionStatus.Failed ?
+				localize('chat.session.status.failed', "Failed") :
+				localize('chat.session.status.completed', "Completed");
+			return true;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -165,9 +165,7 @@
 				}
 			}
 
-			.agent-session-diff-container,
-			.agent-session-badge {
-				font-weight: 500;
+			.agent-session-diff-container {
 				font-variant-numeric: tabular-nums;
 				overflow: hidden;
 			}
@@ -223,6 +221,7 @@
 			flex: 1;
 			overflow: hidden;
 			white-space: nowrap;
+			text-overflow: ellipsis;
 		}
 
 		.agent-session-title {


### PR DESCRIPTION
Fixes several issues in the sessions list view:

- **Always show description**: Removed the condition that suppressed the description text (e.g. "Completed in 2 mins") when a badge was present and the session was completed
- **Remove semibold from badge and diff**: Removed `font-weight: 500` from both `.agent-session-badge` and `.agent-session-diff-container`
- **Add text-overflow ellipsis**: Description now truncates with ellipsis when overflowing instead of being clipped
