### PR TITLE
Fix scripts and support npm tasks

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
+++ b/src/vs/sessions/contrib/chat/browser/runScriptAction.ts
@@ -225,7 +225,10 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 			return;
 		}
 
-		await this._sessionsConfigService.createAndAddTask(command, session, target);
+		const newTask = await this._sessionsConfigService.createAndAddTask(command, session, target);
+		if (newTask) {
+			await this._sessionsConfigService.runTask(newTask, session);
+		}
 	}
 
 	private async _pickStorageTarget(session: IActiveSessionItem): Promise<TaskStorageTarget | undefined> {
@@ -267,13 +270,13 @@ export class RunScriptContribution extends Disposable implements IWorkbenchContr
 			picker.onDidAccept(() => {
 				const selected = picker.activeItems[0];
 				if (selected && (selected.target !== 'workspace' || hasWorktree)) {
-					picker.dispose();
 					resolve(selected.target);
+					picker.dispose();
 				}
 			});
 			picker.onDidHide(() => {
-				picker.dispose();
 				resolve(undefined);
+				picker.dispose();
 			});
 			picker.show();
 		});

--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -67,7 +67,7 @@ export interface ISessionsConfigurationService {
 	 * Creates a new shell task with `inSessions: true` and writes it to
 	 * the appropriate tasks.json (user or workspace).
 	 */
-	createAndAddTask(command: string, session: IActiveSessionItem, target: TaskStorageTarget): Promise<void>;
+	createAndAddTask(command: string, session: IActiveSessionItem, target: TaskStorageTarget): Promise<ITaskEntry | undefined>;
 
 	/**
 	 * Runs a task entry in a terminal, resolving the correct platform
@@ -88,6 +88,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	declare readonly _serviceBrand: undefined;
 
 	private static readonly _LAST_RUN_TASK_LABELS_KEY = 'agentSessions.lastRunTaskLabels';
+	private static readonly _SUPPORTED_TASK_TYPES = new Set(['shell', 'npm']);
 
 	private readonly _sessionTasks = observableValue<readonly ITaskEntry[]>(this, []);
 	private readonly _fileWatcher = this._register(new MutableDisposable());
@@ -151,10 +152,10 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		}
 	}
 
-	async createAndAddTask(command: string, session: IActiveSessionItem, target: TaskStorageTarget): Promise<void> {
+	async createAndAddTask(command: string, session: IActiveSessionItem, target: TaskStorageTarget): Promise<ITaskEntry | undefined> {
 		const tasksJsonUri = this._getTasksJsonUri(session, target);
 		if (!tasksJsonUri) {
-			return;
+			return undefined;
 		}
 
 		const tasksJson = await this._readTasksJson(tasksJsonUri);
@@ -174,6 +175,8 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		if (target === 'workspace') {
 			await this._commitTasksFile(session);
 		}
+
+		return newTask;
 	}
 
 	async runTask(task: ITaskEntry, session: IActiveSessionItem): Promise<void> {
@@ -265,7 +268,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		if (workspaceUri) {
 			const workspaceJson = await this._readTasksJson(workspaceUri);
 			if (workspaceJson.tasks) {
-				result.push(...workspaceJson.tasks);
+				result.push(...workspaceJson.tasks.filter(t => this._isSupportedTask(t)));
 			}
 		}
 
@@ -274,14 +277,21 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		if (userUri) {
 			const userJson = await this._readTasksJson(userUri);
 			if (userJson.tasks) {
-				result.push(...userJson.tasks);
+				result.push(...userJson.tasks.filter(t => this._isSupportedTask(t)));
 			}
 		}
 
 		return result;
 	}
 
+	private _isSupportedTask(task: ITaskEntry): boolean {
+		return !!task.type && SessionsConfigurationService._SUPPORTED_TASK_TYPES.has(task.type);
+	}
+
 	private _resolveCommand(task: ITaskEntry): string | undefined {
+		if (task.type === 'npm') {
+			return task.script ? `npm run ${task.script}` : undefined;
+		}
 		if (isWindows && task.windows?.command) {
 			return task.windows.command;
 		}
@@ -321,12 +331,12 @@ export class SessionsConfigurationService extends Disposable implements ISession
 
 		const tasksUri = joinPath(folder, '.vscode', 'tasks.json');
 		const tasksJson = await this._readTasksJson(tasksUri);
-		const sessionTasks = (tasksJson.tasks ?? []).filter(t => t.inSessions);
+		const sessionTasks = (tasksJson.tasks ?? []).filter(t => t.inSessions && this._isSupportedTask(t));
 
 		// Also include user-level session tasks
 		const userUri = joinPath(dirname(this._preferencesService.userSettingsResource), 'tasks.json');
 		const userJson = await this._readTasksJson(userUri);
-		const userSessionTasks = (userJson.tasks ?? []).filter(t => t.inSessions);
+		const userSessionTasks = (userJson.tasks ?? []).filter(t => t.inSessions && this._isSupportedTask(t));
 
 		transaction(tx => this._sessionTasks.set([...sessionTasks, ...userSessionTasks], tx));
 	}

--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -290,7 +290,13 @@ export class SessionsConfigurationService extends Disposable implements ISession
 
 	private _resolveCommand(task: ITaskEntry): string | undefined {
 		if (task.type === 'npm') {
-			return task.script ? `npm run ${task.script}` : undefined;
+			if (!task.script) {
+				return undefined;
+			}
+			if (task.path) {
+				return `npm --prefix ${task.path} run ${task.script}`;
+			}
+			return `npm run ${task.script}`;
 		}
 		if (isWindows && task.windows?.command) {
 			return task.windows.command;

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -30,6 +30,14 @@ function makeTask(label: string, command?: string, inSessions?: boolean): ITaskE
 	return { label, type: 'shell', command: command ?? label, inSessions };
 }
 
+function makeNpmTask(label: string, script: string, inSessions?: boolean): ITaskEntry {
+	return { label, type: 'npm', script, inSessions };
+}
+
+function makeUnsupportedTask(label: string, inSessions?: boolean): ITaskEntry {
+	return { label, type: 'gulp', command: label, inSessions };
+}
+
 function tasksJsonContent(tasks: ITaskEntry[]): string {
 	return JSON.stringify({ version: '2.0.0', tasks });
 }
@@ -128,6 +136,8 @@ suite('SessionsConfigurationService', () => {
 			makeTask('build', 'npm run build', true),
 			makeTask('lint', 'npm run lint', false),
 			makeTask('test', 'npm test', true),
+			makeNpmTask('watch', 'watch', true),
+			makeUnsupportedTask('gulp-task', true),
 		]));
 		// user tasks.json — empty
 		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
@@ -140,7 +150,7 @@ suite('SessionsConfigurationService', () => {
 		await new Promise(r => setTimeout(r, 10));
 		const tasks = obs.get();
 
-		assert.deepStrictEqual(tasks.map(t => t.label), ['build', 'test']);
+		assert.deepStrictEqual(tasks.map(t => t.label), ['build', 'test', 'watch']);
 	});
 
 	test('getSessionTasks returns empty array when no worktree', async () => {
@@ -169,12 +179,14 @@ suite('SessionsConfigurationService', () => {
 
 	// --- getNonSessionTasks ---
 
-	test('getNonSessionTasks returns only tasks without inSessions', async () => {
+	test('getNonSessionTasks returns only tasks without inSessions and with supported types', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('build', 'npm run build', true),
 			makeTask('lint', 'npm run lint', false),
 			makeTask('test', 'npm test'),
+			makeNpmTask('watch', 'watch', false),
+			makeUnsupportedTask('gulp-task', false),
 		]));
 		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
@@ -182,7 +194,7 @@ suite('SessionsConfigurationService', () => {
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
 		const nonSessionTasks = await service.getNonSessionTasks(session);
 
-		assert.deepStrictEqual(nonSessionTasks.map(t => t.label), ['lint', 'test']);
+		assert.deepStrictEqual(nonSessionTasks.map(t => t.label), ['lint', 'test', 'watch']);
 	});
 
 	test('getNonSessionTasks reads from repository when no worktree', async () => {
@@ -303,6 +315,28 @@ suite('SessionsConfigurationService', () => {
 		assert.strictEqual(createdTerminals[0].name, 'build');
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'npm run build');
+	});
+
+	test('runTask resolves npm task to npm run <script>', async () => {
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+		const task = makeNpmTask('watch', 'watch');
+
+		await service.runTask(task, session);
+
+		assert.strictEqual(createdTerminals.length, 1);
+		assert.strictEqual(createdTerminals[0].name, 'watch');
+		assert.strictEqual(sentCommands.length, 1);
+		assert.strictEqual(sentCommands[0].command, 'npm run watch');
+	});
+
+	test('runTask does nothing for npm task without script', async () => {
+		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+		const task: ITaskEntry = { label: 'broken', type: 'npm', inSessions: true };
+
+		await service.runTask(task, session);
+
+		assert.strictEqual(createdTerminals.length, 0);
+		assert.strictEqual(sentCommands.length, 0);
 	});
 
 	test('runTask does nothing when no cwd available', async () => {


### PR DESCRIPTION
```Copilot Generated Description:``` Update the task creation method to return the created task entry, allowing for immediate execution of the task. Filter session tasks to include only supported types, specifically shell and npm tasks. Adjust the command resolution for npm tasks to support script execution.

