### PR TITLE
Split combined /create-* tip into focused agent, prompt, and skill tips

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -182,27 +182,33 @@ const TIP_CATALOG: ITipDefinition[] = [
 		onlyWhenModelIds: ['gpt-4.1'],
 	},
 	{
-		id: 'tip.createSlashCommands',
-		message: localize(
-			'tip.createSlashCommands',
-			"Tip: Use [/create-instruction](command:workbench.action.chat.generateInstruction), [/create-prompt](command:workbench.action.chat.generatePrompt), [/create-agent](command:workbench.action.chat.generateAgent), or [/create-skill](command:workbench.action.chat.generateSkill) to generate reusable agent customization files."
-		),
+		id: 'tip.createAgent',
+		message: localize('tip.createAgent', "Tip: Use [/create-agent](command:workbench.action.chat.generateAgent) to build a custom agent with its own persona, tools, and expertise — right from your conversation."),
 		when: ContextKeyExpr.and(
 			ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-			ChatContextKeys.hasUsedCreateSlashCommands.negate(),
+			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
 		),
-		enabledCommands: [
-			'workbench.action.chat.generateInstruction',
-			'workbench.action.chat.generatePrompt',
-			'workbench.action.chat.generateAgent',
-			'workbench.action.chat.generateSkill',
-		],
-		excludeWhenCommandsExecuted: [
-			'workbench.action.chat.generateInstruction',
-			'workbench.action.chat.generatePrompt',
-			'workbench.action.chat.generateAgent',
-			'workbench.action.chat.generateSkill',
-		],
+		enabledCommands: ['workbench.action.chat.generateAgent'],
+		excludeWhenCommandsExecuted: ['workbench.action.chat.generateAgent', 'workbench.command.new.agent'],
+		excludeWhenPromptFilesExist: { promptType: PromptsType.agent, excludeUntilChecked: true },
+	},
+	{
+		id: 'tip.createPrompt',
+		message: localize('tip.createPrompt', "Tip: Use [/create-prompt](command:workbench.action.chat.generatePrompt) to turn a repetitive task into a reusable prompt file you can invoke anytime."),
+		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+		enabledCommands: ['workbench.action.chat.generatePrompt'],
+		excludeWhenCommandsExecuted: ['workbench.action.chat.generatePrompt'],
+	},
+	{
+		id: 'tip.createSkill',
+		message: localize('tip.createSkill', "Tip: Use [/create-skill](command:workbench.action.chat.generateSkill) to package a multi-step workflow the agent can load on demand."),
+		when: ContextKeyExpr.and(
+			ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+		),
+		enabledCommands: ['workbench.action.chat.generateSkill'],
+		excludeWhenCommandsExecuted: ['workbench.action.chat.generateSkill', 'workbench.command.new.skill'],
+		excludeWhenPromptFilesExist: { promptType: PromptsType.skill, excludeUntilChecked: true },
 	},
 	{
 		id: 'tip.agentMode',
@@ -247,22 +253,6 @@ const TIP_CATALOG: ITipDefinition[] = [
 		enabledCommands: ['workbench.action.chat.generateInstructions'],
 		excludeWhenCommandsExecuted: ['workbench.action.chat.generateInstructions'],
 		excludeWhenPromptFilesExist: { promptType: PromptsType.instructions, agentFileType: AgentFileType.copilotInstructionsMd, excludeUntilChecked: true },
-	},
-	{
-		id: 'tip.customAgent',
-		message: localize('tip.customAgent', "Tip: [Create a custom agent](command:workbench.command.new.agent) to define reusable personas with tailored instructions and tools for your workflow."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		enabledCommands: ['workbench.command.new.agent'],
-		excludeWhenCommandsExecuted: ['workbench.command.new.agent'],
-		excludeWhenPromptFilesExist: { promptType: PromptsType.agent, excludeUntilChecked: true },
-	},
-	{
-		id: 'tip.skill',
-		message: localize('tip.skill', "Tip: [Create a skill](command:workbench.command.new.skill) to teach the agent specialized workflows, loaded only when relevant."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		enabledCommands: ['workbench.command.new.skill'],
-		excludeWhenCommandsExecuted: ['workbench.command.new.skill'],
-		excludeWhenPromptFilesExist: { promptType: PromptsType.skill, excludeUntilChecked: true },
 	},
 	{
 		id: 'tip.messageQueueing',

--- a/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatTipService.test.ts
@@ -846,53 +846,58 @@ suite('ChatTipService', () => {
 		assert.strictEqual(tracker.isExcluded(tip), false, 'Should not be excluded when no skill files exist');
 	});
 
-	test('shows tip.createSlashCommands when context key is false', () => {
+	test('shows tip.createAgent in local agent sessions', () => {
 		const service = createService();
-		contextKeyService.createKey(ChatContextKeys.hasUsedCreateSlashCommands.key, false);
 		contextKeyService.createKey(ChatContextKeys.chatSessionType.key, localChatSessionType);
+		contextKeyService.createKey(ChatContextKeys.chatModeKind.key, ChatModeKind.Agent);
 
-		// Dismiss tips until we find createSlashCommands or run out
 		let found = false;
 		for (let i = 0; i < 100; i++) {
 			const tip = service.getWelcomeTip(contextKeyService);
 			if (!tip) {
 				break;
 			}
-			if (tip.id === 'tip.createSlashCommands') {
+			if (tip.id === 'tip.createAgent') {
 				found = true;
 				break;
 			}
 			service.dismissTip();
 		}
 
-		assert.ok(found, 'Should eventually show tip.createSlashCommands when context key is false');
+		assert.ok(found, 'Should eventually show tip.createAgent in a local agent session');
 	});
 
-	test('does not show tip.createSlashCommands in non-local chat sessions', () => {
+	test('shows tip.createPrompt in local sessions regardless of mode', () => {
 		const service = createService();
-		contextKeyService.createKey(ChatContextKeys.hasUsedCreateSlashCommands.key, false);
-		contextKeyService.createKey(ChatContextKeys.chatSessionType.key, 'cloud');
+		contextKeyService.createKey(ChatContextKeys.chatSessionType.key, localChatSessionType);
 
+		let found = false;
 		for (let i = 0; i < 100; i++) {
 			const tip = service.getWelcomeTip(contextKeyService);
 			if (!tip) {
 				break;
 			}
-			assert.notStrictEqual(tip.id, 'tip.createSlashCommands', 'Should not show tip.createSlashCommands in non-local sessions');
+			if (tip.id === 'tip.createPrompt') {
+				found = true;
+				break;
+			}
 			service.dismissTip();
 		}
+
+		assert.ok(found, 'Should eventually show tip.createPrompt in a local session');
 	});
 
-	test('does not show tip.createSlashCommands when context key is true', () => {
-		storageService.store('chat.tips.usedCreateSlashCommands', true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+	test('does not show tip.createAgent in non-local chat sessions', () => {
 		const service = createService();
+		contextKeyService.createKey(ChatContextKeys.chatSessionType.key, 'cloud');
+		contextKeyService.createKey(ChatContextKeys.chatModeKind.key, ChatModeKind.Agent);
 
 		for (let i = 0; i < 100; i++) {
 			const tip = service.getWelcomeTip(contextKeyService);
 			if (!tip) {
 				break;
 			}
-			assert.notStrictEqual(tip.id, 'tip.createSlashCommands', 'Should not show tip.createSlashCommands when context key is true');
+			assert.notStrictEqual(tip.id, 'tip.createAgent', 'Should not show tip.createAgent in non-local sessions');
 			service.dismissTip();
 		}
 	});


### PR DESCRIPTION
Replace the combined `tip.createSlashCommands` tip (which listed all four `/create-*` commands in one dense message) with 3 focused, engaging tips:

- **`tip.createAgent`** — *\"Use /create-agent to build a custom agent with its own persona, tools, and expertise — right from your conversation.\"* (agent mode only)
- **`tip.createPrompt`** — *\"Use /create-prompt to turn a repetitive task into a reusable prompt file you can invoke anytime.\"* (any mode)
- **`tip.createSkill`** — *\"Use /create-skill to package a multi-step workflow the agent can load on demand.\"* (agent mode only)

Also removes the now-redundant `tip.customAgent` and `tip.skill` tips (which promoted the template picker UI) since the `/create-*` slash commands are the better UX for discovery.

`/create-instruction` is dropped from the split — already covered by `tip.customInstructions`.

Updates tests to match the new tip IDs."