### PR TITLE
Fix copy button not working during chat code block streaming

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -407,7 +407,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 			this._codeblocks[data.codeBlockPartIndex].codemapperUri = e.codemapperUri;
 		});
 
-		editorInfo.render(data, currentWidth);
+		editorInfo.render(data, currentWidth, text);
 
 		return ref;
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/codeBlockPart.ts
@@ -411,10 +411,22 @@ export class CodeBlockPart extends Disposable {
 		return this.editor.getContentHeight();
 	}
 
-	async render(data: ICodeBlockData, width: number) {
+	async render(data: ICodeBlockData, width: number, text?: string) {
 		this.currentCodeBlockData = data;
 		if (data.parentContextKeyService) {
 			this.contextKeyService.updateParent(data.parentContextKeyService);
+		}
+
+		// Set initial toolbar context immediately with available text so copy works during streaming
+		if (text !== undefined) {
+			this.toolbar.context = {
+				code: text,
+				codeBlockIndex: data.codeBlockIndex,
+				element: data.element,
+				languageId: data.languageId,
+				codemapperUri: data.codemapperUri,
+				chatSessionResource: data.chatSessionResource
+			} satisfies ICodeBlockActionContext;
 		}
 
 		if (this.getEditorOptionsFromConfig().wordWrap === 'on') {


### PR DESCRIPTION
When users click the Copy button on a code block while Copilot Chat is still streaming its response, nothing gets copied. They have to wait for the entire response to finish before copying works.

## Root Cause

The `CodeBlockPart.render()` method sets the toolbar context (including the `code` property used by the Copy action) only **after** awaiting the text model promise. During streaming, this promise takes time to resolve while the model is being created and populated. If a user clicks Copy before the promise resolves, `context.code` is undefined and the copy silently fails.

## Solution

Pass the raw text (which is already available from markdown parsing) to `render()` and set an initial toolbar context immediately, before awaiting the model. This ensures the Copy action has access to the code text from the moment the code block appears. The context is later refined with the fully resolved model data once available.

The change is backwards compatible — the `text` parameter is optional, so existing callers that don't pass it continue to work.

Fixes #255290

---

Created with [Copilot Desktop](https://github.com/githubnext/copilot-tauri-app)