### PR TITLE
Update viewpane filter container to use :has selector for focus state

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -346,7 +346,7 @@
 	margin-right: 10px;
 }
 
-.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:has(.monaco-inputbox .input:focus) {
+.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:has(.monaco-inputbox .input:focus, .viewpane-filter-controls :focus) {
 	max-width: 400px;
 }
 

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -346,8 +346,7 @@
 	margin-right: 10px;
 }
 
-.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:active,
-.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:focus-within {
+.panel > .title .monaco-action-bar .action-item.viewpane-filter-container:has(.monaco-inputbox .input:focus) {
 	max-width: 400px;
 }
 


### PR DESCRIPTION
Refactor the viewpane filter container to utilize the `:has` selector for improved focus state handling. This change enhances the user experience by ensuring the focus state is applied correctly when an input box within the container is focused. Testing can be done by interacting with the viewpane filter and observing the focus behavior.

Addresses: https://github.com/microsoft/vscode/issues/277988
