### PR TITLE
Add 'Review Changes' action to SCM view title bar

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -17,7 +17,6 @@ import { IModelService } from '../../../../editor/common/services/model.js';
 import { ITextModelContentProvider, ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import { localize } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { CodeDataTransfers } from '../../../../platform/dnd/browser/dnd.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
@@ -27,7 +26,7 @@ import { ChatContextKeys } from '../../chat/common/actions/chatContextKeys.js';
 import { ISCMHistoryItemChangeVariableEntry, ISCMHistoryItemVariableEntry } from '../../chat/common/attachments/chatVariableEntries.js';
 import { ScmHistoryItemResolver } from '../../multiDiffEditor/browser/scmMultiDiffSourceResolver.js';
 import { ISCMHistoryItem, ISCMHistoryItemChange } from '../common/history.js';
-import { ISCMProvider, ISCMService, ISCMViewService, VIEW_PANE_ID } from '../common/scm.js';
+import { ISCMProvider, ISCMService, ISCMViewService } from '../common/scm.js';
 
 export interface SCMHistoryItemTransferData {
 	readonly name: string;
@@ -343,16 +342,6 @@ registerAction2(class extends Action2 {
 			id: 'workbench.scm.action.reviewChanges',
 			title: localize('chat.action.scmReviewChanges', 'Review Changes'),
 			f1: false,
-			menu: {
-				id: MenuId.SCMTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.and(
-					ContextKeyExpr.equals('view', VIEW_PANE_ID),
-					ContextKeyExpr.notEquals('scmRepositoryCount', 0),
-					ChatContextKeys.enabled
-				),
-				order: 0
-			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts
@@ -343,7 +343,6 @@ registerAction2(class extends Action2 {
 			id: 'workbench.scm.action.reviewChanges',
 			title: localize('chat.action.scmReviewChanges', 'Review Changes'),
 			f1: false,
-			icon: Codicon.sparkle,
 			menu: {
 				id: MenuId.SCMTitle,
 				group: 'navigation',


### PR DESCRIPTION
## Summary

Adds a prominent ✨ sparkle button to the SCM view navigation toolbar that kicks off an agentic code review of working tree changes via chat.

## What changed

In `src/vs/workbench/contrib/scm/browser/scmHistoryChatContext.ts`:

- Registered a new `workbench.scm.action.reviewChanges` action on `MenuId.SCMTitle` in the `navigation` group
- When clicked, it reveals the chat widget and sends "Review my changes" to start an agentic code review
- Gated on `ChatContextKeys.enabled` (respects AI feature disable setting) and repository count > 0
- Uses the `sparkle` icon for visual consistency with other AI-powered actions

## Motivation

Previously, chat-based code review from the SCM view was only accessible through:
- Right-clicking a commit in the history graph → "Explain Changes"
- The editor context menu → "Code Review"

There was no prominent, one-click way to review **working tree changes** from the main SCM view. This adds that entry point as a toolbar button.