### PR TITLE
Move update status bar entry to the leftmost position

### DIFF
--- a/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
@@ -170,7 +170,10 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 				entry,
 				'status.update',
 				StatusbarAlignment.LEFT,
-				-Number.MAX_VALUE
+				{
+					location: { id: 'status.host', priority: Number.MAX_VALUE },
+					alignment: StatusbarAlignment.LEFT
+				}
 			);
 		}
 	}


### PR DESCRIPTION
Fixes #295639

This will likely be replaced by title bar UI going forward, but for this release leftmost makes more sense.
