### PR TITLE
Add compact cursor position format setting for status bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -338,6 +338,8 @@ class StatusInputMode extends Disposable {
 const nlsSingleSelectionRange = localize('singleSelectionRange', "Ln {0}, Col {1} ({2} selected)");
 const nlsSingleSelection = localize('singleSelection', "Ln {0}, Col {1}");
 const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections ({1} characters selected)");
+const nlsSingleSelectionCompact = localize('singleSelectionCompact', "{0}:{1}");
+const nlsSingleSelectionRangeCompact = localize('singleSelectionRangeCompact', "{0}:{1} ({2} selected)");
 const nlsMultiSelection = localize('multiSelection', "{0} selections");
 const nlsEOLLF = localize('endOfLineLineFeed', "LF");
 const nlsEOLCRLF = localize('endOfLineCarriageReturnLineFeed', "CRLF");
@@ -655,12 +657,18 @@ class EditorStatus extends Disposable {
 			return undefined;
 		}
 
+		const compact = this.configurationService.getValue<boolean>('workbench.statusBar.compactPositionFormat');
+
 		if (info.selections.length === 1) {
 			if (info.charactersSelected) {
-				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
+				return compact
+				? format(nlsSingleSelectionRangeCompact, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected)
+				: format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
 			}
 
-			return format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);
+			return compact
+			? format(nlsSingleSelectionCompact, info.selections[0].positionLineNumber, info.selections[0].positionColumn)
+			: format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);
 		}
 
 		if (info.charactersSelected) {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -617,6 +617,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': true,
 				'description': localize('statusBarVisibility', "Controls the visibility of the status bar at the bottom of the workbench.")
 			},
+			'workbench.statusBar.compactPositionFormat' : {
+				'type': 'boolean',
+				'default': false,
+				'markdownDescription': localize('statusBarCompactPositionFormat', "When enabled, shows the cursor position in a compact `line:column` format (for example `42:7`) instead of `Ln 42, Col 7`."),
+			},
 			[NotificationsSettings.NOTIFICATIONS_POSITION]: {
 				'type': 'string',
 				'enum': [NotificationsPosition.BOTTOM_RIGHT, NotificationsPosition.BOTTOM_LEFT, NotificationsPosition.TOP_RIGHT],


### PR DESCRIPTION
Resolves #296912

Add a workbench setting to show the editor cursor position in a compact `line:column` format in the status bar instead of the default `Ln X, Col Y`.

### Changes

- Add `workbench.statusBar.compactPositionFormat` setting under Workbench settings.
- Render the cursor position as `line:column` when the setting is enabled.
- Keep `Ln X, Col Y` as the default format.

### How to test

- Build and run VS Code from this branch.
- Open a text file and observe the default cursor position format: `Ln X, Col Y`.
- Enable **Workbench › Status Bar: Compact Position Format** in Settings.
- Verify the cursor position shows as `line:column` (for example `42:7`), including for selections / ranges.
- Disable the setting and verify the format returns to `Ln X, Col Y`.

### Screenshots

1. Setting in Settings UI search  

   <img width="1195" height="538" alt="Screenshot 2026-02-24 at 11 15 51 PM" src="https://github.com/user-attachments/assets/9179bdec-1d0d-4f67-abe7-bc531118b43b" />

2. Default status bar cursor format  

   <img width="304" height="24" alt="Screenshot 2026-02-24 at 11 16 15 PM" src="https://github.com/user-attachments/assets/1087d442-91fa-4a1f-8b25-7add992a62f6" />

3. Compact status bar cursor format  

   <img width="394" height="18" alt="Screenshot 2026-02-24 at 11 16 22 PM" src="https://github.com/user-attachments/assets/525d630e-8a39-4fc5-9131-e4656e103610" />

CC @bpasero
