### PR TITLE
Handle pending confirmation as error case in inline chat

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -11,7 +11,7 @@ import { EmbeddedDiffEditorWidget } from '../../../../editor/browser/widget/diff
 import { EmbeddedCodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/embeddedCodeEditorWidget.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { InlineChatController, InlineChatRunOptions } from './inlineChatController.js';
-import { ACTION_ACCEPT_CHANGES, ACTION_ASK_IN_CHAT, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_POSSIBLE, ACTION_START, CTX_INLINE_CHAT_V2_ENABLED, CTX_INLINE_CHAT_V1_ENABLED, CTX_HOVER_MODE, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, InlineChatConfigKeys, CTX_FIX_DIAGNOSTICS_ENABLED } from '../common/inlineChat.js';
+import { ACTION_ACCEPT_CHANGES, ACTION_ASK_IN_CHAT, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_POSSIBLE, ACTION_START, CTX_INLINE_CHAT_V2_ENABLED, CTX_INLINE_CHAT_V1_ENABLED, CTX_HOVER_MODE, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_PENDING_CONFIRMATION, InlineChatConfigKeys, CTX_FIX_DIAGNOSTICS_ENABLED } from '../common/inlineChat.js';
 import { ctxHasEditorModification, ctxHasRequestInProgress } from '../../chat/browser/chatEditing/chatEditingEditorContextKeys.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, IAction2Options, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
@@ -364,7 +364,7 @@ export class UndoAndCloseSessionAction2 extends KeepOrUndoSessionAction {
 			title: localize2('close2', "Close"),
 			f1: true,
 			icon: Codicon.close,
-			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_HOVER_MODE.negate()),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE),
 			keybinding: [{
 				when: ContextKeyExpr.or(
 					ContextKeyExpr.and(EditorContextKeys.focus, ctxHasEditorModification.negate()),
@@ -379,7 +379,8 @@ export class UndoAndCloseSessionAction2 extends KeepOrUndoSessionAction {
 				order: 100,
 				when: ContextKeyExpr.or(
 					CTX_HOVER_MODE.negate(),
-					ContextKeyExpr.and(CTX_HOVER_MODE, ctxHasEditorModification.negate(), ctxHasRequestInProgress.negate())
+					ContextKeyExpr.and(CTX_HOVER_MODE, ctxHasEditorModification.negate(), ctxHasRequestInProgress.negate()),
+					ContextKeyExpr.and(CTX_HOVER_MODE, CTX_INLINE_CHAT_PENDING_CONFIRMATION)
 				)
 			}]
 		});

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
@@ -32,6 +32,7 @@ import { ChatEditingAcceptRejectActionViewItem } from '../../chat/browser/chatEd
 import { CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED } from '../common/inlineChat.js';
 import { StickyScrollController } from '../../../../editor/contrib/stickyScroll/browser/stickyScrollController.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../codeEditor/browser/simpleEditorOptions.js';
 import { PlaceholderTextContribution } from '../../../../editor/contrib/placeholderText/browser/placeholderTextContribution.js';
@@ -369,6 +370,7 @@ export class InlineChatSessionOverlayWidget extends Disposable {
 		private readonly _editorObs: ObservableCodeEditor,
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -434,6 +436,14 @@ export class InlineChatSessionOverlayWidget extends Disposable {
 				};
 			}
 
+			const pendingConfirmation = response.isPendingConfirmation.read(r);
+			if (pendingConfirmation) {
+				return {
+					message: localize('needsApproval', "Sorry, but an expected error happened"),
+					icon: Codicon.error
+				};
+			}
+
 			const lastPart = observableFromEventOpts({ equalsFn: () => false }, response.onDidChange, () => response.response.value)
 				.read(r)
 				.filter(part => part.kind === 'progressMessage' || part.kind === 'toolInvocation')
@@ -460,6 +470,15 @@ export class InlineChatSessionOverlayWidget extends Disposable {
 			}
 		}));
 
+		// Log when pending confirmation changes
+		this._showStore.add(autorun(r => {
+			const response = session.chatModel.lastRequestObs.read(r)?.response;
+			const pending = response?.isPendingConfirmation.read(r);
+			if (pending) {
+				this._logService.info(`[InlineChat] UNEXPECTED approval needed: ${pending.detail ?? 'unknown'}`);
+			}
+		}));
+
 		// Add toolbar
 		this._container.appendChild(this._toolbarNode);
 		this._showStore.add(toDisposable(() => this._toolbarNode.remove()));
@@ -475,7 +494,7 @@ export class InlineChatSessionOverlayWidget extends Disposable {
 			},
 			menuOptions: { renderShortTitle: true },
 			actionViewItemProvider: (action, options) => {
-				const primaryActions = ['inlineChat2.cancel', 'inlineChat2.keep'];
+				const primaryActions = ['inlineChat2.cancel', 'inlineChat2.keep', 'inlineChat2.close'];
 				const labeledActions = primaryActions.concat(['inlineChat2.undo']);
 
 				if (!labeledActions.includes(action.id)) {

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -129,6 +129,7 @@ export const CTX_INLINE_CHAT_CHANGE_SHOWS_DIFF = new RawContextKey<boolean>('inl
 export const CTX_INLINE_CHAT_REQUEST_IN_PROGRESS = new RawContextKey<boolean>('inlineChatRequestInProgress', false, localize('inlineChatRequestInProgress', "Whether an inline chat request is currently in progress"));
 export const CTX_INLINE_CHAT_RESPONSE_TYPE = new RawContextKey<InlineChatResponseType>('inlineChatResponseType', InlineChatResponseType.None, localize('inlineChatResponseTypes', "What type was the responses have been receieved, nothing yet, just messages, or messaged and local edits"));
 export const CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT = new RawContextKey<boolean>('inlineChatFileBelongsToChat', false, localize('inlineChatFileBelongsToChat', "Whether the current file belongs to a chat editing session"));
+export const CTX_INLINE_CHAT_PENDING_CONFIRMATION = new RawContextKey<boolean>('inlineChatPendingConfirmation', false, localize('inlineChatPendingConfirmation', "Whether an inline chat request is pending user confirmation"));
 
 export const CTX_INLINE_CHAT_V1_ENABLED = ContextKeyExpr.or(
 	ContextKeyExpr.and(NOTEBOOK_IS_ACTIVE_EDITOR, CTX_INLINE_CHAT_HAS_NOTEBOOK_INLINE)


### PR DESCRIPTION
part two of https://github.com/microsoft/vscode/issues/297375