### PR TITLE
fix: avoid encoding spaces in local paths during git clone

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -473,7 +473,12 @@ export class Git {
 		};
 
 		try {
-			const command = ['clone', url.includes(' ') ? encodeURI(url) : url, folderPath, '--progress'];
+			// Only encode remote URLs with a protocol scheme. Local paths
+			// should not be encoded since cp.spawn handles spaces in
+			// arguments correctly without shell interpretation.
+			const isRemoteUrl = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url);
+			const cloneUrl = url.includes(' ') && isRemoteUrl ? encodeURI(url) : url;
+			const command = ['clone', cloneUrl, folderPath, '--progress'];
 			if (options.recursive) {
 				command.push('--recursive');
 			}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When cloning a local repository whose path contains spaces (e.g. `/users/test/Application Support/mnt/repo/XYZ`), the spaces are silently converted to `%20` via `encodeURI()`, producing an invalid path that git cannot find. The clone fails with an error, or worse, clones from the wrong location.

This happens because line 476 of `extensions/git/src/git.ts` unconditionally applies `encodeURI()` to any clone URL containing spaces:

```typescript
const command = ['clone', url.includes(' ') ? encodeURI(url) : url, folderPath, '--progress'];
```

Closes #267471

## What is the new behavior?

The `encodeURI()` encoding is now only applied to URLs with a recognized remote protocol scheme (e.g. `https://`, `ssh://`, `git://`). Local paths are passed through unmodified.

This is safe because `cp.spawn()` passes arguments directly to the process without shell interpretation, so spaces in local paths are handled correctly by the OS process spawning mechanism.

```typescript
const isRemoteUrl = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url);
const cloneUrl = url.includes(' ') && isRemoteUrl ? encodeURI(url) : url;
const command = ['clone', cloneUrl, folderPath, '--progress'];
```

**Before:** `git clone /users/test/Application%20Support/repo` (fails - `%20` is literal)
**After:** `git clone /users/test/Application Support/repo` (works - spaces preserved)

## Additional context

The original `encodeURI()` was introduced in commit `1db0f527` (2018, "Fix git problems with spaces") to handle spaces in HTTP URLs. However, it also affects local paths, which do not need URI encoding. This fix preserves the original behavior for remote URLs while fixing local paths.

SCP-style remote URLs (e.g. `git@github.com:user/repo.git`) are not affected since they rarely contain spaces and don't match the protocol scheme regex.