### PR TITLE
New AI Customization Overview

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -46,6 +46,7 @@ export const enum AccessibleViewProviderId {
 	WebviewFindHelp = 'webviewFindHelp',
 	OutputFindHelp = 'outputFindHelp',
 	ProblemsFilterHelp = 'problemsFilterHelp',
+	AICustomizationHelp = 'aiCustomizationHelp',
 }
 
 export const enum AccessibleViewType {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -67,7 +67,8 @@ export const enum AccessibilityVerbositySettingId {
 	Debug = 'accessibility.verbosity.debug',
 	Walkthrough = 'accessibility.verbosity.walkthrough',
 	SourceControl = 'accessibility.verbosity.sourceControl',
-	Find = 'accessibility.verbosity.find'
+	Find = 'accessibility.verbosity.find',
+	AICustomizationHelp = 'accessibility.verbosity.aiCustomization'
 }
 
 const baseVerbosityProperty: IConfigurationPropertySchema = {
@@ -203,6 +204,10 @@ const configuration: IConfigurationNode = {
 		},
 		[AccessibilityVerbositySettingId.Find]: {
 			description: localize('verbosity.find', 'Provide information about how to access the find accessibility help menu when the find input is focused.'),
+			...baseVerbosityProperty
+		},
+		[AccessibilityVerbositySettingId.AICustomizationHelp]: {
+			description: localize('verbosity.aiCustomizationHelp', 'Provide information about how to access the Chat Customization accessibility help menu when the editor is focused.'),
 			...baseVerbosityProperty
 		},
 		'accessibility.signalOptions.volume': {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationAccessibilityHelp.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
+import { AccessibleContentProvider, AccessibleViewProviderId, AccessibleViewType } from '../../../../../platform/accessibility/browser/accessibleView.js';
+import { IAccessibleViewImplementation } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { AccessibilityVerbositySettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
+import { CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_EDITOR, CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_SECTION, AICustomizationManagementSection } from './aiCustomizationManagement.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { AICustomizationManagementEditor } from './aiCustomizationManagementEditor.js';
+
+export class AICustomizationAccessibilityHelp implements IAccessibleViewImplementation {
+	readonly priority = 110;
+	readonly name = 'aiCustomization';
+	readonly type = AccessibleViewType.Help;
+	readonly when = ContextKeyExpr.and(CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_EDITOR, CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_SECTION.isEqualTo(AICustomizationManagementSection.Overview));
+	getProvider(accessor: ServicesAccessor) {
+		const editorService = accessor.get(IEditorService);
+		const activeEditorPane = editorService.activeEditorPane;
+		if (!(activeEditorPane instanceof AICustomizationManagementEditor)) {
+			return;
+		}
+
+		const widget = activeEditorPane.getOverviewWidget();
+		if (!widget) {
+			return;
+		}
+
+		return new AccessibleContentProvider(
+			AccessibleViewProviderId.AICustomizationHelp,
+			{ type: AccessibleViewType.Help },
+			() => widget.getAccessibleDetails(),
+			() => {
+				widget.focus();
+			},
+			AccessibilityVerbositySettingId.AICustomizationHelp,
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
@@ -13,6 +13,11 @@ import { registerIcon } from '../../../../../platform/theme/common/iconRegistry.
 export const aiCustomizationViewIcon = registerIcon('ai-customization-view-icon', Codicon.sparkle, localize('aiCustomizationViewIcon', "Icon for the Chat Customization view."));
 
 /**
+ * Icon for the Overview section.
+ */
+export const overviewIcon = registerIcon('ai-customization-overview', Codicon.home, localize('aiCustomizationOverviewIcon', "Icon for Overview section."));
+
+/**
  * Icon for custom agents.
  */
 export const agentIcon = registerIcon('ai-customization-agent', Codicon.agent, localize('aiCustomizationAgentIcon', "Icon for custom agents."));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -37,7 +37,7 @@ import { basename } from '../../../../../base/common/resources.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, isMacintosh } from '../../../../../base/common/platform.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
-import { IAccessibleViewRegistry, AccessibleViewRegistry } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { AccessibleViewRegistry } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
 import { AICustomizationAccessibilityHelp } from './aiCustomizationAccessibilityHelp.js';
 
 //#region Editor Registration

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -37,6 +37,8 @@ import { basename } from '../../../../../base/common/resources.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, isMacintosh } from '../../../../../base/common/platform.js';
 import { ResourceContextKey } from '../../../../common/contextkeys.js';
+import { IAccessibleViewRegistry, AccessibleViewRegistry } from '../../../../../platform/accessibility/browser/accessibleViewRegistry.js';
+import { AICustomizationAccessibilityHelp } from './aiCustomizationAccessibilityHelp.js';
 
 //#region Editor Registration
 
@@ -311,5 +313,11 @@ registerWorkbenchContribution2(
 	AICustomizationManagementActionsContribution,
 	WorkbenchPhase.AfterRestored
 );
+
+//#endregion
+
+//#region Accessibility
+
+AccessibleViewRegistry.register(new AICustomizationAccessibilityHelp());
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -28,7 +28,7 @@ export const AICustomizationManagementCommands = {
 	OpenEditor: 'aiCustomization.openManagementEditor',
 	CreateNewAgent: 'aiCustomization.createNewAgent',
 	CreateNewSkill: 'aiCustomization.createNewSkill',
-	CreateNewInstructions: 'aiCustomization.createNewInstructions',
+	CreateNewInstructions: 'workbench.action.chat.generateInstructions',
 	CreateNewPrompt: 'aiCustomization.createNewPrompt',
 } as const;
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -223,10 +223,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 			}
 		}
 
-		// Restore selected section from storage, falling back to first available
+		// Restore selected section from storage, falling back to Overview or first available
 		const savedSection = this.storageService.get(AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY, StorageScope.PROFILE);
 		if (savedSection && this.sections.some(s => s.id === savedSection)) {
 			this.selectedSection = savedSection as AICustomizationManagementSection;
+		} else if (this.sections.some(s => s.id === AICustomizationManagementSection.Overview)) {
+			this.selectedSection = AICustomizationManagementSection.Overview;
 		} else if (this.sections.length > 0) {
 			this.selectedSection = this.sections[0].id;
 		}
@@ -280,6 +282,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			layout: (width, _, height) => {
 				this.contentContainer.style.width = `${width}px`;
 				if (height !== undefined) {
+					this.overviewWidget?.layout(new DOM.Dimension(width, height));
 					this.listWidget.layout(height - 16, width - 24);
 					this.mcpListWidget?.layout(height - 16, width - 24);
 					const modelsFooterHeight = this.modelsFooterElement?.offsetHeight || 80;
@@ -443,6 +446,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Load items for the initial section
 		if (this.isPromptsSection(this.selectedSection)) {
 			void this.listWidget.setSection(this.selectedSection);
+		} else if (this.selectedSection === AICustomizationManagementSection.Overview) {
+			this.overviewWidget?.refresh();
 		}
 	}
 
@@ -478,6 +483,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Update content visibility
 		this.updateContentVisibility();
 
+		// Update Overview counts if selected
+		if (section === AICustomizationManagementSection.Overview) {
+			this.overviewWidget?.refresh();
+		}
+
 		// Load items for the new section (only for prompts-based sections)
 		if (this.isPromptsSection(section)) {
 			void this.listWidget.setSection(section);
@@ -494,10 +504,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private updateContentVisibility(): void {
 		const isEditorMode = this.viewMode === 'editor';
 		const isMcpDetailMode = this.viewMode === 'mcpDetail';
+		const isOverviewSection = this.selectedSection === AICustomizationManagementSection.Overview;
 		const isPromptsSection = this.isPromptsSection(this.selectedSection);
 		const isModelsSection = this.selectedSection === AICustomizationManagementSection.Models;
 		const isMcpSection = this.selectedSection === AICustomizationManagementSection.McpServers;
 
+		this.overviewContentContainer.style.display = !isEditorMode && !isMcpDetailMode && isOverviewSection ? '' : 'none';
 		this.promptsContentContainer.style.display = !isEditorMode && !isMcpDetailMode && isPromptsSection ? '' : 'none';
 		if (this.modelsContentContainer) {
 			this.modelsContentContainer.style.display = !isEditorMode && !isMcpDetailMode && isModelsSection ? '' : 'none';

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -134,6 +134,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private sectionsList!: WorkbenchList<ISectionItem>;
 	private contentContainer!: HTMLElement;
 	private overviewWidget: AICustomizationOverviewWidget | undefined;
+	private lastOverviewRefreshTime = 0;
 	private overviewContentContainer!: HTMLElement;
 	private listWidget!: AICustomizationListWidget;
 	private mcpListWidget: McpListWidget | undefined;
@@ -232,6 +233,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		} else if (this.sections.length > 0) {
 			this.selectedSection = this.sections[0].id;
 		}
+	}
+
+	getOverviewWidget(): AICustomizationOverviewWidget | undefined {
+		return this.overviewWidget;
 	}
 
 	protected override createEditor(parent: HTMLElement): void {
@@ -352,6 +357,16 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.editorDisposables.add(this.sectionsList.onDidChangeSelection(e => {
 			if (e.elements.length > 0) {
 				this.selectSection(e.elements[0].id);
+			}
+		}));
+
+		this.editorDisposables.add(this.sectionsList.onDidOpen(e => {
+			if (e.element?.id === AICustomizationManagementSection.Overview) {
+				const now = Date.now();
+				if (now - this.lastOverviewRefreshTime > 100) {
+					this.overviewWidget?.refresh();
+					this.lastOverviewRefreshTime = now;
+				}
 			}
 		}));
 	}
@@ -486,6 +501,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Update Overview counts if selected
 		if (section === AICustomizationManagementSection.Overview) {
 			this.overviewWidget?.refresh();
+			this.lastOverviewRefreshTime = Date.now();
 		}
 
 		// Load items for the new section (only for prompts-based sections)

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
@@ -3,16 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { $, append, clearNode } from '../../../../../base/browser/dom.js';
 import { Dimension } from '../../../../../base/browser/dom.js';
+import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { localize } from '../../../../../nls.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { IMcpWorkbenchService } from '../../../../contrib/mcp/common/mcpTypes.js';
 import { AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
+import * as AICustomizationIcons from './aiCustomizationIcons.js';
 
 interface ISectionCount {
 	readonly section: AICustomizationManagementSection;
@@ -24,8 +31,18 @@ export class AICustomizationOverviewWidget extends Disposable {
 	private readonly _onDidSelectSection = this._register(new Emitter<AICustomizationManagementSection>());
 	readonly onDidSelectSection: Event<AICustomizationManagementSection> = this._onDidSelectSection.event;
 
+	private readonly refreshScheduler: RunOnceScheduler;
 	private container: HTMLElement | undefined;
-	private counts = new Map<AICustomizationManagementSection, number | undefined>();
+	private readonly counts = new Map<AICustomizationManagementSection, number | undefined>();
+	private readonly badges = new Map<AICustomizationManagementSection, HTMLElement>();
+
+	private get totalCount(): number {
+		let total = 0;
+		for (const count of this.counts.values()) {
+			total += count ?? 0;
+		}
+		return total;
+	}
 
 	constructor(
 		@IPromptsService private readonly promptsService: IPromptsService,
@@ -34,19 +51,135 @@ export class AICustomizationOverviewWidget extends Disposable {
 		@IOpenerService private readonly openerService: IOpenerService,
 	) {
 		super();
+
+		this.refreshScheduler = this._register(new RunOnceScheduler(() => {
+			if (this.container) {
+				this.refresh();
+			}
+		}, 300));
+
+		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refreshScheduler.schedule()));
+		this._register(this.promptsService.onDidChangeSlashCommands(() => this.refreshScheduler.schedule()));
+		this._register(this.mcpWorkbenchService.onChange(() => this.refreshScheduler.schedule()));
 	}
 
 	render(parent: HTMLElement): void {
 		// TODO: implement two-mode rendering (2.3)
 		this.container = parent;
+		this.renderContent();
 	}
 
 	async refresh(): Promise<void> {
 		await this.refreshCounts();
+		this.renderContent();
 	}
 
 	private updateCountBadge(section: AICustomizationManagementSection, count: number | undefined): void {
-		// stub for now (2.3)
+		const badge = this.badges.get(section);
+		if (badge) {
+			badge.textContent = count === undefined ? "--" : `${count}`;
+		}
+	}
+
+	private renderContent(): void {
+		if (!this.container) {
+			return;
+		}
+
+		clearNode(this.container);
+		this.badges.clear();
+
+		if (this.totalCount <= 1) {
+			this.renderWelcome(this.container);
+		} else {
+			this.renderDashboard(this.container);
+		}
+	}
+
+	private renderWelcome(parent: HTMLElement): void {
+		const welcome = append(parent, $('.ai-customization-overview.overview-welcome'));
+
+		const header = append(welcome, $('.overview-header'));
+		append(header, $('h2')).textContent = localize('welcomeTitle', "Personalize Your AI Assistant");
+		append(header, $('p.overview-subtitle')).textContent = localize('welcomeSubtitle', "Shape how Copilot works with custom instructions, agents, prompts, and more.");
+
+		const suggestions = append(welcome, $('.overview-suggestions'));
+		this.renderSuggestionCard(suggestions, AICustomizationManagementSection.Instructions, AICustomizationIcons.instructionsIcon, localize('instructionsTitle', "Instructions"), localize('instructionsDescription', "Guidelines that influence AI code generation"), localize('createInstructions', "Create Instructions"));
+		this.renderSuggestionCard(suggestions, AICustomizationManagementSection.Agents, AICustomizationIcons.agentIcon, localize('agentsTitle', "Agents"), localize('agentsDescription', "Custom AI personas with specific tools and instructions"), localize('createAgent', "Create Agent"));
+		this.renderSuggestionCard(suggestions, AICustomizationManagementSection.Prompts, AICustomizationIcons.promptIcon, localize('promptsTitle', "Prompts"), localize('promptsDescription', "Reusable prompts for common development tasks"), localize('createPrompt', "Create Prompt"));
+
+		const footer = append(welcome, $('.overview-footer'));
+		const exploreLink = append(footer, $('a.overview-explore-link'));
+		exploreLink.textContent = localize('exploreLink', "Explore all customization types →");
+		exploreLink.role = 'button';
+		exploreLink.onclick = () => this._onDidSelectSection.fire(AICustomizationManagementSection.Agents); // Default to agents or keep on overview? Plan says explore all.
+	}
+
+	private renderSuggestionCard(parent: HTMLElement, section: AICustomizationManagementSection, icon: ThemeIcon, title: string, description: string, buttonLabel: string): void {
+		const card = append(parent, $('.overview-suggestion-card'));
+		
+		const iconContainer = append(card, $('.suggestion-icon'));
+		append(iconContainer, renderIcon(icon));
+
+		const content = append(card, $('.suggestion-content'));
+		append(content, $('.suggestion-title')).textContent = title;
+		append(content, $('.suggestion-description')).textContent = description;
+
+		const button = append(card, $('button.monaco-button'));
+		button.textContent = buttonLabel;
+		button.setAttribute('data-section', section);
+	}
+
+	private renderDashboard(parent: HTMLElement): void {
+		const dashboard = append(parent, $('.ai-customization-overview.overview-dashboard'));
+		const sectionsGrid = append(dashboard, $('.overview-sections'));
+
+		const sections = [
+			{ id: AICustomizationManagementSection.Agents, icon: AICustomizationIcons.agentIcon, label: localize('sectionAgents', "Agents"), description: localize('descAgents', "Custom AI personas with specific tools and instructions") },
+			{ id: AICustomizationManagementSection.Skills, icon: AICustomizationIcons.skillIcon, label: localize('sectionSkills', "Skills"), description: localize('descSkills', "Folders of instructions Copilot loads when relevant") },
+			{ id: AICustomizationManagementSection.Instructions, icon: AICustomizationIcons.instructionsIcon, label: localize('sectionInstructions', "Instructions"), description: localize('descInstructions', "Guidelines that influence AI code generation") },
+			{ id: AICustomizationManagementSection.Prompts, icon: AICustomizationIcons.promptIcon, label: localize('sectionPrompts', "Prompts"), description: localize('descPrompts', "Reusable prompts for common development tasks") },
+			{ id: AICustomizationManagementSection.Hooks, icon: AICustomizationIcons.hookIcon, label: localize('sectionHooks', "Hooks"), description: localize('descHooks', "Prompts executed at specific lifecycle points") },
+			{ id: AICustomizationManagementSection.McpServers, icon: Codicon.server, label: localize('sectionMCP', "MCP Servers"), description: localize('descMCP', "External tools and services for AI") }
+		];
+
+		const emptySections: typeof sections = [];
+
+		for (const section of sections) {
+			const count = this.counts.get(section.id);
+			if (count === 0) {
+				emptySections.push(section);
+			}
+
+			const card = append(sectionsGrid, $('button.overview-section'));
+			card.onclick = () => this._onDidSelectSection.fire(section.id);
+
+			const iconContainer = append(card, $('.section-icon'));
+			append(iconContainer, renderIcon(section.icon));
+
+			const textContainer = append(card, $('.section-text'));
+			append(textContainer, $('.section-label')).textContent = section.label;
+			append(textContainer, $('.section-description')).textContent = section.description;
+
+			const badge = append(card, $('.section-count'));
+			this.badges.set(section.id, badge);
+			this.updateCountBadge(section.id, count);
+		}
+
+		if (emptySections.length > 0) {
+			const inlineSuggestions = append(dashboard, $('.overview-inline-suggestions'));
+			for (const section of emptySections) {
+				const suggestion = append(inlineSuggestions, $('.overview-inline-suggestion'));
+				const icon = append(suggestion, $('.codicon'));
+				icon.classList.add(...ThemeIcon.asClassNameArray(section.icon));
+				
+				append(suggestion, $('span')).textContent = localize('noItems', "No {0} yet", section.label.toLowerCase());
+				const link = append(suggestion, $('a'));
+				link.textContent = localize('createOne', "Create one →");
+				link.role = 'button';
+				link.setAttribute('data-section', section.id);
+			}
+		}
 	}
 
 	private async refreshCounts(): Promise<void> {
@@ -101,6 +234,6 @@ export class AICustomizationOverviewWidget extends Disposable {
 	}
 
 	layout(dimension: Dimension): void {
-		// TODO: implement responsive layout
+		// TODO: implement responsive layout (4.1)
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
@@ -81,6 +81,7 @@ export class AICustomizationOverviewWidget extends Disposable {
 	render(parent: HTMLElement): void {
 		this.container = parent;
 		this.container.role = 'region';
+		this.container.tabIndex = -1;
 		this.container.ariaLabel = localize('aiCustomizationOverview', "AI Customization Overview");
 		this.renderContent();
 	}
@@ -105,6 +106,8 @@ export class AICustomizationOverviewWidget extends Disposable {
 				badge.textContent = text;
 				badge.ariaLive = 'polite';
 			}
+			badge.classList.toggle('loading', count === undefined);
+
 			const card = this._sectionCards.get(section);
 			if (card) {
 				const sectionLabel = this._getSectionLabel(section);
@@ -333,5 +336,27 @@ export class AICustomizationOverviewWidget extends Disposable {
 
 	layout(dimension: Dimension): void {
 		// TODO: implement responsive layout (4.1)
+	}
+
+	focus(): void {
+		if (this.container) {
+			this.container.focus();
+		}
+	}
+
+	getAccessibleDetails(): string {
+		const content: string[] = [];
+		if (this.currentMode === 'welcome') {
+			content.push(localize('overviewWelcomeAria', "AI Customization Overview: Welcome mode. Shape how Copilot works with custom instructions, agents, and prompts."));
+			content.push(localize('overviewWelcomeInstructions', "Available actions: Create Instructions, Create Agent, or Create Prompt."));
+		} else {
+			content.push(localize('overviewDashboardAria', "AI Customization Overview: Dashboard mode."));
+			for (const [section, count] of this.counts) {
+				const label = this._getSectionLabel(section);
+				const countLabel = count === undefined ? localize('loading', "loading") : (count === 1 ? localize('oneItem', "1 item") : localize('manyItems', "{0} items", count));
+				content.push(`${label}: ${countLabel}`);
+			}
+		}
+		return content.join('\n');
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Dimension } from '../../../../../base/browser/dom.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { IMcpWorkbenchService } from '../../../../contrib/mcp/common/mcpTypes.js';
+import { AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
+
+interface ISectionCount {
+	readonly section: AICustomizationManagementSection;
+	readonly count: number | undefined; // undefined = loading
+}
+
+export class AICustomizationOverviewWidget extends Disposable {
+
+	private readonly _onDidSelectSection = this._register(new Emitter<AICustomizationManagementSection>());
+	readonly onDidSelectSection: Event<AICustomizationManagementSection> = this._onDidSelectSection.event;
+
+	private container: HTMLElement | undefined;
+	private counts = new Map<AICustomizationManagementSection, number | undefined>();
+
+	constructor(
+		@IPromptsService private readonly promptsService: IPromptsService,
+		@IMcpWorkbenchService private readonly mcpWorkbenchService: IMcpWorkbenchService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IOpenerService private readonly openerService: IOpenerService,
+	) {
+		super();
+	}
+
+	render(parent: HTMLElement): void {
+		// TODO: implement two-mode rendering (2.3)
+		this.container = parent;
+	}
+
+	async refresh(): Promise<void> {
+		await this.refreshCounts();
+	}
+
+	private updateCountBadge(section: AICustomizationManagementSection, count: number | undefined): void {
+		// stub for now (2.3)
+	}
+
+	private async refreshCounts(): Promise<void> {
+		const sections = [
+			AICustomizationManagementSection.Agents,
+			AICustomizationManagementSection.Skills,
+			AICustomizationManagementSection.Instructions,
+			AICustomizationManagementSection.Prompts,
+			AICustomizationManagementSection.Hooks,
+			AICustomizationManagementSection.McpServers
+		];
+
+		// Set to skeleton state
+		for (const section of sections) {
+			this.counts.set(section, undefined);
+			this.updateCountBadge(section, undefined);
+		}
+
+		// MCP is sync
+		const mcpCount = this.mcpWorkbenchService.local.length;
+		this.counts.set(AICustomizationManagementSection.McpServers, mcpCount);
+		this.updateCountBadge(AICustomizationManagementSection.McpServers, mcpCount);
+
+		// Other sections are async
+		await Promise.allSettled([
+			this.promptsService.getCustomAgents(CancellationToken.None).then(agents => {
+				const count = agents.length;
+				this.counts.set(AICustomizationManagementSection.Agents, count);
+				this.updateCountBadge(AICustomizationManagementSection.Agents, count);
+			}),
+			this.promptsService.findAgentSkills(CancellationToken.None).then(skills => {
+				const count = skills?.length ?? 0;
+				this.counts.set(AICustomizationManagementSection.Skills, count);
+				this.updateCountBadge(AICustomizationManagementSection.Skills, count);
+			}),
+			this.promptsService.listPromptFiles(PromptsType.instructions, CancellationToken.None).then(files => {
+				const count = files.length;
+				this.counts.set(AICustomizationManagementSection.Instructions, count);
+				this.updateCountBadge(AICustomizationManagementSection.Instructions, count);
+			}),
+			this.promptsService.getPromptSlashCommands(CancellationToken.None).then(prompts => {
+				const count = prompts.length;
+				this.counts.set(AICustomizationManagementSection.Prompts, count);
+				this.updateCountBadge(AICustomizationManagementSection.Prompts, count);
+			}),
+			this.promptsService.getHooks(CancellationToken.None).then(hooksInfo => {
+				const count = hooksInfo ? Object.values(hooksInfo.hooks).reduce((acc: number, current) => acc + (current?.length ?? 0), 0) : 0;
+				this.counts.set(AICustomizationManagementSection.Hooks, count);
+				this.updateCountBadge(AICustomizationManagementSection.Hooks, count);
+			})
+		]);
+	}
+
+	layout(dimension: Dimension): void {
+		// TODO: implement responsive layout
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { $, addDisposableListener, append, clearNode, Dimension, EventType } from '../../../../../base/browser/dom.js';
+import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent.js';
 import { renderIcon } from '../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
@@ -33,6 +35,29 @@ const createCommands: Record<AICustomizationManagementSection, string | undefine
 	[AICustomizationManagementSection.Overview]: undefined
 };
 
+/**
+ * Journey steps ordered by impact (80/20 Rule):
+ * Instructions (50% of value) -> Prompts -> Agents -> Advanced (Skills, MCP, Hooks)
+ */
+interface IJourneyStep {
+	readonly section: AICustomizationManagementSection;
+	readonly icon: ThemeIcon;
+	readonly title: string;
+	readonly description: string;
+	readonly ctaLabel: string;
+	readonly docUrl: string;
+}
+
+/**
+ * Advanced sub-items grouped into the collapsible final step.
+ */
+interface IAdvancedSubItem {
+	readonly section: AICustomizationManagementSection;
+	readonly icon: ThemeIcon;
+	readonly label: string;
+	readonly ctaLabel: string;
+}
+
 /** Sections ordered by 80/20 priority for dashboard cards */
 const DASHBOARD_SECTIONS = [
 	AICustomizationManagementSection.Instructions,
@@ -54,6 +79,16 @@ export class AICustomizationOverviewWidget extends Disposable {
 	private readonly counts = new Map<AICustomizationManagementSection, number | undefined>();
 	private readonly badges = new Map<AICustomizationManagementSection, HTMLElement>();
 	private readonly _sectionCards = new Map<AICustomizationManagementSection, HTMLElement>();
+	private currentMode: 'welcome' | 'dashboard' | undefined;
+	private _advancedExpanded = false;
+
+	private get totalCount(): number {
+		let total = 0;
+		for (const count of this.counts.values()) {
+			total += count ?? 0;
+		}
+		return total;
+	}
 
 	private get activeTypeCount(): number {
 		let active = 0;
@@ -90,12 +125,21 @@ export class AICustomizationOverviewWidget extends Disposable {
 		this.container.role = 'region';
 		this.container.tabIndex = -1;
 		this.container.ariaLabel = localize('aiCustomizationOverview', "AI Customization Overview");
+		// Fetch counts first so we render the correct mode immediately,
+		// avoiding a flash from welcome → dashboard.
 		this.refresh();
 	}
 
 	async refresh(): Promise<void> {
 		await this.refreshCounts();
-		this.renderContent();
+		const newMode = this.totalCount <= 1 ? 'welcome' : 'dashboard';
+		if (newMode !== this.currentMode) {
+			this.renderContent();
+		} else {
+			for (const [section, count] of this.counts) {
+				this.updateCountBadge(section, count);
+			}
+		}
 	}
 
 	private updateCountBadge(section: AICustomizationManagementSection, count: number | undefined): void {
@@ -131,9 +175,9 @@ export class AICustomizationOverviewWidget extends Disposable {
 
 	private _getSectionDescription(section: AICustomizationManagementSection): string {
 		switch (section) {
-			case AICustomizationManagementSection.Instructions: return localize('descInstructions', "Teach Copilot your coding standards once and keep every session aligned");
-			case AICustomizationManagementSection.Prompts: return localize('descPrompts', "Package repeatable workflows into reusable slash-command prompts");
-			case AICustomizationManagementSection.Agents: return localize('descAgents', "Create specialist collaborators for review, architecture, and testing");
+			case AICustomizationManagementSection.Instructions: return localize('descInstructions', "Define coding conventions, preferred libraries, and project structure");
+			case AICustomizationManagementSection.Prompts: return localize('descPrompts', "Build reusable prompts for tasks you repeat every day");
+			case AICustomizationManagementSection.Agents: return localize('descAgents', "Give Copilot personas for code review, architecture, or testing");
 			case AICustomizationManagementSection.Skills: return localize('descSkills', "Folders of instructions Copilot loads when relevant");
 			case AICustomizationManagementSection.McpServers: return localize('descMCP', "Connect external tools and services to Copilot");
 			case AICustomizationManagementSection.Hooks: return localize('descHooks', "Automate prompts at specific lifecycle events");
@@ -141,40 +185,56 @@ export class AICustomizationOverviewWidget extends Disposable {
 		}
 	}
 
-	private _getSectionPitch(section: AICustomizationManagementSection): string {
-		switch (section) {
-			case AICustomizationManagementSection.Instructions: return localize('pitchInstructions', "Highest impact: remove most Copilot friction with one shared instruction file.");
-			case AICustomizationManagementSection.Prompts: return localize('pitchPrompts', "Turn recurring tasks into one-click, repeatable workflows.");
-			case AICustomizationManagementSection.Agents: return localize('pitchAgents', "Assign specialized personas with their own tools and context.");
-			case AICustomizationManagementSection.Skills: return localize('pitchSkills', "Bundle domain playbooks Copilot can load automatically.");
-			case AICustomizationManagementSection.McpServers: return localize('pitchMcp', "Bring external systems and internal tools directly into chat.");
-			case AICustomizationManagementSection.Hooks: return localize('pitchHooks', "Trigger custom behavior at key moments in every session.");
-			default: return '';
-		}
+	private _getJourneySteps(): IJourneyStep[] {
+		return [
+			{
+				section: AICustomizationManagementSection.Instructions,
+				icon: AICustomizationIcons.instructionsIcon,
+				title: localize('stepInstructionsTitle', "Set Your Standards"),
+				description: localize('stepInstructionsDesc', "Define coding conventions, preferred libraries, and project structure. This single file eliminates most friction with Copilot."),
+				ctaLabel: localize('generateInstructionsCta', "Generate Instructions"),
+				docUrl: 'https://code.visualstudio.com/docs/copilot/copilot-customization',
+			},
+			{
+				section: AICustomizationManagementSection.Prompts,
+				icon: AICustomizationIcons.promptIcon,
+				title: localize('stepPromptsTitle', "Automate Your Workflows"),
+				description: localize('stepPromptsDesc', "Build reusable prompts for tasks you repeat every day -- code reviews, documentation, test generation."),
+				ctaLabel: localize('createPrompt', "Create Prompt"),
+				docUrl: 'https://code.visualstudio.com/docs/copilot/prompt-files',
+			},
+			{
+				section: AICustomizationManagementSection.Agents,
+				icon: AICustomizationIcons.agentIcon,
+				title: localize('stepAgentsTitle', "Create Specialist AI"),
+				description: localize('stepAgentsDesc', "Give Copilot specialized personas with their own instructions, tools, and knowledge for specific roles."),
+				ctaLabel: localize('createAgent', "Create Agent"),
+				docUrl: 'https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview',
+			},
+		];
 	}
 
-	private _getSectionDocUrl(section: AICustomizationManagementSection): string {
-		switch (section) {
-			case AICustomizationManagementSection.Instructions: return 'https://code.visualstudio.com/docs/copilot/copilot-customization';
-			case AICustomizationManagementSection.Prompts: return 'https://code.visualstudio.com/docs/copilot/prompt-files';
-			case AICustomizationManagementSection.Agents: return 'https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview';
-			case AICustomizationManagementSection.Skills: return 'https://code.visualstudio.com/docs/copilot/copilot-customization';
-			case AICustomizationManagementSection.McpServers: return 'https://code.visualstudio.com/docs/copilot/chat/mcp-servers';
-			case AICustomizationManagementSection.Hooks: return 'https://code.visualstudio.com/docs/copilot/customization/overview';
-			default: return 'https://code.visualstudio.com/docs/copilot/customization/overview';
-		}
-	}
-
-	private _getSectionActionLabel(section: AICustomizationManagementSection): string {
-		switch (section) {
-			case AICustomizationManagementSection.Instructions: return localize('generateInstructionsCta', "Generate Instructions");
-			case AICustomizationManagementSection.Prompts: return localize('createPrompt', "Create Prompt");
-			case AICustomizationManagementSection.Agents: return localize('createAgent', "Create Agent");
-			case AICustomizationManagementSection.Skills: return localize('createSkill', "Create Skill");
-			case AICustomizationManagementSection.McpServers: return localize('addMCPServer', "Add Server");
-			case AICustomizationManagementSection.Hooks: return localize('createHook', "Create Hook");
-			default: return localize('createLabel', "Create");
-		}
+	private _getAdvancedSubItems(): IAdvancedSubItem[] {
+		return [
+			{
+				section: AICustomizationManagementSection.Skills,
+				icon: AICustomizationIcons.skillIcon,
+				label: localize('sectionSkills', "Skills"),
+				ctaLabel: localize('createSkill', "Create Skill"),
+			},
+			{
+				section: AICustomizationManagementSection.McpServers,
+				icon: Codicon.server,
+				label: localize('sectionMCP', "MCP Servers"),
+				ctaLabel: localize('addMCPServer', "Add Server"),
+			},
+			{
+				section: AICustomizationManagementSection.Hooks,
+				icon: AICustomizationIcons.hookIcon,
+				label: localize('sectionHooks', "Hooks"),
+				ctaLabel: localize('createHook', "Create Hook"),
+			},
+		];
 	}
 
 	private renderContent(): void {
@@ -182,29 +242,232 @@ export class AICustomizationOverviewWidget extends Disposable {
 			return;
 		}
 
+		this.currentMode = this.totalCount <= 1 ? 'welcome' : 'dashboard';
+
 		clearNode(this.container);
 		this._renderDisposables.clear();
 		this.badges.clear();
 		this._sectionCards.clear();
-		this.renderDashboard(this.container);
+
+		if (this.currentMode === 'welcome') {
+			this.renderWelcome(this.container);
+		} else {
+			this.renderDashboard(this.container);
+		}
+	}
+
+	private renderWelcome(parent: HTMLElement): void {
+		const welcome = append(parent, $('.ai-customization-overview-welcome'));
+		welcome.role = 'region';
+		welcome.ariaLabel = localize('welcomeRegion', "AI Customization Setup Guide");
+
+		const header = append(welcome, $('.welcome-header'));
+		append(header, $('h2.hero-heading')).textContent = localize('welcomeTitle', "Copilot already writes great code. Teach it yours.");
+		append(header, $('p.hero-subtitle')).textContent = localize('welcomeSubtitle', "Start with what matters most -- each step builds on the last.");
+
+		// Journey stepper
+		const stepper = append(welcome, $('.journey-stepper'));
+		stepper.role = 'list';
+		stepper.ariaLabel = localize('journeyStepperLabel', "Setup steps");
+
+		const steps = this._getJourneySteps();
+		let foundCurrent = false;
+
+		for (let i = 0; i < steps.length; i++) {
+			const step = steps[i];
+			const count = this.counts.get(step.section) ?? 0;
+			const isComplete = count > 0;
+			const isCurrent = !isComplete && !foundCurrent;
+			if (isCurrent) {
+				foundCurrent = true;
+			}
+
+			this._renderJourneyStep(stepper, step, i + 1, isComplete, isCurrent);
+		}
+
+		// Advanced collapsible section
+		this._renderAdvancedSection(welcome);
+
+		// Footer doc link
+		const footer = append(welcome, $('.overview-footer'));
+		const docLink = append(footer, $('a.overview-explore-link'));
+		docLink.textContent = localize('exploreDocsLink', "Explore the customization guide");
+		docLink.tabIndex = 0;
+		this._renderDisposables.add(addDisposableListener(docLink, EventType.CLICK, (e: MouseEvent) => {
+			this.openerService.open(URI.parse('https://code.visualstudio.com/docs/copilot/customization/overview'));
+			e.preventDefault();
+		}));
+		this._renderDisposables.add(addDisposableListener(docLink, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const keyboardEvent = new StandardKeyboardEvent(e);
+			if (keyboardEvent.equals(KeyCode.Enter) || keyboardEvent.equals(KeyCode.Space)) {
+				this.openerService.open(URI.parse('https://code.visualstudio.com/docs/copilot/customization/overview'));
+				e.preventDefault();
+			}
+		}));
+	}
+
+	private _renderJourneyStep(parent: HTMLElement, step: IJourneyStep, stepNumber: number, isComplete: boolean, isCurrent: boolean): void {
+		const stepEl = append(parent, $('.journey-step'));
+		stepEl.role = 'listitem';
+		stepEl.classList.toggle('complete', isComplete);
+		stepEl.classList.toggle('current', isCurrent);
+
+		const statusLabel = isComplete
+			? localize('stepComplete', "Completed")
+			: (isCurrent ? localize('stepCurrent', "Current step") : localize('stepUpcoming', "Upcoming"));
+		stepEl.ariaLabel = localize('journeyStepAriaLabel', "Step {0}: {1}, {2}. {3}", stepNumber, step.title, statusLabel, step.description);
+
+		// Step indicator (number or check)
+		const indicator = append(stepEl, $('.step-indicator'));
+		indicator.ariaHidden = 'true';
+		if (isComplete) {
+			indicator.classList.add('complete');
+			append(indicator, renderIcon(Codicon.check));
+		} else {
+			indicator.textContent = `${stepNumber}`;
+		}
+
+		// Step content
+		const content = append(stepEl, $('.step-content'));
+		const stepHeader = append(content, $('.step-header'));
+
+		const iconContainer = append(stepHeader, $('.step-icon'));
+		iconContainer.ariaHidden = 'true';
+		append(iconContainer, renderIcon(step.icon));
+		append(stepHeader, $('span.step-title')).textContent = step.title;
+
+		append(content, $('p.step-description')).textContent = step.description;
+
+		// Actions row
+		const actions = append(content, $('.step-actions'));
+
+		const commandId = createCommands[step.section];
+		if (commandId) {
+			const ctaButton = append(actions, $('button.step-cta'));
+			ctaButton.ariaLabel = step.ctaLabel;
+			if (step.section === AICustomizationManagementSection.Instructions) {
+				ctaButton.classList.add('generate-instructions');
+				const sparkleIcon = append(ctaButton, renderIcon(Codicon.sparkle));
+				sparkleIcon.classList.add('step-cta-icon');
+				sparkleIcon.ariaHidden = 'true';
+				append(ctaButton, $('span')).textContent = step.ctaLabel;
+			} else {
+				ctaButton.textContent = step.ctaLabel;
+			}
+			this._renderDisposables.add(addDisposableListener(ctaButton, EventType.CLICK, () => {
+				this.commandService.executeCommand(commandId);
+			}));
+		}
+
+		const learnMore = append(actions, $('a.step-learn-more'));
+		learnMore.textContent = localize('learnMore', "Learn more");
+		learnMore.tabIndex = 0;
+		this._renderDisposables.add(addDisposableListener(learnMore, EventType.CLICK, (e: MouseEvent) => {
+			this.openerService.open(URI.parse(step.docUrl));
+			e.preventDefault();
+		}));
+		this._renderDisposables.add(addDisposableListener(learnMore, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const keyboardEvent = new StandardKeyboardEvent(e);
+			if (keyboardEvent.equals(KeyCode.Enter) || keyboardEvent.equals(KeyCode.Space)) {
+				this.openerService.open(URI.parse(step.docUrl));
+				e.preventDefault();
+			}
+		}));
+
+		// "View" link for completed steps to navigate
+		if (isComplete) {
+			const viewLink = append(actions, $('a.step-view-link'));
+			viewLink.textContent = localize('viewItems', "View");
+			viewLink.tabIndex = 0;
+			viewLink.role = 'button';
+			this._renderDisposables.add(addDisposableListener(viewLink, EventType.CLICK, () => {
+				this._onDidSelectSection.fire(step.section);
+			}));
+			this._renderDisposables.add(addDisposableListener(viewLink, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+				const keyboardEvent = new StandardKeyboardEvent(e);
+				if (keyboardEvent.equals(KeyCode.Enter) || keyboardEvent.equals(KeyCode.Space)) {
+					this._onDidSelectSection.fire(step.section);
+					e.preventDefault();
+				}
+			}));
+		}
+	}
+
+	private _renderAdvancedSection(parent: HTMLElement): void {
+		const advanced = append(parent, $('.journey-advanced'));
+
+		const toggle = append(advanced, $('button.advanced-toggle'));
+		const toggleIcon = append(toggle, $('.toggle-icon'));
+		append(toggleIcon, renderIcon(this._advancedExpanded ? Codicon.chevronDown : Codicon.chevronRight));
+		append(toggle, $('span')).textContent = localize('advancedTitle', "Extend Your Reach");
+		toggle.ariaExpanded = `${this._advancedExpanded}`;
+		toggle.ariaLabel = localize('advancedToggleLabel', "Extend Your Reach -- connect external tools, add skills, and automate lifecycle events");
+
+		const body = append(advanced, $('.advanced-body'));
+		body.style.display = this._advancedExpanded ? '' : 'none';
+
+		this._renderDisposables.add(addDisposableListener(toggle, EventType.CLICK, () => {
+			this._advancedExpanded = !this._advancedExpanded;
+			body.style.display = this._advancedExpanded ? '' : 'none';
+			toggle.ariaExpanded = `${this._advancedExpanded}`;
+			clearNode(toggleIcon);
+			append(toggleIcon, renderIcon(this._advancedExpanded ? Codicon.chevronDown : Codicon.chevronRight));
+		}));
+
+		const subItems = this._getAdvancedSubItems();
+		for (const item of subItems) {
+			const row = append(body, $('.advanced-item'));
+
+			const iconEl = append(row, $('.advanced-item-icon'));
+			iconEl.ariaHidden = 'true';
+			append(iconEl, renderIcon(item.icon));
+
+			const label = append(row, $('span.advanced-item-label'));
+			label.textContent = item.label;
+
+			const count = this.counts.get(item.section) ?? 0;
+			const badge = append(row, $('span.advanced-item-badge'));
+			badge.textContent = `${count}`;
+			this.badges.set(item.section, badge);
+
+			// Navigate to section
+			const viewButton = append(row, $('a.advanced-item-action'));
+			viewButton.tabIndex = 0;
+			viewButton.role = 'button';
+
+			const commandId = createCommands[item.section];
+			if (count > 0) {
+				viewButton.textContent = localize('viewItems', "View");
+				this._renderDisposables.add(addDisposableListener(viewButton, EventType.CLICK, () => {
+					this._onDidSelectSection.fire(item.section);
+				}));
+				this._renderDisposables.add(addDisposableListener(viewButton, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const keyboardEvent = new StandardKeyboardEvent(e);
+					if (keyboardEvent.equals(KeyCode.Enter) || keyboardEvent.equals(KeyCode.Space)) {
+						this._onDidSelectSection.fire(item.section);
+						e.preventDefault();
+					}
+				}));
+			} else if (commandId) {
+				viewButton.textContent = item.ctaLabel;
+				this._renderDisposables.add(addDisposableListener(viewButton, EventType.CLICK, () => {
+					this.commandService.executeCommand(commandId);
+				}));
+				this._renderDisposables.add(addDisposableListener(viewButton, EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const keyboardEvent = new StandardKeyboardEvent(e);
+					if (keyboardEvent.equals(KeyCode.Enter) || keyboardEvent.equals(KeyCode.Space)) {
+						this.commandService.executeCommand(commandId);
+						e.preventDefault();
+					}
+				}));
+			}
+		}
 	}
 
 	private renderDashboard(parent: HTMLElement): void {
 		const dashboard = append(parent, $('.ai-customization-overview-dashboard'));
 		dashboard.role = 'region';
 		dashboard.ariaLabel = localize('dashboardRegion', "AI Customization Dashboard");
-
-		const intro = append(dashboard, $('.dashboard-intro'));
-		append(intro, $('h2.dashboard-hero-heading')).textContent = localize('dashboardHeroHeading', "Copilot writes better code when it learns yours.");
-		append(intro, $('p.dashboard-hero-subtitle')).textContent = localize('dashboardHeroSubtitle', "Start with Instructions, then add Prompts and Agents to scale your best practices across every session.");
-
-		const introLink = append(intro, $('a.overview-explore-link'));
-		introLink.textContent = localize('exploreDocsLink', "Explore the customization guide");
-		introLink.setAttribute('href', this._getSectionDocUrl(AICustomizationManagementSection.Overview));
-		this._renderDisposables.add(addDisposableListener(introLink, EventType.CLICK, (e: MouseEvent) => {
-			this.openerService.open(URI.parse(this._getSectionDocUrl(AICustomizationManagementSection.Overview)));
-			e.preventDefault();
-		}));
 
 		// Progress header
 		const progressHeader = append(dashboard, $('.dashboard-progress'));
@@ -213,18 +476,17 @@ export class AICustomizationOverviewWidget extends Disposable {
 
 		// "What's Next" recommendation
 		this._renderWhatsNext(dashboard);
-		this._renderLearnMoreLinks(dashboard);
 
 		// Section cards grid
 		const sectionsGrid = append(dashboard, $('.section-cards'));
 
-		const sectionMeta: Record<string, { icon: ThemeIcon; label: string; description: string; pitch: string }> = {
-			[AICustomizationManagementSection.Instructions]: { icon: AICustomizationIcons.instructionsIcon, label: localize('sectionInstructions', "Instructions"), description: this._getSectionDescription(AICustomizationManagementSection.Instructions), pitch: this._getSectionPitch(AICustomizationManagementSection.Instructions) },
-			[AICustomizationManagementSection.Prompts]: { icon: AICustomizationIcons.promptIcon, label: localize('sectionPrompts', "Prompts"), description: this._getSectionDescription(AICustomizationManagementSection.Prompts), pitch: this._getSectionPitch(AICustomizationManagementSection.Prompts) },
-			[AICustomizationManagementSection.Agents]: { icon: AICustomizationIcons.agentIcon, label: localize('sectionAgents', "Agents"), description: this._getSectionDescription(AICustomizationManagementSection.Agents), pitch: this._getSectionPitch(AICustomizationManagementSection.Agents) },
-			[AICustomizationManagementSection.Skills]: { icon: AICustomizationIcons.skillIcon, label: localize('sectionSkills', "Skills"), description: this._getSectionDescription(AICustomizationManagementSection.Skills), pitch: this._getSectionPitch(AICustomizationManagementSection.Skills) },
-			[AICustomizationManagementSection.McpServers]: { icon: Codicon.server, label: localize('sectionMCP', "MCP Servers"), description: this._getSectionDescription(AICustomizationManagementSection.McpServers), pitch: this._getSectionPitch(AICustomizationManagementSection.McpServers) },
-			[AICustomizationManagementSection.Hooks]: { icon: AICustomizationIcons.hookIcon, label: localize('sectionHooks', "Hooks"), description: this._getSectionDescription(AICustomizationManagementSection.Hooks), pitch: this._getSectionPitch(AICustomizationManagementSection.Hooks) },
+		const sectionMeta: Record<string, { icon: ThemeIcon; label: string; description: string }> = {
+			[AICustomizationManagementSection.Instructions]: { icon: AICustomizationIcons.instructionsIcon, label: localize('sectionInstructions', "Instructions"), description: this._getSectionDescription(AICustomizationManagementSection.Instructions) },
+			[AICustomizationManagementSection.Prompts]: { icon: AICustomizationIcons.promptIcon, label: localize('sectionPrompts', "Prompts"), description: this._getSectionDescription(AICustomizationManagementSection.Prompts) },
+			[AICustomizationManagementSection.Agents]: { icon: AICustomizationIcons.agentIcon, label: localize('sectionAgents', "Agents"), description: this._getSectionDescription(AICustomizationManagementSection.Agents) },
+			[AICustomizationManagementSection.Skills]: { icon: AICustomizationIcons.skillIcon, label: localize('sectionSkills', "Skills"), description: this._getSectionDescription(AICustomizationManagementSection.Skills) },
+			[AICustomizationManagementSection.McpServers]: { icon: Codicon.server, label: localize('sectionMCP', "MCP Servers"), description: this._getSectionDescription(AICustomizationManagementSection.McpServers) },
+			[AICustomizationManagementSection.Hooks]: { icon: AICustomizationIcons.hookIcon, label: localize('sectionHooks', "Hooks"), description: this._getSectionDescription(AICustomizationManagementSection.Hooks) },
 		};
 
 		for (const sectionId of DASHBOARD_SECTIONS) {
@@ -246,7 +508,6 @@ export class AICustomizationOverviewWidget extends Disposable {
 			const textContainer = append(card, $('.card-info'));
 			append(textContainer, $('.card-title')).textContent = meta.label;
 			append(textContainer, $('.card-description')).textContent = meta.description;
-			append(textContainer, $('.card-pitch')).textContent = meta.pitch;
 
 			if (count !== undefined && count > 0) {
 				const badge = append(card, $('.count-badge'));
@@ -257,27 +518,6 @@ export class AICustomizationOverviewWidget extends Disposable {
 				getStarted.textContent = localize('getStarted', "Get started");
 				this.badges.set(sectionId, getStarted);
 			}
-		}
-	}
-
-	private _renderLearnMoreLinks(parent: HTMLElement): void {
-		const linksContainer = append(parent, $('.dashboard-learn-links'));
-		append(linksContainer, $('span.learn-links-label')).textContent = localize('learnMoreLabel', "Learn more:");
-
-		const learnSections = [
-			AICustomizationManagementSection.Instructions,
-			AICustomizationManagementSection.Prompts,
-			AICustomizationManagementSection.Agents,
-		];
-
-		for (const section of learnSections) {
-			const link = append(linksContainer, $('a.dashboard-learn-link'));
-			link.textContent = this._getSectionLabel(section);
-			link.setAttribute('href', this._getSectionDocUrl(section));
-			this._renderDisposables.add(addDisposableListener(link, EventType.CLICK, (e: MouseEvent) => {
-				this.openerService.open(URI.parse(this._getSectionDocUrl(section)));
-				e.preventDefault();
-			}));
 		}
 	}
 
@@ -320,21 +560,11 @@ export class AICustomizationOverviewWidget extends Disposable {
 
 		const commandId = createCommands[nextSection];
 		if (commandId) {
-			const actions = append(whatsNext, $('.whats-next-actions'));
-
-			const cta = append(actions, $('button.whats-next-cta'));
-			cta.textContent = this._getSectionActionLabel(nextSection);
-			cta.ariaLabel = this._getSectionActionLabel(nextSection);
+			const cta = append(whatsNext, $('button.whats-next-cta'));
+			cta.textContent = localize('whatsNextCta', "Create {0}", this._getSectionLabel(nextSection));
+			cta.ariaLabel = localize('whatsNextCta', "Create {0}", this._getSectionLabel(nextSection));
 			this._renderDisposables.add(addDisposableListener(cta, EventType.CLICK, () => {
 				this.commandService.executeCommand(commandId);
-			}));
-
-			const learnMore = append(actions, $('a.whats-next-learn-more'));
-			learnMore.textContent = localize('learnMore', "Learn more");
-			learnMore.setAttribute('href', this._getSectionDocUrl(nextSection));
-			this._renderDisposables.add(addDisposableListener(learnMore, EventType.CLICK, (e: MouseEvent) => {
-				this.openerService.open(URI.parse(this._getSectionDocUrl(nextSection)));
-				e.preventDefault();
 			}));
 		}
 	}
@@ -402,12 +632,28 @@ export class AICustomizationOverviewWidget extends Disposable {
 
 	getAccessibleDetails(): string {
 		const content: string[] = [];
-		content.push(localize('overviewDashboardAriaV3', "AI Customization Dashboard. {0} of {1} customization types active.", this.activeTypeCount, DASHBOARD_SECTIONS.length));
-		for (const section of DASHBOARD_SECTIONS) {
-			const label = this._getSectionLabel(section);
-			const count = this.counts.get(section);
-			const countLabel = count === undefined ? localize('loading', "loading") : (count === 1 ? localize('oneItem', "1 item") : localize('manyItems', "{0} items", count));
-			content.push(`${label}: ${countLabel}`);
+		if (this.currentMode === 'welcome') {
+			content.push(localize('overviewWelcomeAria', "AI Customization Setup Guide. Copilot already writes great code -- teach it your codebase with these steps."));
+			const steps = this._getJourneySteps();
+			for (let i = 0; i < steps.length; i++) {
+				const step = steps[i];
+				const count = this.counts.get(step.section) ?? 0;
+				const status = count > 0 ? localize('stepDone', "done") : localize('stepPending', "pending");
+				content.push(localize('stepStatus', "Step {0}: {1} ({2})", i + 1, step.title, status));
+			}
+			const subItems = this._getAdvancedSubItems();
+			content.push(localize('advancedSectionLabel', "Advanced: {0}", subItems.map(item => {
+				const count = this.counts.get(item.section) ?? 0;
+				return `${item.label} (${count})`;
+			}).join(', ')));
+		} else {
+			content.push(localize('overviewDashboardAriaV2', "AI Customization Dashboard. {0} of {1} customization types active.", this.activeTypeCount, DASHBOARD_SECTIONS.length));
+			for (const section of DASHBOARD_SECTIONS) {
+				const label = this._getSectionLabel(section);
+				const count = this.counts.get(section);
+				const countLabel = count === undefined ? localize('loading', "loading") : (count === 1 ? localize('oneItem', "1 item") : localize('manyItems', "{0} items", count));
+				content.push(`${label}: ${countLabel}`);
+			}
 		}
 		return content.join('\n');
 	}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -44,6 +44,7 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 	}
 
 	readonly managementSections: readonly AICustomizationManagementSection[] = [
+		AICustomizationManagementSection.Overview,
 		AICustomizationManagementSection.Agents,
 		AICustomizationManagementSection.Skills,
 		AICustomizationManagementSection.Instructions,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -45,12 +45,12 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 
 	readonly managementSections: readonly AICustomizationManagementSection[] = [
 		AICustomizationManagementSection.Overview,
-		AICustomizationManagementSection.Agents,
-		AICustomizationManagementSection.Skills,
 		AICustomizationManagementSection.Instructions,
 		AICustomizationManagementSection.Prompts,
-		AICustomizationManagementSection.Hooks,
+		AICustomizationManagementSection.Agents,
+		AICustomizationManagementSection.Skills,
 		AICustomizationManagementSection.McpServers,
+		AICustomizationManagementSection.Hooks,
 	];
 
 	readonly preferManualCreation = false;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -685,6 +685,25 @@
 	padding: 24px 30px;
 }
 
+.ai-customization-overview-dashboard .dashboard-intro {
+	margin-bottom: 18px;
+}
+
+.ai-customization-overview-dashboard .dashboard-hero-heading {
+	font-size: 24px;
+	font-weight: 400;
+	color: var(--vscode-foreground);
+	margin-bottom: 8px;
+}
+
+.ai-customization-overview-dashboard .dashboard-hero-subtitle {
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--vscode-descriptionForeground);
+	max-width: 760px;
+	margin-bottom: 10px;
+}
+
 /* Dashboard progress header */
 .ai-customization-overview-dashboard .dashboard-progress {
 	margin-bottom: 20px;
@@ -721,6 +740,13 @@
 	margin: 0 0 10px;
 }
 
+.ai-customization-overview-dashboard .whats-next-actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
 .ai-customization-overview-dashboard .whats-next-cta {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
@@ -740,6 +766,40 @@
 .ai-customization-overview-dashboard .whats-next-cta:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 2px;
+}
+
+.ai-customization-overview-dashboard .whats-next-learn-more {
+	font-size: 12px;
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview-dashboard .whats-next-learn-more:hover {
+	text-decoration: underline;
+}
+
+.ai-customization-overview-dashboard .dashboard-learn-links {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-bottom: 18px;
+	font-size: 12px;
+}
+
+.ai-customization-overview-dashboard .dashboard-learn-links .learn-links-label {
+	color: var(--vscode-descriptionForeground);
+}
+
+.ai-customization-overview-dashboard .dashboard-learn-links .dashboard-learn-link {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview-dashboard .dashboard-learn-links .dashboard-learn-link:hover {
+	text-decoration: underline;
 }
 
 /* Dashboard section cards grid */
@@ -809,6 +869,14 @@
 	font-size: 12px;
 	line-height: 1.4;
 	margin-top: 4px;
+}
+
+.ai-customization-overview-dashboard .card .card-pitch {
+	color: var(--vscode-foreground);
+	font-size: 11px;
+	line-height: 1.4;
+	margin-top: 6px;
+	opacity: 0.85;
 }
 
 .ai-customization-overview-dashboard .card .count-badge {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -587,15 +587,25 @@
 
 .ai-customization-overview-welcome .step-learn-more,
 .ai-customization-overview-welcome .step-view-link {
-	font-size: 12px;
+	font-size: inherit;
 	color: var(--vscode-textLink-foreground);
 	text-decoration: none;
 	cursor: pointer;
+	border: none;
+	background: transparent;
+	padding: 0;
+	font-family: inherit;
 }
 
 .ai-customization-overview-welcome .step-learn-more:hover,
 .ai-customization-overview-welcome .step-view-link:hover {
 	text-decoration: underline;
+}
+
+.ai-customization-overview-welcome .step-learn-more:focus,
+.ai-customization-overview-welcome .step-view-link:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 /* --- Advanced Collapsible Section --- */
@@ -670,14 +680,23 @@
 }
 
 .ai-customization-overview-welcome .advanced-item-action {
-	font-size: 12px;
+	font-size: inherit;
 	color: var(--vscode-textLink-foreground);
 	text-decoration: none;
 	cursor: pointer;
+	border: none;
+	background: transparent;
+	padding: 0;
+	font-family: inherit;
 }
 
 .ai-customization-overview-welcome .advanced-item-action:hover {
 	text-decoration: underline;
+}
+
+.ai-customization-overview-welcome .advanced-item-action:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 /* --- Dashboard Mode --- */
@@ -848,13 +867,9 @@
 	text-decoration: underline;
 }
 
-/* Reduced motion */
-@media (prefers-reduced-motion: reduce) {
-	.ai-customization-overview-dashboard .card,
-	.ai-customization-overview-welcome .step-cta,
-	.ai-customization-overview-dashboard .whats-next-cta {
-		transition: none;
-	}
+.ai-customization-overview .overview-explore-link:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 /* Content container visibility */
@@ -1158,6 +1173,11 @@
 	background-color: var(--vscode-toolbar-activeBackground);
 }
 
+.ai-customization-management-editor .editor-back-button:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
 .ai-customization-management-editor .editor-item-info {
 	display: flex;
 	flex-direction: column;
@@ -1232,6 +1252,9 @@
 @media (prefers-reduced-motion: reduce) {
 	.ai-customization-overview .card,
 	.ai-customization-overview .create-button,
+	.ai-customization-overview-dashboard .card,
+	.ai-customization-overview-welcome .step-cta,
+	.ai-customization-overview-dashboard .whats-next-cta,
 	.ai-customization-management-editor .section-list-item,
 	.ai-customization-group-header .group-info,
 	.ai-customization-list-item .item-right,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -685,25 +685,6 @@
 	padding: 24px 30px;
 }
 
-.ai-customization-overview-dashboard .dashboard-intro {
-	margin-bottom: 18px;
-}
-
-.ai-customization-overview-dashboard .dashboard-hero-heading {
-	font-size: 24px;
-	font-weight: 400;
-	color: var(--vscode-foreground);
-	margin-bottom: 8px;
-}
-
-.ai-customization-overview-dashboard .dashboard-hero-subtitle {
-	font-size: 13px;
-	line-height: 1.5;
-	color: var(--vscode-descriptionForeground);
-	max-width: 760px;
-	margin-bottom: 10px;
-}
-
 /* Dashboard progress header */
 .ai-customization-overview-dashboard .dashboard-progress {
 	margin-bottom: 20px;
@@ -740,13 +721,6 @@
 	margin: 0 0 10px;
 }
 
-.ai-customization-overview-dashboard .whats-next-actions {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	flex-wrap: wrap;
-}
-
 .ai-customization-overview-dashboard .whats-next-cta {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
@@ -766,40 +740,6 @@
 .ai-customization-overview-dashboard .whats-next-cta:focus {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: 2px;
-}
-
-.ai-customization-overview-dashboard .whats-next-learn-more {
-	font-size: 12px;
-	color: var(--vscode-textLink-foreground);
-	text-decoration: none;
-	cursor: pointer;
-}
-
-.ai-customization-overview-dashboard .whats-next-learn-more:hover {
-	text-decoration: underline;
-}
-
-.ai-customization-overview-dashboard .dashboard-learn-links {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	flex-wrap: wrap;
-	margin-bottom: 18px;
-	font-size: 12px;
-}
-
-.ai-customization-overview-dashboard .dashboard-learn-links .learn-links-label {
-	color: var(--vscode-descriptionForeground);
-}
-
-.ai-customization-overview-dashboard .dashboard-learn-links .dashboard-learn-link {
-	color: var(--vscode-textLink-foreground);
-	text-decoration: none;
-	cursor: pointer;
-}
-
-.ai-customization-overview-dashboard .dashboard-learn-links .dashboard-learn-link:hover {
-	text-decoration: underline;
 }
 
 /* Dashboard section cards grid */
@@ -869,14 +809,6 @@
 	font-size: 12px;
 	line-height: 1.4;
 	margin-top: 4px;
-}
-
-.ai-customization-overview-dashboard .card .card-pitch {
-	color: var(--vscode-foreground);
-	font-size: 11px;
-	line-height: 1.4;
-	margin-top: 6px;
-	opacity: 0.85;
 }
 
 .ai-customization-overview-dashboard .card .count-badge {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -1023,3 +1023,31 @@
 .ai-customization-management-editor .embedded-editor-container .monaco-editor {
 	border-radius: 4px;
 }
+
+/* Skeleton loading and reduced motion */
+.ai-customization-overview .count-badge.loading {
+	opacity: 0.5;
+	animation: badge-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes badge-pulse {
+	0%, 100% { opacity: 0.5; }
+	50% { opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.ai-customization-overview .card,
+	.ai-customization-overview .create-button,
+	.ai-customization-management-editor .section-list-item,
+	.ai-customization-group-header .group-info,
+	.ai-customization-list-item .item-right,
+	.ai-customization-management-editor .editor-back-button,
+	.ai-customization-management-editor .editor-save-indicator {
+		transition: none !important;
+	}
+
+	.ai-customization-overview .count-badge.loading {
+		animation: none !important;
+	}
+}
+

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -421,13 +421,13 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
-/* Overview View */
+/* ===== Overview View ===== */
 .ai-customization-overview {
 	overflow-y: auto;
 	height: 100%;
 }
 
-/* Welcome mode */
+/* --- Welcome Mode: Journey Stepper --- */
 .ai-customization-overview-welcome {
 	max-width: 700px;
 	margin: 0 auto;
@@ -446,29 +446,311 @@
 	line-height: 1.5;
 	color: var(--vscode-descriptionForeground);
 	max-width: 500px;
-	margin-bottom: 24px;
+	margin-bottom: 28px;
 }
 
-.ai-customization-overview-welcome .suggestion-cards {
+/* Journey Stepper */
+.ai-customization-overview-welcome .journey-stepper {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	margin-top: 24px;
+	gap: 0;
+	position: relative;
 }
 
-/* Dashboard mode */
+.ai-customization-overview-welcome .journey-step {
+	display: flex;
+	gap: 16px;
+	padding: 16px 0;
+	position: relative;
+}
+
+/* Connector line between steps */
+.ai-customization-overview-welcome .journey-step:not(:last-child)::before {
+	content: '';
+	position: absolute;
+	left: 15px;
+	top: 48px;
+	bottom: -16px;
+	width: 1px;
+	background: var(--vscode-widget-border);
+}
+
+/* Step indicator */
+.ai-customization-overview-welcome .step-indicator {
+	flex-shrink: 0;
+	width: 30px;
+	height: 30px;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 13px;
+	font-weight: 500;
+	border: 2px solid var(--vscode-widget-border);
+	color: var(--vscode-descriptionForeground);
+	background: transparent;
+	z-index: 1;
+	position: relative;
+}
+
+.ai-customization-overview-welcome .journey-step.current .step-indicator {
+	border-color: var(--vscode-textLink-foreground);
+	color: var(--vscode-textLink-foreground);
+}
+
+.ai-customization-overview-welcome .journey-step .step-indicator.complete {
+	border-color: var(--vscode-testing-iconPassed);
+	color: var(--vscode-testing-iconPassed);
+	background: transparent;
+}
+
+/* Step content */
+.ai-customization-overview-welcome .step-content {
+	flex: 1;
+	min-width: 0;
+	padding-top: 3px;
+}
+
+.ai-customization-overview-welcome .step-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
+}
+
+.ai-customization-overview-welcome .step-icon {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+}
+
+.ai-customization-overview-welcome .step-title {
+	font-weight: 500;
+	font-size: 14px;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-overview-welcome .journey-step.complete .step-title {
+	color: var(--vscode-descriptionForeground);
+}
+
+.ai-customization-overview-welcome .step-description {
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 10px;
+}
+
+/* Step actions */
+.ai-customization-overview-welcome .step-actions {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
+.ai-customization-overview-welcome .step-cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	border: none;
+	border-radius: 4px;
+	padding: 5px 14px;
+	cursor: pointer;
+	font-size: 12px;
+	font-family: inherit;
+	transition: background 0.15s ease;
+	white-space: nowrap;
+}
+
+.ai-customization-overview-welcome .step-cta:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.ai-customization-overview-welcome .step-cta:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.ai-customization-overview-welcome .journey-step.complete .step-cta {
+	background: var(--vscode-button-secondaryBackground);
+	color: var(--vscode-button-secondaryForeground);
+}
+
+.ai-customization-overview-welcome .step-cta.generate-instructions .step-cta-icon {
+	font-size: 13px;
+}
+
+.ai-customization-overview-welcome .step-learn-more,
+.ai-customization-overview-welcome .step-view-link {
+	font-size: 12px;
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview-welcome .step-learn-more:hover,
+.ai-customization-overview-welcome .step-view-link:hover {
+	text-decoration: underline;
+}
+
+/* --- Advanced Collapsible Section --- */
+.ai-customization-overview-welcome .journey-advanced {
+	margin-top: 8px;
+	border-top: 1px solid var(--vscode-widget-border);
+	padding-top: 12px;
+}
+
+.ai-customization-overview-welcome .advanced-toggle {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	background: transparent;
+	border: none;
+	color: var(--vscode-foreground);
+	font-family: inherit;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	padding: 4px 0;
+}
+
+.ai-customization-overview-welcome .advanced-toggle:hover {
+	color: var(--vscode-textLink-foreground);
+}
+
+.ai-customization-overview-welcome .advanced-toggle:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.ai-customization-overview-welcome .toggle-icon {
+	display: flex;
+	align-items: center;
+	font-size: 14px;
+}
+
+.ai-customization-overview-welcome .advanced-body {
+	padding: 8px 0 0 26px;
+}
+
+.ai-customization-overview-welcome .advanced-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 0;
+	font-size: 13px;
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-overview-welcome .advanced-item-icon {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	font-size: 14px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.ai-customization-overview-welcome .advanced-item-label {
+	flex: 1;
+}
+
+.ai-customization-overview-welcome .advanced-item-badge {
+	background: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	border-radius: 10px;
+	padding: 1px 7px;
+	font-size: 11px;
+	min-width: 14px;
+	text-align: center;
+}
+
+.ai-customization-overview-welcome .advanced-item-action {
+	font-size: 12px;
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview-welcome .advanced-item-action:hover {
+	text-decoration: underline;
+}
+
+/* --- Dashboard Mode --- */
 .ai-customization-overview-dashboard {
 	padding: 24px 30px;
 }
 
+/* Dashboard progress header */
+.ai-customization-overview-dashboard .dashboard-progress {
+	margin-bottom: 20px;
+}
+
+.ai-customization-overview-dashboard .progress-text {
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+}
+
+/* What's Next recommendation */
+.ai-customization-overview-dashboard .whats-next {
+	border-left: 3px solid var(--vscode-textLink-foreground);
+	background: var(--vscode-welcomePage-tileBackground, transparent);
+	border-radius: 0 6px 6px 0;
+	padding: 14px 18px;
+	margin-bottom: 20px;
+}
+
+.ai-customization-overview-dashboard .whats-next-header {
+	display: block;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--vscode-textLink-foreground);
+	margin-bottom: 6px;
+}
+
+.ai-customization-overview-dashboard .whats-next-message {
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--vscode-foreground);
+	margin: 0 0 10px;
+}
+
+.ai-customization-overview-dashboard .whats-next-cta {
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	border: none;
+	border-radius: 4px;
+	padding: 5px 14px;
+	cursor: pointer;
+	font-size: 12px;
+	font-family: inherit;
+	transition: background 0.15s ease;
+}
+
+.ai-customization-overview-dashboard .whats-next-cta:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.ai-customization-overview-dashboard .whats-next-cta:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+/* Dashboard section cards grid */
 .ai-customization-overview-dashboard .section-cards {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 12px;
 }
 
-/* Common Card Styles */
-.ai-customization-overview .card {
+/* Common card styles (shared by dashboard) */
+.ai-customization-overview-dashboard .card {
 	border: 1px solid var(--vscode-welcomePage-tileBorder);
 	border-radius: 6px;
 	padding: 14px 18px;
@@ -481,87 +763,26 @@
 	box-sizing: border-box;
 	font-family: inherit;
 	color: inherit;
-}
-
-.ai-customization-overview .card:hover {
-	background: var(--vscode-welcomePage-tileHoverBackground);
-	border-color: var(--vscode-focusBorder);
-}
-
-.ai-customization-overview .card:focus,
-.ai-customization-overview .card:focus-within {
-	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: -1px;
-}
-
-/* Base button inside card for navigation (Option B) */
-.ai-customization-overview .card .card-content-button {
-	flex: 1;
-	display: flex;
-	align-items: center;
-	padding: 0;
-	margin: 0;
-	background: transparent;
-	border: none;
-	text-align: left;
-	color: inherit;
-	font-family: inherit;
-	font-size: inherit;
-	cursor: pointer;
-	gap: 16px;
-	min-width: 0;
-}
-
-.ai-customization-overview .card .card-content-button:focus {
-	outline: none; /* Container card handles focus outline */
-}
-
-.ai-customization-overview .card .suggestion-icon,
-.ai-customization-overview .card .section-icon {
-	flex-shrink: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.ai-customization-overview .card .card-title {
-	font-weight: 500;
-	font-size: 14px;
-	color: var(--vscode-foreground);
-}
-
-.ai-customization-overview .card .card-description {
-	color: var(--vscode-descriptionForeground);
-	font-size: 12px;
-	line-height: 1.4;
-}
-
-/* Welcome Suggestion Cards Specifics */
-.ai-customization-overview-welcome .card {
-	gap: 16px;
-	align-items: center;
-}
-
-.ai-customization-overview-welcome .card .suggestion-icon {
-	font-size: 24px;
-	width: 24px;
-	height: 24px;
-}
-
-.ai-customization-overview-welcome .card .card-content {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-}
-
-/* Dashboard Section Cards Specifics */
-.ai-customization-overview-dashboard .card {
 	flex: 1 1 calc(33.333% - 8px);
 	min-width: 200px;
 	gap: 12px;
 }
 
+.ai-customization-overview-dashboard .card:hover {
+	background: var(--vscode-welcomePage-tileHoverBackground);
+	border-color: var(--vscode-focusBorder);
+}
+
+.ai-customization-overview-dashboard .card:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
 .ai-customization-overview-dashboard .card .section-icon {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 20px;
 	width: 20px;
 	height: 20px;
@@ -575,12 +796,18 @@
 }
 
 .ai-customization-overview-dashboard .card .card-title {
+	font-weight: 500;
+	font-size: 14px;
+	color: var(--vscode-foreground);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
 .ai-customization-overview-dashboard .card .card-description {
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+	line-height: 1.4;
 	margin-top: 4px;
 }
 
@@ -596,27 +823,11 @@
 	margin-left: 4px;
 }
 
-/* Create button styling */
-.ai-customization-overview .create-button {
-	background: var(--vscode-button-background);
-	color: var(--vscode-button-foreground);
-	border: none;
-	border-radius: 4px;
-	padding: 4px 12px;
-	cursor: pointer;
-	font-size: 12px;
-	transition: background 0.15s ease;
-	white-space: nowrap;
+.ai-customization-overview-dashboard .card .get-started-link {
 	flex-shrink: 0;
-}
-
-.ai-customization-overview .create-button:hover {
-	background: var(--vscode-button-hoverBackground);
-}
-
-.ai-customization-overview .create-button:focus {
-	outline: 1px solid var(--vscode-focusBorder);
-	outline-offset: 2px;
+	font-size: 12px;
+	color: var(--vscode-textLink-foreground);
+	margin-left: 4px;
 }
 
 /* Footer and utility links */
@@ -637,30 +848,13 @@
 	text-decoration: underline;
 }
 
-/* Inline suggestions in dashboard */
-.ai-customization-overview-dashboard .overview-inline-suggestions {
-	margin-top: 24px;
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.ai-customization-overview-dashboard .overview-inline-suggestion {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-size: 12px;
-	color: var(--vscode-descriptionForeground);
-}
-
-.ai-customization-overview-dashboard .overview-inline-suggestion a {
-	color: var(--vscode-textLink-foreground);
-	text-decoration: none;
-	cursor: pointer;
-}
-
-.ai-customization-overview-dashboard .overview-inline-suggestion a:hover {
-	text-decoration: underline;
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+	.ai-customization-overview-dashboard .card,
+	.ai-customization-overview-welcome .step-cta,
+	.ai-customization-overview-dashboard .whats-next-cta {
+		transition: none;
+	}
 }
 
 /* Content container visibility */

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -421,79 +421,246 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
-/* Overview View (compact snapshot) */
+/* Overview View */
 .ai-customization-overview {
+	overflow-y: auto;
+	height: 100%;
+}
+
+/* Welcome mode */
+.ai-customization-overview-welcome {
+	max-width: 700px;
+	margin: 0 auto;
+	padding: 40px 40px 30px;
+}
+
+.ai-customization-overview-welcome .hero-heading {
+	font-size: 26px;
+	font-weight: 400;
+	color: var(--vscode-foreground);
+	margin-bottom: 8px;
+}
+
+.ai-customization-overview-welcome .hero-subtitle {
+	font-size: 14px;
+	line-height: 1.5;
+	color: var(--vscode-descriptionForeground);
+	max-width: 500px;
+	margin-bottom: 24px;
+}
+
+.ai-customization-overview-welcome .suggestion-cards {
 	display: flex;
 	flex-direction: column;
-	height: 100%;
-	padding: 8px;
+	gap: 12px;
+	margin-top: 24px;
 }
 
-.ai-customization-overview .overview-sections {
+/* Dashboard mode */
+.ai-customization-overview-dashboard {
+	padding: 24px 30px;
+}
+
+.ai-customization-overview-dashboard .section-cards {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 12px;
 }
 
-
-.ai-customization-overview .overview-section {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 10px 12px;
-	background-color: var(--vscode-sideBar-background);
-	border: 1px solid var(--vscode-widget-border);
+/* Common Card Styles */
+.ai-customization-overview .card {
+	border: 1px solid var(--vscode-welcomePage-tileBorder);
 	border-radius: 6px;
+	padding: 14px 18px;
 	cursor: pointer;
-	transition: background-color 0.1s ease;
-	flex: 1 1 120px;
-	min-width: 100px;
+	transition: background 0.15s ease, border-color 0.15s ease;
+	background: transparent;
+	display: flex;
+	align-items: flex-start;
+	text-align: left;
+	box-sizing: border-box;
+	font-family: inherit;
+	color: inherit;
 }
 
-.ai-customization-overview .overview-section:hover {
-	background-color: var(--vscode-list-hoverBackground);
+.ai-customization-overview .card:hover {
+	background: var(--vscode-welcomePage-tileHoverBackground);
 	border-color: var(--vscode-focusBorder);
 }
 
-.ai-customization-overview .overview-section:focus {
+.ai-customization-overview .card:focus,
+.ai-customization-overview .card:focus-within {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.ai-customization-overview .overview-section .section-icon {
-	flex-shrink: 0;
-	width: 16px;
-	height: 16px;
-	opacity: 0.9;
-}
-
-.ai-customization-overview .overview-section .section-text {
+/* Base button inside card for navigation (Option B) */
+.ai-customization-overview .card .card-content-button {
 	flex: 1;
+	display: flex;
+	align-items: center;
+	padding: 0;
+	margin: 0;
+	background: transparent;
+	border: none;
+	text-align: left;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	cursor: pointer;
+	gap: 16px;
 	min-width: 0;
 }
 
-.ai-customization-overview .overview-section .section-label {
-	font-size: 12px;
+.ai-customization-overview .card .card-content-button:focus {
+	outline: none; /* Container card handles focus outline */
+}
+
+.ai-customization-overview .card .suggestion-icon,
+.ai-customization-overview .card .section-icon {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.ai-customization-overview .card .card-title {
 	font-weight: 500;
+	font-size: 14px;
 	color: var(--vscode-foreground);
+}
+
+.ai-customization-overview .card .card-description {
+	color: var(--vscode-descriptionForeground);
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+/* Welcome Suggestion Cards Specifics */
+.ai-customization-overview-welcome .card {
+	gap: 16px;
+	align-items: center;
+}
+
+.ai-customization-overview-welcome .card .suggestion-icon {
+	font-size: 24px;
+	width: 24px;
+	height: 24px;
+}
+
+.ai-customization-overview-welcome .card .card-content {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
+
+/* Dashboard Section Cards Specifics */
+.ai-customization-overview-dashboard .card {
+	flex: 1 1 calc(33.333% - 8px);
+	min-width: 200px;
+	gap: 12px;
+}
+
+.ai-customization-overview-dashboard .card .section-icon {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+}
+
+.ai-customization-overview-dashboard .card .card-info {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.ai-customization-overview-dashboard .card .card-title {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
+.ai-customization-overview-dashboard .card .card-description {
+	margin-top: 4px;
+}
 
-
-.ai-customization-overview .overview-section .section-count {
+.ai-customization-overview-dashboard .card .count-badge {
 	flex-shrink: 0;
-	font-size: 9px;
-	font-weight: 600;
-	padding: 1px 5px;
-	background-color: var(--vscode-badge-background);
+	background: var(--vscode-badge-background);
 	color: var(--vscode-badge-foreground);
-	border-radius: 8px;
-	border: 1px solid transparent;
+	border-radius: 10px;
+	padding: 1px 7px;
+	font-size: 11px;
 	min-width: 14px;
 	text-align: center;
+	margin-left: 4px;
+}
+
+/* Create button styling */
+.ai-customization-overview .create-button {
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	border: none;
+	border-radius: 4px;
+	padding: 4px 12px;
+	cursor: pointer;
+	font-size: 12px;
+	transition: background 0.15s ease;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
+.ai-customization-overview .create-button:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.ai-customization-overview .create-button:focus {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+/* Footer and utility links */
+.ai-customization-overview .overview-footer {
+	margin-top: 32px;
+	padding-top: 16px;
+	border-top: 1px solid var(--vscode-widget-border);
+}
+
+.ai-customization-overview .overview-explore-link {
+	font-size: 13px;
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview .overview-explore-link:hover {
+	text-decoration: underline;
+}
+
+/* Inline suggestions in dashboard */
+.ai-customization-overview-dashboard .overview-inline-suggestions {
+	margin-top: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.ai-customization-overview-dashboard .overview-inline-suggestion {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.ai-customization-overview-dashboard .overview-inline-suggestion a {
+	color: var(--vscode-textLink-foreground);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.ai-customization-overview-dashboard .overview-inline-suggestion a:hover {
+	text-decoration: underline;
 }
 
 /* Content container visibility */

--- a/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
@@ -14,6 +14,7 @@ export const IAICustomizationWorkspaceService = createDecorator<IAICustomization
  * Possible section IDs for the AI Customization Management Editor sidebar.
  */
 export const AICustomizationManagementSection = {
+	Overview: 'overview',
 	Agents: 'agents',
 	Skills: 'skills',
 	Instructions: 'instructions',


### PR DESCRIPTION
## New AI Customization Overview

Adds a dual-mode overview widget to the AI Customization Management editor: a **welcome stepper** for new users and a **dashboard** for users with existing customizations.

### Welcome Mode (≤2 total customizations)
- Guided journey: Instructions → Prompts → Agents → Advanced (Skills, MCP, Hooks)
- Each step shows completion state, CTA button, learn-more link, and view link
- Collapsible "Advanced" section groups lower-priority items

### Dashboard Mode (>2 total customizations)
- Card grid showing all customization sections with live count badges
- "What's Next" suggestion pointing to the highest-priority empty section
- 0-count cards execute create commands instead of navigating to empty lists

### Implementation Details

**Widget (`aiCustomizationOverviewWidget.ts`)**
- `WELCOME_MODE_THRESHOLD` constant controls the mode switch point
- `RunOnceScheduler` (300ms) debounces refresh from data change events
- Subscribes to `onDidChangeCustomAgents`, `onDidChangeSlashCommands`, `mcpWorkbenchService.onChange`, and `workspaceContextService.onDidChangeWorkspaceFolders`
- `_store.isDisposed` guards after all `await` points and in all `Promise.allSettled` callbacks
- ARIA `status()` announcement on mode transitions
- `updateCountBadge` dynamically toggles `.count-badge` / `.get-started-link` classes for correct styling when counts change without a full re-render

**Editor integration (`aiCustomizationManagementEditor.ts`)**
- `ILogService` replaces `console.error` for embedded editor failures
- Removed manual `Date.now()` throttle — `selectSection` already calls `refresh()`, and data events use the widget's `RunOnceScheduler`

**Accessibility & semantics**
- Native `<button>` elements for all action triggers (no `<a role="button">`)
- `<a>` doc links have proper `href` attributes
- Button reset CSS: `border: none; background: transparent; padding: 0; font-family: inherit; font-size: inherit`
- `:focus` styles (`outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px`) on `.step-learn-more`, `.step-view-link`, `.advanced-item-action`, `.overview-explore-link`, `.editor-back-button`
- `prefers-reduced-motion` consolidated into a single media query block covering all transitions

### Changed Files
- `src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationOverviewWidget.ts` — new widget
- `src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts` — editor integration + ILogService
- `src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css` — all overview styling