### PR TITLE
Inform if user is internal during update requests

### DIFF
--- a/src/vs/platform/assignment/common/assignment.ts
+++ b/src/vs/platform/assignment/common/assignment.ts
@@ -177,3 +177,10 @@ export class AssignmentFilterProvider implements IExperimentationFilterProvider 
 		return filters;
 	}
 }
+
+export function getInternalOrg(organisations: string[] | undefined): 'vscode' | 'github' | 'microsoft' | undefined {
+	const isVSCodeInternal = organisations?.includes('Visual-Studio-Code');
+	const isGitHubInternal = organisations?.includes('github');
+	const isMicrosoftInternal = organisations?.includes('microsoft') || organisations?.includes('ms-copilot') || organisations?.includes('MicrosoftCopilot');
+	return isVSCodeInternal ? 'vscode' : isGitHubInternal ? 'github' : isMicrosoftInternal ? 'microsoft' : undefined;
+}

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -111,7 +111,10 @@ export interface IUpdateService {
 	applyUpdate(): Promise<void>;
 	quitAndInstall(): Promise<void>;
 
+	/**
+	 * @deprecated This method should not be used any more. It will be removed in a future release.
+	*/
 	isLatestVersion(): Promise<boolean | undefined>;
 	_applySpecificUpdate(packagePath: string): Promise<void>;
-	disableProgressiveReleases(): Promise<void>;
+	setInternalOrg(internalOrg: string | undefined): Promise<void>;
 }

--- a/src/vs/platform/update/common/updateIpc.ts
+++ b/src/vs/platform/update/common/updateIpc.ts
@@ -29,7 +29,7 @@ export class UpdateChannel implements IServerChannel {
 			case '_getInitialState': return Promise.resolve(this.service.state);
 			case 'isLatestVersion': return this.service.isLatestVersion();
 			case '_applySpecificUpdate': return this.service._applySpecificUpdate(arg);
-			case 'disableProgressiveReleases': return this.service.disableProgressiveReleases();
+			case 'setInternalOrg': return this.service.setInternalOrg(arg);
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -80,8 +80,8 @@ export class UpdateChannelClient implements IUpdateService {
 		return this.channel.call('_applySpecificUpdate', packagePath);
 	}
 
-	disableProgressiveReleases(): Promise<void> {
-		return this.channel.call('disableProgressiveReleases');
+	setInternalOrg(internalOrg: string | undefined): Promise<void> {
+		return this.channel.call('setInternalOrg', internalOrg);
 	}
 
 	dispose(): void {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -20,6 +20,7 @@ import { AvailableForDownload, DisablementReason, IUpdateService, State, StateTy
 
 export interface IUpdateURLOptions {
 	readonly background?: boolean;
+	readonly internalOrg?: string;
 }
 
 export function createUpdateURL(baseUpdateUrl: string, platform: string, quality: string, commit: string, options?: IUpdateURLOptions): string {
@@ -27,6 +28,10 @@ export function createUpdateURL(baseUpdateUrl: string, platform: string, quality
 
 	if (options?.background) {
 		url.searchParams.set('bg', 'true');
+	}
+
+	if (options?.internalOrg) {
+		url.searchParams.set('org', options.internalOrg);
 	}
 
 	return url.toString();
@@ -77,7 +82,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	protected _overwrite: boolean = false;
 	private _hasCheckedForOverwriteOnQuit: boolean = false;
 	private readonly overwriteUpdatesCheckInterval = new IntervalTimer();
-	private _disableProgressiveReleases: boolean = false;
+	private _internalOrg: string | undefined = undefined;
 
 	private readonly _onStateChange = new Emitter<State>();
 	readonly onStateChange: Event<State> = this._onStateChange.event;
@@ -342,13 +347,17 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		// noop
 	}
 
-	async disableProgressiveReleases(): Promise<void> {
-		this.logService.info('update#disableProgressiveReleases');
-		this._disableProgressiveReleases = true;
+	async setInternalOrg(internalOrg: string | undefined): Promise<void> {
+		if (this._internalOrg === internalOrg) {
+			return;
+		}
+
+		this.logService.info('update#setInternalOrg', internalOrg);
+		this._internalOrg = internalOrg;
 	}
 
-	protected shouldDisableProgressiveReleases(): boolean {
-		return this._disableProgressiveReleases;
+	protected getInternalOrg(): string | undefined {
+		return this._internalOrg;
 	}
 
 	protected getUpdateType(): UpdateType {

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -127,8 +127,9 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 		this.setState(State.CheckingForUpdates(explicit));
 
-		const background = !explicit && !this.shouldDisableProgressiveReleases();
-		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background });
+		const internalOrg = this.getInternalOrg();
+		const background = !explicit && !internalOrg;
+		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 
 		if (!url) {
 			return;
@@ -205,7 +206,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 	protected override async doDownloadUpdate(state: AvailableForDownload): Promise<void> {
 		// Rebuild feed URL and trigger download via Electron's auto-updater
-		this.buildUpdateFeedUrl(this.quality!, state.update.version);
+		this.buildUpdateFeedUrl(this.quality!, state.update.version, { internalOrg: this.getInternalOrg() });
 		this.setState(State.CheckingForUpdates(true));
 		electron.autoUpdater.checkForUpdates();
 	}

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -39,8 +39,9 @@ export class LinuxUpdateService extends AbstractUpdateService {
 			return;
 		}
 
-		const background = !explicit && !this.shouldDisableProgressiveReleases();
-		const url = this.buildUpdateFeedUrl(this.quality, this.productService.commit!, { background });
+		const internalOrg = this.getInternalOrg();
+		const background = !explicit && !internalOrg;
+		const url = this.buildUpdateFeedUrl(this.quality, this.productService.commit!, { background, internalOrg });
 		this.setState(State.CheckingForUpdates(explicit));
 
 		this.requestService.request({ url }, CancellationToken.None)

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -133,7 +133,7 @@ abstract class AbstractUpdateService implements IUpdateService {
 		// noop
 	}
 
-	async disableProgressiveReleases(): Promise<void> {
+	async setInternalOrg(_internalOrg: string | undefined): Promise<void> {
 		// noop - not applicable for snap
 	}
 

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -189,8 +189,9 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 			return;
 		}
 
-		const background = !explicit && !this.shouldDisableProgressiveReleases();
-		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background });
+		const internalOrg = this.getInternalOrg();
+		const background = !explicit && !internalOrg;
+		const url = this.buildUpdateFeedUrl(this.quality, pendingCommit ?? this.productService.commit!, { background, internalOrg });
 
 		// Only set CheckingForUpdates if we're not already in Overwriting state
 		if (this.state.type !== StateType.Overwriting) {

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -26,11 +26,12 @@ import { IHostService } from '../../../services/host/browser/host.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IUserDataSyncEnablementService, IUserDataSyncService, IUserDataSyncStoreManagementService, SyncStatus, UserDataSyncStoreType } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { IsWebContext } from '../../../../platform/contextkey/common/contextkeys.js';
-import { Promises } from '../../../../base/common/async.js';
+import { Promises, Throttler } from '../../../../base/common/async.js';
 import { IUserDataSyncWorkbenchService } from '../../../services/userDataSync/common/userDataSync.js';
 import { Event } from '../../../../base/common/event.js';
 import { toAction } from '../../../../base/common/actions.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
+import { getInternalOrg } from '../../../../platform/assignment/common/assignment.js';
 
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
@@ -675,9 +676,14 @@ export class SwitchProductQualityContribution extends Disposable implements IWor
 
 export class DefaultAccountUpdateContribution extends Disposable implements IWorkbenchContribution {
 
+	private static readonly STORAGE_KEY = 'update/internalOrg';
+	#internalOrg: string | undefined = undefined;
+	private throttler: Throttler = this._register(new Throttler());
+
 	constructor(
 		@IUpdateService private readonly updateService: IUpdateService,
-		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService
+		@IDefaultAccountService private readonly defaultAccountService: IDefaultAccountService,
+		@IStorageService private readonly storageService: IStorageService
 	) {
 		super();
 
@@ -685,25 +691,36 @@ export class DefaultAccountUpdateContribution extends Disposable implements IWor
 			return; // Electron only
 		}
 
+		this.#internalOrg = this.storageService.get(DefaultAccountUpdateContribution.STORAGE_KEY, StorageScope.APPLICATION, undefined);
+		this.throttler.queue(() => this.updateService.setInternalOrg(this.#internalOrg));
+
 		// Check on startup
-		this.checkDefaultAccount();
+		this.refresh();
 
 		// Listen for account changes
-		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => {
-			this.checkDefaultAccount();
-		}));
+		this._register(this.defaultAccountService.onDidChangeDefaultAccount(() => this.refresh()));
 	}
 
-	private async checkDefaultAccount(): Promise<void> {
+	private refresh(): void {
+		this.throttler.queue(() => this.doRefresh());
+	}
+
+	private async doRefresh(): Promise<void> {
 		try {
 			const defaultAccount = await this.defaultAccountService.getDefaultAccount();
-			const shouldDisable = defaultAccount?.entitlementsData?.organization_login_list?.some(
-				org => org.toLowerCase() === 'visual-studio-code'
-			) ?? false;
+			const internalOrg = getInternalOrg(defaultAccount?.entitlementsData?.organization_login_list);
 
-			if (shouldDisable) {
-				await this.updateService.disableProgressiveReleases();
-				this.dispose();
+			if (internalOrg === this.#internalOrg) {
+				return;
+			}
+
+			this.#internalOrg = internalOrg;
+			await this.updateService.setInternalOrg(this.#internalOrg);
+
+			if (this.#internalOrg) {
+				this.storageService.store(DefaultAccountUpdateContribution.STORAGE_KEY, internalOrg, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			} else {
+				this.storageService.remove(DefaultAccountUpdateContribution.STORAGE_KEY, StorageScope.APPLICATION);
 			}
 		} catch (error) {
 			// Silently ignore errors - if we can't get the account, we don't disable background updates

--- a/src/vs/workbench/services/assignment/common/assignmentFilters.ts
+++ b/src/vs/workbench/services/assignment/common/assignmentFilters.ts
@@ -11,6 +11,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IChatEntitlementService } from '../../chat/common/chatEntitlementService.js';
+import { getInternalOrg } from '../../../../platform/assignment/common/assignment.js';
 
 export enum ExtensionsFilter {
 
@@ -135,10 +136,7 @@ export class CopilotAssignmentFilterProvider extends Disposable implements IExpe
 	private updateCopilotEntitlementInfo() {
 		const newSku = this._chatEntitlementService.sku;
 		const newTrackingId = this._chatEntitlementService.copilotTrackingId;
-		const newIsGitHubInternal = this._chatEntitlementService.organisations?.includes('github');
-		const newIsMicrosoftInternal = this._chatEntitlementService.organisations?.includes('microsoft') || this._chatEntitlementService.organisations?.includes('ms-copilot') || this._chatEntitlementService.organisations?.includes('MicrosoftCopilot');
-		const newIsVSCodeInternal = this._chatEntitlementService.organisations?.includes('Visual-Studio-Code');
-		const newInternalOrg = newIsVSCodeInternal ? 'vscode' : newIsGitHubInternal ? 'github' : newIsMicrosoftInternal ? 'microsoft' : undefined;
+		const newInternalOrg = getInternalOrg(this._chatEntitlementService.organisations);
 
 		if (this.copilotSku === newSku && this.copilotInternalOrg === newInternalOrg && this.copilotTrackingId === newTrackingId) {
 			return;

--- a/src/vs/workbench/services/update/browser/updateService.ts
+++ b/src/vs/workbench/services/update/browser/updateService.ts
@@ -98,7 +98,7 @@ export class BrowserUpdateService extends Disposable implements IUpdateService {
 		// noop
 	}
 
-	async disableProgressiveReleases(): Promise<void> {
+	async setInternalOrg(_internalOrg: string | undefined): Promise<void> {
 		// noop - not applicable in browser
 	}
 }


### PR DESCRIPTION
The update service now includes functionality to determine if a user is internal. This change introduces a new method, `setInternalOrg`, which logs the internal organization when invoked. The update process will also utilize this information to adjust the update feed URL accordingly. Testing can be done by checking the logs for the internal organization information during update requests.
Fixes #297453

