### PR TITLE
Fix spelling errors in nls.localize strings in extensions activation events

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsRegistry.ts
@@ -266,7 +266,7 @@ export const schema: IJSONSchema = {
 				defaultSnippets: [
 					{
 						label: 'onWebviewPanel',
-						description: nls.localize('vscode.extension.activationEvents.onWebviewPanel', 'An activation event emmited when a webview is loaded of a certain viewType'),
+						description: nls.localize('vscode.extension.activationEvents.onWebviewPanel', 'An activation event emitted when a webview is loaded of a certain viewType'),
 						body: 'onWebviewPanel:viewType'
 					},
 					{
@@ -421,7 +421,7 @@ export const schema: IJSONSchema = {
 					},
 					{
 						label: 'onMcpCollection',
-						description: nls.localize('vscode.extension.activationEvents.onMcpCollection', 'An activation event emitted whenver a tool from the MCP server is requested.'),
+						description: nls.localize('vscode.extension.activationEvents.onMcpCollection', 'An activation event emitted whenever a tool from the MCP server is requested.'),
 						body: 'onMcpCollection:${2:collectionId}',
 					},
 					{


### PR DESCRIPTION
Fixed two typos in translatable (nls.localize) strings in `extensionsRegistry.ts`:

- `emmited` → `emitted` (activation event description for `onWebviewPanel`)
- `whenver` → `whenever` (activation event description for MCP tool activation)

These strings are user-facing and need to be correctly spelled for localization quality.