### PR TITLE
Fix markdown preview not refreshing on external file changes

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -114,10 +114,10 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			const watcher = this._register(vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(resource, '*')));
 			this._register(watcher.onDidChange(uri => {
 				if (this.isPreviewOf(uri)) {
-					// Only use the file system event when VS Code does not already know about the file
-					if (!vscode.workspace.textDocuments.some(doc => doc.uri.toString() === uri.toString())) {
-						this.refresh();
-					}
+					// Always refresh on file system changes, including external modifications
+					// (e.g. AI agents, scripts, git sync). The throttle in refresh() prevents
+					// performance issues from duplicate events with onDidChangeTextDocument.
+					this.refresh(true);
 				}
 			}));
 		}

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -114,10 +114,19 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			const watcher = this._register(vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(resource, '*')));
 			this._register(watcher.onDidChange(uri => {
 				if (this.isPreviewOf(uri)) {
-					// Always refresh on file system changes, including external modifications
-					// (e.g. AI agents, scripts, git sync). The throttle in refresh() prevents
-					// performance issues from duplicate events with onDidChangeTextDocument.
-					this.refresh(true);
+					// Only skip the file-system event when the document has unsaved
+					// edits in the editor.  A dirty document means the preview is
+					// already kept up-to-date via onDidChangeTextDocument.
+					// For non-dirty or closed documents we must refresh from disk
+					// because onDidChangeTextDocument may not fire reliably — the
+					// underlying TextFileEditorModel (and its file watcher) is
+					// disposed when the editor tab is closed, even though the
+					// TextDocument can linger in textDocuments for up to 5 minutes.
+					const doc = vscode.workspace.textDocuments.find(
+						d => d.uri.toString() === uri.toString());
+					if (!doc || !doc.isDirty) {
+						this.refresh(true);
+					}
 				}
 			}));
 		}


### PR DESCRIPTION
## Summary

- Remove the `textDocuments.some()` guard in the file system watcher callback that prevented preview refresh when VS Code already had the document open
- Pass `forceUpdate=true` to `refresh()` to bypass the internal version check, which may not reflect external changes
- The existing 300ms throttle in `refresh()` prevents performance issues from duplicate events

## Problem

When a markdown file is modified by an external process (AI coding agents like Claude Code / Copilot, scripts, git sync, file copy/overwrite), the preview does not update. Even closing and reopening the preview tab shows stale content.

**Root cause:** The watcher callback checks `!vscode.workspace.textDocuments.some(doc => doc.uri.toString() === uri.toString())` before refreshing. Since the document is almost always already known to VS Code when a preview is open, external file changes are silently ignored. Additionally, `onDidChangeTextDocument` does not fire for external overwrites, creating a gap where no refresh path is triggered.

## Test plan

- [ ] Open a markdown file and show preview side by side
- [ ] From a terminal, modify the file externally (e.g. `echo "# Updated" >> file.md`)
- [ ] Verify the preview updates automatically
- [ ] Verify that normal in-editor editing still updates the preview (no regression)
- [ ] Verify that switching tabs and returning shows current content

Fixes #265277
Fixes #194421

🤖 Generated with [Claude Code](https://claude.com/claude-code)