### PR TITLE
Enable subagent custom agent setting by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1227,8 +1227,7 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.SubagentToolCustomAgents]: {
 			type: 'boolean',
 			description: nls.localize('chat.subagentTool.customAgents', "Whether the runSubagent tool is able to use custom agents. When enabled, the tool can take the name of a custom agent, but it must be given the exact name of the agent."),
-			default: false,
-			tags: ['experimental'],
+			default: true,
 			experiment: {
 				mode: 'auto'
 			}


### PR DESCRIPTION
Enable `chat.customAgentInSubagent.enabled` by default and remove the `experimental` tag. The experiment override (`experiment.mode: 'auto'`) is kept so AB testing can still control the rollout.