### PR TITLE
ensure rendering of questions can happen while askQuestions tool call is in flight and chat is moved

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -521,6 +521,12 @@ export class ChatListWidget extends Disposable {
 			return;
 		}
 
+		// Skip refresh when the container is disconnected from the DOM to avoid
+		// caching incorrect measurements (e.g. 0 heights) for tree elements.
+		if (!this._container.isConnected) {
+			return;
+		}
+
 		const items = this._viewModel.getItems();
 		this._lastItem = items.at(-1);
 		this._lastItemIdContextKey.set(this._lastItem ? [this._lastItem.id] : []);
@@ -547,6 +553,9 @@ export class ChatListWidget extends Disposable {
 							// If a response is in the process of progressive rendering, we need to ensure that it will
 							// be re-rendered so progressive rendering is restarted, even if the model wasn't updated.
 							`${isResponseVM(element) && element.renderData ? `_${this._visibleChangeCount}` : ''}` +
+							// Re-render when new content parts are added to the response (e.g. question carousels
+							// arriving after progressive rendering caught up and stopped its timer).
+							(isResponseVM(element) ? `_parts${element.response.value.length}` : '') +
 							// Re-render once content references are loaded
 							(isResponseVM(element) ? `_${element.contentReferences.length}` : '') +
 							// Re-render if element becomes hidden due to undo/redo


### PR DESCRIPTION
fix #297752

When chat moves from editor to panel while a tool call is in-flight, two things go wrong: the old widget measures heights as 0 because it's no longer on screen, and the new widget doesn't notice that new content (like questions) arrived because nothing told the tree it changed. The fix skips the bad measurement and makes the tree aware of new content.

Repro'd every time:
- start `#askQuestions` from welcome view
- move it to the panel before questions get rendered
- 🐛 no questions rendered

https://github.com/user-attachments/assets/7d8922be-23f1-4ac9-82da-485a3eb6b3d8

