### PR TITLE
Thinking block styling refinements

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -445,6 +445,8 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 		} else {
 			this.autoScrollEnabled = false;
 		}
+
+		this.updateOverflowClasses(scrollTop, maxScrollTop);
 	}
 
 	// try to schedule scroll
@@ -497,6 +499,17 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 			height: viewportHeight,
 			scrollHeight: contentHeight
 		});
+
+		const scrollTop = this.scrollableElement.getScrollPosition().scrollTop;
+		const maxScrollTop = contentHeight - viewportHeight;
+		this.updateOverflowClasses(scrollTop, maxScrollTop);
+	}
+
+	private updateOverflowClasses(scrollTop: number, maxScrollTop: number): void {
+		const overflowTop = scrollTop > 0;
+		const overflowBottom = maxScrollTop > 0 && scrollTop < maxScrollTop - 10;
+		this.wrapper.classList.toggle('chat-thinking-overflow-top', overflowTop);
+		this.wrapper.classList.toggle('chat-thinking-overflow-bottom', overflowBottom);
 	}
 
 	private scrollToBottom(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 .interactive-item-container.interactive-response .value .chat-markdown-part.rendered-markdown .code:has(.chat-codeblock-pill-container) {
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 }
 
 .chat-markdown-part.rendered-markdown .code .chat-codeblock-pill-container {
 	display: flex;
 	align-items: center;
 	gap: 5px;
-	margin: 0 0 6px 0px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	color: var(--vscode-descriptionForeground);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -42,10 +42,14 @@
 		}
 	}
 
+	&.chat-thinking-active > .chat-used-context-label {
+		display: none;
+	}
+
 	&.chat-thinking-active > .chat-used-context-label .monaco-button.monaco-icon-button {
 
 		.codicon.codicon-circle-filled {
-			display: none;
+			visibility: hidden;
 		}
 
 		.chat-thinking-title-shimmer {
@@ -89,14 +93,15 @@
 	}
 
 	.chat-used-context-list.chat-thinking-collapsible {
-		border: 1px solid var(--vscode-chat-requestBorder);
-		border-radius: var(--vscode-cornerRadius-medium);
+		border: none;
+		border-radius: 0;
+		padding: 0;
 		margin-bottom: 0;
 		position: relative;
 		overflow: hidden;
 
 		.chat-tool-invocation-part {
-			padding: 4px 12px 4px 18px;
+			padding: 4px 12px 4px 13px;
 			position: relative;
 		}
 
@@ -154,13 +159,13 @@
 
 			.chat-used-context.chat-hook-outcome-blocked,
 			.chat-used-context.chat-hook-outcome-warning {
-					padding: 4px 12px 4px 20px;
+					padding: 4px 12px 4px 15px;
 					margin-bottom: 0;
 				}
 		}
 
 		.chat-thinking-item.markdown-content {
-			padding: 6px 12px 6px 24px;
+			padding: 4px 12px 4px 19px;
 			position: relative;
 			font-size: var(--vscode-chat-font-size-body-s);
 
@@ -179,7 +184,7 @@
 		}
 
 		.chat-thinking-tool-wrapper .chat-markdown-part.rendered-markdown {
-			padding: 5px 12px 4px 20px;
+			padding: 4px 12px 4px 15px;
 
 			.status-icon.codicon-check {
 				display: none;
@@ -211,7 +216,7 @@
 			&::before {
 				content: '';
 				position: absolute;
-				left: 10.5px;
+				left: 5.5px;
 				top: 0px;
 				bottom: 0px;
 				width: 1px;
@@ -235,7 +240,7 @@
 
 			> .chat-thinking-icon {
 				position: absolute;
-				left: 5px;
+				left: 0px;
 				top: 9px;
 				width: 12px;
 				height: 12px;
@@ -253,7 +258,7 @@
 		}
 
 		.chat-thinking-spinner-item {
-			padding: 6px 12px 6px 24px;
+			padding: 4px 12px 4px 19px;
 			font-size: var(--vscode-chat-font-size-body-s);
 
 			.chat-thinking-spinner-label {
@@ -263,7 +268,7 @@
 	}
 
 	.chat-thinking-item {
-		padding: 6px 12px;
+		padding: 4px 12px;
 		position: relative;
 
 		.progress-container {
@@ -310,12 +315,36 @@
 	.chat-terminal-thinking-content .rendered-markdown [data-code] {
 		margin-bottom: 0px;
 	}
+
+	&.shimmer-running .chat-terminal-running-shimmer {
+		background: linear-gradient(
+			90deg,
+			var(--vscode-descriptionForeground) 0%,
+			var(--vscode-descriptionForeground) 30%,
+			var(--vscode-chat-thinkingShimmer) 50%,
+			var(--vscode-descriptionForeground) 70%,
+			var(--vscode-descriptionForeground) 100%
+		);
+		background-size: 400% 100%;
+		background-clip: text;
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		animation: chat-thinking-shimmer 2s linear infinite;
+	}
 }
 
 .interactive-session .interactive-response .value .chat-thinking-fixed-mode {
 	outline: none;
 
+	&.chat-thinking-box:has(.chat-thinking-streaming) > .chat-used-context-label {
+		display: none;
+	}
+
 	> .monaco-scrollable-element > .shadow {
+		display: none;
+	}
+
+	> .monaco-scrollable-element > .scrollbar {
 		display: none;
 	}
 
@@ -327,6 +356,18 @@
 		max-height: 200px;
 		overflow: hidden;
 		display: block;
+	}
+
+	&.chat-used-context-collapsed .chat-used-context-list.chat-thinking-collapsible.chat-thinking-streaming.chat-thinking-overflow-top.chat-thinking-overflow-bottom {
+		mask-image: linear-gradient(to bottom, transparent, black 24px, black calc(100% - 24px), transparent);
+	}
+
+	&.chat-used-context-collapsed .chat-used-context-list.chat-thinking-collapsible.chat-thinking-streaming.chat-thinking-overflow-top:not(.chat-thinking-overflow-bottom) {
+		mask-image: linear-gradient(to bottom, transparent, black 24px);
+	}
+
+	&.chat-used-context-collapsed .chat-used-context-list.chat-thinking-collapsible.chat-thinking-streaming.chat-thinking-overflow-bottom:not(.chat-thinking-overflow-top) {
+		mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent);
 	}
 
 	&:not(.chat-used-context-collapsed) .chat-used-context-list.chat-thinking-collapsible.chat-thinking-streaming {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -358,7 +358,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this.markdownPart = this._register(_instantiationService.createInstance(ChatMarkdownContentPart, chatMarkdownContent, context, editorPool, false, codeBlockStartIndex, renderer, {}, currentWidthDelegate(), codeBlockModelCollection, markdownOptions));
 
 		elements.message.append(this.markdownPart.domNode);
-		const progressPart = this._register(_instantiationService.createInstance(ChatProgressSubPart, elements.container, this.getIcon(), terminalData.autoApproveInfo));
+		const progressPart = this._register(_instantiationService.createInstance(ChatProgressSubPart, elements.container, Codicon.check, terminalData.autoApproveInfo));
 		this._decoration.update();
 
 		// Keep thinking-container semantics separate from wrapper semantics.
@@ -1504,6 +1504,8 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 
 		if (isComplete) {
 			this.icon = Codicon.check;
+		} else {
+			this.domNode.classList.add('shimmer-running');
 		}
 
 		this._setCodeFormattedTitle();
@@ -1521,11 +1523,15 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 		const prefixText = this._isComplete
 			? localize('chat.terminal.ran.prefix', "Ran ")
 			: localize('chat.terminal.running.prefix', "Running ");
-		const ranText = document.createTextNode(prefixText);
+		const prefixSpan = document.createElement('span');
+		prefixSpan.textContent = prefixText;
+		if (!this._isComplete) {
+			prefixSpan.classList.add('chat-terminal-running-shimmer');
+		}
 		const codeElement = document.createElement('code');
 		codeElement.textContent = this._commandText;
 
-		labelElement.appendChild(ranText);
+		labelElement.appendChild(prefixSpan);
 		labelElement.appendChild(codeElement);
 	}
 
@@ -1535,6 +1541,7 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 		}
 		this._isComplete = true;
 		this.icon = Codicon.check;
+		this.domNode.classList.remove('shimmer-running');
 		this._setCodeFormattedTitle();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -282,7 +282,7 @@
 }
 
 .interactive-item-container > .value .chat-used-context {
-	margin-bottom: 10px;
+	margin-bottom: 16px;
 }
 
 .interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {


### PR DESCRIPTION
Styling refinements for thinking/working blocks:

- Remove border and border-radius from collapsible thinking content list
- Adjust padding and alignment for thinking items, tool wrappers, and spinner items
- Shift chain-of-thought vertical line and icons to align with new padding
- Hide collapse button label when thinking is active (show shimmer title separately)
- Use `visibility: hidden` instead of `display: none` for circle-filled icon during active state
- Add overflow mask gradients for fixed-mode collapsed streaming content
- Hide scrollbar in fixed-mode thinking blocks
- Add shimmer animation for terminal "Running" prefix text
- Add overflow class tracking (`chat-thinking-overflow-top`/`chat-thinking-overflow-bottom`) for scroll position
- Adjust code block pill and collapsible context spacing