### PR TITLE
ensure question carousel renders in chat sessions hover

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -27,88 +27,89 @@
 	container-type: inline-size;
 }
 
-/* container and header */
+/* input part wrapper */
 .interactive-session .interactive-input-part > .chat-question-carousel-widget-container {
 	width: 100%;
 	position: relative;
+}
 
-	.chat-question-carousel-content {
+/* container and header */
+.interactive-session .chat-question-carousel-container .chat-question-carousel-content {
+	display: flex;
+	flex-direction: column;
+	background: var(--vscode-chat-requestBackground);
+	padding: 8px 16px 10px 16px;
+	overflow: hidden;
+
+	.chat-question-header-row {
 		display: flex;
-		flex-direction: column;
-		background: var(--vscode-chat-requestBackground);
-		padding: 8px 16px 10px 16px;
-		overflow: hidden;
+		justify-content: space-between;
+		align-items: center;
+		gap: 8px;
+		min-width: 0;
+		padding-bottom: 5px;
+		margin-left: -16px;
+		margin-right: -16px;
+		padding-left: 16px;
+		padding-right: 16px;
+		border-bottom: 1px solid var(--vscode-chat-requestBorder);
 
-		.chat-question-header-row {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			gap: 8px;
+		.chat-question-title {
+			flex: 1;
 			min-width: 0;
-			padding-bottom: 5px;
-			margin-left: -16px;
-			margin-right: -16px;
-			padding-left: 16px;
-			padding-right: 16px;
-			border-bottom: 1px solid var(--vscode-chat-requestBorder);
+			word-wrap: break-word;
+			overflow-wrap: break-word;
+			font-weight: 500;
+			font-size: var(--vscode-chat-font-size-body-s);
+			margin: 0;
 
-			.chat-question-title {
-				flex: 1;
-				min-width: 0;
-				word-wrap: break-word;
-				overflow-wrap: break-word;
-				font-weight: 500;
-				font-size: var(--vscode-chat-font-size-body-s);
-				margin: 0;
-
-				.rendered-markdown {
-					a {
-						color: var(--vscode-textLink-foreground);
-					}
-
-					a:hover,
-					a:active {
-						color: var(--vscode-textLink-activeForeground);
-					}
-
-					p {
-						margin: 0;
-					}
+			.rendered-markdown {
+				a {
+					color: var(--vscode-textLink-foreground);
 				}
 
-				.chat-question-title-main {
-					font-weight: 500;
+				a:hover,
+				a:active {
+					color: var(--vscode-textLink-activeForeground);
 				}
 
-				.chat-question-title-subtitle {
-					font-weight: normal;
-					color: var(--vscode-descriptionForeground);
+				p {
+					margin: 0;
 				}
 			}
 
-			.chat-question-close-container {
-				flex-shrink: 0;
+			.chat-question-title-main {
+				font-weight: 500;
+			}
 
-				.monaco-button.chat-question-close {
-					min-width: 22px;
-					width: 22px;
-					height: 22px;
-					padding: 0;
-					border: none;
-					background: transparent !important;
-					color: var(--vscode-foreground) !important;
-				}
+			.chat-question-title-subtitle {
+				font-weight: normal;
+				color: var(--vscode-descriptionForeground);
+			}
+		}
 
-				.monaco-button.chat-question-close:hover:not(.disabled) {
-					background: var(--vscode-toolbar-hoverBackground) !important;
-				}
+		.chat-question-close-container {
+			flex-shrink: 0;
+
+			.monaco-button.chat-question-close {
+				min-width: 22px;
+				width: 22px;
+				height: 22px;
+				padding: 0;
+				border: none;
+				background: transparent !important;
+				color: var(--vscode-foreground) !important;
+			}
+
+			.monaco-button.chat-question-close:hover:not(.disabled) {
+				background: var(--vscode-toolbar-hoverBackground) !important;
 			}
 		}
 	}
 }
 
 /* questions list and freeform area */
-.interactive-session .interactive-input-part > .chat-question-carousel-widget-container .chat-question-input-container {
+.interactive-session .chat-question-carousel-container .chat-question-input-container {
 	display: flex;
 	flex-direction: column;
 	margin-top: 4px;
@@ -294,7 +295,7 @@
 }
 
 /* footer with step indicator and nav buttons */
-.interactive-session .interactive-input-part > .chat-question-carousel-widget-container .chat-question-footer-row {
+.interactive-session .chat-question-carousel-container .chat-question-footer-row {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;


### PR DESCRIPTION
fix #297405

The question carousel CSS had its styles scoped to only work when rendered inside the chat input area (.interactive-input-part > .chat-question-carousel-widget-container). When the same carousel renders inline in the chat list — like in the agent session hover — those selectors didn't match, so it appeared unstyled.

The fix widens three selectors to target `.chat-question-carousel-container` instead, so the styles apply wherever the carousel appears. The input-part-specific overrides (custom border/background) remain scoped to the input part.

<img width="845" height="324" alt="Screenshot 2026-02-25 at 2 48 21 PM" src="https://github.com/user-attachments/assets/f4bb0fd8-b863-465e-b189-fb10f07ede74" />
