### PR TITLE
Enhance notification icons and functionality for expand/collapse actions

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
@@ -22,6 +22,9 @@ const expandIcon = registerIcon('notifications-expand', Codicon.chevronUp, local
 const expandDownIcon = registerIcon('notifications-expand-down', Codicon.chevronDown, localize('expandDownIcon', 'Icon for the expand action in notifications when the notification center is at the top.'));
 const collapseIcon = registerIcon('notifications-collapse', Codicon.chevronDown, localize('collapseIcon', 'Icon for the collapse action in notifications.'));
 const collapseUpIcon = registerIcon('notifications-collapse-up', Codicon.chevronUp, localize('collapseUpIcon', 'Icon for the collapse action in notifications when the notification center is at the top.'));
+const configureIcon = registerIcon('notifications-configure', Codicon.gear, localize('configureIcon', 'Icon for the configure action in notifications.'));
+const doNotDisturbIcon = registerIcon('notifications-do-not-disturb', Codicon.bellSlash, localize('doNotDisturbIcon', 'Icon for the mute all action in notifications.'));
+export const positionIcon = registerIcon('notifications-position', Codicon.arrowSwap, localize('positionIcon', 'Icon for the position action in notifications.'));
 
 export function getNotificationExpandIcon(position: NotificationsPosition): ThemeIcon {
 	return position === NotificationsPosition.TOP_RIGHT ? expandDownIcon : expandIcon;
@@ -30,10 +33,6 @@ export function getNotificationExpandIcon(position: NotificationsPosition): Them
 export function getNotificationCollapseIcon(position: NotificationsPosition): ThemeIcon {
 	return position === NotificationsPosition.TOP_RIGHT ? collapseUpIcon : collapseIcon;
 }
-
-const configureIcon = registerIcon('notifications-configure', Codicon.gear, localize('configureIcon', 'Icon for the configure action in notifications.'));
-const doNotDisturbIcon = registerIcon('notifications-do-not-disturb', Codicon.bellSlash, localize('doNotDisturbIcon', 'Icon for the mute all action in notifications.'));
-export const positionIcon = registerIcon('notifications-position', Codicon.arrowSwap, localize('positionIcon', 'Icon for the position action in notifications.'));
 
 export class ClearNotificationAction extends Action {
 

--- a/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsActions.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/notificationsActions.css';
-import { INotificationViewItem } from '../../../common/notifications.js';
+import { INotificationViewItem, NotificationsPosition } from '../../../common/notifications.js';
 import { localize } from '../../../../nls.js';
 import { Action } from '../../../../base/common/actions.js';
 import { CLEAR_NOTIFICATION, EXPAND_NOTIFICATION, COLLAPSE_NOTIFICATION, CLEAR_ALL_NOTIFICATIONS, HIDE_NOTIFICATIONS_CENTER, TOGGLE_DO_NOT_DISTURB_MODE, TOGGLE_DO_NOT_DISTURB_MODE_BY_SOURCE } from './notificationsCommands.js';
@@ -19,7 +19,18 @@ const clearAllIcon = registerIcon('notifications-clear-all', Codicon.clearAll, l
 export const hideIcon = registerIcon('notifications-hide', Codicon.chevronDown, localize('hideIcon', 'Icon for the hide action in notifications.'));
 export const hideUpIcon = registerIcon('notifications-hide-up', Codicon.chevronUp, localize('hideUpIcon', 'Icon for the hide action in notifications when positioned at the top.'));
 const expandIcon = registerIcon('notifications-expand', Codicon.chevronUp, localize('expandIcon', 'Icon for the expand action in notifications.'));
+const expandDownIcon = registerIcon('notifications-expand-down', Codicon.chevronDown, localize('expandDownIcon', 'Icon for the expand action in notifications when the notification center is at the top.'));
 const collapseIcon = registerIcon('notifications-collapse', Codicon.chevronDown, localize('collapseIcon', 'Icon for the collapse action in notifications.'));
+const collapseUpIcon = registerIcon('notifications-collapse-up', Codicon.chevronUp, localize('collapseUpIcon', 'Icon for the collapse action in notifications when the notification center is at the top.'));
+
+export function getNotificationExpandIcon(position: NotificationsPosition): ThemeIcon {
+	return position === NotificationsPosition.TOP_RIGHT ? expandDownIcon : expandIcon;
+}
+
+export function getNotificationCollapseIcon(position: NotificationsPosition): ThemeIcon {
+	return position === NotificationsPosition.TOP_RIGHT ? collapseUpIcon : collapseIcon;
+}
+
 const configureIcon = registerIcon('notifications-configure', Codicon.gear, localize('configureIcon', 'Icon for the configure action in notifications.'));
 const doNotDisturbIcon = registerIcon('notifications-do-not-disturb', Codicon.bellSlash, localize('doNotDisturbIcon', 'Icon for the mute all action in notifications.'));
 export const positionIcon = registerIcon('notifications-position', Codicon.arrowSwap, localize('positionIcon', 'Icon for the position action in notifications.'));

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -321,6 +321,7 @@ export class NotificationTemplateRenderer extends Disposable {
 		if (!NotificationTemplateRenderer.expandNotificationAction) {
 			return;
 		}
+
 		const position = getNotificationsPosition(configurationService);
 		NotificationTemplateRenderer.expandNotificationAction.class = ThemeIcon.asClassName(getNotificationExpandIcon(position));
 		NotificationTemplateRenderer.collapseNotificationAction.class = ThemeIcon.asClassName(getNotificationCollapseIcon(position));

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -14,8 +14,8 @@ import { ActionRunner, IAction, IActionRunner, Separator, toAction } from '../..
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { dispose, DisposableStore, Disposable } from '../../../../base/common/lifecycle.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-import { INotificationViewItem, NotificationViewItem, NotificationViewItemContentChangeKind, INotificationMessage, ChoiceAction } from '../../../common/notifications.js';
-import { ClearNotificationAction, ExpandNotificationAction, CollapseNotificationAction, ConfigureNotificationAction } from './notificationsActions.js';
+import { INotificationViewItem, NotificationViewItem, NotificationViewItemContentChangeKind, INotificationMessage, ChoiceAction, NotificationsSettings, getNotificationsPosition } from '../../../common/notifications.js';
+import { ClearNotificationAction, ExpandNotificationAction, CollapseNotificationAction, ConfigureNotificationAction, getNotificationExpandIcon, getNotificationCollapseIcon } from './notificationsActions.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ProgressBar } from '../../../../base/browser/ui/progressbar/progressbar.js';
 import { INotificationService, NotificationsFilter, Severity, isNotificationSource } from '../../../../platform/notification/common/notification.js';
@@ -32,6 +32,7 @@ import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import type { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 export class NotificationsListDelegate implements IListVirtualDelegate<INotificationViewItem> {
 
@@ -316,6 +317,15 @@ export class NotificationTemplateRenderer extends Disposable {
 	private static expandNotificationAction: ExpandNotificationAction;
 	private static collapseNotificationAction: CollapseNotificationAction;
 
+	private static updateExpandCollapseIcons(configurationService: IConfigurationService): void {
+		if (!NotificationTemplateRenderer.expandNotificationAction) {
+			return;
+		}
+		const position = getNotificationsPosition(configurationService);
+		NotificationTemplateRenderer.expandNotificationAction.class = ThemeIcon.asClassName(getNotificationExpandIcon(position));
+		NotificationTemplateRenderer.collapseNotificationAction.class = ThemeIcon.asClassName(getNotificationCollapseIcon(position));
+	}
+
 	private static readonly SEVERITIES = [Severity.Info, Severity.Warning, Severity.Error];
 
 	private readonly inputDisposables = this._register(new DisposableStore());
@@ -328,6 +338,7 @@ export class NotificationTemplateRenderer extends Disposable {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -335,7 +346,14 @@ export class NotificationTemplateRenderer extends Disposable {
 			NotificationTemplateRenderer.closeNotificationAction = instantiationService.createInstance(ClearNotificationAction, ClearNotificationAction.ID, ClearNotificationAction.LABEL);
 			NotificationTemplateRenderer.expandNotificationAction = instantiationService.createInstance(ExpandNotificationAction, ExpandNotificationAction.ID, ExpandNotificationAction.LABEL);
 			NotificationTemplateRenderer.collapseNotificationAction = instantiationService.createInstance(CollapseNotificationAction, CollapseNotificationAction.ID, CollapseNotificationAction.LABEL);
+			NotificationTemplateRenderer.updateExpandCollapseIcons(configurationService);
 		}
+
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(NotificationsSettings.NOTIFICATIONS_POSITION)) {
+				NotificationTemplateRenderer.updateExpandCollapseIcons(configurationService);
+			}
+		}));
 	}
 
 	setInput(notification: INotificationViewItem): void {

--- a/src/vs/workbench/test/browser/notificationsPosition.test.ts
+++ b/src/vs/workbench/test/browser/notificationsPosition.test.ts
@@ -9,7 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../base/test/comm
 import { DEFAULT_CUSTOM_TITLEBAR_HEIGHT } from '../../../platform/window/common/window.js';
 import { NotificationsPosition, NotificationsSettings } from '../../common/notifications.js';
 import { Codicon } from '../../../base/common/codicons.js';
-import { hideIcon, hideUpIcon } from '../../browser/parts/notifications/notificationsActions.js';
+import { hideIcon, hideUpIcon, getNotificationExpandIcon, getNotificationCollapseIcon } from '../../browser/parts/notifications/notificationsActions.js';
 
 suite('Notifications Position', () => {
 
@@ -140,6 +140,33 @@ suite('Notifications Position', () => {
 		test('hide icon defaults use correct codicons', () => {
 			assert.strictEqual(Codicon.chevronDown.id, 'chevron-down');
 			assert.strictEqual(Codicon.chevronUp.id, 'chevron-up');
+		});
+	});
+
+	suite('Expand/Collapse Notification Icons', () => {
+
+		test('bottom-right expand uses notifications-expand icon', () => {
+			assert.strictEqual(getNotificationExpandIcon(NotificationsPosition.BOTTOM_RIGHT).id, 'notifications-expand');
+		});
+
+		test('bottom-left expand uses notifications-expand icon', () => {
+			assert.strictEqual(getNotificationExpandIcon(NotificationsPosition.BOTTOM_LEFT).id, 'notifications-expand');
+		});
+
+		test('top-right expand uses notifications-expand-down icon', () => {
+			assert.strictEqual(getNotificationExpandIcon(NotificationsPosition.TOP_RIGHT).id, 'notifications-expand-down');
+		});
+
+		test('bottom-right collapse uses notifications-collapse icon', () => {
+			assert.strictEqual(getNotificationCollapseIcon(NotificationsPosition.BOTTOM_RIGHT).id, 'notifications-collapse');
+		});
+
+		test('bottom-left collapse uses notifications-collapse icon', () => {
+			assert.strictEqual(getNotificationCollapseIcon(NotificationsPosition.BOTTOM_LEFT).id, 'notifications-collapse');
+		});
+
+		test('top-right collapse uses notifications-collapse-up icon', () => {
+			assert.strictEqual(getNotificationCollapseIcon(NotificationsPosition.TOP_RIGHT).id, 'notifications-collapse-up');
 		});
 	});
 });


### PR DESCRIPTION
Improve the icons and functionality for expanding and collapsing notifications. Add new icons for different notification positions and ensure the correct icons are displayed based on the notification center's position. Include tests to verify the icon behavior for various positions.

Addresses: https://github.com/microsoft/vscode/issues/297282

