### PR TITLE
Add depth shadows for panels in the editor

### DIFF
--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -17,6 +17,10 @@
 	--shadow-button-active: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 	--shadow-active-tab: 0 8px 12px rgba(0, 0, 0, 0.02);
 
+	/* Panel depth shadows cast onto the editor surface */
+	--shadow-depth-x: 5px 0 10px -4px rgba(0, 0, 0, 0.05);
+	--shadow-depth-y: 0 5px 10px -4px rgba(0, 0, 0, 0.04);
+
 	--backdrop-blur-md: blur(20px) saturate(180%);
 	--backdrop-blur-lg: blur(40px) saturate(180%);
 }
@@ -25,16 +29,17 @@
 .monaco-workbench.vs-dark {
 	--backdrop-blur-md: blur(20px) saturate(180%) brightness(0.55);
 	--backdrop-blur-lg: blur(40px) saturate(180%) brightness(0.55);
+
+	--shadow-depth-x: 5px 0 12px -4px rgba(0, 0, 0, 0.14);
+	--shadow-depth-y: 0 5px 12px -4px rgba(0, 0, 0, 0.10);
 }
 
-/* Stealth Shadows - shadow-based depth for UI elements, controlled by workbench.stealthShadows.enabled */
+/* Stealth Shadows - panels appear to float above the editor.
+ * Instead of z-index on panels (which breaks webviews, iframes, sashes),
+ * the editor draws its own "received shadow" via a ::after pseudo-element.
+ * The surrounding panels stay at default stacking — no z-index needed. */
 
-/* Activity Bar */
-.monaco-workbench.vs .part.activitybar {
-	z-index: 50;
-	position: relative;
-}
-
+/* Activity Bar - only needs shadow when sidebar is hidden */
 .monaco-workbench.nosidebar .part.activitybar {
 	box-shadow: var(--shadow-md);
 }
@@ -43,94 +48,55 @@
 	box-shadow: var(--shadow-md);
 }
 
-/* Sidebar */
-.monaco-workbench.vs .part.sidebar {
-	box-shadow: var(--shadow-md);
-	z-index: 40;
-	position: relative;
-}
-
-.monaco-workbench.sidebar-right.vs .part.sidebar {
-	box-shadow: var(--shadow-md);
-}
-
-.monaco-workbench.vs .part.auxiliarybar {
-	box-shadow: var(--shadow-md);
-	z-index: 35;
-	position: relative;
-}
-
-/* Ensure iframe containers in pane-body render above sidebar z-index */
-.monaco-workbench.vs > div[data-keybinding-context] {
-	z-index: 50 !important;
-}
-
-/* Ensure in-editor pane iframes render below sidebar z-index */
-.monaco-workbench.vs > div[data-parent-flow-to-element-id] {
-	z-index: 0 !important;
-}
-
-
-/* Ensure webview containers render above sidebar z-index */
-.monaco-workbench.vs .part.sidebar .webview,
-.monaco-workbench.vs .part.sidebar .webview-container,
-.monaco-workbench.vs .part.auxiliarybar .webview,
-.monaco-workbench.vs .part.auxiliarybar .webview-container {
-	position: relative;
-	z-index: 50;
-	transform: translateZ(0);
-}
-
-/* Panel */
-.monaco-workbench.vs .part.panel {
-	box-shadow: var(--shadow-md);
-	position: relative;
-}
-
-.monaco-workbench.panel-position-left.vs .part.panel {
-	box-shadow: var(--shadow-md);
-}
-
-.monaco-workbench.panel-position-right.vs .part.panel {
-	box-shadow: var(--shadow-md);
-}
-
 .monaco-pane-view .split-view-view:first-of-type > .pane > .pane-header {
 	border-top: 1px solid var(--vscode-sideBarSectionHeader-border) !important;
 }
 
-/* Sashes - ensure they extend full height and are above other panels */
-.monaco-workbench.vs .monaco-sash {
-	z-index: 35;
-}
-
-.monaco-workbench.vs .monaco-sash.vertical {
-	z-index: 40;
-}
-
-.monaco-workbench.vs .monaco-sash.vertical:nth-child(2) {
-	z-index: 45;
-}
-
-.monaco-workbench.vs .monaco-sash.horizontal {
-	z-index: 35;
-}
-
-/* Editor */
+/* Editor - the ::after pseudo-element draws inset shadows on each edge,
+ * creating the illusion that sidebar, panel, and auxiliarybar float above it. */
 .monaco-workbench.vs .part.editor {
 	position: relative;
 }
 
+.monaco-workbench.vs .part.editor::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 10;
+	box-shadow:
+		inset var(--shadow-depth-x),
+		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.04),
+		inset 0 calc(-1 * 5px) 10px -4px rgba(0, 0, 0, 0.05);
+}
+
+/* When sidebar is on the right, flip the stronger shadow to the right edge */
+.monaco-workbench.sidebar-right.vs .part.editor::after {
+	box-shadow:
+		inset 5px 0 10px -4px rgba(0, 0, 0, 0.04),
+		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.05),
+		inset 0 calc(-1 * 5px) 10px -4px rgba(0, 0, 0, 0.05);
+}
+
+/* Panel positions: strengthen the shadow on whichever edge faces the panel */
+.monaco-workbench.panel-position-left.vs .part.editor::after {
+	box-shadow:
+		inset var(--shadow-depth-x),
+		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.04);
+}
+
+.monaco-workbench.panel-position-right.vs .part.editor::after {
+	box-shadow:
+		inset 5px 0 10px -4px rgba(0, 0, 0, 0.04),
+		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.05);
+}
+
 .monaco-workbench.vs .part.editor > .content .editor-group-container > .title {
 	box-shadow: none;
-	position: relative;
-	z-index: 10;
 }
 
 .monaco-workbench.vs .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	box-shadow: inset var(--shadow-active-tab);
-	position: relative;
-	z-index: 5;
 }
 
 .monaco-workbench.vs .part.editor > .content .editor-group-container > .title .tabs-container > .tab:hover:not(.active) {
@@ -635,10 +601,6 @@
 }
 
 /* Notebook */
-
-.monaco-workbench .notebookOverlay.notebook-editor {
-	z-index: 35 !important;
-}
 
 .monaco-workbench .notebookOverlay .monaco-list-row .cell-editor-part:before {
 	box-shadow: inset var(--shadow-sm);

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -91,6 +91,12 @@
 		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.05);
 }
 
+.monaco-workbench.panel-position-top.vs .part.editor::after {
+	box-shadow:
+		inset var(--shadow-depth-x),
+		inset calc(-1 * 5px) 0 10px -4px rgba(0, 0, 0, 0.04),
+		inset 0 var(--shadow-depth-y);
+}
 .monaco-workbench.vs .part.editor > .content .editor-group-container > .title {
 	box-shadow: none;
 }


### PR DESCRIPTION
Enhance UI layering by adding depth shadows for panels in the editor. This change improves the visual hierarchy and makes panels appear to float above the editor surface, whilst removing the z-index manipulation that was causing unintended issues.

Addresses: https://github.com/microsoft/vscode/issues/297640

