### PR TITLE
Improve discoverability of browser open tool

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/clickBrowserTool.ts
@@ -24,7 +24,7 @@ export const ClickBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			selector: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/dragElementTool.ts
@@ -24,7 +24,7 @@ export const DragElementToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			fromSelector: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/handleDialogBrowserTool.ts
@@ -24,7 +24,7 @@ export const HandleDialogBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			accept: {
 				type: 'boolean',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/hoverElementTool.ts
@@ -24,7 +24,7 @@ export const HoverElementToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			selector: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool.ts
@@ -24,7 +24,7 @@ export const NavigateBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID to navigate, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID to navigate, acquired from context or the open tool.`
 			},
 			type: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/readBrowserTool.ts
@@ -26,7 +26,7 @@ export const ReadBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID to read, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID to read, acquired from context or the open tool.`
 			},
 		},
 		required: ['pageId'],

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
@@ -25,7 +25,7 @@ export const RunPlaywrightCodeToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			code: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/screenshotBrowserTool.ts
@@ -25,7 +25,7 @@ export const ScreenshotBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID to capture, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID to capture, acquired from context or the open tool.`
 			},
 			selector: {
 				type: 'string',

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/typeBrowserTool.ts
@@ -24,7 +24,7 @@ export const TypeBrowserToolData: IToolData = {
 		properties: {
 			pageId: {
 				type: 'string',
-				description: `The browser page ID, acquired from context or ${OpenPageToolId}.`
+				description: `The browser page ID, acquired from context or the open tool.`
 			},
 			text: {
 				type: 'string',


### PR DESCRIPTION
Fixes #297723.

The issue is that the tool search tool only returns a limited number of results, and they may not be prioritized as expected. So we shouldn't reference the open tool name in other tools to keep the results clean.