### PR TITLE
Chat Debug Panel: Cleanup and simplify filtering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFilters.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFilters.ts
@@ -12,12 +12,9 @@ import { CommandsRegistry } from '../../../../../platform/commands/common/comman
 import { viewFilterSubmenu } from '../../../../browser/parts/views/viewFilter.js';
 import {
 	CHAT_DEBUG_FILTER_ACTIVE,
-	CHAT_DEBUG_KIND_TOOL_CALL, CHAT_DEBUG_KIND_MODEL_TURN, CHAT_DEBUG_KIND_GENERIC, CHAT_DEBUG_KIND_SUBAGENT,
-	CHAT_DEBUG_KIND_USER_MESSAGE, CHAT_DEBUG_KIND_AGENT_RESPONSE,
-	CHAT_DEBUG_LEVEL_TRACE, CHAT_DEBUG_LEVEL_INFO, CHAT_DEBUG_LEVEL_WARNING, CHAT_DEBUG_LEVEL_ERROR,
-	CHAT_DEBUG_CMD_TOGGLE_TOOL_CALL, CHAT_DEBUG_CMD_TOGGLE_MODEL_TURN, CHAT_DEBUG_CMD_TOGGLE_GENERIC,
-	CHAT_DEBUG_CMD_TOGGLE_SUBAGENT, CHAT_DEBUG_CMD_TOGGLE_USER_MESSAGE, CHAT_DEBUG_CMD_TOGGLE_AGENT_RESPONSE,
-	CHAT_DEBUG_CMD_TOGGLE_TRACE, CHAT_DEBUG_CMD_TOGGLE_INFO, CHAT_DEBUG_CMD_TOGGLE_WARNING, CHAT_DEBUG_CMD_TOGGLE_ERROR,
+	CHAT_DEBUG_KIND_TOOL_CALL, CHAT_DEBUG_KIND_MODEL_TURN, CHAT_DEBUG_KIND_PROMPT_DISCOVERY, CHAT_DEBUG_KIND_SUBAGENT,
+	CHAT_DEBUG_CMD_TOGGLE_TOOL_CALL, CHAT_DEBUG_CMD_TOGGLE_MODEL_TURN, CHAT_DEBUG_CMD_TOGGLE_PROMPT_DISCOVERY,
+	CHAT_DEBUG_CMD_TOGGLE_SUBAGENT,
 } from './chatDebugTypes.js';
 
 /**
@@ -35,45 +32,38 @@ export class ChatDebugFilterState extends Disposable {
 	// Kind visibility
 	filterKindToolCall: boolean = true;
 	filterKindModelTurn: boolean = true;
-	filterKindGeneric: boolean = true;
+	filterKindPromptDiscovery: boolean = true;
 	filterKindSubagent: boolean = true;
-	filterKindUserMessage: boolean = true;
-	filterKindAgentResponse: boolean = true;
-
-	// Level visibility
-	filterLevelTrace: boolean = true;
-	filterLevelInfo: boolean = true;
-	filterLevelWarning: boolean = true;
-	filterLevelError: boolean = true;
 
 	// Text filter
 	textFilter: string = '';
 
-	isKindVisible(kind: string): boolean {
+	isKindVisible(kind: string, category?: string): boolean {
 		switch (kind) {
 			case 'toolCall': return this.filterKindToolCall;
 			case 'modelTurn': return this.filterKindModelTurn;
-			case 'generic': return this.filterKindGeneric;
+			case 'generic':
+				// The "Prompt Discovery" toggle only hides events produced by
+				// the prompt discovery pipeline (category === 'discovery').
+				// Other generic events (e.g. from external providers) are
+				// always visible and are not affected by this toggle.
+				if (category !== 'discovery') {
+					return true;
+				}
+				return this.filterKindPromptDiscovery;
 			case 'subagentInvocation': return this.filterKindSubagent;
-			case 'userMessage': return this.filterKindUserMessage;
-			case 'agentResponse': return this.filterKindAgentResponse;
+
 			default: return true;
 		}
 	}
 
 	isAllKindsVisible(): boolean {
 		return this.filterKindToolCall && this.filterKindModelTurn &&
-			this.filterKindGeneric && this.filterKindSubagent &&
-			this.filterKindUserMessage && this.filterKindAgentResponse;
-	}
-
-	isAllLevelsVisible(): boolean {
-		return this.filterLevelTrace && this.filterLevelInfo &&
-			this.filterLevelWarning && this.filterLevelError;
+			this.filterKindPromptDiscovery && this.filterKindSubagent;
 	}
 
 	isAllFiltersDefault(): boolean {
-		return this.isAllKindsVisible() && this.isAllLevelsVisible();
+		return this.isAllKindsVisible();
 	}
 
 	setTextFilter(text: string): void {
@@ -106,23 +96,10 @@ export function registerFilterMenuItems(
 	kindToolCallKey.set(true);
 	const kindModelTurnKey = CHAT_DEBUG_KIND_MODEL_TURN.bindTo(scopedContextKeyService);
 	kindModelTurnKey.set(true);
-	const kindGenericKey = CHAT_DEBUG_KIND_GENERIC.bindTo(scopedContextKeyService);
-	kindGenericKey.set(true);
+	const kindPromptDiscoveryKey = CHAT_DEBUG_KIND_PROMPT_DISCOVERY.bindTo(scopedContextKeyService);
+	kindPromptDiscoveryKey.set(true);
 	const kindSubagentKey = CHAT_DEBUG_KIND_SUBAGENT.bindTo(scopedContextKeyService);
 	kindSubagentKey.set(true);
-	const kindUserMessageKey = CHAT_DEBUG_KIND_USER_MESSAGE.bindTo(scopedContextKeyService);
-	kindUserMessageKey.set(true);
-	const kindAgentResponseKey = CHAT_DEBUG_KIND_AGENT_RESPONSE.bindTo(scopedContextKeyService);
-	kindAgentResponseKey.set(true);
-	const levelTraceKey = CHAT_DEBUG_LEVEL_TRACE.bindTo(scopedContextKeyService);
-	levelTraceKey.set(true);
-	const levelInfoKey = CHAT_DEBUG_LEVEL_INFO.bindTo(scopedContextKeyService);
-	levelInfoKey.set(true);
-	const levelWarningKey = CHAT_DEBUG_LEVEL_WARNING.bindTo(scopedContextKeyService);
-	levelWarningKey.set(true);
-	const levelErrorKey = CHAT_DEBUG_LEVEL_ERROR.bindTo(scopedContextKeyService);
-	levelErrorKey.set(true);
-
 	const registerToggle = (
 		id: string, title: string, key: RawContextKey<boolean>, group: string,
 		getter: () => boolean, setter: (v: boolean) => void, ctxKey: IContextKey<boolean>,
@@ -142,15 +119,8 @@ export function registerFilterMenuItems(
 
 	registerToggle(CHAT_DEBUG_CMD_TOGGLE_TOOL_CALL, localize('chatDebug.filter.toolCall', "Tool Calls"), CHAT_DEBUG_KIND_TOOL_CALL, '1_kind', () => state.filterKindToolCall, v => { state.filterKindToolCall = v; }, kindToolCallKey);
 	registerToggle(CHAT_DEBUG_CMD_TOGGLE_MODEL_TURN, localize('chatDebug.filter.modelTurn', "Model Turns"), CHAT_DEBUG_KIND_MODEL_TURN, '1_kind', () => state.filterKindModelTurn, v => { state.filterKindModelTurn = v; }, kindModelTurnKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_GENERIC, localize('chatDebug.filter.generic', "Generic"), CHAT_DEBUG_KIND_GENERIC, '1_kind', () => state.filterKindGeneric, v => { state.filterKindGeneric = v; }, kindGenericKey);
+	registerToggle(CHAT_DEBUG_CMD_TOGGLE_PROMPT_DISCOVERY, localize('chatDebug.filter.promptDiscovery', "Prompt Discovery"), CHAT_DEBUG_KIND_PROMPT_DISCOVERY, '1_kind', () => state.filterKindPromptDiscovery, v => { state.filterKindPromptDiscovery = v; }, kindPromptDiscoveryKey);
 	registerToggle(CHAT_DEBUG_CMD_TOGGLE_SUBAGENT, localize('chatDebug.filter.subagent', "Subagent Invocations"), CHAT_DEBUG_KIND_SUBAGENT, '1_kind', () => state.filterKindSubagent, v => { state.filterKindSubagent = v; }, kindSubagentKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_USER_MESSAGE, localize('chatDebug.filter.userMessage', "User Messages"), CHAT_DEBUG_KIND_USER_MESSAGE, '1_kind', () => state.filterKindUserMessage, v => { state.filterKindUserMessage = v; }, kindUserMessageKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_AGENT_RESPONSE, localize('chatDebug.filter.agentResponse', "Agent Responses"), CHAT_DEBUG_KIND_AGENT_RESPONSE, '1_kind', () => state.filterKindAgentResponse, v => { state.filterKindAgentResponse = v; }, kindAgentResponseKey);
-
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_TRACE, localize('chatDebug.filter.trace', "Trace"), CHAT_DEBUG_LEVEL_TRACE, '2_level', () => state.filterLevelTrace, v => { state.filterLevelTrace = v; }, levelTraceKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_INFO, localize('chatDebug.filter.info', "Info"), CHAT_DEBUG_LEVEL_INFO, '2_level', () => state.filterLevelInfo, v => { state.filterLevelInfo = v; }, levelInfoKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_WARNING, localize('chatDebug.filter.warning', "Warning"), CHAT_DEBUG_LEVEL_WARNING, '2_level', () => state.filterLevelWarning, v => { state.filterLevelWarning = v; }, levelWarningKey);
-	registerToggle(CHAT_DEBUG_CMD_TOGGLE_ERROR, localize('chatDebug.filter.error', "Error"), CHAT_DEBUG_LEVEL_ERROR, '2_level', () => state.filterLevelError, v => { state.filterLevelError = v; }, levelErrorKey);
 
 	return store;
 }
@@ -166,25 +136,12 @@ export function bindFilterContextKeys(
 	CHAT_DEBUG_FILTER_ACTIVE.bindTo(scopedContextKeyService).set(true);
 	const kindToolCallKey = CHAT_DEBUG_KIND_TOOL_CALL.bindTo(scopedContextKeyService);
 	const kindModelTurnKey = CHAT_DEBUG_KIND_MODEL_TURN.bindTo(scopedContextKeyService);
-	const kindGenericKey = CHAT_DEBUG_KIND_GENERIC.bindTo(scopedContextKeyService);
+	const kindPromptDiscoveryKey = CHAT_DEBUG_KIND_PROMPT_DISCOVERY.bindTo(scopedContextKeyService);
 	const kindSubagentKey = CHAT_DEBUG_KIND_SUBAGENT.bindTo(scopedContextKeyService);
-	const kindUserMessageKey = CHAT_DEBUG_KIND_USER_MESSAGE.bindTo(scopedContextKeyService);
-	const kindAgentResponseKey = CHAT_DEBUG_KIND_AGENT_RESPONSE.bindTo(scopedContextKeyService);
-	const levelTraceKey = CHAT_DEBUG_LEVEL_TRACE.bindTo(scopedContextKeyService);
-	const levelInfoKey = CHAT_DEBUG_LEVEL_INFO.bindTo(scopedContextKeyService);
-	const levelWarningKey = CHAT_DEBUG_LEVEL_WARNING.bindTo(scopedContextKeyService);
-	const levelErrorKey = CHAT_DEBUG_LEVEL_ERROR.bindTo(scopedContextKeyService);
-
 	return () => {
 		kindToolCallKey.set(state.filterKindToolCall);
 		kindModelTurnKey.set(state.filterKindModelTurn);
-		kindGenericKey.set(state.filterKindGeneric);
+		kindPromptDiscoveryKey.set(state.filterKindPromptDiscovery);
 		kindSubagentKey.set(state.filterKindSubagent);
-		kindUserMessageKey.set(state.filterKindUserMessage);
-		kindAgentResponseKey.set(state.filterKindAgentResponse);
-		levelTraceKey.set(state.filterLevelTrace);
-		levelInfoKey.set(state.filterLevelInfo);
-		levelWarningKey.set(state.filterLevelWarning);
-		levelErrorKey.set(state.filterLevelError);
 	};
 }

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowChartView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowChartView.ts
@@ -224,7 +224,7 @@ export class ChatDebugFlowChartView extends Disposable {
 		// Build, filter, slice, and render the flow chart
 		const flowNodes = buildFlowGraph(events);
 		const filtered = filterFlowNodes(flowNodes, {
-			isKindVisible: kind => this.filterState.isKindVisible(kind),
+			isKindVisible: (kind, category) => this.filterState.isKindVisible(kind, category),
 			textFilter: this.filterState.textFilter,
 		});
 
@@ -541,9 +541,17 @@ export class ChatDebugFlowChartView extends Disposable {
 		}
 		const svgWidth = parseFloat(this.svgElement.getAttribute('width') || '0');
 		const svgHeight = parseFloat(this.svgElement.getAttribute('height') || '0');
+		if (svgWidth <= 0 || svgHeight <= 0) {
+			return;
+		}
 
-		this.translateX = (containerRect.width - svgWidth) / 2;
-		this.translateY = Math.max(20, (containerRect.height - svgHeight) / 2);
+		const PADDING = 20;
+		// Pin the top of the diagram near the top of the viewport so the start
+		// of the flow is immediately visible. Center horizontally when the
+		// diagram fits; otherwise align to the left edge with padding so
+		// nothing is clipped behind overflow:hidden.
+		this.translateX = Math.max(PADDING, (containerRect.width - svgWidth) / 2);
+		this.translateY = PADDING;
 		this.applyTransform();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
@@ -21,7 +21,7 @@ import { ServiceCollection } from '../../../../../platform/instantiation/common/
 import { WorkbenchList, WorkbenchObjectTree } from '../../../../../platform/list/browser/listService.js';
 import { defaultBreadcrumbsWidgetStyles, defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { FilterWidget } from '../../../../browser/parts/views/viewFilter.js';
-import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugService } from '../../common/chatDebugService.js';
+import { IChatDebugEvent, IChatDebugService } from '../../common/chatDebugService.js';
 import { IChatService } from '../../common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { ChatDebugEventRenderer, ChatDebugEventDelegate, ChatDebugEventTreeRenderer } from './chatDebugEventList.js';
@@ -290,23 +290,11 @@ export class ChatDebugLogsView extends Disposable {
 	refreshList(): void {
 		let filtered = this.events;
 
-		// Filter by kind toggles
-		filtered = filtered.filter(e => this.filterState.isKindVisible(e.kind));
-
-		// Filter by level toggles
+		// Filter by kind toggles (pass category for generic events so only
+		// discovery-category events are affected by the Prompt Discovery toggle)
 		filtered = filtered.filter(e => {
-			if (e.kind === 'generic') {
-				switch (e.level) {
-					case ChatDebugLogLevel.Trace: return this.filterState.filterLevelTrace;
-					case ChatDebugLogLevel.Info: return this.filterState.filterLevelInfo;
-					case ChatDebugLogLevel.Warning: return this.filterState.filterLevelWarning;
-					case ChatDebugLogLevel.Error: return this.filterState.filterLevelError;
-				}
-			}
-			if (e.kind === 'toolCall' && e.result === 'error') {
-				return this.filterState.filterLevelError;
-			}
-			return true;
+			const category = e.kind === 'generic' ? e.category : undefined;
+			return this.filterState.isKindVisible(e.kind, category);
 		});
 
 		// Filter by text search

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugTypes.ts
@@ -36,26 +36,14 @@ export const enum LogsViewMode {
 export const CHAT_DEBUG_FILTER_ACTIVE = new RawContextKey<boolean>('chatDebugFilterActive', false);
 export const CHAT_DEBUG_KIND_TOOL_CALL = new RawContextKey<boolean>('chatDebug.kindToolCall', true);
 export const CHAT_DEBUG_KIND_MODEL_TURN = new RawContextKey<boolean>('chatDebug.kindModelTurn', true);
-export const CHAT_DEBUG_KIND_GENERIC = new RawContextKey<boolean>('chatDebug.kindGeneric', true);
+export const CHAT_DEBUG_KIND_PROMPT_DISCOVERY = new RawContextKey<boolean>('chatDebug.kindPromptDiscovery', true);
 export const CHAT_DEBUG_KIND_SUBAGENT = new RawContextKey<boolean>('chatDebug.kindSubagent', true);
-export const CHAT_DEBUG_KIND_USER_MESSAGE = new RawContextKey<boolean>('chatDebug.kindUserMessage', true);
-export const CHAT_DEBUG_KIND_AGENT_RESPONSE = new RawContextKey<boolean>('chatDebug.kindAgentResponse', true);
-export const CHAT_DEBUG_LEVEL_TRACE = new RawContextKey<boolean>('chatDebug.levelTrace', true);
-export const CHAT_DEBUG_LEVEL_INFO = new RawContextKey<boolean>('chatDebug.levelInfo', true);
-export const CHAT_DEBUG_LEVEL_WARNING = new RawContextKey<boolean>('chatDebug.levelWarning', true);
-export const CHAT_DEBUG_LEVEL_ERROR = new RawContextKey<boolean>('chatDebug.levelError', true);
 
 // Filter toggle command IDs
 export const CHAT_DEBUG_CMD_TOGGLE_TOOL_CALL = 'chatDebug.filter.toggleToolCall';
 export const CHAT_DEBUG_CMD_TOGGLE_MODEL_TURN = 'chatDebug.filter.toggleModelTurn';
-export const CHAT_DEBUG_CMD_TOGGLE_GENERIC = 'chatDebug.filter.toggleGeneric';
+export const CHAT_DEBUG_CMD_TOGGLE_PROMPT_DISCOVERY = 'chatDebug.filter.togglePromptDiscovery';
 export const CHAT_DEBUG_CMD_TOGGLE_SUBAGENT = 'chatDebug.filter.toggleSubagent';
-export const CHAT_DEBUG_CMD_TOGGLE_USER_MESSAGE = 'chatDebug.filter.toggleUserMessage';
-export const CHAT_DEBUG_CMD_TOGGLE_AGENT_RESPONSE = 'chatDebug.filter.toggleAgentResponse';
-export const CHAT_DEBUG_CMD_TOGGLE_TRACE = 'chatDebug.filter.toggleTrace';
-export const CHAT_DEBUG_CMD_TOGGLE_INFO = 'chatDebug.filter.toggleInfo';
-export const CHAT_DEBUG_CMD_TOGGLE_WARNING = 'chatDebug.filter.toggleWarning';
-export const CHAT_DEBUG_CMD_TOGGLE_ERROR = 'chatDebug.filter.toggleError';
 
 export class TextBreadcrumbItem extends BreadcrumbsItem {
 	constructor(


### PR DESCRIPTION
**Summary:** 
Renames the "Generic" filter to "Prompt Discovery" and fixes its filtering logic to only hide category: 'discovery' events, so agent responses and other non-discovery generic events remain visible when the toggle is off. Removes the non-functional "User Messages", "Agent Responses", and level (Trace/Info/Warning/Error) filter toggles, and fixes the flow chart initial layout so the diagram is horizontally centered and top-aligned rather than partially clipped off-screen.
