### PR TITLE
Refactor new chat pane pickers into self-contained widgets

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/branchPicker.ts
@@ -177,7 +177,7 @@ export class BranchPicker extends Disposable {
 		return this._branches.map(branch => ({
 			kind: ActionListItemKind.Action,
 			label: branch,
-			group: { title: '', icon: this._selectedBranch === branch ? Codicon.check : Codicon.blank },
+			group: { title: '', icon: Codicon.gitBranch },
 			item: { name: branch },
 		}));
 	}

--- a/src/vs/sessions/contrib/chat/browser/folderPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/folderPicker.ts
@@ -226,7 +226,7 @@ export class FolderPicker extends Disposable {
 			items.push({
 				kind: ActionListItemKind.Action,
 				label: basename(currentFolderUri),
-				group: { title: '', icon: Codicon.check },
+				group: { title: '', icon: Codicon.folder },
 				item: { uri: currentFolderUri, label: basename(currentFolderUri) },
 			});
 		}
@@ -236,18 +236,22 @@ export class FolderPicker extends Disposable {
 			...this._recentlyPickedFolders.map(uri => ({ uri })),
 			...this._cachedRecentFolders,
 		];
+		const dedupedFolders: { uri: URI; label: string }[] = [];
 		for (const folder of allFolders) {
 			const key = folder.uri.toString();
 			if (seenUris.has(key)) {
 				continue;
 			}
 			seenUris.add(key);
-			const label = folder.label || basename(folder.uri);
+			dedupedFolders.push({ uri: folder.uri, label: folder.label || basename(folder.uri) });
+		}
+		dedupedFolders.sort((a, b) => a.label.localeCompare(b.label));
+		for (const folder of dedupedFolders) {
 			items.push({
 				kind: ActionListItemKind.Action,
-				label,
-				group: { title: '', icon: Codicon.blank },
-				item: { uri: folder.uri, label },
+				label: folder.label,
+				group: { title: '', icon: Codicon.folder },
+				item: { uri: folder.uri, label: folder.label },
 				onRemove: () => this._removeFolder(folder.uri),
 			});
 		}
@@ -262,7 +266,7 @@ export class FolderPicker extends Disposable {
 		items.push({
 			kind: ActionListItemKind.Action,
 			label: localize('browseFolder', "Browse..."),
-			group: { title: '', icon: Codicon.folderOpened },
+			group: { title: '', icon: Codicon.search },
 			item: { uri: URI.from({ scheme: 'command', path: 'browse' }), label: localize('browseFolder', "Browse...") },
 		});
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -66,6 +66,12 @@
 	flex: 1;
 }
 
+.sessions-chat-toolbar-pickers {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
 /* Model picker - uses workbench ModelPickerActionItem */
 .sessions-chat-model-picker {
 	display: flex;

--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { IChatSessionProviderOptionItem } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { RemoteNewSession } from './newSession.js';
+
+const FILTER_THRESHOLD = 10;
+
+interface IModelItem {
+	readonly id: string;
+	readonly name: string;
+	readonly description?: string;
+}
+
+/**
+ * A self-contained widget for selecting a model in cloud sessions.
+ * Reads the model option group from the {@link RemoteNewSession} and
+ * renders an action list dropdown with the available models.
+ */
+export class CloudModelPicker extends Disposable {
+
+	private readonly _onDidChange = this._register(new Emitter<IChatSessionProviderOptionItem>());
+	readonly onDidChange: Event<IChatSessionProviderOptionItem> = this._onDidChange.event;
+
+	private _triggerElement: HTMLElement | undefined;
+	private _slotElement: HTMLElement | undefined;
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private readonly _sessionDisposables = this._register(new DisposableStore());
+
+	private _session: RemoteNewSession | undefined;
+	private _selectedModel: IModelItem | undefined;
+	private _models: IModelItem[] = [];
+
+	get selectedModel(): IModelItem | undefined {
+		return this._selectedModel;
+	}
+
+	constructor(
+		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+	) {
+		super();
+	}
+
+	/**
+	 * Sets the remote session and loads the available models from it.
+	 */
+	setSession(session: RemoteNewSession): void {
+		this._session = session;
+		this._sessionDisposables.clear();
+		this._loadModels(session);
+
+		// Sync selected model to the new session
+		if (this._selectedModel) {
+			session.setModelId(this._selectedModel.id);
+			session.setOptionValue('models', { id: this._selectedModel.id, name: this._selectedModel.name });
+		}
+
+		// Re-load models when option groups change
+		this._sessionDisposables.add(session.onDidChangeOptionGroups(() => {
+			this._loadModels(session);
+		}));
+	}
+
+	/**
+	 * Renders the model picker trigger button into the given container.
+	 */
+	render(container: HTMLElement): HTMLElement {
+		this._renderDisposables.clear();
+
+		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
+		this._slotElement = slot;
+		this._renderDisposables.add({ dispose: () => slot.remove() });
+
+		const trigger = dom.append(slot, dom.$('a.action-label'));
+		trigger.tabIndex = 0;
+		trigger.role = 'button';
+		this._triggerElement = trigger;
+
+		this._updateTriggerLabel();
+
+		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.CLICK, (e) => {
+			dom.EventHelper.stop(e, true);
+			this._showPicker();
+		}));
+
+		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				dom.EventHelper.stop(e, true);
+				this._showPicker();
+			}
+		}));
+
+		return slot;
+	}
+
+	/**
+	 * Shows or hides the picker.
+	 */
+	setVisible(visible: boolean): void {
+		if (this._slotElement) {
+			this._slotElement.style.display = visible ? '' : 'none';
+		}
+	}
+
+	private _loadModels(session: RemoteNewSession): void {
+		const modelOption = session.getModelOptionGroup();
+		if (modelOption?.group.items.length) {
+			this._models = modelOption.group.items.map(item => ({
+				id: item.id,
+				name: item.name,
+				description: item.description,
+			}));
+
+			// Select the session's current value, or the default, or the first
+			if (!this._selectedModel || !this._models.some(m => m.id === this._selectedModel!.id)) {
+				const value = modelOption.value;
+				this._selectedModel = value
+					? { id: value.id, name: value.name, description: value.description }
+					: this._models[0];
+			}
+		} else {
+			this._models = [];
+		}
+		this._updateTriggerLabel();
+	}
+
+	private _showPicker(): void {
+		if (!this._triggerElement || this.actionWidgetService.isVisible || this._models.length === 0) {
+			return;
+		}
+
+		const items = this._buildItems();
+		const showFilter = items.filter(i => i.kind === ActionListItemKind.Action).length > FILTER_THRESHOLD;
+
+		const triggerElement = this._triggerElement;
+		const delegate: IActionListDelegate<IModelItem> = {
+			onSelect: (item) => {
+				this.actionWidgetService.hide();
+				this._selectModel(item);
+			},
+			onHide: () => { triggerElement.focus(); },
+		};
+
+		this.actionWidgetService.show<IModelItem>(
+			'remoteModelPicker',
+			false,
+			items,
+			delegate,
+			this._triggerElement,
+			undefined,
+			[],
+			{
+				getAriaLabel: (item) => item.label ?? '',
+				getWidgetAriaLabel: () => localize('modelPicker.ariaLabel', "Model Picker"),
+			},
+			showFilter ? { showFilter: true, filterPlaceholder: localize('modelPicker.filter', "Filter models...") } : undefined,
+		);
+	}
+
+	private _buildItems(): IActionListItem<IModelItem>[] {
+		return this._models.map(model => ({
+			kind: ActionListItemKind.Action,
+			label: model.name,
+			group: { title: '', icon: this._selectedModel?.id === model.id ? Codicon.check : Codicon.blank },
+			item: model,
+		}));
+	}
+
+	private _selectModel(item: IModelItem): void {
+		this._selectedModel = item;
+		this._updateTriggerLabel();
+
+		if (this._session) {
+			this._session.setModelId(item.id);
+			this._session.setOptionValue('models', { id: item.id, name: item.name });
+		}
+		this._onDidChange.fire({ id: item.id, name: item.name, description: item.description });
+	}
+
+	private _updateTriggerLabel(): void {
+		if (!this._triggerElement) {
+			return;
+		}
+
+		dom.clearNode(this._triggerElement);
+		const label = this._selectedModel?.name ?? localize('modelPicker.auto', "Auto");
+
+		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+
+		this._slotElement?.classList.toggle('disabled', this._models.length === 0);
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -40,6 +40,7 @@ export class CloudModelPicker extends Disposable {
 	private _session: RemoteNewSession | undefined;
 	private _selectedModel: IModelItem | undefined;
 	private _models: IModelItem[] = [];
+	private _modelGroupId: string | undefined;
 
 	get selectedModel(): IModelItem | undefined {
 		return this._selectedModel;
@@ -60,9 +61,9 @@ export class CloudModelPicker extends Disposable {
 		this._loadModels(session);
 
 		// Sync selected model to the new session
-		if (this._selectedModel) {
+		if (this._selectedModel && this._modelGroupId) {
 			session.setModelId(this._selectedModel.id);
-			session.setOptionValue('models', { id: this._selectedModel.id, name: this._selectedModel.name });
+			session.setOptionValue(this._modelGroupId, { id: this._selectedModel.id, name: this._selectedModel.name });
 		}
 
 		// Re-load models when option groups change
@@ -115,6 +116,7 @@ export class CloudModelPicker extends Disposable {
 	private _loadModels(session: RemoteNewSession): void {
 		const modelOption = session.getModelOptionGroup();
 		if (modelOption?.group.items.length) {
+			this._modelGroupId = modelOption.group.id;
 			this._models = modelOption.group.items.map(item => ({
 				id: item.id,
 				name: item.name,
@@ -180,9 +182,9 @@ export class CloudModelPicker extends Disposable {
 		this._selectedModel = item;
 		this._updateTriggerLabel();
 
-		if (this._session) {
+		if (this._session && this._modelGroupId) {
 			this._session.setModelId(item.id);
-			this._session.setOptionValue('models', { id: item.id, name: item.name });
+			this._session.setOptionValue(this._modelGroupId, { id: item.id, name: item.name });
 		}
 		this._onDidChange.fire({ id: item.id, name: item.name, description: item.description });
 	}

--- a/src/vs/sessions/contrib/chat/browser/modelPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/modelPicker.ts
@@ -40,7 +40,6 @@ export class CloudModelPicker extends Disposable {
 	private _session: RemoteNewSession | undefined;
 	private _selectedModel: IModelItem | undefined;
 	private _models: IModelItem[] = [];
-	private _modelGroupId: string | undefined;
 
 	get selectedModel(): IModelItem | undefined {
 		return this._selectedModel;
@@ -61,9 +60,9 @@ export class CloudModelPicker extends Disposable {
 		this._loadModels(session);
 
 		// Sync selected model to the new session
-		if (this._selectedModel && this._modelGroupId) {
+		if (this._selectedModel) {
 			session.setModelId(this._selectedModel.id);
-			session.setOptionValue(this._modelGroupId, { id: this._selectedModel.id, name: this._selectedModel.name });
+			session.setOptionValue('models', { id: this._selectedModel.id, name: this._selectedModel.name });
 		}
 
 		// Re-load models when option groups change
@@ -116,7 +115,6 @@ export class CloudModelPicker extends Disposable {
 	private _loadModels(session: RemoteNewSession): void {
 		const modelOption = session.getModelOptionGroup();
 		if (modelOption?.group.items.length) {
-			this._modelGroupId = modelOption.group.id;
 			this._models = modelOption.group.items.map(item => ({
 				id: item.id,
 				name: item.name,
@@ -182,9 +180,9 @@ export class CloudModelPicker extends Disposable {
 		this._selectedModel = item;
 		this._updateTriggerLabel();
 
-		if (this._session && this._modelGroupId) {
+		if (this._session) {
 			this._session.setModelId(item.id);
-			this._session.setOptionValue(this._modelGroupId, { id: item.id, name: item.name });
+			this._session.setOptionValue('models', { id: item.id, name: item.name });
 		}
 		this._onDidChange.fire({ id: item.id, name: item.name, description: item.description });
 	}

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -21,7 +21,7 @@ import { EditorExtensionsRegistry } from '../../../../editor/browser/editorExten
 import { IEditorConstructionOptions } from '../../../../editor/browser/config/editorConfiguration.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKeyService, IContextKey, RawContextKey, ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKeyService, IContextKey, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -39,7 +39,7 @@ import { ISessionsManagementService } from '../../sessions/browser/sessionsManag
 import { ChatSessionPosition, getResourceForNewChatSession } from '../../../../workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.js';
 import { ChatSessionPickerActionItem, IChatSessionPickerDelegate } from '../../../../workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.js';
 import { SearchableOptionPickerActionItem } from '../../../../workbench/contrib/chat/browser/chatSessions/searchableOptionPickerActionItem.js';
-import { IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChatSessionProviderOptionItem } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { IModelPickerDelegate } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem.js';
 import { EnhancedModelPickerActionItem } from '../../../../workbench/contrib/chat/browser/widget/input/modelPickerActionItem2.js';
@@ -49,14 +49,15 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { ContextMenuController } from '../../../../editor/contrib/contextmenu/browser/contextmenu.js';
 import { getSimpleEditorOptions } from '../../../../workbench/contrib/codeEditor/browser/simpleEditorOptions.js';
-import { isString } from '../../../../base/common/types.js';
 import { NewChatContextAttachments } from './newChatContextAttachments.js';
 import { GITHUB_REMOTE_FILE_SCHEME } from '../../fileTreeView/browser/githubFileSystemProvider.js';
 import { FolderPicker } from './folderPicker.js';
 import { IGitService } from '../../../../workbench/contrib/git/common/gitService.js';
 import { IsolationModePicker, SessionTargetPicker } from './sessionTargetPicker.js';
 import { BranchPicker } from './branchPicker.js';
-import { INewSession } from './newSession.js';
+import { INewSession, ISessionOptionGroup, RemoteNewSession } from './newSession.js';
+import { RepoPicker } from './repoPicker.js';
+import { CloudModelPicker } from './modelPicker.js';
 import { getErrorMessage } from '../../../../base/common/errors.js';
 
 const STORAGE_KEY_LAST_MODEL = 'sessions.selectedModel';
@@ -109,16 +110,18 @@ class NewChatWidget extends Disposable {
 	// Welcome part
 	private _pickersContainer: HTMLElement | undefined;
 	private _extensionPickersLeftContainer: HTMLElement | undefined;
-	private _extensionPickersRightContainer: HTMLElement | undefined;
+	private _toolbarPickersContainer: HTMLElement | undefined;
+	private _localModelPickerContainer: HTMLElement | undefined;
 	private _inputSlot: HTMLElement | undefined;
 	private readonly _folderPicker: FolderPicker;
 	private _folderPickerContainer: HTMLElement | undefined;
-	private readonly _pickerWidgets = new Map<string, ChatSessionPickerActionItem | SearchableOptionPickerActionItem>();
-	private readonly _pickerWidgetDisposables = this._register(new DisposableStore());
+	private readonly _repoPicker: RepoPicker;
+	private _repoPickerContainer: HTMLElement | undefined;
+	private readonly _cloudModelPicker: CloudModelPicker;
+	private readonly _toolbarPickerWidgets = new Map<string, ChatSessionPickerActionItem | SearchableOptionPickerActionItem>();
+	private readonly _toolbarPickerDisposables = this._register(new DisposableStore());
 	private readonly _optionEmitters = new Map<string, Emitter<IChatSessionProviderOptionItem>>();
-	private readonly _selectedOptions = new Map<string, IChatSessionProviderOptionItem>();
 	private readonly _optionContextKeys = new Map<string, IContextKey<string>>();
-	private readonly _whenClauseKeys = new Set<string>();
 
 	// Attached context
 	private readonly _contextAttachments: NewChatContextAttachments;
@@ -126,7 +129,6 @@ class NewChatWidget extends Disposable {
 	constructor(
 		options: INewChatWidgetOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
 		@IModelService private readonly modelService: IModelService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
@@ -142,6 +144,8 @@ class NewChatWidget extends Disposable {
 		super();
 		this._contextAttachments = this._register(this.instantiationService.createInstance(NewChatContextAttachments));
 		this._folderPicker = this._register(this.instantiationService.createInstance(FolderPicker));
+		this._repoPicker = this._register(this.instantiationService.createInstance(RepoPicker));
+		this._cloudModelPicker = this._register(this.instantiationService.createInstance(CloudModelPicker));
 		this._targetPicker = this._register(new SessionTargetPicker(options.allowedTargets, options.defaultTarget));
 		this._isolationModePicker = this._register(this.instantiationService.createInstance(IsolationModePicker));
 		this._branchPicker = this._register(this.instantiationService.createInstance(BranchPicker));
@@ -154,12 +158,6 @@ class NewChatWidget extends Disposable {
 			this._isolationModePicker.setVisible(isLocal);
 			this._branchPicker.setVisible(isLocal);
 			this._focusEditor();
-		}));
-
-		this._register(this.contextKeyService.onDidChangeContext(e => {
-			if (this._whenClauseKeys.size > 0 && e.affectsSome(this._whenClauseKeys)) {
-				this._renderExtensionPickers(true);
-			}
 		}));
 
 		this._register(this._branchPicker.onDidChangeLoading(loading => {
@@ -177,6 +175,11 @@ class NewChatWidget extends Disposable {
 
 		this._register(this._isolationModePicker.onDidChange(() => {
 			this._focusEditor();
+		}));
+
+		// When language models change (e.g., extension activates), reinitialize if no model selected
+		this._register(this.languageModelsService.onDidChangeLanguageModels(() => {
+			this._initDefaultModel();
 		}));
 	}
 
@@ -262,10 +265,11 @@ class NewChatWidget extends Disposable {
 
 		// Wire pickers to the new session
 		this._folderPicker.setNewSession(session);
+		this._repoPicker.setNewSession(session);
 		this._isolationModePicker.setNewSession(session);
 		this._branchPicker.setNewSession(session);
 
-		// Set the current model on the session
+		// Set the current model on the session (for local sessions)
 		const currentModel = this._currentLanguageModel.get();
 		if (currentModel) {
 			session.setModelId(currentModel.identifier);
@@ -276,26 +280,30 @@ class NewChatWidget extends Disposable {
 			this._openRepository(session.repoUri);
 		}
 
-		// Render extension pickers for the new session
-		this._renderExtensionPickers(true);
-
 		// Listen for session changes
-		this._newSessionListener.value = session.onDidChange((changeType) => {
+		const listeners = new DisposableStore();
+		listeners.add(session.onDidChange((changeType) => {
 			if (changeType === 'repoUri' && session.repoUri) {
 				this._openRepository(session.repoUri);
 			}
 			if (changeType === 'isolationMode') {
 				this._branchPicker.setVisible(session.isolationMode === 'worktree');
 			}
-			if (changeType === 'options') {
-				this._syncOptionsFromSession(session.resource);
-				this._renderExtensionPickers();
-			}
 			if (changeType === 'disabled') {
 				this._updateSendButtonState();
 			}
-		});
+		}));
 
+		if (session instanceof RemoteNewSession) {
+			this._renderRemoteSessionPickers(session, true);
+			listeners.add(session.onDidChangeOptionGroups(() => {
+				this._renderRemoteSessionPickers(session);
+			}));
+		} else {
+			this._renderLocalSessionPickers();
+		}
+
+		this._newSessionListener.value = listeners;
 		this._updateSendButtonState();
 	}
 
@@ -424,18 +432,14 @@ class NewChatWidget extends Disposable {
 			return this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
 		}
 
-		// For cloud targets, look for a repository option in the selected options
-		for (const [groupId, option] of this._selectedOptions) {
-			if (isRepoOrFolderGroup({ id: groupId, name: groupId, items: [] })) {
-				const nwo = option.id; // e.g. "owner/repo"
-				if (nwo && nwo.includes('/')) {
-					return URI.from({
-						scheme: GITHUB_REMOTE_FILE_SCHEME,
-						authority: 'github',
-						path: `/${nwo}/HEAD`,
-					});
-				}
-			}
+		// For cloud targets, use the repo picker's selection
+		const selectedRepo = this._repoPicker.selectedRepo;
+		if (selectedRepo && selectedRepo.includes('/')) {
+			return URI.from({
+				scheme: GITHUB_REMOTE_FILE_SCHEME,
+				authority: 'github',
+				path: `/${selectedRepo}/HEAD`,
+			});
 		}
 
 		return undefined;
@@ -446,8 +450,15 @@ class NewChatWidget extends Disposable {
 
 		this._createAttachButton(toolbar);
 
-		const modelPickerContainer = dom.append(toolbar, dom.$('.sessions-chat-model-picker'));
-		this._createModelPicker(modelPickerContainer);
+		// Local model picker (EnhancedModelPickerActionItem)
+		this._localModelPickerContainer = dom.append(toolbar, dom.$('.sessions-chat-model-picker'));
+		this._createLocalModelPicker(this._localModelPickerContainer);
+
+		// Remote model picker (action list dropdown)
+		this._cloudModelPicker.render(toolbar);
+		this._cloudModelPicker.setVisible(false);
+
+		this._toolbarPickersContainer = dom.append(toolbar, dom.$('.sessions-chat-toolbar-pickers'));
 
 		dom.append(toolbar, dom.$('.sessions-chat-toolbar-spacer'));
 
@@ -467,7 +478,7 @@ class NewChatWidget extends Disposable {
 
 	// --- Model picker ---
 
-	private _createModelPicker(container: HTMLElement): void {
+	private _createLocalModelPicker(container: HTMLElement): void {
 		const delegate: IModelPickerDelegate = {
 			currentModel: this._currentLanguageModel,
 			setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
@@ -495,27 +506,14 @@ class NewChatWidget extends Disposable {
 	}
 
 	private _initDefaultModel(): void {
-		const lastModelId = this.storageService.get(STORAGE_KEY_LAST_MODEL, StorageScope.PROFILE);
 		const models = this._getAvailableModels();
+		const lastModelId = this.storageService.get(STORAGE_KEY_LAST_MODEL, StorageScope.PROFILE);
 		const lastModel = lastModelId ? models.find(m => m.identifier === lastModelId) : undefined;
 		if (lastModel) {
 			this._currentLanguageModel.set(lastModel, undefined);
 		} else if (models.length > 0) {
 			this._currentLanguageModel.set(models[0], undefined);
 		}
-
-		this._register(this.languageModelsService.onDidChangeLanguageModels(() => {
-			if (!this._currentLanguageModel.get()) {
-				const storedId = this.storageService.get(STORAGE_KEY_LAST_MODEL, StorageScope.PROFILE);
-				const updated = this._getAvailableModels();
-				const stored = storedId ? updated.find(m => m.identifier === storedId) : undefined;
-				if (stored) {
-					this._currentLanguageModel.set(stored, undefined);
-				} else if (updated.length > 0) {
-					this._currentLanguageModel.set(updated[0], undefined);
-				}
-			}
-		}));
 	}
 
 	private _getAvailableModels(): ILanguageModelChatMetadataAndIdentifier[] {
@@ -534,7 +532,7 @@ class NewChatWidget extends Disposable {
 			return;
 		}
 
-		this._clearExtensionPickers();
+		this._clearAllPickers();
 		dom.clearNode(this._pickersContainer);
 
 		const pickersRow = dom.append(this._pickersContainer, dom.$('.chat-full-welcome-pickers'));
@@ -547,178 +545,135 @@ class NewChatWidget extends Disposable {
 		// Right half: separator + pickers (left-justified within its half)
 		const rightHalf = dom.append(pickersRow, dom.$('.sessions-chat-pickers-right-half'));
 		this._extensionPickersLeftContainer = dom.append(rightHalf, dom.$('.sessions-chat-pickers-left-separator'));
-		this._extensionPickersRightContainer = dom.append(rightHalf, dom.$('.sessions-chat-extension-pickers-right'));
+		this._extensionPickersLeftContainer.style.display = 'none';
 
-		// Folder picker (rendered once, shown/hidden based on target)
+		// Repo picker for cloud (rendered once, shown/hidden based on target)
+		this._repoPickerContainer = dom.append(rightHalf, dom.$('.sessions-chat-extension-pickers-right'));
+		this._repoPickerContainer.style.display = 'none';
+		this._repoPicker.render(this._repoPickerContainer);
+
+		// Folder picker for local (rendered once, shown/hidden based on target)
 		this._folderPickerContainer = this._folderPicker.render(rightHalf);
 		this._folderPickerContainer.style.display = 'none';
-
-		this._renderExtensionPickers();
 	}
 
-	// --- Welcome: Extension option pickers (Cloud target only) ---
+	// --- Local session pickers ---
 
-	private _renderExtensionPickers(force?: boolean): void {
-		if (!this._extensionPickersRightContainer) {
+	private _renderLocalSessionPickers(): void {
+		this._clearAllPickers();
+		if (this._folderPickerContainer) {
+			this._folderPickerContainer.style.display = '';
+		}
+		if (this._extensionPickersLeftContainer) {
+			this._extensionPickersLeftContainer.style.display = 'block';
+		}
+		// Show local model picker, hide remote
+		if (this._localModelPickerContainer) {
+			this._localModelPickerContainer.style.display = '';
+		}
+		this._cloudModelPicker.setVisible(false);
+	}
+
+	// --- Remote session pickers ---
+
+	private _renderRemoteSessionPickers(session: RemoteNewSession, force?: boolean): void {
+		if (!this._repoPickerContainer) {
 			return;
 		}
 
-		const activeSessionType = this._targetPicker.selectedTarget;
+		// Hide local-only pickers
+		if (this._folderPickerContainer) {
+			this._folderPickerContainer.style.display = 'none';
+		}
 
-		// Extension pickers are only shown for Cloud target
-		if (activeSessionType === AgentSessionProviders.Background) {
-			this._clearExtensionPickers();
-			if (this._folderPickerContainer) {
-				this._folderPickerContainer.style.display = '';
-			}
-			if (this._extensionPickersLeftContainer) {
-				this._extensionPickersLeftContainer.style.display = 'block';
-			}
+		// Show remote model picker, hide local
+		if (this._localModelPickerContainer) {
+			this._localModelPickerContainer.style.display = 'none';
+		}
+		this._cloudModelPicker.setSession(session);
+		this._cloudModelPicker.setVisible(true);
+
+		// Show repo picker and separator
+		if (this._extensionPickersLeftContainer) {
+			this._extensionPickersLeftContainer.style.display = 'block';
+		}
+		this._repoPickerContainer.style.display = '';
+
+		// Render toolbar pickers (other groups)
+		this._renderToolbarPickers(session, force);
+	}
+
+	private _renderToolbarPickers(session: RemoteNewSession, force?: boolean): void {
+		if (!this._toolbarPickersContainer) {
 			return;
 		}
 
-		const optionGroups = this.chatSessionsService.getOptionGroupsForSessionType(activeSessionType);
-		if (!optionGroups || optionGroups.length === 0) {
-			this._clearExtensionPickers();
-			return;
-		}
+		const toolbarOptions = session.getOtherOptionGroups();
 
-		const visibleGroups: IChatSessionProviderOptionGroup[] = [];
-		this._whenClauseKeys.clear();
-		for (const group of optionGroups) {
-			if (isModelOptionGroup(group)) {
-				continue;
-			}
-			if (group.when) {
-				const expr = ContextKeyExpr.deserialize(group.when);
-				if (expr) {
-					for (const key of expr.keys()) {
-						this._whenClauseKeys.add(key);
-					}
-				}
-			}
-			const hasItems = group.items.length > 0 || (group.commands || []).length > 0 || !!group.searchable;
-			const passesWhenClause = this._evaluateOptionGroupVisibility(group);
-			if (hasItems && passesWhenClause) {
-				visibleGroups.push(group);
-			}
-		}
+		// Filter by item availability (when-clause filtering is done by the session)
+		const visibleGroups = toolbarOptions.filter(option => {
+			const group = option.group;
+			return group.items.length > 0 || (group.commands || []).length > 0 || !!group.searchable;
+		});
 
 		if (visibleGroups.length === 0) {
-			this._clearExtensionPickers();
+			this._clearToolbarPickers();
 			return;
 		}
 
-		if (!force && this._pickerWidgets.size === visibleGroups.length) {
-			const allMatch = visibleGroups.every(g => this._pickerWidgets.has(g.id));
+		if (!force) {
+			const allMatch = visibleGroups.length === this._toolbarPickerWidgets.size && visibleGroups.every(o => this._toolbarPickerWidgets.has(o.group.id));
 			if (allMatch) {
 				return;
 			}
 		}
 
-		this._clearExtensionPickers();
+		this._clearToolbarPickers();
 
-		if (this._extensionPickersLeftContainer) {
-			this._extensionPickersLeftContainer.style.display = 'block';
-		}
-
-		for (const optionGroup of visibleGroups) {
-			const initialItem = this._getDefaultOptionForGroup(optionGroup);
-			const initialState = { group: optionGroup, item: initialItem };
-
-			if (initialItem) {
-				this._updateOptionContextKey(optionGroup.id, initialItem.id);
-			}
-
-			const emitter = this._getOrCreateOptionEmitter(optionGroup.id);
-			const itemDelegate: IChatSessionPickerDelegate = {
-				getCurrentOption: () => this._selectedOptions.get(optionGroup.id) ?? this._getDefaultOptionForGroup(optionGroup),
-				onDidChangeOption: emitter.event,
-				setOption: (option: IChatSessionProviderOptionItem) => {
-					this._selectedOptions.set(optionGroup.id, option);
-					this._updateOptionContextKey(optionGroup.id, option.id);
-					emitter.fire(option);
-
-					this._newSession.value?.setOption(optionGroup.id, option);
-
-					this._renderExtensionPickers(true);
-					this._focusEditor();
-				},
-				getOptionGroup: () => {
-					const groups = this.chatSessionsService.getOptionGroupsForSessionType(activeSessionType);
-					return groups?.find((g: { id: string }) => g.id === optionGroup.id);
-				},
-				getSessionResource: () => this._newSession.value?.resource,
-			};
-
-			const action = toAction({ id: optionGroup.id, label: optionGroup.name, run: () => { } });
-			const widget = this.instantiationService.createInstance(
-				optionGroup.searchable ? SearchableOptionPickerActionItem : ChatSessionPickerActionItem,
-				action, initialState, itemDelegate
-			);
-
-			this._pickerWidgetDisposables.add(widget);
-			this._pickerWidgets.set(optionGroup.id, widget);
-
-			const slot = dom.append(this._extensionPickersRightContainer!, dom.$('.sessions-chat-picker-slot'));
-			widget.render(slot);
+		for (const option of visibleGroups) {
+			this._renderToolbarPickerWidget(option, session);
 		}
 	}
 
-	private _evaluateOptionGroupVisibility(optionGroup: { id: string; when?: string }): boolean {
-		if (!optionGroup.when) {
-			return true;
-		}
-		const expr = ContextKeyExpr.deserialize(optionGroup.when);
-		return !expr || this.contextKeyService.contextMatchesRules(expr);
-	}
+	private _renderToolbarPickerWidget(option: ISessionOptionGroup, session: RemoteNewSession): void {
+		const { group: optionGroup, value: initialItem } = option;
 
-	private _getDefaultOptionForGroup(optionGroup: IChatSessionProviderOptionGroup): IChatSessionProviderOptionItem | undefined {
-		const selectedOption = this._selectedOptions.get(optionGroup.id);
-		if (selectedOption) {
-			return selectedOption;
+		if (initialItem) {
+			this._updateOptionContextKey(optionGroup.id, initialItem.id);
 		}
 
-		if (this._newSession.value) {
-			const sessionOption = this.chatSessionsService.getSessionOption(this._newSession.value.resource, optionGroup.id);
-			if (!isString(sessionOption)) {
-				return sessionOption;
-			}
-		}
-
-		return optionGroup.items.find((item) => item.default === true);
-	}
-
-	private _syncOptionsFromSession(sessionResource: URI): void {
-		const activeSessionType = this._targetPicker.selectedTarget;
-		if (!activeSessionType) {
-			return;
-		}
-		const optionGroups = this.chatSessionsService.getOptionGroupsForSessionType(activeSessionType);
-		if (!optionGroups) {
-			return;
-		}
-		for (const optionGroup of optionGroups) {
-			if (isModelOptionGroup(optionGroup)) {
-				continue;
-			}
-			const currentOption = this.chatSessionsService.getSessionOption(sessionResource, optionGroup.id);
-			if (!currentOption) {
-				continue;
-			}
-			let item: IChatSessionProviderOptionItem | undefined;
-			if (typeof currentOption === 'string') {
-				item = optionGroup.items.find((m: { id: string }) => m.id === currentOption.trim());
-			} else {
-				item = currentOption;
-			}
-			if (item) {
-				const { locked: _locked, ...unlocked } = item;
-				this._selectedOptions.set(optionGroup.id, unlocked as IChatSessionProviderOptionItem);
+		const initialState = { group: optionGroup, item: initialItem };
+		const emitter = this._getOrCreateOptionEmitter(optionGroup.id);
+		const itemDelegate: IChatSessionPickerDelegate = {
+			getCurrentOption: () => session.getOptionValue(optionGroup.id) ?? initialItem,
+			onDidChangeOption: emitter.event,
+			setOption: (item: IChatSessionProviderOptionItem) => {
 				this._updateOptionContextKey(optionGroup.id, item.id);
-				this._optionEmitters.get(optionGroup.id)?.fire(item);
-			}
-		}
+				emitter.fire(item);
+				session.setOptionValue(optionGroup.id, item);
+				this._focusEditor();
+			},
+			getOptionGroup: () => {
+				const modelOpt = session.getModelOptionGroup();
+				if (modelOpt?.group.id === optionGroup.id) {
+					return modelOpt.group;
+				}
+				return session.getOtherOptionGroups().find(o => o.group.id === optionGroup.id)?.group;
+			},
+			getSessionResource: () => session.resource,
+		};
+
+		const action = toAction({ id: optionGroup.id, label: optionGroup.name, run: () => { } });
+		const widget = this.instantiationService.createInstance(
+			optionGroup.searchable ? SearchableOptionPickerActionItem : ChatSessionPickerActionItem,
+			action, initialState, itemDelegate
+		);
+
+		this._toolbarPickerDisposables.add(widget);
+		this._toolbarPickerWidgets.set(optionGroup.id, widget);
+
+		const slot = dom.append(this._toolbarPickersContainer!, dom.$('.sessions-chat-picker-slot'));
+		widget.render(slot);
 	}
 
 	private _updateOptionContextKey(optionGroupId: string, optionItemId: string): void {
@@ -736,23 +691,30 @@ class NewChatWidget extends Disposable {
 		if (!emitter) {
 			emitter = new Emitter<IChatSessionProviderOptionItem>();
 			this._optionEmitters.set(optionGroupId, emitter);
-			this._pickerWidgetDisposables.add(emitter);
+			this._toolbarPickerDisposables.add(emitter);
 		}
 		return emitter;
 	}
 
-	private _clearExtensionPickers(): void {
-		this._pickerWidgetDisposables.clear();
-		this._pickerWidgets.clear();
+	private _clearToolbarPickers(): void {
+		this._toolbarPickerDisposables.clear();
+		this._toolbarPickerWidgets.clear();
 		this._optionEmitters.clear();
+		if (this._toolbarPickersContainer) {
+			dom.clearNode(this._toolbarPickersContainer);
+		}
+	}
+
+	private _clearAllPickers(): void {
+		this._clearToolbarPickers();
 		if (this._folderPickerContainer) {
 			this._folderPickerContainer.style.display = 'none';
 		}
+		if (this._repoPickerContainer) {
+			this._repoPickerContainer.style.display = 'none';
+		}
 		if (this._extensionPickersLeftContainer) {
 			this._extensionPickersLeftContainer.style.display = 'none';
-		}
-		if (this._extensionPickersRightContainer) {
-			dom.clearNode(this._extensionPickersRightContainer);
 		}
 	}
 
@@ -887,28 +849,3 @@ export class NewChatViewPane extends ViewPane {
 }
 
 // #endregion
-
-/**
- * Check whether an option group represents the model picker.
- * The convention is `id: 'models'` but extensions may use different IDs
- * per session type, so we also fall back to name matching.
- */
-function isModelOptionGroup(group: IChatSessionProviderOptionGroup): boolean {
-	if (group.id === 'models') {
-		return true;
-	}
-	const nameLower = group.name.toLowerCase();
-	return nameLower === 'model' || nameLower === 'models';
-}
-
-/**
- * Check whether an option group represents a repository or folder picker.
- * These are placed on the right side of the pickers row.
- */
-function isRepoOrFolderGroup(group: IChatSessionProviderOptionGroup): boolean {
-	const idLower = group.id.toLowerCase();
-	const nameLower = group.name.toLowerCase();
-	return idLower === 'repositories' || idLower === 'folders' ||
-		nameLower === 'repository' || nameLower === 'repositories' ||
-		nameLower === 'folder' || nameLower === 'folders';
-}

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -573,15 +573,7 @@ class NewChatWidget extends Disposable {
 	}
 
 	private _initDefaultModel(): void {
-		const currentModel = this._currentLanguageModel.get();
 		const models = this._getAvailableModels();
-
-		// If current model is still available, keep it
-		if (currentModel && models.some(m => m.identifier === currentModel.identifier)) {
-			return;
-		}
-
-		// Try to restore from storage, otherwise pick the first available
 		const lastModelId = this.storageService.get(STORAGE_KEY_LAST_MODEL, StorageScope.PROFILE);
 		const lastModel = lastModelId ? models.find(m => m.identifier === lastModelId) : undefined;
 		if (lastModel) {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -573,7 +573,15 @@ class NewChatWidget extends Disposable {
 	}
 
 	private _initDefaultModel(): void {
+		const currentModel = this._currentLanguageModel.get();
 		const models = this._getAvailableModels();
+
+		// If current model is still available, keep it
+		if (currentModel && models.some(m => m.identifier === currentModel.identifier)) {
+			return;
+		}
+
+		// Try to restore from storage, otherwise pick the first available
 		const lastModelId = this.storageService.get(STORAGE_KEY_LAST_MODEL, StorageScope.PROFILE);
 		const lastModel = lastModelId ? models.find(m => m.identifier === lastModelId) : undefined;
 		if (lastModel) {

--- a/src/vs/sessions/contrib/chat/browser/newSession.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSession.ts
@@ -6,6 +6,7 @@
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IsolationMode } from './sessionTargetPicker.js';
@@ -202,6 +203,13 @@ export class RemoteNewSession extends Disposable implements INewSession {
 			this._updateWhenClauseKeys();
 			this._onDidChangeOptionGroups.fire();
 			this._onDidChange.fire('options');
+		}));
+		this._register(this.chatSessionsService.onDidChangeSessionOptions((e: URI | undefined) => {
+			if (isEqual(this.resource, e)) {
+				this._onDidChangeOptionGroups.fire();
+				this._onDidChange.fire('options');
+				this._onDidChange.fire('disabled');
+			}
 		}));
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (this._whenClauseKeys.size > 0 && e.affectsSome(this._whenClauseKeys)) {

--- a/src/vs/sessions/contrib/chat/browser/newSession.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSession.ts
@@ -6,15 +6,23 @@
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isEqual } from '../../../../base/common/resources.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
+import { IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IsolationMode } from './sessionTargetPicker.js';
 import { AgentSessionProviders } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
+import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 
 import { IChatRequestVariableEntry } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 
 export type NewSessionChangeType = 'repoUri' | 'isolationMode' | 'branch' | 'options' | 'disabled';
+
+/**
+ * Represents a resolved option group with its current selected value.
+ */
+export interface ISessionOptionGroup {
+	readonly group: IChatSessionProviderOptionGroup;
+	readonly value: IChatSessionProviderOptionItem | undefined;
+}
 
 /**
  * A new session represents a session being configured before the first
@@ -85,8 +93,8 @@ export class LocalNewSession extends Disposable implements INewSession {
 	constructor(
 		readonly resource: URI,
 		defaultRepoUri: URI | undefined,
-		private readonly chatSessionsService: IChatSessionsService,
-		private readonly logService: ILogService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 		if (defaultRepoUri) {
@@ -149,13 +157,12 @@ export class LocalNewSession extends Disposable implements INewSession {
 
 /**
  * Remote new session for Cloud agent sessions.
- * Fires `onDidChange` and notifies the extension service when `repoUri` changes.
- * Ignores `isolationMode` (not relevant for cloud).
+ * Manages extension-driven option groups (models, etc.) and their values.
+ * Fires events for option group changes.
  */
 export class RemoteNewSession extends Disposable implements INewSession {
 
 	private _repoUri: URI | undefined;
-	private _isolationMode: IsolationMode = 'worktree';
 	private _modelId: string | undefined;
 	private _query: string | undefined;
 	private _attachedContext: IChatRequestVariableEntry[] | undefined;
@@ -163,33 +170,40 @@ export class RemoteNewSession extends Disposable implements INewSession {
 	private readonly _onDidChange = this._register(new Emitter<NewSessionChangeType>());
 	readonly onDidChange: Event<NewSessionChangeType> = this._onDidChange.event;
 
+	private readonly _onDidChangeOptionGroups = this._register(new Emitter<void>());
+	readonly onDidChangeOptionGroups: Event<void> = this._onDidChangeOptionGroups.event;
+
 	readonly selectedOptions = new Map<string, IChatSessionProviderOptionItem>();
 
 	get repoUri(): URI | undefined { return this._repoUri; }
-	get isolationMode(): IsolationMode { return this._isolationMode; }
+	get isolationMode(): IsolationMode { return 'worktree'; }
 	get branch(): string | undefined { return undefined; }
 	get modelId(): string | undefined { return this._modelId; }
 	get query(): string | undefined { return this._query; }
 	get attachedContext(): IChatRequestVariableEntry[] | undefined { return this._attachedContext; }
 	get disabled(): boolean {
-		return !this._repoUri && !this._hasRepositoryOption();
+		return !this._repoUri && !this.selectedOptions.has('repositories');
 	}
+
+	private readonly _whenClauseKeys = new Set<string>();
 
 	constructor(
 		readonly resource: URI,
 		readonly target: AgentSessionProviders,
-		private readonly chatSessionsService: IChatSessionsService,
-		private readonly logService: ILogService,
+		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
-		// Listen for extension-driven option group and session option changes
 		this._register(this.chatSessionsService.onDidChangeOptionGroups(() => {
+			this._updateWhenClauseKeys();
+			this._onDidChangeOptionGroups.fire();
 			this._onDidChange.fire('options');
 		}));
-		this._register(this.chatSessionsService.onDidChangeSessionOptions((e: URI | undefined) => {
-			if (isEqual(this.resource, e)) {
-				this._onDidChange.fire('options');
+		this._register(this.contextKeyService.onDidChangeContext(e => {
+			if (this._whenClauseKeys.size > 0 && e.affectsSome(this._whenClauseKeys)) {
+				this._onDidChangeOptionGroups.fire();
 			}
 		}));
 	}
@@ -202,11 +216,11 @@ export class RemoteNewSession extends Disposable implements INewSession {
 	}
 
 	setIsolationMode(_mode: IsolationMode): void {
-		// No-op for remote sessions — isolation mode is not relevant
+		// No-op for remote sessions
 	}
 
 	setBranch(_branch: string | undefined): void {
-		// No-op for remote sessions — branch is not relevant
+		// No-op for remote sessions
 	}
 
 	setModelId(modelId: string | undefined): void {
@@ -233,7 +247,95 @@ export class RemoteNewSession extends Disposable implements INewSession {
 		).catch((err) => this.logService.error(`Failed to notify extension of ${optionId} change:`, err));
 	}
 
-	private _hasRepositoryOption(): boolean {
-		return this.selectedOptions.has('repositories');
+	// --- Option group accessors ---
+
+	getModelOptionGroup(): ISessionOptionGroup | undefined {
+		const groups = this._getOptionGroups();
+		if (!groups) {
+			return undefined;
+		}
+		const group = groups.find(g => isModelOptionGroup(g));
+		if (!group) {
+			return undefined;
+		}
+		return { group, value: this._getValueForGroup(group) };
 	}
+
+	getOtherOptionGroups(): ISessionOptionGroup[] {
+		const groups = this._getOptionGroups();
+		if (!groups) {
+			return [];
+		}
+		return groups
+			.filter(g => !isModelOptionGroup(g) && this._isOptionGroupVisible(g))
+			.map(g => ({ group: g, value: this._getValueForGroup(g) }));
+	}
+
+	getOptionValue(groupId: string): IChatSessionProviderOptionItem | undefined {
+		return this.selectedOptions.get(groupId);
+	}
+
+	setOptionValue(groupId: string, value: IChatSessionProviderOptionItem): void {
+		this.setOption(groupId, value);
+	}
+
+	// --- Internals ---
+
+	private _getOptionGroups(): IChatSessionProviderOptionGroup[] | undefined {
+		return this.chatSessionsService.getOptionGroupsForSessionType(this.target);
+	}
+
+	private _isOptionGroupVisible(group: IChatSessionProviderOptionGroup): boolean {
+		if (!group.when) {
+			return true;
+		}
+		const expr = ContextKeyExpr.deserialize(group.when);
+		return !expr || this.contextKeyService.contextMatchesRules(expr);
+	}
+
+	private _updateWhenClauseKeys(): void {
+		this._whenClauseKeys.clear();
+		const groups = this._getOptionGroups();
+		if (!groups) {
+			return;
+		}
+		for (const group of groups) {
+			if (group.when) {
+				const expr = ContextKeyExpr.deserialize(group.when);
+				if (expr) {
+					for (const key of expr.keys()) {
+						this._whenClauseKeys.add(key);
+					}
+				}
+			}
+		}
+	}
+
+	private _getValueForGroup(group: IChatSessionProviderOptionGroup): IChatSessionProviderOptionItem | undefined {
+		const selected = this.selectedOptions.get(group.id);
+		if (selected) {
+			return selected;
+		}
+		// Check for extension-set session option
+		const sessionOption = this.chatSessionsService.getSessionOption(this.resource, group.id);
+		if (sessionOption && typeof sessionOption !== 'string') {
+			return sessionOption;
+		}
+		if (typeof sessionOption === 'string') {
+			const item = group.items.find(i => i.id === sessionOption.trim());
+			if (item) {
+				return item;
+			}
+		}
+		// Default to first item marked as default, or first item
+		return group.items.find(i => i.default === true) ?? group.items[0];
+	}
+}
+
+function isModelOptionGroup(group: IChatSessionProviderOptionGroup): boolean {
+	if (group.id === 'models') {
+		return true;
+	}
+	const nameLower = group.name.toLowerCase();
+	return nameLower === 'model' || nameLower === 'models';
 }

--- a/src/vs/sessions/contrib/chat/browser/newSession.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSession.ts
@@ -269,7 +269,7 @@ export class RemoteNewSession extends Disposable implements INewSession {
 			return [];
 		}
 		return groups
-			.filter(g => !isModelOptionGroup(g) && !isRepoOrFolderGroup(g) && this._isOptionGroupVisible(g))
+			.filter(g => !isModelOptionGroup(g) && this._isOptionGroupVisible(g))
 			.map(g => ({ group: g, value: this._getValueForGroup(g) }));
 	}
 
@@ -340,12 +340,4 @@ function isModelOptionGroup(group: IChatSessionProviderOptionGroup): boolean {
 	}
 	const nameLower = group.name.toLowerCase();
 	return nameLower === 'model' || nameLower === 'models';
-}
-
-function isRepoOrFolderGroup(group: IChatSessionProviderOptionGroup): boolean {
-	const idLower = group.id.toLowerCase();
-	const nameLower = group.name.toLowerCase();
-	return idLower === 'repositories' || idLower === 'folders' ||
-		nameLower === 'repository' || nameLower === 'repositories' ||
-		nameLower === 'folder' || nameLower === 'folders';
 }

--- a/src/vs/sessions/contrib/chat/browser/newSession.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSession.ts
@@ -6,7 +6,6 @@
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
-import { isEqual } from '../../../../base/common/resources.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IChatSessionProviderOptionGroup, IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IsolationMode } from './sessionTargetPicker.js';
@@ -203,13 +202,6 @@ export class RemoteNewSession extends Disposable implements INewSession {
 			this._updateWhenClauseKeys();
 			this._onDidChangeOptionGroups.fire();
 			this._onDidChange.fire('options');
-		}));
-		this._register(this.chatSessionsService.onDidChangeSessionOptions((e: URI | undefined) => {
-			if (isEqual(this.resource, e)) {
-				this._onDidChangeOptionGroups.fire();
-				this._onDidChange.fire('options');
-				this._onDidChange.fire('disabled');
-			}
 		}));
 		this._register(this.contextKeyService.onDidChangeContext(e => {
 			if (this._whenClauseKeys.size > 0 && e.affectsSome(this._whenClauseKeys)) {

--- a/src/vs/sessions/contrib/chat/browser/newSession.ts
+++ b/src/vs/sessions/contrib/chat/browser/newSession.ts
@@ -269,7 +269,7 @@ export class RemoteNewSession extends Disposable implements INewSession {
 			return [];
 		}
 		return groups
-			.filter(g => !isModelOptionGroup(g) && this._isOptionGroupVisible(g))
+			.filter(g => !isModelOptionGroup(g) && !isRepoOrFolderGroup(g) && this._isOptionGroupVisible(g))
 			.map(g => ({ group: g, value: this._getValueForGroup(g) }));
 	}
 
@@ -340,4 +340,12 @@ function isModelOptionGroup(group: IChatSessionProviderOptionGroup): boolean {
 	}
 	const nameLower = group.name.toLowerCase();
 	return nameLower === 'model' || nameLower === 'models';
+}
+
+function isRepoOrFolderGroup(group: IChatSessionProviderOptionGroup): boolean {
+	const idLower = group.id.toLowerCase();
+	const nameLower = group.name.toLowerCase();
+	return idLower === 'repositories' || idLower === 'folders' ||
+		nameLower === 'repository' || nameLower === 'repositories' ||
+		nameLower === 'folder' || nameLower === 'folders';
 }

--- a/src/vs/sessions/contrib/chat/browser/repoPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/repoPicker.ts
@@ -1,0 +1,270 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
+import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../../../platform/actionWidget/browser/actionList.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { INewSession } from './newSession.js';
+
+const OPEN_REPO_COMMAND = 'github.copilot.chat.cloudSessions.openRepository';
+const STORAGE_KEY_LAST_REPO = 'agentSessions.lastPickedRepo';
+const STORAGE_KEY_RECENT_REPOS = 'agentSessions.recentlyPickedRepos';
+const MAX_RECENT_REPOS = 10;
+const FILTER_THRESHOLD = 10;
+
+interface IRepoItem {
+	readonly id: string;
+	readonly name: string;
+}
+
+/**
+ * A self-contained widget for selecting the repository in cloud sessions.
+ * Uses the `github.copilot.chat.cloudSessions.openRepository` command for
+ * browsing repositories. Manages recently used repos in storage.
+ * Behaves like FolderPicker: trigger button with dropdown, storage persistence,
+ * recently used list with remove buttons.
+ */
+export class RepoPicker extends Disposable {
+
+	private readonly _onDidSelectRepo = this._register(new Emitter<string>());
+	readonly onDidSelectRepo: Event<string> = this._onDidSelectRepo.event;
+
+	private _triggerElement: HTMLElement | undefined;
+	private readonly _renderDisposables = this._register(new DisposableStore());
+	private _browseGeneration = 0;
+
+	private _newSession: INewSession | undefined;
+	private _selectedRepo: IRepoItem | undefined;
+	private _recentlyPickedRepos: IRepoItem[] = [];
+
+	get selectedRepo(): string | undefined {
+		return this._selectedRepo?.id;
+	}
+
+	constructor(
+		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
+		@IStorageService private readonly storageService: IStorageService,
+		@ICommandService private readonly commandService: ICommandService,
+	) {
+		super();
+
+		// Restore last picked repo
+		try {
+			const last = this.storageService.get(STORAGE_KEY_LAST_REPO, StorageScope.PROFILE);
+			if (last) {
+				this._selectedRepo = JSON.parse(last);
+			}
+		} catch { /* ignore */ }
+
+		// Restore recently picked repos
+		try {
+			const stored = this.storageService.get(STORAGE_KEY_RECENT_REPOS, StorageScope.PROFILE);
+			if (stored) {
+				this._recentlyPickedRepos = JSON.parse(stored);
+			}
+		} catch { /* ignore */ }
+	}
+
+	/**
+	 * Sets the pending session that this picker writes to.
+	 * If a repository is already selected, notifies the session.
+	 */
+	setNewSession(session: INewSession | undefined): void {
+		this._newSession = session;
+		this._browseGeneration++;
+		if (session && this._selectedRepo) {
+			session.setOption('repositories', this._selectedRepo);
+		}
+	}
+
+	/**
+	 * Renders the repo picker trigger button into the given container.
+	 * Returns the container element.
+	 */
+	render(container: HTMLElement): HTMLElement {
+		this._renderDisposables.clear();
+
+		const slot = dom.append(container, dom.$('.sessions-chat-picker-slot'));
+		this._renderDisposables.add({ dispose: () => slot.remove() });
+
+		const trigger = dom.append(slot, dom.$('a.action-label'));
+		trigger.tabIndex = 0;
+		trigger.role = 'button';
+		this._triggerElement = trigger;
+
+		this._updateTriggerLabel();
+
+		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.CLICK, (e) => {
+			dom.EventHelper.stop(e, true);
+			this.showPicker();
+		}));
+
+		this._renderDisposables.add(dom.addDisposableListener(trigger, dom.EventType.KEY_DOWN, (e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				dom.EventHelper.stop(e, true);
+				this.showPicker();
+			}
+		}));
+
+		return slot;
+	}
+
+	/**
+	 * Shows the repo picker dropdown anchored to the trigger element.
+	 */
+	showPicker(): void {
+		if (!this._triggerElement || this.actionWidgetService.isVisible) {
+			return;
+		}
+
+		const items = this._buildItems();
+		const showFilter = items.filter(i => i.kind === ActionListItemKind.Action).length > FILTER_THRESHOLD;
+
+		const triggerElement = this._triggerElement;
+		const delegate: IActionListDelegate<IRepoItem> = {
+			onSelect: (item) => {
+				this.actionWidgetService.hide();
+				if (item.id === 'browse') {
+					this._browseForRepo();
+				} else {
+					this._selectRepo(item);
+				}
+			},
+			onHide: () => { triggerElement.focus(); },
+		};
+
+		this.actionWidgetService.show<IRepoItem>(
+			'repoPicker',
+			false,
+			items,
+			delegate,
+			this._triggerElement,
+			undefined,
+			[],
+			{
+				getAriaLabel: (item) => item.label ?? '',
+				getWidgetAriaLabel: () => localize('repoPicker.ariaLabel', "Repository Picker"),
+			},
+			showFilter ? { showFilter: true, filterPlaceholder: localize('repoPicker.filter', "Filter repositories...") } : undefined,
+		);
+	}
+
+	/**
+	 * Programmatically set the selected repository.
+	 */
+	setSelectedRepo(repoPath: string): void {
+		this._selectRepo({ id: repoPath, name: repoPath });
+	}
+
+	/**
+	 * Clears the selected repository.
+	 */
+	clearSelection(): void {
+		this._selectedRepo = undefined;
+		this._updateTriggerLabel();
+	}
+
+	private _selectRepo(item: IRepoItem): void {
+		this._selectedRepo = item;
+		this._addToRecentlyPicked(item);
+		this.storageService.store(STORAGE_KEY_LAST_REPO, JSON.stringify(item), StorageScope.PROFILE, StorageTarget.MACHINE);
+		this._updateTriggerLabel();
+		this._newSession?.setOption('repositories', item);
+		this._onDidSelectRepo.fire(item.id);
+	}
+
+	private async _browseForRepo(): Promise<void> {
+		const generation = this._browseGeneration;
+		try {
+			const result: string | undefined = await this.commandService.executeCommand(OPEN_REPO_COMMAND);
+			if (result && generation === this._browseGeneration) {
+				this._selectRepo({ id: result, name: result });
+			}
+		} catch {
+			// command was cancelled or failed — nothing to do
+		}
+	}
+
+	private _addToRecentlyPicked(item: IRepoItem): void {
+		this._recentlyPickedRepos = [
+			{ id: item.id, name: item.name },
+			...this._recentlyPickedRepos.filter(r => r.id !== item.id),
+		].slice(0, MAX_RECENT_REPOS);
+		this.storageService.store(STORAGE_KEY_RECENT_REPOS, JSON.stringify(this._recentlyPickedRepos), StorageScope.PROFILE, StorageTarget.MACHINE);
+	}
+
+	private _buildItems(): IActionListItem<IRepoItem>[] {
+		const seenIds = new Set<string>();
+		const items: IActionListItem<IRepoItem>[] = [];
+
+		// Currently selected (shown first, checked)
+		if (this._selectedRepo) {
+			seenIds.add(this._selectedRepo.id);
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: this._selectedRepo.name,
+				group: { title: '', icon: Codicon.repo },
+				item: this._selectedRepo,
+			});
+		}
+
+		// Recently picked repos (sorted by name)
+		const dedupedRepos = this._recentlyPickedRepos.filter(r => !seenIds.has(r.id));
+		dedupedRepos.sort((a, b) => a.name.localeCompare(b.name));
+		for (const repo of dedupedRepos) {
+			seenIds.add(repo.id);
+			items.push({
+				kind: ActionListItemKind.Action,
+				label: repo.name,
+				group: { title: '', icon: Codicon.repo },
+				item: repo,
+				onRemove: () => this._removeRepo(repo.id),
+			});
+		}
+
+		// Separator + Browse...
+		if (items.length > 0) {
+			items.push({ kind: ActionListItemKind.Separator, label: '' });
+		}
+		items.push({
+			kind: ActionListItemKind.Action,
+			label: localize('browseRepo', "Browse..."),
+			group: { title: '', icon: Codicon.search },
+			item: { id: 'browse', name: localize('browseRepo', "Browse...") },
+		});
+
+		return items;
+	}
+
+	private _removeRepo(repoId: string): void {
+		this._recentlyPickedRepos = this._recentlyPickedRepos.filter(r => r.id !== repoId);
+		this.storageService.store(STORAGE_KEY_RECENT_REPOS, JSON.stringify(this._recentlyPickedRepos), StorageScope.PROFILE, StorageTarget.MACHINE);
+
+		// Re-show picker with updated items
+		this.actionWidgetService.hide();
+		this.showPicker();
+	}
+
+	private _updateTriggerLabel(): void {
+		if (!this._triggerElement) {
+			return;
+		}
+
+		dom.clearNode(this._triggerElement);
+		const label = this._selectedRepo?.name ?? localize('pickRepo', "Pick Repository");
+
+		dom.append(this._triggerElement, renderIcon(Codicon.repo));
+		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
+		labelSpan.textContent = label;
+		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/repoPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/repoPicker.ts
@@ -26,6 +26,12 @@ interface IRepoItem {
 	readonly name: string;
 }
 
+function isValidRepoItem(value: unknown): value is IRepoItem {
+	return typeof value === 'object' && value !== null
+		&& typeof (value as IRepoItem).id === 'string'
+		&& typeof (value as IRepoItem).name === 'string';
+}
+
 /**
  * A self-contained widget for selecting the repository in cloud sessions.
  * Uses the `github.copilot.chat.cloudSessions.openRepository` command for
@@ -61,7 +67,10 @@ export class RepoPicker extends Disposable {
 		try {
 			const last = this.storageService.get(STORAGE_KEY_LAST_REPO, StorageScope.PROFILE);
 			if (last) {
-				this._selectedRepo = JSON.parse(last);
+				const parsed = JSON.parse(last);
+				if (isValidRepoItem(parsed)) {
+					this._selectedRepo = parsed;
+				}
 			}
 		} catch { /* ignore */ }
 
@@ -69,7 +78,10 @@ export class RepoPicker extends Disposable {
 		try {
 			const stored = this.storageService.get(STORAGE_KEY_RECENT_REPOS, StorageScope.PROFILE);
 			if (stored) {
-				this._recentlyPickedRepos = JSON.parse(stored);
+				const parsed = JSON.parse(stored);
+				if (Array.isArray(parsed)) {
+					this._recentlyPickedRepos = parsed.filter(isValidRepoItem);
+				}
 			}
 		} catch { /* ignore */ }
 	}

--- a/src/vs/sessions/contrib/chat/browser/repoPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/repoPicker.ts
@@ -26,12 +26,6 @@ interface IRepoItem {
 	readonly name: string;
 }
 
-function isValidRepoItem(value: unknown): value is IRepoItem {
-	return typeof value === 'object' && value !== null
-		&& typeof (value as IRepoItem).id === 'string'
-		&& typeof (value as IRepoItem).name === 'string';
-}
-
 /**
  * A self-contained widget for selecting the repository in cloud sessions.
  * Uses the `github.copilot.chat.cloudSessions.openRepository` command for
@@ -67,10 +61,7 @@ export class RepoPicker extends Disposable {
 		try {
 			const last = this.storageService.get(STORAGE_KEY_LAST_REPO, StorageScope.PROFILE);
 			if (last) {
-				const parsed = JSON.parse(last);
-				if (isValidRepoItem(parsed)) {
-					this._selectedRepo = parsed;
-				}
+				this._selectedRepo = JSON.parse(last);
 			}
 		} catch { /* ignore */ }
 
@@ -78,10 +69,7 @@ export class RepoPicker extends Disposable {
 		try {
 			const stored = this.storageService.get(STORAGE_KEY_RECENT_REPOS, StorageScope.PROFILE);
 			if (stored) {
-				const parsed = JSON.parse(stored);
-				if (Array.isArray(parsed)) {
-					this._recentlyPickedRepos = parsed.filter(isValidRepoItem);
-				}
+				this._recentlyPickedRepos = JSON.parse(stored);
 			}
 		} catch { /* ignore */ }
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -233,9 +233,9 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 		let newSession: INewSession;
 		if (target === AgentSessionProviders.Background || target === AgentSessionProviders.Local) {
-			newSession = new LocalNewSession(sessionResource, defaultRepoUri, this.chatSessionsService, this.logService);
+			newSession = this.instantiationService.createInstance(LocalNewSession, sessionResource, defaultRepoUri);
 		} else {
-			newSession = new RemoteNewSession(sessionResource, target, this.chatSessionsService, this.logService);
+			newSession = this.instantiationService.createInstance(RemoteNewSession, sessionResource, target);
 		}
 		this._newSession.value = newSession;
 		this.setActiveSession(newSession);


### PR DESCRIPTION
Extract picker logic from NewChatWidget into independent widget classes that follow a consistent pattern (trigger button + action list dropdown):

- RepoPicker: Cloud repository selection with storage persistence, recently used list, and browse command integration
- CloudModelPicker: Cloud model selection from session option groups
- IsolationModePicker: Worktree/Folder mode using action widget
- BranchPicker: Git branch icons

Simplify RemoteNewSession:
- getModelOptionGroup/getOtherOptionGroups for extension option groups
- When-clause evaluation and context key listening
- Remove dead code (getRepositoryOptionGroup, _syncValuesFromService, onDidChangeOptionValues, _cachedRepoGroup)

Use instantiation service for session object creation. Add toolbar pickers CSS for flex layout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>