### PR TITLE
sessions welcome flow: fix stale session after sign in

### DIFF
--- a/src/vs/sessions/contrib/welcome/browser/sessionsWelcomeOverlay.ts
+++ b/src/vs/sessions/contrib/welcome/browser/sessionsWelcomeOverlay.ts
@@ -57,12 +57,7 @@ export class SessionsWelcomeOverlay extends Disposable {
 		this._register(autorun(reader => {
 			const steps = this.welcomeService.steps.read(reader);
 			const current = this.welcomeService.currentStep.read(reader);
-			const isComplete = this.welcomeService.isComplete.read(reader);
-
-			if (isComplete) {
-				this.dismiss();
-				return;
-			}
+			this.welcomeService.isComplete.read(reader);
 
 			// Render step indicators
 			this.renderStepList(stepList, steps, current);
@@ -135,7 +130,7 @@ export class SessionsWelcomeOverlay extends Disposable {
 		}
 	}
 
-	private dismiss(): void {
+	dismiss(): void {
 		this.overlay.classList.add('sessions-welcome-overlay-dismissed');
 		this._onDidDismiss.fire();
 		// Allow CSS transition to finish before disposing


### PR DESCRIPTION
After the welcome overlay completes (extension installed + user signed in), restart the extension host so the copilot-chat extension picks up the new auth session cleanly. Without this, the extension activates before the auth provider is ready, gets stuck in GitHubLoginFailed, and models never appear.

The overlay stays visible during the restart so the user doesn't see a broken intermediate state. Dismiss is controlled by the contribution via an autorun watching isComplete, not by the overlay itself.

The copilot-chat code is really tangled and I don't see a safe way to fix this in the extension itself during endgame week.


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
