### PR TITLE
fix: strip host from SCP-style SSH URLs when deriving clone folder name

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -432,7 +432,7 @@ export class Git {
 	}
 
 	async clone(url: string, options: ICloneOptions, cancellationToken?: CancellationToken): Promise<string> {
-		const baseFolderName = decodeURI(url).replace(/[\/]+$/, '').replace(/^.*[\/\\]/, '').replace(/\.git$/, '') || 'repository';
+		const baseFolderName = decodeURI(url).replace(/[\/]+$/, '').replace(/^.*[\/\\:]/, '').replace(/\.git$/, '') || 'repository';
 		let folderName = baseFolderName;
 		let folderPath = path.join(options.parentPath, folderName);
 		let count = 1;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When cloning a repository using an SCP-style SSH URL without a nested path (e.g. `git@versions.somedomain.net:climate-project`), the entire URL including `git@host:` is used as the clone target folder name. On Windows, this fails with:

```
fatal: could not create work tree dir '...\git@versions.somedomain.net:climate-project': Invalid argument
```

because colons are illegal in Windows filenames. On macOS/Linux, it creates an oddly named directory.

The root cause is in the folder name extraction regex on line 435 of `extensions/git/src/git.ts`:

```typescript
decodeURI(url).replace(/[\/]+$/, '').replace(/^.*[\/\]/, '').replace(/\.git$/, '')
```

The second regex only recognizes `/` and `\` as path separators, but SCP-style SSH URLs use `:` as the separator between host and path.

Closes #175062

## What is the new behavior?

Added `:` to the separator character class: `/^.*[\/\:]/`

This correctly strips the `git@host:` prefix, leaving just the project name as the folder name.

**Examples:**

| URL | Before | After |
|-----|--------|-------|
| `git@host:climate-project` | `git@host:climate-project` | `climate-project` |
| `git@host:climate-project.git` | `git@host:climate-project.git` | `climate-project` |
| `git@github.com:user/repo.git` | `repo` (already worked) | `repo` (unchanged) |
| `https://github.com/user/repo.git` | `repo` (already worked) | `repo` (unchanged) |
| `/local/path/to/repo` | `repo` (already worked) | `repo` (unchanged) |
| `C:\Users\test\repo` | `repo` (already worked) | `repo` (unchanged) |

The `.*` is greedy, so it matches up to the **last** occurrence of any character in `[\/\:]`. Since `/` and `\` always appear after `:` in standard URLs and Windows paths, the existing behavior for all non-SCP-style URLs is preserved exactly.

## Additional context

This is a one-character change (`[\/\]` -> `[\/\:]`). The issue has been open since 2023 and is labeled `team-low-hanging`.