### PR TITLE
fix editor punctuation width

### DIFF
--- a/src/vs/editor/browser/widget/codeEditor/editor.css
+++ b/src/vs/editor/browser/widget/codeEditor/editor.css
@@ -21,6 +21,7 @@
 	position: relative;
 	overflow: visible;
 	-webkit-text-size-adjust: 100%;
+	text-spacing-trim: space-all;
 	color: var(--vscode-editor-foreground);
 	background-color: var(--vscode-editor-background);
 	overflow-wrap: initial;


### PR DESCRIPTION
Close #242138 

This PR adds a simple one-line `text-spacing-trim: space-all;` for `.monaco-editor`.

Investigations showed that the issue was not introduced by an active change in this repository; instead, it might come from an upstream change of default value. So I am not creating a PR for a new setting entry.