### PR TITLE
fix: support keybinding invocation for git reveal commands

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4431,30 +4431,42 @@ export class CommandCenter {
 
 	@command('git.revealInExplorer')
 	async revealInExplorer(resourceState: SourceControlResourceState): Promise<void> {
-		if (!resourceState) {
+		let uri: Uri | undefined;
+
+		if (resourceState && resourceState.resourceUri instanceof Uri) {
+			uri = resourceState.resourceUri;
+		} else {
+			// can happen when called from a keybinding
+			const resource = this.getSCMResource();
+			uri = resource?.resourceUri ?? window.activeTextEditor?.document.uri;
+		}
+
+		if (!uri) {
 			return;
 		}
 
-		if (!(resourceState.resourceUri instanceof Uri)) {
-			return;
-		}
-
-		await commands.executeCommand('revealInExplorer', resourceState.resourceUri);
+		await commands.executeCommand('revealInExplorer', uri);
 	}
 
 	@command('git.revealFileInOS.linux')
 	@command('git.revealFileInOS.mac')
 	@command('git.revealFileInOS.windows')
 	async revealFileInOS(resourceState: SourceControlResourceState): Promise<void> {
-		if (!resourceState) {
+		let uri: Uri | undefined;
+
+		if (resourceState && resourceState.resourceUri instanceof Uri) {
+			uri = resourceState.resourceUri;
+		} else {
+			// can happen when called from a keybinding
+			const resource = this.getSCMResource();
+			uri = resource?.resourceUri ?? window.activeTextEditor?.document.uri;
+		}
+
+		if (!uri) {
 			return;
 		}
 
-		if (!(resourceState.resourceUri instanceof Uri)) {
-			return;
-		}
-
-		await commands.executeCommand('revealFileInOS', resourceState.resourceUri);
+		await commands.executeCommand('revealFileInOS', uri);
 	}
 
 	private async _stash(repository: Repository, includeUntracked = false, staged = false): Promise<boolean> {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `git.revealFileInOS.*` commands (Open Containing Folder / Reveal in Finder / Reveal in File Explorer) and `git.revealInExplorer` silently do nothing when invoked via a keybinding. This is because both commands expect a `SourceControlResourceState` argument that is only provided when invoked from a context menu. When invoked via a keybinding, no argument is passed, so the function hits the early return at `if (!resourceState) { return; }`.

Closes #260898

## What is the new behavior?

When no `resourceState` argument is provided (keybinding invocation), both commands now fall back to:
1. `this.getSCMResource()` — resolves the SCM resource for the active editor's document
2. `window.activeTextEditor?.document.uri` — uses the active editor's URI directly

This matches the existing pattern used by `openFile` (line 1259-1261) and `ignore` (line 4411-4412) commands in the same file, which already handle keybinding invocation gracefully.

## Additional context

The fix is minimal and follows established conventions in the codebase. Both `revealInExplorer` and `revealFileInOS` now work identically whether invoked from a context menu or a keybinding.

**Before:** Keybinding for "Git: Open Containing Folder" does nothing
**After:** Keybinding reveals the active file's containing folder in the OS file manager