### PR TITLE
chat: support installing plugins from private marketplaces

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginRepositoryService.ts
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action } from '../../../../base/common/actions.js';
+import { Lazy } from '../../../../base/common/lazy.js';
+import { revive } from '../../../../base/common/marshalling.js';
+import { dirname, isEqualOrParent, joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import type { Dto } from '../../../services/extensions/common/proxyIdentifier.js';
+import { IAgentPluginRepositoryService, IEnsureRepositoryOptions, IPullRepositoryOptions } from '../common/plugins/agentPluginRepositoryService.js';
+import { IMarketplacePlugin, IMarketplaceReference, MarketplaceReferenceKind, MarketplaceType } from '../common/plugins/pluginMarketplaceService.js';
+
+const MARKETPLACE_INDEX_STORAGE_KEY = 'chat.plugins.marketplaces.index.v1';
+
+interface IMarketplaceIndexEntry {
+	repositoryUri: URI;
+	marketplaceType?: MarketplaceType;
+}
+
+type IStoredMarketplaceIndex = Dto<Record<string, IMarketplaceIndexEntry>>;
+
+export class AgentPluginRepositoryService implements IAgentPluginRepositoryService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _cacheRoot: URI;
+	private readonly _marketplaceIndex = new Lazy<Map<string, IMarketplaceIndexEntry>>(() => this._loadMarketplaceIndex());
+
+	constructor(
+		@ICommandService private readonly _commandService: ICommandService,
+		@IEnvironmentService environmentService: IEnvironmentService,
+		@IFileService private readonly _fileService: IFileService,
+		@ILogService private readonly _logService: ILogService,
+		@INotificationService private readonly _notificationService: INotificationService,
+		@IProgressService private readonly _progressService: IProgressService,
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		this._cacheRoot = joinPath(environmentService.cacheHome, 'agentPlugins');
+	}
+
+	getRepositoryUri(marketplace: IMarketplaceReference, marketplaceType?: MarketplaceType): URI {
+		if (marketplace.kind === MarketplaceReferenceKind.LocalFileUri && marketplace.localRepositoryUri) {
+			return marketplace.localRepositoryUri;
+		}
+
+		const indexed = this._marketplaceIndex.value.get(marketplace.canonicalId);
+		if (indexed?.repositoryUri) {
+			return indexed.repositoryUri;
+		}
+
+		return this._getRepoCacheDirForReference(marketplace);
+	}
+
+	getPluginInstallUri(plugin: IMarketplacePlugin): URI {
+		const repoDir = this.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+		return this._getPluginDir(repoDir, plugin.source);
+	}
+
+	async ensureRepository(marketplace: IMarketplaceReference, options?: IEnsureRepositoryOptions): Promise<URI> {
+		const repoDir = this.getRepositoryUri(marketplace, options?.marketplaceType);
+		const repoExists = await this._fileService.exists(repoDir);
+		if (repoExists) {
+			this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType);
+			return repoDir;
+		}
+
+		if (marketplace.kind === MarketplaceReferenceKind.LocalFileUri) {
+			throw new Error(`Local marketplace repository does not exist: ${repoDir.fsPath}`);
+		}
+
+		const progressTitle = options?.progressTitle ?? localize('preparingMarketplace', "Preparing plugin marketplace '{0}'...", marketplace.displayLabel);
+		const failureLabel = options?.failureLabel ?? marketplace.displayLabel;
+		await this._cloneRepository(repoDir, marketplace.cloneUrl, progressTitle, failureLabel);
+		this._updateMarketplaceIndex(marketplace, repoDir, options?.marketplaceType);
+		return repoDir;
+	}
+
+	async pullRepository(marketplace: IMarketplaceReference, options?: IPullRepositoryOptions): Promise<void> {
+		const repoDir = this.getRepositoryUri(marketplace, options?.marketplaceType);
+		const repoExists = await this._fileService.exists(repoDir);
+		if (!repoExists) {
+			this._logService.warn(`[AgentPluginRepositoryService] Cannot update plugin '${options?.pluginName ?? marketplace.displayLabel}': repository not cloned`);
+			return;
+		}
+
+		const updateLabel = options?.pluginName ?? marketplace.displayLabel;
+
+		try {
+			await this._progressService.withProgress(
+				{
+					location: ProgressLocation.Notification,
+					title: localize('updatingPlugin', "Updating plugin '{0}'...", updateLabel),
+					cancellable: false,
+				},
+				async () => {
+					await this._commandService.executeCommand('_git.pull', repoDir.fsPath);
+				}
+			);
+		} catch (err) {
+			this._logService.error(`[AgentPluginRepositoryService] Failed to update ${marketplace.displayLabel}:`, err);
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('pullFailed', "Failed to update plugin '{0}': {1}", options?.failureLabel ?? updateLabel, err?.message ?? String(err)),
+				actions: {
+					primary: [new Action('showGitOutput', localize('showGitOutput', "Show Git Output"), undefined, true, () => {
+						this._commandService.executeCommand('git.showOutput');
+					})],
+				},
+			});
+		}
+	}
+
+	private _getRepoCacheDirForReference(reference: IMarketplaceReference): URI {
+		return joinPath(this._cacheRoot, ...reference.cacheSegments);
+	}
+
+	private _loadMarketplaceIndex(): Map<string, IMarketplaceIndexEntry> {
+		const result = new Map<string, IMarketplaceIndexEntry>();
+		const stored = this._storageService.getObject<IStoredMarketplaceIndex>(MARKETPLACE_INDEX_STORAGE_KEY, StorageScope.APPLICATION);
+		if (!stored) {
+			return result;
+		}
+
+		const revived = revive<IStoredMarketplaceIndex>(stored);
+		for (const [canonicalId, entry] of Object.entries(revived)) {
+			if (!entry || !entry.repositoryUri) {
+				continue;
+			}
+
+			result.set(canonicalId, {
+				repositoryUri: entry.repositoryUri,
+				marketplaceType: entry.marketplaceType,
+			});
+		}
+
+		return result;
+	}
+
+	private _updateMarketplaceIndex(marketplace: IMarketplaceReference, repositoryUri: URI, marketplaceType?: MarketplaceType): void {
+		if (marketplace.kind === MarketplaceReferenceKind.LocalFileUri) {
+			return;
+		}
+
+		const previous = this._marketplaceIndex.value.get(marketplace.canonicalId);
+		if (previous && previous.repositoryUri.toString() === repositoryUri.toString() && previous.marketplaceType === marketplaceType) {
+			return;
+		}
+
+		this._marketplaceIndex.value.set(marketplace.canonicalId, { repositoryUri, marketplaceType });
+		this._saveMarketplaceIndex();
+	}
+
+	private _saveMarketplaceIndex(): void {
+		const serialized: IStoredMarketplaceIndex = {};
+		for (const [canonicalId, entry] of this._marketplaceIndex.value) {
+			serialized[canonicalId] = JSON.parse(JSON.stringify({
+				repositoryUri: entry.repositoryUri,
+				marketplaceType: entry.marketplaceType,
+			}));
+		}
+
+		if (Object.keys(serialized).length === 0) {
+			this._storageService.remove(MARKETPLACE_INDEX_STORAGE_KEY, StorageScope.APPLICATION);
+			return;
+		}
+
+		this._storageService.store(MARKETPLACE_INDEX_STORAGE_KEY, JSON.stringify(serialized), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+
+	private async _cloneRepository(repoDir: URI, cloneUrl: string, progressTitle: string, failureLabel: string): Promise<void> {
+		try {
+			await this._progressService.withProgress(
+				{
+					location: ProgressLocation.Notification,
+					title: progressTitle,
+					cancellable: false,
+				},
+				async () => {
+					await this._fileService.createFolder(dirname(repoDir));
+					await this._commandService.executeCommand('_git.cloneRepository', cloneUrl, dirname(repoDir).fsPath);
+				}
+			);
+		} catch (err) {
+			this._logService.error(`[AgentPluginRepositoryService] Failed to clone ${cloneUrl}:`, err);
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('cloneFailed', "Failed to install plugin '{0}': {1}", failureLabel, err?.message ?? String(err)),
+				actions: {
+					primary: [new Action('showGitOutput', localize('showGitOutput', "Show Git Output"), undefined, true, () => {
+						this._commandService.executeCommand('git.showOutput');
+					})],
+				},
+			});
+			throw err;
+		}
+	}
+
+	private _getPluginDir(repoDir: URI, source: string): URI {
+		const normalizedSource = source.trim().replace(/^\.?\/+|\/+$/g, '');
+		const pluginDir = normalizedSource ? joinPath(repoDir, normalizedSource) : repoDir;
+		if (!isEqualOrParent(pluginDir, repoDir)) {
+			throw new Error(`Invalid plugin source path '${source}'`);
+		}
+		return pluginDir;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -38,7 +38,7 @@ import { DefaultViewsContext, SearchAgentPluginsContext } from '../../extensions
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IAgentPlugin, IAgentPluginService } from '../common/plugins/agentPluginService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
-import { IMarketplacePlugin, IPluginMarketplaceService, MarketplaceType } from '../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceType } from '../common/plugins/pluginMarketplaceService.js';
 
 export const HasInstalledAgentPluginsContext = new RawContextKey<boolean>('hasInstalledAgentPlugins', false);
 
@@ -63,6 +63,7 @@ interface IMarketplacePluginItem {
 	readonly description: string;
 	readonly source: string;
 	readonly marketplace: string;
+	readonly marketplaceReference: IMarketplaceReference;
 	readonly marketplaceType: MarketplaceType;
 	readonly readmeUri?: URI;
 }
@@ -83,6 +84,7 @@ function marketplacePluginToItem(plugin: IMarketplacePlugin): IMarketplacePlugin
 		description: plugin.description,
 		source: plugin.source,
 		marketplace: plugin.marketplace,
+		marketplaceReference: plugin.marketplaceReference,
 		marketplaceType: plugin.marketplaceType,
 		readmeUri: plugin.readmeUri,
 	};
@@ -109,6 +111,7 @@ class InstallPluginAction extends Action {
 			version: '',
 			source: this.item.source,
 			marketplace: this.item.marketplace,
+			marketplaceReference: this.item.marketplaceReference,
 			marketplaceType: this.item.marketplaceType,
 			readmeUri: this.item.readmeUri,
 		});
@@ -426,6 +429,7 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 				version: '',
 				source: m.source,
 				marketplace: m.marketplace,
+				marketplaceReference: m.marketplaceReference,
 				marketplaceType: m.marketplaceType,
 			});
 			return !installedPaths.has(expectedUri.toString());

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -141,9 +141,11 @@ import './widget/input/editor/chatInputEditorHover.js';
 import { LanguageModelToolsConfirmationService } from './tools/languageModelToolsConfirmationService.js';
 import { LanguageModelToolsService, globalAutoApproveDescription } from './tools/languageModelToolsService.js';
 import { AgentPluginService, ConfiguredAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
+import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
 import { AgentPluginsViewsContribution } from './agentPluginsView.js';
+import { AgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { PluginInstallService } from './pluginInstallService.js';
 import './promptSyntax/promptCodingAgentActionContribution.js';
 import './promptSyntax/promptToolsCodeLensProvider.js';
@@ -662,7 +664,7 @@ configurationRegistry.registerConfiguration({
 			items: {
 				type: 'string',
 			},
-			markdownDescription: nls.localize('chat.plugins.marketplaces', "GitHub repositories to use as plugin marketplaces. Each entry should be in `owner/repo` format."),
+			markdownDescription: nls.localize('chat.plugins.marketplaces', "Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated."),
 			default: ['github/copilot-plugins', 'github/awesome-copilot'],
 			scope: ConfigurationScope.APPLICATION,
 			tags: ['experimental'],
@@ -1661,6 +1663,7 @@ registerSingleton(IChatAgentNameService, ChatAgentNameService, InstantiationType
 registerSingleton(IChatVariablesService, ChatVariablesService, InstantiationType.Delayed);
 registerSingleton(IAgentPluginService, AgentPluginService, InstantiationType.Delayed);
 registerSingleton(IPluginMarketplaceService, PluginMarketplaceService, InstantiationType.Delayed);
+registerSingleton(IAgentPluginRepositoryService, AgentPluginRepositoryService, InstantiationType.Delayed);
 registerSingleton(IPluginInstallService, PluginInstallService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsService, LanguageModelToolsService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsConfirmationService, LanguageModelToolsConfirmationService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginRepositoryService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginRepositoryService.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IMarketplacePlugin, IMarketplaceReference, MarketplaceType } from './pluginMarketplaceService.js';
+
+export const IAgentPluginRepositoryService = createDecorator<IAgentPluginRepositoryService>('agentPluginRepositoryService');
+
+/**
+ * Options for ensuring a marketplace repository is available locally.
+ */
+export interface IEnsureRepositoryOptions {
+	/** Optional progress notification title shown during clone. */
+	readonly progressTitle?: string;
+	/** Label used in clone failure messaging. */
+	readonly failureLabel?: string;
+	/** Marketplace type metadata to persist in the marketplace index. */
+	readonly marketplaceType?: MarketplaceType;
+}
+
+/**
+ * Options for pulling the latest changes from a cloned marketplace repository.
+ */
+export interface IPullRepositoryOptions {
+	/** Optional plugin name used in progress messaging. */
+	readonly pluginName?: string;
+	/** Label used in pull failure messaging. */
+	readonly failureLabel?: string;
+	/** Marketplace type metadata for repository index updates. */
+	readonly marketplaceType?: MarketplaceType;
+}
+
+/**
+ * Manages cloning, cache location resolution, and update operations for
+ * agent plugin marketplace repositories.
+ */
+export interface IAgentPluginRepositoryService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Returns the local cache URI for a marketplace repository reference.
+	 * Uses a storage-backed marketplace index when available.
+	 */
+	getRepositoryUri(marketplace: IMarketplaceReference, marketplaceType?: MarketplaceType): URI;
+
+	/**
+	 * Returns the local install URI for a plugin source directory inside its
+	 * marketplace repository cache.
+	 */
+	getPluginInstallUri(plugin: IMarketplacePlugin): URI;
+
+	/**
+	 * Ensures a marketplace repository is cloned locally and returns its cache URI.
+	 */
+	ensureRepository(marketplace: IMarketplaceReference, options?: IEnsureRepositoryOptions): Promise<URI>;
+
+	/**
+	 * Pulls latest changes for a cloned marketplace repository.
+	 */
+	pullRepository(marketplace: IMarketplaceReference, options?: IPullRepositoryOptions): Promise<void>;
+}

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -4,17 +4,41 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { Lazy } from '../../../../../base/common/lazy.js';
+import { revive } from '../../../../../base/common/marshalling.js';
 import { joinPath, normalizePath, relativePath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { asJson, IRequestService } from '../../../../../platform/request/common/request.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import type { Dto } from '../../../../services/extensions/common/proxyIdentifier.js';
 import { ChatConfiguration } from '../constants.js';
+import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 
 export const enum MarketplaceType {
 	Copilot = 'copilot',
 	Claude = 'claude',
+}
+
+export const enum MarketplaceReferenceKind {
+	GitHubShorthand = 'githubShorthand',
+	GitUri = 'gitUri',
+	LocalFileUri = 'localFileUri',
+}
+
+export interface IMarketplaceReference {
+	readonly rawValue: string;
+	readonly displayLabel: string;
+	readonly cloneUrl: string;
+	readonly canonicalId: string;
+	readonly cacheSegments: readonly string[];
+	readonly kind: MarketplaceReferenceKind;
+	readonly githubRepo?: string;
+	readonly localRepositoryUri?: URI;
 }
 
 export interface IMarketplacePlugin {
@@ -23,8 +47,10 @@ export interface IMarketplacePlugin {
 	readonly version: string;
 	/** Subdirectory within the repository where the plugin lives. */
 	readonly source: string;
-	/** The `owner/repo` identifier of the marketplace repository. */
+	/** Marketplace label shown in UI and plugin provenance. */
 	readonly marketplace: string;
+	/** Canonical reference for clone/update/install location resolution. */
+	readonly marketplaceReference: IMarketplaceReference;
 	/** The type of marketplace this plugin comes from. */
 	readonly marketplaceType: MarketplaceType;
 	readonly readmeUri?: URI;
@@ -58,26 +84,59 @@ const MARKETPLACE_DEFINITIONS: { type: MarketplaceType; path: string }[] = [
 	{ type: MarketplaceType.Claude, path: '.claude-plugin/marketplace.json' },
 ];
 
+const GITHUB_MARKETPLACE_CACHE_TTL_MS = 8 * 60 * 60 * 1000;
+const GITHUB_MARKETPLACE_CACHE_STORAGE_KEY = 'chat.plugins.marketplaces.githubCache.v1';
+
+interface IGitHubMarketplaceCacheEntry {
+	readonly plugins: readonly IMarketplacePlugin[];
+	readonly expiresAt: number;
+	readonly referenceRawValue: string;
+}
+
+type IStoredGitHubMarketplaceCache = Dto<Record<string, IGitHubMarketplaceCacheEntry>>;
+
 export class PluginMarketplaceService implements IPluginMarketplaceService {
 	declare readonly _serviceBrand: undefined;
+	private readonly _gitHubMarketplaceCache = new Lazy<Map<string, IGitHubMarketplaceCacheEntry>>(() => this._loadPersistedGitHubMarketplaceCache());
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IRequestService private readonly _requestService: IRequestService,
+		@IFileService private readonly _fileService: IFileService,
+		@IAgentPluginRepositoryService private readonly _pluginRepositoryService: IAgentPluginRepositoryService,
 		@ILogService private readonly _logService: ILogService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) { }
 
 	async fetchMarketplacePlugins(token: CancellationToken): Promise<IMarketplacePlugin[]> {
-		const repos: string[] = this._configurationService.getValue(ChatConfiguration.PluginMarketplaces) ?? [];
+		const configuredRefs = this._configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+		const refs = parseMarketplaceReferences(configuredRefs);
+
+		for (const value of configuredRefs) {
+			if (typeof value !== 'string' || !parseMarketplaceReference(value)) {
+				this._logService.debug(`[PluginMarketplaceService] Ignoring invalid marketplace entry: ${String(value)}`);
+			}
+		}
+
 		const results = await Promise.all(
-			repos
-				.filter(repo => typeof repo === 'string' && /^[^/]+\/[^/]+$/.test(repo.trim()))
-				.map(repo => this._fetchFromRepo(repo.trim(), token))
+			refs.map(ref => {
+				if (ref.kind === MarketplaceReferenceKind.GitHubShorthand && ref.githubRepo) {
+					return this._fetchFromGitHubRepo(ref, ref.githubRepo, token);
+				}
+				return this._fetchFromClonedRepo(ref, token);
+			})
 		);
 		return results.flat();
 	}
 
-	private async _fetchFromRepo(repo: string, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+	private async _fetchFromGitHubRepo(reference: IMarketplaceReference, repo: string, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+		const cache = this._gitHubMarketplaceCache.value;
+
+		const cached = this._getCachedGitHubMarketplacePlugins(cache, reference.canonicalId);
+		if (cached) {
+			return cached;
+		}
+
 		for (const def of MARKETPLACE_DEFINITIONS) {
 			if (token.isCancellationRequested) {
 				return [];
@@ -85,8 +144,14 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 			const url = `https://raw.githubusercontent.com/${repo}/main/${def.path}`;
 			try {
 				const context = await this._requestService.request({ type: 'GET', url }, token);
-				if (context.res.statusCode !== 200) {
-					this._logService.debug(`[PluginMarketplaceService] ${url} returned status ${context.res.statusCode}, skipping`);
+				const statusCode = context.res.statusCode;
+				if (statusCode !== 200) {
+					if (statusCode !== undefined && statusCode >= 401 && statusCode <= 404) {
+						this._logService.debug(`[PluginMarketplaceService] ${url} returned status ${statusCode}, attempting clone-based marketplace discovery`);
+						return this._fetchFromClonedRepo(reference, token);
+					}
+
+					this._logService.debug(`[PluginMarketplaceService] ${url} returned status ${statusCode}, skipping`);
 					continue;
 				}
 				const json = await asJson<IMarketplaceJson>(context);
@@ -94,7 +159,7 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 					this._logService.debug(`[PluginMarketplaceService] ${url} did not contain a valid plugins array, skipping`);
 					continue;
 				}
-				return json.plugins
+				const plugins = json.plugins
 					.filter((p): p is { name: string; description?: string; version?: string; source?: string } =>
 						typeof p.name === 'string' && !!p.name
 					)
@@ -110,11 +175,21 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 							description: p.description ?? '',
 							version: p.version ?? '',
 							source,
-							marketplace: repo,
+							marketplace: reference.displayLabel,
+							marketplaceReference: reference,
 							marketplaceType: def.type,
 							readmeUri: getMarketplaceReadmeUri(repo, source),
 						}];
 					});
+
+				cache.set(reference.canonicalId, {
+					plugins,
+					expiresAt: Date.now() + GITHUB_MARKETPLACE_CACHE_TTL_MS,
+					referenceRawValue: reference.rawValue,
+				});
+				this._savePersistedGitHubMarketplaceCache(cache);
+
+				return plugins;
 			} catch (err) {
 				this._logService.debug(`[PluginMarketplaceService] Failed to fetch marketplace.json from ${url}:`, err);
 				continue;
@@ -123,6 +198,295 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 		this._logService.debug(`[PluginMarketplaceService] No marketplace.json found in ${repo}`);
 		return [];
 	}
+
+	private _getCachedGitHubMarketplacePlugins(cache: Map<string, IGitHubMarketplaceCacheEntry>, cacheKey: string): IMarketplacePlugin[] | undefined {
+		const cached = cache.get(cacheKey);
+		if (!cached) {
+			return undefined;
+		}
+
+		if (cached.expiresAt <= Date.now()) {
+			cache.delete(cacheKey);
+			this._savePersistedGitHubMarketplaceCache(cache);
+			return undefined;
+		}
+
+		return [...cached.plugins];
+	}
+
+	private _loadPersistedGitHubMarketplaceCache(): Map<string, IGitHubMarketplaceCacheEntry> {
+		const cache = new Map<string, IGitHubMarketplaceCacheEntry>();
+		const now = Date.now();
+		const stored = this._storageService.getObject<IStoredGitHubMarketplaceCache>(GITHUB_MARKETPLACE_CACHE_STORAGE_KEY, StorageScope.APPLICATION);
+		if (!stored) {
+			return cache;
+		}
+
+		const revived = revive<IStoredGitHubMarketplaceCache>(stored);
+
+		for (const [cacheKey, entry] of Object.entries(revived)) {
+			if (!entry || !Array.isArray(entry.plugins) || typeof entry.expiresAt !== 'number' || entry.expiresAt <= now || typeof entry.referenceRawValue !== 'string') {
+				continue;
+			}
+
+			const reference = parseMarketplaceReference(entry.referenceRawValue);
+			if (!reference) {
+				continue;
+			}
+
+			const plugins = entry.plugins.map(plugin => ({
+				...plugin,
+				marketplace: reference.displayLabel,
+				marketplaceReference: reference,
+			}));
+
+			cache.set(cacheKey, {
+				plugins,
+				expiresAt: entry.expiresAt,
+				referenceRawValue: entry.referenceRawValue,
+			});
+		}
+
+		return cache;
+	}
+
+	private _savePersistedGitHubMarketplaceCache(cache: Map<string, IGitHubMarketplaceCacheEntry>): void {
+		const serialized: IStoredGitHubMarketplaceCache = {};
+		for (const [cacheKey, entry] of cache) {
+			if (!entry.plugins.length || entry.expiresAt <= Date.now()) {
+				continue;
+			}
+
+			const dtoEntry: Dto<IGitHubMarketplaceCacheEntry> = JSON.parse(JSON.stringify({
+				expiresAt: entry.expiresAt,
+				referenceRawValue: entry.referenceRawValue,
+				plugins: entry.plugins,
+			}));
+
+			serialized[cacheKey] = dtoEntry;
+		}
+
+		if (Object.keys(serialized).length === 0) {
+			this._storageService.remove(GITHUB_MARKETPLACE_CACHE_STORAGE_KEY, StorageScope.APPLICATION);
+			return;
+		}
+
+		this._storageService.store(
+			GITHUB_MARKETPLACE_CACHE_STORAGE_KEY,
+			JSON.stringify(serialized),
+			StorageScope.APPLICATION,
+			StorageTarget.MACHINE,
+		);
+	}
+
+	private async _fetchFromClonedRepo(reference: IMarketplaceReference, token: CancellationToken): Promise<IMarketplacePlugin[]> {
+		let repoDir: URI;
+		try {
+			repoDir = await this._pluginRepositoryService.ensureRepository(reference);
+		} catch (err) {
+			this._logService.debug(`[PluginMarketplaceService] Failed to prepare marketplace repository ${reference.rawValue}:`, err);
+			return [];
+		}
+
+		for (const def of MARKETPLACE_DEFINITIONS) {
+			if (token.isCancellationRequested) {
+				return [];
+			}
+
+			const definitionUri = joinPath(repoDir, def.path);
+			let json: IMarketplaceJson | undefined;
+			try {
+				const contents = await this._fileService.readFile(definitionUri);
+				json = parseJSONC(contents.value.toString()) as IMarketplaceJson | undefined;
+			} catch {
+				continue;
+			}
+
+			if (!json?.plugins || !Array.isArray(json.plugins)) {
+				this._logService.debug(`[PluginMarketplaceService] ${definitionUri.toString()} did not contain a valid plugins array, skipping`);
+				continue;
+			}
+
+			return json.plugins
+				.filter((p): p is { name: string; description?: string; version?: string; source?: string } =>
+					typeof p.name === 'string' && !!p.name
+				)
+				.flatMap(p => {
+					const source = resolvePluginSource(json.metadata?.pluginRoot, p.source ?? '');
+					if (source === undefined) {
+						this._logService.warn(`[PluginMarketplaceService] Skipping plugin '${p.name}' in ${reference.rawValue}: invalid source path '${p.source ?? ''}' with pluginRoot '${json.metadata?.pluginRoot ?? ''}'`);
+						return [];
+					}
+
+					return [{
+						name: p.name,
+						description: p.description ?? '',
+						version: p.version ?? '',
+						source,
+						marketplace: reference.displayLabel,
+						marketplaceReference: reference,
+						marketplaceType: def.type,
+						readmeUri: getMarketplaceReadmeFileUri(repoDir, source),
+					}];
+				});
+		}
+
+		this._logService.debug(`[PluginMarketplaceService] No marketplace.json found in ${reference.rawValue}`);
+		return [];
+	}
+}
+
+export function parseMarketplaceReferences(values: readonly unknown[]): IMarketplaceReference[] {
+	const byCanonicalId = new Map<string, IMarketplaceReference>();
+
+	for (const value of values) {
+		if (typeof value !== 'string') {
+			continue;
+		}
+
+		const parsed = parseMarketplaceReference(value);
+		if (!parsed) {
+			continue;
+		}
+
+		if (!byCanonicalId.has(parsed.canonicalId)) {
+			byCanonicalId.set(parsed.canonicalId, parsed);
+		}
+	}
+
+	return [...byCanonicalId.values()];
+}
+
+export function parseMarketplaceReference(value: string): IMarketplaceReference | undefined {
+	const rawValue = value.trim();
+	if (!rawValue) {
+		return undefined;
+	}
+
+	const uriReference = parseUriMarketplaceReference(rawValue);
+	if (uriReference) {
+		return uriReference;
+	}
+
+	const scpReference = parseScpMarketplaceReference(rawValue);
+	if (scpReference) {
+		return scpReference;
+	}
+
+	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(rawValue);
+	if (shorthandMatch) {
+		const owner = shorthandMatch[1];
+		const repo = shorthandMatch[2];
+		return {
+			rawValue,
+			displayLabel: `${owner}/${repo}`,
+			cloneUrl: `https://github.com/${owner}/${repo}.git`,
+			canonicalId: getGitHubCanonicalId(owner, repo),
+			cacheSegments: ['github.com', owner, repo],
+			kind: MarketplaceReferenceKind.GitHubShorthand,
+			githubRepo: `${owner}/${repo}`,
+		};
+	}
+
+	return undefined;
+}
+
+function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
+	let uri: URI;
+	try {
+		uri = URI.parse(rawValue);
+	} catch {
+		return undefined;
+	}
+
+	const scheme = uri.scheme.toLowerCase();
+	if (scheme === 'file' && /^file:\/\//i.test(rawValue)) {
+		const localRepositoryUri = URI.file(uri.fsPath);
+		return {
+			rawValue,
+			displayLabel: localRepositoryUri.fsPath,
+			cloneUrl: rawValue,
+			canonicalId: `file:${localRepositoryUri.toString().toLowerCase()}`,
+			cacheSegments: [],
+			kind: MarketplaceReferenceKind.LocalFileUri,
+			localRepositoryUri,
+		};
+	}
+
+	if (scheme !== 'http' && scheme !== 'https' && scheme !== 'ssh') {
+		return undefined;
+	}
+
+	if (!uri.authority) {
+		return undefined;
+	}
+
+	const normalizedPath = normalizeGitRepoPath(uri.path);
+	if (!normalizedPath) {
+		return undefined;
+	}
+
+	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
+	const pathSegments = normalizedPath.slice(1, -4).split('/').map(sanitizePathSegment);
+	return {
+		rawValue,
+		displayLabel: rawValue,
+		cloneUrl: rawValue,
+		canonicalId: `git:${uri.authority.toLowerCase()}/${normalizedPath.slice(1).toLowerCase()}`,
+		cacheSegments: [sanitizedAuthority, ...pathSegments],
+		kind: MarketplaceReferenceKind.GitUri,
+	};
+}
+
+function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
+	const match = /^([^@\s]+)@([^:\s]+):(.+\.git)$/i.exec(rawValue);
+	if (!match) {
+		return undefined;
+	}
+
+	const authority = match[2];
+	const pathWithGit = match[3].replace(/^\/+/, '');
+	if (!pathWithGit.toLowerCase().endsWith('.git')) {
+		return undefined;
+	}
+
+	const pathSegments = pathWithGit.slice(0, -4).split('/').map(sanitizePathSegment);
+	return {
+		rawValue,
+		displayLabel: rawValue,
+		cloneUrl: rawValue,
+		canonicalId: `git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`,
+		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments],
+		kind: MarketplaceReferenceKind.GitUri,
+	};
+}
+
+function normalizeGitRepoPath(path: string): string | undefined {
+	const normalized = path.replace(/\/+/g, '/');
+	if (!normalized.toLowerCase().endsWith('.git')) {
+		return undefined;
+	}
+
+	const trimmed = normalized.replace(/\/+/g, '/').replace(/\/+$/g, '');
+	if (!trimmed.toLowerCase().endsWith('.git')) {
+		return undefined;
+	}
+
+	const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+	const pathWithoutGit = withLeadingSlash.slice(1, -4);
+	if (!pathWithoutGit || !pathWithoutGit.includes('/')) {
+		return undefined;
+	}
+
+	return withLeadingSlash;
+}
+
+function getGitHubCanonicalId(owner: string, repo: string): string {
+	return `github:${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+function sanitizePathSegment(value: string): string {
+	return value.replace(/[\\/:*?"<>|]/g, '_');
 }
 
 function normalizeMarketplacePath(value: string): string {
@@ -159,4 +523,9 @@ function getMarketplaceReadmeUri(repo: string, source: string): URI {
 	const normalizedSource = source.trim().replace(/^\.?\/+|\/+$/g, '');
 	const readmePath = normalizedSource ? `${normalizedSource}/README.md` : 'README.md';
 	return URI.parse(`https://github.com/${repo}/blob/main/${readmePath}`);
+}
+
+function getMarketplaceReadmeFileUri(repoDir: URI, source: string): URI {
+	const normalizedSource = source.trim().replace(/^\.?\/+|\/+$/g, '');
+	return normalizedSource ? joinPath(repoDir, normalizedSource, 'README.md') : joinPath(repoDir, 'README.md');
 }

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -137,6 +137,8 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 			return cached;
 		}
 
+		let repoMayBePrivate = true;
+
 		for (const def of MARKETPLACE_DEFINITIONS) {
 			if (token.isCancellationRequested) {
 				return [];
@@ -146,11 +148,7 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 				const context = await this._requestService.request({ type: 'GET', url }, token);
 				const statusCode = context.res.statusCode;
 				if (statusCode !== 200) {
-					if (statusCode !== undefined && statusCode >= 401 && statusCode <= 404) {
-						this._logService.debug(`[PluginMarketplaceService] ${url} returned status ${statusCode}, attempting clone-based marketplace discovery`);
-						return this._fetchFromClonedRepo(reference, token);
-					}
-
+					repoMayBePrivate &&= statusCode !== undefined && statusCode >= 400 && statusCode < 500;
 					this._logService.debug(`[PluginMarketplaceService] ${url} returned status ${statusCode}, skipping`);
 					continue;
 				}
@@ -195,6 +193,12 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 				continue;
 			}
 		}
+
+		if (repoMayBePrivate) {
+			this._logService.debug(`[PluginMarketplaceService] ${repo} may be private, attempting clone-based marketplace discovery`);
+			return this._fetchFromClonedRepo(reference, token);
+		}
+
 		this._logService.debug(`[PluginMarketplaceService] No marketplace.json found in ${repo}`);
 		return [];
 	}
@@ -257,13 +261,11 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 				continue;
 			}
 
-			const dtoEntry: Dto<IGitHubMarketplaceCacheEntry> = JSON.parse(JSON.stringify({
+			serialized[cacheKey] = {
 				expiresAt: entry.expiresAt,
 				referenceRawValue: entry.referenceRawValue,
 				plugins: entry.plugins,
-			}));
-
-			serialized[cacheKey] = dtoEntry;
+			};
 		}
 
 		if (Object.keys(serialized).length === 0) {
@@ -462,12 +464,7 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 }
 
 function normalizeGitRepoPath(path: string): string | undefined {
-	const normalized = path.replace(/\/+/g, '/');
-	if (!normalized.toLowerCase().endsWith('.git')) {
-		return undefined;
-	}
-
-	const trimmed = normalized.replace(/\/+/g, '/').replace(/\/+$/g, '');
+	const trimmed = path.replace(/\/+/g, '/').replace(/\/+$/g, '');
 	if (!trimmed.toLowerCase().endsWith('.git')) {
 		return undefined;
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
@@ -1,0 +1,173 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IEnvironmentService } from '../../../../../../platform/environment/common/environment.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
+import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { AgentPluginRepositoryService } from '../../../browser/agentPluginRepositoryService.js';
+import { IMarketplacePlugin, MarketplaceType, parseMarketplaceReference } from '../../../common/plugins/pluginMarketplaceService.js';
+
+suite('AgentPluginRepositoryService', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createPlugin(marketplace: string, source: string): IMarketplacePlugin {
+		const marketplaceReference = parseMarketplaceReference(marketplace);
+		assert.ok(marketplaceReference);
+		if (!marketplaceReference) {
+			throw new Error('Expected marketplace reference to parse.');
+		}
+
+		return {
+			name: 'test-plugin',
+			description: '',
+			version: '',
+			source,
+			marketplace: marketplaceReference.displayLabel,
+			marketplaceReference,
+			marketplaceType: MarketplaceType.Copilot,
+		};
+	}
+
+	function createService(
+		onExists?: (resource: URI) => Promise<boolean>,
+		onExecuteCommand?: (id: string) => void,
+	): AgentPluginRepositoryService {
+		const instantiationService = store.add(new TestInstantiationService());
+
+		const fileService = {
+			exists: async (resource: URI) => onExists ? onExists(resource) : true,
+		} as unknown as IFileService;
+
+		const progressService = {
+			withProgress: async (_options: unknown, callback: (...args: unknown[]) => Promise<unknown>) => callback(),
+		} as unknown as IProgressService;
+
+		instantiationService.stub(ICommandService, {
+			executeCommand: async (id: string) => {
+				onExecuteCommand?.(id);
+				return undefined;
+			},
+		} as unknown as ICommandService);
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as unknown as IEnvironmentService);
+		instantiationService.stub(IFileService, fileService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(INotificationService, { notify: () => undefined } as unknown as INotificationService);
+		instantiationService.stub(IProgressService, progressService);
+		instantiationService.stub(IStorageService, new InMemoryStorageService());
+
+		return instantiationService.createInstance(AgentPluginRepositoryService);
+	}
+
+	test('uses cacheSegments path for GitHub shorthand plugin references', () => {
+		const service = createService();
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+		const uri = service.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+
+		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+	});
+
+	test('uses marketplaces cache path for direct git URI plugin references', () => {
+		const service = createService();
+		const plugin = createPlugin('https://example.com/org/repo.git', 'plugins/myPlugin');
+		const uri = service.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+
+		assert.strictEqual(uri.path, '/cache/agentPlugins/example.com/org/repo');
+	});
+
+	test('uses same cache path for equivalent GitHub shorthand and URI references', () => {
+		const service = createService();
+		const shorthandPlugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+		const uriPlugin = createPlugin('https://github.com/microsoft/vscode.git', 'plugins/myPlugin');
+
+		const shorthandUri = service.getRepositoryUri(shorthandPlugin.marketplaceReference, shorthandPlugin.marketplaceType);
+		const uriRefUri = service.getRepositoryUri(uriPlugin.marketplaceReference, uriPlugin.marketplaceType);
+
+		assert.strictEqual(shorthandUri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+		assert.strictEqual(uriRefUri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+	});
+
+	test('ensures plugin repositories via cacheSegments path', async () => {
+		let checkedPath: string | undefined;
+		const service = createService(async resource => {
+			checkedPath = resource.path;
+			return true;
+		});
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+		const uri = await service.ensureRepository(plugin.marketplaceReference, { marketplaceType: plugin.marketplaceType });
+
+		assert.strictEqual(checkedPath, '/cache/agentPlugins/github.com/microsoft/vscode');
+		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode');
+	});
+
+	test('builds install URI from source inside repository root', () => {
+		const service = createService();
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+		const uri = service.getPluginInstallUri(plugin);
+
+		assert.strictEqual(uri.path, '/cache/agentPlugins/github.com/microsoft/vscode/plugins/myPlugin');
+	});
+
+	test('uses indexed repository URI when available', () => {
+		const storage = new InMemoryStorageService();
+		storage.store('chat.plugins.marketplaces.index.v1', JSON.stringify({
+			'github:microsoft/vscode': {
+				repositoryUri: URI.file('/cache/agentPlugins/indexed/microsoft/vscode'),
+				marketplaceType: MarketplaceType.Copilot,
+			},
+		}), StorageScope.APPLICATION, StorageTarget.MACHINE);
+
+		const instantiationService = store.add(new TestInstantiationService());
+		instantiationService.stub(ICommandService, { executeCommand: async () => undefined } as unknown as ICommandService);
+		instantiationService.stub(IEnvironmentService, { cacheHome: URI.file('/cache') } as unknown as IEnvironmentService);
+		instantiationService.stub(IFileService, { exists: async () => true } as unknown as IFileService);
+		instantiationService.stub(ILogService, new NullLogService());
+		instantiationService.stub(INotificationService, { notify: () => undefined } as unknown as INotificationService);
+		instantiationService.stub(IProgressService, { withProgress: async (_options: unknown, callback: (...args: unknown[]) => Promise<unknown>) => callback() } as unknown as IProgressService);
+		instantiationService.stub(IStorageService, storage);
+
+		const service = instantiationService.createInstance(AgentPluginRepositoryService);
+		const plugin = createPlugin('microsoft/vscode', 'plugins/myPlugin');
+		const uri = service.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+
+		assert.strictEqual(uri.path, '/cache/agentPlugins/indexed/microsoft/vscode');
+	});
+
+	test('rejects plugin source paths that escape repository root', () => {
+		const service = createService();
+		const plugin = createPlugin('microsoft/vscode', '../outside');
+
+		assert.throws(() => service.getPluginInstallUri(plugin));
+	});
+
+	test('uses local repository URI for file marketplace references', () => {
+		const service = createService();
+		const plugin = createPlugin('file:///tmp/marketplace-repo', 'plugins/myPlugin');
+		const uri = service.getRepositoryUri(plugin.marketplaceReference, plugin.marketplaceType);
+
+		assert.strictEqual(uri.scheme, 'file');
+		assert.strictEqual(uri.path, '/tmp/marketplace-repo');
+	});
+
+	test('does not invoke clone command when ensuring existing local file repository', async () => {
+		let commandInvocationCount = 0;
+		const service = createService(async () => true, () => {
+			commandInvocationCount++;
+		});
+		const plugin = createPlugin('file:///tmp/marketplace-repo', 'plugins/myPlugin');
+
+		const uri = await service.ensureRepository(plugin.marketplaceReference, { marketplaceType: plugin.marketplaceType });
+
+		assert.strictEqual(uri.path, '/tmp/marketplace-repo');
+		assert.strictEqual(commandInvocationCount, 0);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/agentPluginRepositoryService.test.ts
@@ -63,7 +63,7 @@ suite('AgentPluginRepositoryService', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(INotificationService, { notify: () => undefined } as unknown as INotificationService);
 		instantiationService.stub(IProgressService, progressService);
-		instantiationService.stub(IStorageService, new InMemoryStorageService());
+		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
 
 		return instantiationService.createInstance(AgentPluginRepositoryService);
 	}
@@ -118,7 +118,7 @@ suite('AgentPluginRepositoryService', () => {
 	});
 
 	test('uses indexed repository URI when available', () => {
-		const storage = new InMemoryStorageService();
+		const storage = store.add(new InMemoryStorageService());
 		storage.store('chat.plugins.marketplaces.index.v1', JSON.stringify({
 			'github:microsoft/vscode': {
 				repositoryUri: URI.file('/cache/agentPlugins/indexed/microsoft/vscode'),

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -72,6 +72,17 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parseMarketplaceReference('git@example.com:org/repo'), undefined);
 	});
 
+	test('parses HTTPS URI with trailing slash after .git', () => {
+		const parsed = parseMarketplaceReference('https://example.com/org/repo.git/');
+		assert.ok(parsed);
+		if (!parsed) {
+			return;
+		}
+		assert.strictEqual(parsed.kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(parsed.canonicalId, 'git:example.com/org/repo.git');
+		assert.deepStrictEqual(parsed.cacheSegments, ['example.com', 'org', 'repo']);
+	});
+
 	test('deduplicates equivalent Git URI forms but keeps shorthand distinct', () => {
 		const parsed = parseMarketplaceReferences([
 			'microsoft/vscode',
@@ -79,8 +90,15 @@ suite('PluginMarketplaceService', () => {
 			'git@github.com:microsoft/vscode.git',
 		]);
 
-		assert.strictEqual(parsed.length, 2);
+		assert.deepStrictEqual(parsed.map(r => r.canonicalId), [
+			'github:microsoft/vscode',
+			'git:github.com/microsoft/vscode.git',
+		]);
+	});
+
+	test('parseMarketplaceReferences ignores non-string entries', () => {
+		const parsed = parseMarketplaceReferences([null, 42, {}, 'microsoft/vscode']);
+		assert.strictEqual(parsed.length, 1);
 		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode');
-		assert.strictEqual(parsed[1].canonicalId, 'git:github.com/microsoft/vscode.git');
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from '../../../common/plugins/pluginMarketplaceService.js';
+
+suite('PluginMarketplaceService', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('parses GitHub shorthand marketplace', () => {
+		const parsed = parseMarketplaceReference('microsoft/vscode');
+		assert.ok(parsed);
+		if (!parsed) {
+			return;
+		}
+		assert.strictEqual(parsed.kind, MarketplaceReferenceKind.GitHubShorthand);
+		assert.strictEqual(parsed.cloneUrl, 'https://github.com/microsoft/vscode.git');
+		assert.strictEqual(parsed.canonicalId, 'github:microsoft/vscode');
+		assert.strictEqual(parsed.displayLabel, 'microsoft/vscode');
+		assert.deepStrictEqual(parsed.cacheSegments, ['github.com', 'microsoft', 'vscode']);
+	});
+
+	test('parses direct HTTPS and SSH marketplaces ending in .git', () => {
+		const https = parseMarketplaceReference('https://example.com/org/repo.git');
+		assert.ok(https);
+		if (!https) {
+			return;
+		}
+		assert.strictEqual(https.kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(https.displayLabel, 'https://example.com/org/repo.git');
+		assert.deepStrictEqual(https.cacheSegments, ['example.com', 'org', 'repo']);
+
+		const ssh = parseMarketplaceReference('ssh://git@example.com/org/repo.git');
+		assert.ok(ssh);
+		if (!ssh) {
+			return;
+		}
+		assert.strictEqual(ssh.kind, MarketplaceReferenceKind.GitUri);
+		assert.deepStrictEqual(ssh.cacheSegments, ['git@example.com', 'org', 'repo']);
+	});
+
+	test('parses scp-like git URI marketplaces', () => {
+		const parsed = parseMarketplaceReference('git@example.com:org/repo.git');
+		assert.ok(parsed);
+		if (!parsed) {
+			return;
+		}
+		assert.strictEqual(parsed.kind, MarketplaceReferenceKind.GitUri);
+		assert.strictEqual(parsed.cloneUrl, 'git@example.com:org/repo.git');
+		assert.strictEqual(parsed.canonicalId, 'git:example.com/org/repo.git');
+		assert.deepStrictEqual(parsed.cacheSegments, ['example.com', 'org', 'repo']);
+	});
+
+	test('parses local file marketplace references', () => {
+		const parsed = parseMarketplaceReference('file:///tmp/marketplace-repo');
+		assert.ok(parsed);
+		if (!parsed) {
+			return;
+		}
+		assert.strictEqual(parsed.kind, MarketplaceReferenceKind.LocalFileUri);
+		assert.strictEqual(parsed.localRepositoryUri?.scheme, 'file');
+		assert.strictEqual(parsed.cloneUrl, 'file:///tmp/marketplace-repo');
+		assert.deepStrictEqual(parsed.cacheSegments, []);
+	});
+
+	test('rejects non-shorthand marketplace entries without .git', () => {
+		assert.strictEqual(parseMarketplaceReference('https://example.com/org/repo'), undefined);
+		assert.strictEqual(parseMarketplaceReference('ssh://git@example.com/org/repo'), undefined);
+		assert.strictEqual(parseMarketplaceReference('git@example.com:org/repo'), undefined);
+	});
+
+	test('deduplicates equivalent Git URI forms but keeps shorthand distinct', () => {
+		const parsed = parseMarketplaceReferences([
+			'microsoft/vscode',
+			'https://github.com/microsoft/vscode.git',
+			'git@github.com:microsoft/vscode.git',
+		]);
+
+		assert.strictEqual(parsed.length, 2);
+		assert.strictEqual(parsed[0].canonicalId, 'github:microsoft/vscode');
+		assert.strictEqual(parsed[1].canonicalId, 'git:github.com/microsoft/vscode.git');
+	});
+});


### PR DESCRIPTION
Adds support for installing plugins from private git repositories, git URIs,
and file paths. Introduces a new agentPluginRepositoryService to handle
cloning and managing custom marketplace repositories.

- Extracts shared repository logic into a dedicated common service
- Adds support for fallback to private repo cloning when public marketplace
  lookup fails
- Allows \https://\ and SCP-style git URIs for marketplace references
- Allows \ile:///\ URIs for local marketplace directories
- Adds comprehensive unit tests for new marketplace functionality

Fixes https://github.com/microsoft/vscode/issues/297524

(Commit message generated by Copilot)