### PR TITLE
chat: add plugins.enabled preview setting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -318,6 +318,12 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 				this.refreshOnPluginsChangedScheduler.schedule();
 			}
 		}));
+
+		this._register(this.pluginMarketplaceService.onDidChangeMarketplaces(() => {
+			if (this.list && this.isBodyVisible()) {
+				this.refreshOnPluginsChangedScheduler.schedule();
+			}
+		}));
 	}
 
 	protected override renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -648,6 +648,12 @@ configurationRegistry.registerConfiguration({
 				},
 			}
 		},
+		[ChatConfiguration.PluginsEnabled]: {
+			type: 'boolean',
+			description: nls.localize('chat.plugins.enabled', "Enable agent plugin integration in chat."),
+			default: true,
+			tags: ['preview'],
+		},
 		[ChatConfiguration.PluginPaths]: {
 			type: 'object',
 			additionalProperties: { type: 'boolean' },

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -10,6 +10,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 
 export enum ChatConfiguration {
 	AIDisabled = 'chat.disableAIFeatures',
+	PluginsEnabled = 'chat.plugins.enabled',
 	PluginPaths = 'chat.plugins.paths',
 	PluginMarketplaces = 'chat.plugins.marketplaces',
 	AgentEnabled = 'chat.agent.enabled',

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Event } from '../../../../../base/common/event.js';
 import { joinPath, normalizePath, relativePath } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -46,6 +47,7 @@ export const IPluginMarketplaceService = createDecorator<IPluginMarketplaceServi
 
 export interface IPluginMarketplaceService {
 	readonly _serviceBrand: undefined;
+	readonly onDidChangeMarketplaces: Event<void>;
 	fetchMarketplacePlugins(token: CancellationToken): Promise<IMarketplacePlugin[]>;
 }
 
@@ -61,11 +63,18 @@ const MARKETPLACE_DEFINITIONS: { type: MarketplaceType; path: string }[] = [
 export class PluginMarketplaceService implements IPluginMarketplaceService {
 	declare readonly _serviceBrand: undefined;
 
+	readonly onDidChangeMarketplaces: Event<void>;
+
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IRequestService private readonly _requestService: IRequestService,
 		@ILogService private readonly _logService: ILogService,
-	) { }
+	) {
+		this.onDidChangeMarketplaces = Event.filter(
+			_configurationService.onDidChangeConfiguration,
+			e => e.affectsConfiguration(ChatConfiguration.PluginsEnabled) || e.affectsConfiguration(ChatConfiguration.PluginMarketplaces),
+		) as Event<void>;
+	}
 
 	async fetchMarketplacePlugins(token: CancellationToken): Promise<IMarketplacePlugin[]> {
 		if (!this._configurationService.getValue<boolean>(ChatConfiguration.PluginsEnabled)) {

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -68,6 +68,9 @@ export class PluginMarketplaceService implements IPluginMarketplaceService {
 	) { }
 
 	async fetchMarketplacePlugins(token: CancellationToken): Promise<IMarketplacePlugin[]> {
+		if (!this._configurationService.getValue<boolean>(ChatConfiguration.PluginsEnabled)) {
+			return [];
+		}
 		const repos: string[] = this._configurationService.getValue(ChatConfiguration.PluginMarketplaces) ?? [];
 		const results = await Promise.all(
 			repos


### PR DESCRIPTION
Adds a new 'chat.plugins.enabled' preview setting to control whether plugins are available in chat. When disabled, both IAgentPluginService will return no plugins and IPluginMarketplaceService will return no marketplace plugins.

- Adds PluginsEnabled constant to ChatConfiguration enum
- Registers 'chat.plugins.enabled' boolean setting with default value true
- Gates AgentPluginService to return empty plugin lists when disabled
- Gates PluginMarketplaceService to return no marketplace plugins when disabled

(Commit message generated by Copilot)