### PR TITLE
collapse hidden welcome-tip instead of making it invisible

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chatViewWelcome.css
@@ -22,7 +22,7 @@
 	.chat-welcome-view .chat-welcome-view-message,
 	.chat-welcome-view .chat-welcome-view-disclaimer,
 	.chat-welcome-view .chat-welcome-view-tips {
-		visibility: hidden;
+		display: none;
 	}
 }
 


### PR DESCRIPTION
fixes #297631

<img width="489" height="336" alt="Screenshot 2026-02-25 at 12 59 06 PM" src="https://github.com/user-attachments/assets/9d660e53-ecc9-4e00-95b8-9735539d6976" />
