### PR TITLE
chat: add agent plugins filter option to extensions view

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "uuid",
  "winapi",
  "winreg 0.50.0",
+ "winresource",
  "zbus",
  "zip",
 ]
@@ -2646,6 +2647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,10 +3015,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3017,9 +3051,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower-service"
@@ -3700,6 +3749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
 name = "winreg"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3771,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
+dependencies = [
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -19,7 +19,7 @@ import { ResourceSet } from '../../../../../base/common/map.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { IConfigurationService, ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 import { IPaneCompositePartService } from '../../../../services/panecomposite/browser/panecomposite.js';
-import { IExtensionsViewPaneContainer, VIEWLET_ID } from '../../../extensions/common/extensions.js';
+import { extensionsFilterSubMenu, IExtensionsViewPaneContainer, IExtensionsWorkbenchService, VIEWLET_ID } from '../../../extensions/common/extensions.js';
 import { ViewContainerLocation } from '../../../../common/views.js';
 
 const enum ManagePluginItemKind {
@@ -244,6 +244,30 @@ async function showManagePluginsQuickPick(
 	return result;
 }
 
+class BrowseAgentPluginsAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.browseAgentPlugins';
+
+	constructor() {
+		super({
+			id: BrowseAgentPluginsAction.ID,
+			title: localize2('browseAgentPlugins', 'Agent Plugins'),
+			category: CHAT_CATEGORY,
+			precondition: ChatContextKeys.Setup.hidden.negate(),
+			menu: [{
+				id: extensionsFilterSubMenu,
+				group: '1_predefined',
+				order: 2,
+				when: ChatContextKeys.Setup.hidden.negate(),
+			}],
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get(IExtensionsWorkbenchService).openSearch('@agentPlugins ');
+	}
+}
+
 export function registerChatPluginActions() {
 	registerAction2(ManagePluginsAction);
+	registerAction2(BrowseAgentPluginsAction);
 }


### PR DESCRIPTION
Adds a new 'Agent Plugins' filter option to the Extensions view's
'Filter Extensions...' menu. When clicked, it opens the extensions view
filtered to show agent plugins discovered in the workspace.

- Creates BrowseAgentPluginsAction in chatPluginActions.ts
- Registers the action in the extensionsFilterSubMenu
- Uses the existing '@agentPlugins' search query to display plugins

Fixes https://github.com/microsoft/vscode/issues/297526

(Commit message generated by Copilot)