### PR TITLE
Enhance message sending functionality in NewChatWidget

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -386,6 +386,11 @@ class NewChatWidget extends Disposable {
 				e.stopPropagation();
 				this._send();
 			}
+			if (e.keyCode === KeyCode.Enter && !e.shiftKey && !e.ctrlKey && e.altKey) {
+				e.preventDefault();
+				e.stopPropagation();
+				this._send(/* openNewAfterSend */ true);
+			}
 		}));
 
 		this._register(this._editor.onDidContentSizeChange(() => {
@@ -776,7 +781,7 @@ class NewChatWidget extends Disposable {
 		this._sendButton.enabled = !this._sending && hasText && !(this._newSession.value?.disabled ?? true);
 	}
 
-	private _send(): void {
+	private _send(openNewAfterSend = false): void {
 		const query = this._editor.getModel()?.getValue().trim();
 		const session = this._newSession.value;
 		if (!query || !session || session.disabled || this._sending) {
@@ -800,6 +805,9 @@ class NewChatWidget extends Disposable {
 			this._newSession.clearAndLeak();
 			this._newSessionListener.clear();
 			this._contextAttachments.clear();
+			if (openNewAfterSend) {
+				this.sessionsManagementService.openNewSessionView();
+			}
 		}, e => {
 			this.logService.error('Failed to send request:', e);
 		}).finally(() => {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -98,6 +98,7 @@ class NewChatWidget extends Disposable {
 	// Send button
 	private _sendButton: Button | undefined;
 	private _sending = false;
+	private _altKeyDown = false;
 
 	// Repository loading
 	private readonly _openRepositoryCts = this._register(new MutableDisposable<CancellationTokenSource>());
@@ -466,7 +467,19 @@ class NewChatWidget extends Disposable {
 			ariaLabel: localize('send', "Send"),
 		}));
 		sendButton.icon = Codicon.send;
-		this._register(sendButton.onDidClick(() => this._send()));
+		this._register(sendButton.onDidClick(() => this._send(this._altKeyDown)));
+		this._register(dom.addDisposableListener(dom.getWindow(container), dom.EventType.KEY_DOWN, e => {
+			if (e.key === 'Alt') {
+				this._altKeyDown = true;
+				sendButton.icon = Codicon.runAbove;
+			}
+		}));
+		this._register(dom.addDisposableListener(dom.getWindow(container), dom.EventType.KEY_UP, e => {
+			if (e.key === 'Alt') {
+				this._altKeyDown = false;
+				sendButton.icon = Codicon.send;
+			}
+		}));
 		this._updateSendButtonState();
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -812,15 +812,13 @@ class NewChatWidget extends Disposable {
 		this._updateInputLoadingState();
 
 		this.sessionsManagementService.sendRequestForNewSession(
-			session.resource
+			session.resource,
+			openNewAfterSend ? { openNewSessionView: true } : undefined
 		).then(() => {
 			// Release ref without disposing - the service owns disposal
 			this._newSession.clearAndLeak();
 			this._newSessionListener.clear();
 			this._contextAttachments.clear();
-			if (openNewAfterSend) {
-				this.sessionsManagementService.openNewSessionView();
-			}
 		}, e => {
 			this.logService.error('Failed to send request:', e);
 		}).finally(() => {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -218,10 +218,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return this._activeSession.get();
 	}
 
-	async openSession(sessionResource: URI, openOptions?: ISessionOpenOptions & { hidden?: boolean }): Promise<void> {
-		if (!openOptions?.hidden) {
-			this.isNewChatSessionContext.set(false);
-		}
+	async openSession(sessionResource: URI, openOptions?: ISessionOpenOptions): Promise<void> {
+		this.isNewChatSessionContext.set(false);
 		const existingSession = this.agentSessionsService.model.getSession(sessionResource);
 		if (existingSession) {
 			await this.openExistingSession(existingSession, openOptions);
@@ -311,7 +309,10 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private async doSendRequestForNewSession(session: INewSession, query: string, sendOptions: IChatSendRequestOptions, selectedOptions?: ReadonlyMap<string, IChatSessionProviderOptionItem>, openNewSessionView?: boolean): Promise<void> {
 		// 1. Open the session - loads the model and shows the ChatViewPane
-		await this.openSession(session.resource, openNewSessionView ? { hidden: true } : undefined);
+		await this.openSession(session.resource);
+		if (openNewSessionView) {
+			this.openNewSessionView();
+		}
 
 		// 2. Apply selected options (repository, branch, etc.) to the contributed session
 		if (selectedOptions && selectedOptions.size > 0) {
@@ -365,12 +366,8 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			listener?.dispose();
 		}
 
-		if (newSession) {
-			if (openNewSessionView) {
-				this.openNewSessionView();
-			} else {
-				this.setActiveSession(newSession);
-			}
+		if (newSession && !openNewSessionView) {
+			this.setActiveSession(newSession);
 		}
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -218,8 +218,10 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return this._activeSession.get();
 	}
 
-	async openSession(sessionResource: URI, openOptions?: ISessionOpenOptions): Promise<void> {
-		this.isNewChatSessionContext.set(false);
+	async openSession(sessionResource: URI, openOptions?: ISessionOpenOptions & { hidden?: boolean }): Promise<void> {
+		if (!openOptions?.hidden) {
+			this.isNewChatSessionContext.set(false);
+		}
 		const existingSession = this.agentSessionsService.model.getSession(sessionResource);
 		if (existingSession) {
 			await this.openExistingSession(existingSession, openOptions);
@@ -309,9 +311,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private async doSendRequestForNewSession(session: INewSession, query: string, sendOptions: IChatSendRequestOptions, selectedOptions?: ReadonlyMap<string, IChatSessionProviderOptionItem>, openNewSessionView?: boolean): Promise<void> {
 		// 1. Open the session - loads the model and shows the ChatViewPane
-		if (!openNewSessionView) {
-			await this.openSession(session.resource);
-		}
+		await this.openSession(session.resource, openNewSessionView ? { hidden: true } : undefined);
 
 		// 2. Apply selected options (repository, branch, etc.) to the contributed session
 		if (selectedOptions && selectedOptions.size > 0) {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -309,7 +309,9 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 
 	private async doSendRequestForNewSession(session: INewSession, query: string, sendOptions: IChatSendRequestOptions, selectedOptions?: ReadonlyMap<string, IChatSessionProviderOptionItem>, openNewSessionView?: boolean): Promise<void> {
 		// 1. Open the session - loads the model and shows the ChatViewPane
-		await this.openSession(session.resource);
+		if (!openNewSessionView) {
+			await this.openSession(session.resource);
+		}
 
 		// 2. Apply selected options (repository, branch, etc.) to the contributed session
 		if (selectedOptions && selectedOptions.size > 0) {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce support for sending messages with the Alt key in NewChatWidget, allowing users to open a new session after sending. Update session management to conditionally open a new session view based on user input. Adjust the send method to accept options for opening a new session view.

