### PR TITLE
Fix detected attachment sticking around after editor is closed

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatImplicitContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatImplicitContext.ts
@@ -268,9 +268,11 @@ export class ChatImplicitContextContribution extends Disposable implements IWork
 			const setting = this._implicitContextEnablement[widget.location];
 			const isFirstInteraction = widget.viewModel?.getItems().length === 0;
 			if ((setting === 'always' || setting === 'first' && isFirstInteraction) && !isPromptFile) { // disable implicit context for prompt files
-				// When there's no active code editor (e.g. Settings is open), preserve
-				// existing values so the attachment bar stays visible
-				if (newValue !== undefined || !widget.input.implicitContext.hasValue) {
+				// When there's a non-code active editor (e.g. Settings is open), preserve
+				// existing values so the attachment bar stays visible.
+				// But when there's no active editor at all, clear the values.
+				const hasActiveEditor = !!this.editorService.activeEditor;
+				if (newValue !== undefined || !widget.input.implicitContext.hasValue || !hasActiveEditor) {
 					widget.input.implicitContext.setValues([{ value: newValue, isSelection }, { value: providerContext, isSelection: false }]);
 				}
 			} else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/297284

When all editors are closed, the implicit context (detected attachment) should be cleared. Previously, the guard condition in `updateImplicitContext` preserved stale values because `newValue` was `undefined` and `hasValue` was `true` — both sides of the OR were false, so `setValues` was never called.

Now we also check whether there's any active editor. If there's no active editor at all (all editors closed), the values are cleared instead of preserved. The preserve behavior still applies when a non-code editor (e.g. Settings) is active.