### PR TITLE
Chat Customizations Window: Organize MCP servers by Workspace/User groups and swap button order

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -694,7 +694,6 @@ export class McpListWidget extends Disposable {
 		} else {
 			this.collapsedGroups.add(entry.scope);
 		}
-		entry.collapsed = !entry.collapsed;
 		this.filterServers();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -27,21 +27,125 @@ import { CancellationTokenSource } from '../../../../../base/common/cancellation
 import { Delayer } from '../../../../../base/common/async.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { getContextMenuActions } from '../../../../contrib/mcp/browser/mcpServerActions.js';
+import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
+import { workspaceIcon, userIcon } from './aiCustomizationIcons.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 
 const $ = DOM.$;
 
 const MCP_ITEM_HEIGHT = 60;
+const MCP_GROUP_HEADER_HEIGHT = 32;
+const MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
+
+/**
+ * Represents a collapsible group header in the MCP server list.
+ */
+interface IMcpGroupHeaderEntry {
+	readonly type: 'group-header';
+	readonly id: string;
+	readonly scope: LocalMcpServerScope;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly count: number;
+	readonly isFirst: boolean;
+	readonly description: string;
+	collapsed: boolean;
+}
+
+/**
+ * Represents an individual MCP server item in the list.
+ */
+interface IMcpServerItemEntry {
+	readonly type: 'server-item';
+	readonly server: IWorkbenchMcpServer;
+}
+
+type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry;
 
 /**
  * Delegate for the MCP server list.
  */
-class McpServerItemDelegate implements IListVirtualDelegate<IWorkbenchMcpServer> {
-	getHeight(): number {
+class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
+	getHeight(element: IMcpListEntry): number {
+		if (element.type === 'group-header') {
+			return element.isFirst ? MCP_GROUP_HEADER_HEIGHT : MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR;
+		}
 		return MCP_ITEM_HEIGHT;
 	}
 
-	getTemplateId(element: IWorkbenchMcpServer): string {
-		return element.gallery && !element.local ? 'mcpGalleryItem' : 'mcpServerItem';
+	getTemplateId(element: IMcpListEntry): string {
+		if (element.type === 'group-header') {
+			return 'mcpGroupHeader';
+		}
+		const server = element.server;
+		return server.gallery && !server.local ? 'mcpGalleryItem' : 'mcpServerItem';
+	}
+}
+
+interface IMcpGroupHeaderTemplateData {
+	readonly container: HTMLElement;
+	readonly chevron: HTMLElement;
+	readonly icon: HTMLElement;
+	readonly label: HTMLElement;
+	readonly count: HTMLElement;
+	readonly infoIcon: HTMLElement;
+	readonly disposables: DisposableStore;
+	readonly elementDisposables: DisposableStore;
+}
+
+/**
+ * Renderer for collapsible group headers (Workspace, User).
+ */
+class McpGroupHeaderRenderer implements IListRenderer<IMcpGroupHeaderEntry, IMcpGroupHeaderTemplateData> {
+	readonly templateId = 'mcpGroupHeader';
+
+	constructor(
+		private readonly hoverService: IHoverService,
+	) { }
+
+	renderTemplate(container: HTMLElement): IMcpGroupHeaderTemplateData {
+		const disposables = new DisposableStore();
+		const elementDisposables = new DisposableStore();
+		container.classList.add('ai-customization-group-header');
+
+		const chevron = DOM.append(container, $('.group-chevron'));
+		const icon = DOM.append(container, $('.group-icon'));
+		const labelGroup = DOM.append(container, $('.group-label-group'));
+		const label = DOM.append(labelGroup, $('.group-label'));
+		const infoIcon = DOM.append(labelGroup, $('.group-info'));
+		infoIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
+		const count = DOM.append(container, $('.group-count'));
+
+		return { container, chevron, icon, label, count, infoIcon, disposables, elementDisposables };
+	}
+
+	renderElement(element: IMcpGroupHeaderEntry, _index: number, templateData: IMcpGroupHeaderTemplateData): void {
+		templateData.elementDisposables.clear();
+
+		templateData.chevron.className = 'group-chevron';
+		templateData.chevron.classList.add(...ThemeIcon.asClassNameArray(element.collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+
+		templateData.icon.className = 'group-icon';
+		templateData.icon.classList.add(...ThemeIcon.asClassNameArray(element.icon));
+
+		templateData.label.textContent = element.label;
+		templateData.count.textContent = `${element.count}`;
+
+		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.infoIcon, () => ({
+			content: element.description,
+			appearance: {
+				compact: true,
+				skipFadeInAnimation: true,
+			}
+		})));
+
+		templateData.container.classList.toggle('collapsed', element.collapsed);
+		templateData.container.classList.toggle('has-previous-group', !element.isFirst);
+	}
+
+	disposeTemplate(templateData: IMcpGroupHeaderTemplateData): void {
+		templateData.elementDisposables.dispose();
+		templateData.disposables.dispose();
 	}
 }
 
@@ -57,7 +161,7 @@ interface IMcpServerItemTemplateData {
 /**
  * Renderer for local MCP server list items.
  */
-class McpServerItemRenderer implements IListRenderer<IWorkbenchMcpServer, IMcpServerItemTemplateData> {
+class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpServerItemTemplateData> {
 	readonly templateId = 'mcpServerItem';
 
 	constructor(
@@ -79,14 +183,14 @@ class McpServerItemRenderer implements IListRenderer<IWorkbenchMcpServer, IMcpSe
 		return { container, icon, name, description, status, disposables: new DisposableStore() };
 	}
 
-	renderElement(element: IWorkbenchMcpServer, index: number, templateData: IMcpServerItemTemplateData): void {
+	renderElement(element: IMcpServerItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
 		templateData.disposables.clear();
 
-		templateData.name.textContent = element.label;
-		templateData.description.textContent = element.description || '';
+		templateData.name.textContent = element.server.label;
+		templateData.description.textContent = element.server.description || '';
 
 		// Find the server from IMcpService to get connection state
-		const server = this.mcpService.servers.get().find(s => s.definition.id === element.id);
+		const server = this.mcpService.servers.get().find(s => s.definition.id === element.server.id);
 		templateData.disposables.add(autorun(reader => {
 			const connectionState = server?.connectionState.read(reader);
 			this.updateStatus(templateData.status, connectionState?.state);
@@ -136,7 +240,7 @@ interface IMcpGalleryItemTemplateData {
 /**
  * Renderer for gallery MCP server items with an install button.
  */
-class McpGalleryItemRenderer implements IListRenderer<IWorkbenchMcpServer, IMcpGalleryItemTemplateData> {
+class McpGalleryItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpGalleryItemTemplateData> {
 	readonly templateId = 'mcpGalleryItem';
 
 	constructor(
@@ -165,27 +269,27 @@ class McpGalleryItemRenderer implements IListRenderer<IWorkbenchMcpServer, IMcpG
 		return { container, icon, name, publisher, description, installButton, elementDisposables: new DisposableStore(), templateDisposables };
 	}
 
-	renderElement(element: IWorkbenchMcpServer, _index: number, templateData: IMcpGalleryItemTemplateData): void {
+	renderElement(element: IMcpServerItemEntry, _index: number, templateData: IMcpGalleryItemTemplateData): void {
 		templateData.elementDisposables.clear();
 
-		templateData.name.textContent = element.label;
-		templateData.publisher.textContent = element.publisherDisplayName ? `by ${element.publisherDisplayName}` : '';
-		templateData.description.textContent = element.description || '';
+		templateData.name.textContent = element.server.label;
+		templateData.publisher.textContent = element.server.publisherDisplayName ? `by ${element.server.publisherDisplayName}` : '';
+		templateData.description.textContent = element.server.description || '';
 
-		this.updateInstallButton(templateData.installButton, element);
+		this.updateInstallButton(templateData.installButton, element.server);
 
 		templateData.elementDisposables.add(templateData.installButton.onDidClick(async () => {
-			const canInstall = this.mcpWorkbenchService.canInstall(element);
+			const canInstall = this.mcpWorkbenchService.canInstall(element.server);
 			if (canInstall === true) {
 				templateData.installButton.label = localize('installing', "Installing...");
 				templateData.installButton.enabled = false;
-				await this.mcpWorkbenchService.install(element);
+				await this.mcpWorkbenchService.install(element.server);
 			}
 		}));
 
 		templateData.elementDisposables.add(this.mcpWorkbenchService.onChange(changed => {
-			if (!changed || changed.id === element.id) {
-				this.updateInstallButton(templateData.installButton, element);
+			if (!changed || changed.id === element.server.id) {
+				this.updateInstallButton(templateData.installButton, element.server);
 			}
 		}));
 	}
@@ -229,7 +333,7 @@ export class McpListWidget extends Disposable {
 	private searchAndButtonContainer!: HTMLElement;
 	private searchInput!: InputBox;
 	private listContainer!: HTMLElement;
-	private list!: WorkbenchList<IWorkbenchMcpServer>;
+	private list!: WorkbenchList<IMcpListEntry>;
 	private emptyContainer!: HTMLElement;
 	private emptyText!: HTMLElement;
 	private emptySubtext!: HTMLElement;
@@ -238,9 +342,11 @@ export class McpListWidget extends Disposable {
 	private backLink!: HTMLElement;
 
 	private filteredServers: IWorkbenchMcpServer[] = [];
+	private displayEntries: IMcpListEntry[] = [];
 	private galleryServers: IWorkbenchMcpServer[] = [];
 	private searchQuery: string = '';
 	private browseMode: boolean = false;
+	private readonly collapsedGroups = new Set<LocalMcpServerScope>();
 	private galleryCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
 	private readonly delayedGallerySearch = new Delayer<void>(400);
@@ -253,6 +359,7 @@ export class McpListWidget extends Disposable {
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget');
@@ -284,16 +391,8 @@ export class McpListWidget extends Disposable {
 			}
 		}));
 
-		// Button container (Add Server + Browse Marketplace)
+		// Button container (Browse Marketplace + Add Server)
 		const buttonContainer = DOM.append(this.searchAndButtonContainer, $('.list-button-group'));
-
-		const addButtonContainer = DOM.append(buttonContainer, $('.list-add-button-container'));
-		this.addButton = this._register(new Button(addButtonContainer, { ...defaultButtonStyles, supportIcons: true }));
-		this.addButton.label = `$(${Codicon.add.id}) ${localize('addServer', "Add Server")}`;
-		this.addButton.element.classList.add('list-add-button');
-		this._register(this.addButton.onDidClick(() => {
-			this.commandService.executeCommand(McpCommandIds.AddConfiguration);
-		}));
 
 		// Browse Marketplace button
 		const browseButtonContainer = DOM.append(buttonContainer, $('.list-add-button-container'));
@@ -302,6 +401,14 @@ export class McpListWidget extends Disposable {
 		this.browseButton.element.classList.add('list-add-button');
 		this._register(this.browseButton.onDidClick(() => {
 			this.toggleBrowseMode(!this.browseMode);
+		}));
+
+		const addButtonContainer = DOM.append(buttonContainer, $('.list-add-button-container'));
+		this.addButton = this._register(new Button(addButtonContainer, { ...defaultButtonStyles, supportIcons: true }));
+		this.addButton.label = `$(${Codicon.add.id}) ${localize('addServer', "Add Server")}`;
+		this.addButton.element.classList.add('list-add-button');
+		this._register(this.addButton.onDidClick(() => {
+			this.commandService.executeCommand(McpCommandIds.AddConfiguration);
 		}));
 
 		// Back to installed link (shown only in browse mode)
@@ -351,22 +458,26 @@ export class McpListWidget extends Disposable {
 
 		// Create list
 		const delegate = new McpServerItemDelegate();
+		const groupHeaderRenderer = new McpGroupHeaderRenderer(this.hoverService);
 		const localRenderer = this.instantiationService.createInstance(McpServerItemRenderer);
 		const galleryRenderer = new McpGalleryItemRenderer(this.mcpWorkbenchService);
 
 		this.list = this._register(this.instantiationService.createInstance(
-			WorkbenchList<IWorkbenchMcpServer>,
+			WorkbenchList<IMcpListEntry>,
 			'McpManagementList',
 			this.listContainer,
 			delegate,
-			[localRenderer, galleryRenderer],
+			[groupHeaderRenderer, localRenderer, galleryRenderer],
 			{
 				multipleSelectionSupport: false,
 				setRowLineHeight: false,
 				horizontalScrolling: false,
 				accessibilityProvider: {
-					getAriaLabel(element: IWorkbenchMcpServer) {
-						return element.label;
+					getAriaLabel(element: IMcpListEntry) {
+						if (element.type === 'group-header') {
+							return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
+						}
+						return element.server.label;
 					},
 					getWidgetAriaLabel() {
 						return localize('mcpServersListAriaLabel', "MCP Servers");
@@ -374,8 +485,8 @@ export class McpListWidget extends Disposable {
 				},
 				openOnSingleClick: true,
 				identityProvider: {
-					getId(element: IWorkbenchMcpServer) {
-						return element.id;
+					getId(element: IMcpListEntry) {
+						return element.type === 'group-header' ? element.id : element.server.id;
 					}
 				}
 			}
@@ -383,12 +494,16 @@ export class McpListWidget extends Disposable {
 
 		this._register(this.list.onDidOpen(e => {
 			if (e.element) {
-				this._onDidSelectServer.fire(e.element);
+				if (e.element.type === 'group-header') {
+					this.toggleGroup(e.element);
+				} else {
+					this._onDidSelectServer.fire(e.element.server);
+				}
 			}
 		}));
 
 		// Handle context menu
-		this._register(this.list.onContextMenu(e => this.onContextMenu(e)));
+		this._register(this.list.onContextMenu(e => this.onContextMenu(e as IListContextMenuEvent<IMcpListEntry>)));
 
 		// Listen to MCP service changes
 		this._register(this.mcpWorkbenchService.onChange(() => {
@@ -488,7 +603,8 @@ export class McpListWidget extends Disposable {
 			this.listContainer.style.display = '';
 		}
 
-		this.list.splice(0, this.list.length, this.galleryServers);
+		const entries: IMcpListEntry[] = this.galleryServers.map(server => ({ type: 'server-item' as const, server }));
+		this.list.splice(0, this.list.length, entries);
 	}
 
 	private filterServers(): void {
@@ -522,7 +638,64 @@ export class McpListWidget extends Disposable {
 			this.listContainer.style.display = '';
 		}
 
-		this.list.splice(0, this.list.length, this.filteredServers);
+		// Group servers by scope
+		const groups: { scope: LocalMcpServerScope; label: string; icon: ThemeIcon; description: string; servers: IWorkbenchMcpServer[] }[] = [
+			{ scope: LocalMcpServerScope.Workspace, label: localize('workspaceGroup', "Workspace"), icon: workspaceIcon, description: localize('workspaceGroupDescription', "MCP servers configured in your workspace settings, shared with your team via version control."), servers: [] },
+			{ scope: LocalMcpServerScope.User, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "MCP servers configured in your user settings. Private to you and available across all projects."), servers: [] },
+		];
+
+		for (const server of this.filteredServers) {
+			const scope = server.local?.scope;
+			if (scope === LocalMcpServerScope.Workspace) {
+				groups[0].servers.push(server);
+			} else {
+				// User, RemoteUser, or unknown → group under User
+				groups[1].servers.push(server);
+			}
+		}
+
+		// Build display entries with group headers
+		const entries: IMcpListEntry[] = [];
+		let isFirst = true;
+		for (const group of groups) {
+			if (group.servers.length === 0) {
+				continue;
+			}
+			const collapsed = this.collapsedGroups.has(group.scope);
+			entries.push({
+				type: 'group-header',
+				id: `mcp-group-${group.scope}`,
+				scope: group.scope,
+				label: group.label,
+				icon: group.icon,
+				count: group.servers.length,
+				isFirst,
+				description: group.description,
+				collapsed,
+			});
+			if (!collapsed) {
+				for (const server of group.servers) {
+					entries.push({ type: 'server-item', server });
+				}
+			}
+			isFirst = false;
+		}
+
+		this.displayEntries = entries;
+		this.list.splice(0, this.list.length, this.displayEntries);
+	}
+
+	/**
+	 * Toggles the collapsed state of a group.
+	 */
+	private toggleGroup(entry: IMcpGroupHeaderEntry): void {
+		if (this.collapsedGroups.has(entry.scope)) {
+			this.collapsedGroups.delete(entry.scope);
+		} else {
+			this.collapsedGroups.add(entry.scope);
+		}
+		entry.collapsed = !entry.collapsed;
+		this.filterServers();
 	}
 
 	/**
@@ -560,13 +733,14 @@ export class McpListWidget extends Disposable {
 	/**
 	 * Handles context menu for MCP server items.
 	 */
-	private onContextMenu(e: IListContextMenuEvent<IWorkbenchMcpServer>): void {
-		if (!e.element) {
+	private onContextMenu(e: IListContextMenuEvent<IMcpListEntry>): void {
+		if (!e.element || e.element.type !== 'server-item') {
 			return;
 		}
 
+		const serverEntry = e.element;
 		const disposables = new DisposableStore();
-		const mcpServer = this.mcpWorkbenchService.local.find(local => local.id === e.element!.id) || e.element;
+		const mcpServer = this.mcpWorkbenchService.local.find(local => local.id === serverEntry.server.id) || serverEntry.server;
 
 		// Get context menu actions from the MCP module
 		const groups: IAction[][] = getContextMenuActions(mcpServer, false, this.instantiationService);


### PR DESCRIPTION
- Add collapsible group headers (Workspace, User) to the MCP servers list, consistent with other AI customization pages
- Swap Browse Marketplace and Add Server button positions
- Reuse existing group header CSS and icons from AICustomizationListWidget

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/264631