### PR TITLE
chat: fix plugin hook workspace root resolution and CLAUDE_PLUGIN_ROOT escaping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,7 +98,7 @@
 		"**/*.snap": true,
 	},
 	// --- TypeScript ---
-	"js/ts.experimental.useTsgo": true,
+	"js/ts.experimental.useTsgo": false,
 	"js/ts.tsdk.path": "node_modules/typescript/lib",
 	"js/ts.preferences.importModuleSpecifier": "relative",
 	"js/ts.preferences.quoteStyle": "single",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,7 +98,7 @@
 		"**/*.snap": true,
 	},
 	// --- TypeScript ---
-	"js/ts.experimental.useTsgo": false,
+	"js/ts.experimental.useTsgo": true,
 	"js/ts.tsdk.path": "node_modules/typescript/lib",
 	"js/ts.preferences.importModuleSpecifier": "relative",
 	"js/ts.preferences.quoteStyle": "single",

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -113,7 +113,7 @@ export function shellQuotePluginRootInCommand(command: string, fsPath: string, t
 	const escapedToken = escapeRegExpCharacters(token);
 	const pattern = new RegExp(
 		// Capture an optional leading quote so we know if it's already quoted
-		`(["']?)` + escapedToken + `([^\\s"']*)`,
+		`(["']?)` + escapedToken + `([\\w./\\\\~:-]*)`,
 		'g',
 	);
 
@@ -141,19 +141,36 @@ class ClaudePluginFormatAdapter implements IAgentPluginFormatAdapter {
 	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[] {
 		const token = '${CLAUDE_PLUGIN_ROOT}';
 		const fsPath = pluginUri.fsPath;
-		const typedJson = json as { hooks?: Record<string, { hooks: Mutable<IHookCommand>[]; originalId: string }[]> };
+		const typedJson = json as { hooks?: Record<string, unknown[]> };
+
+		const mutateHookCommand = (hook: Mutable<IHookCommand>): void => {
+			for (const field of ['command', 'windows', 'linux', 'osx'] as const) {
+				if (typeof hook[field] === 'string') {
+					hook[field] = shellQuotePluginRootInCommand(hook[field], fsPath, token);
+				}
+			}
+
+			hook.env ??= {};
+			hook.env.CLAUDE_PLUGIN_ROOT = fsPath;
+		};
 
 		for (const lifecycle of Object.values(typedJson.hooks ?? {})) {
-			for (const { hooks } of lifecycle) {
-				for (const hook of hooks || []) {
-					for (const field of ['command', 'windows', 'linux', 'osx'] as const) {
-						if (typeof hook[field] === 'string') {
-							hook[field] = shellQuotePluginRootInCommand(hook[field], fsPath, token);
-						}
-					}
+			if (!Array.isArray(lifecycle)) {
+				continue;
+			}
 
-					hook.env ??= {};
-					hook.env.CLAUDE_PLUGIN_ROOT = fsPath;
+			for (const lifecycleEntry of lifecycle) {
+				if (!lifecycleEntry || typeof lifecycleEntry !== 'object') {
+					continue;
+				}
+
+				const entry = lifecycleEntry as { hooks?: Mutable<IHookCommand>[] } & Mutable<IHookCommand>;
+				if (Array.isArray(entry.hooks)) {
+					for (const hook of entry.hooks) {
+						mutateHookCommand(hook);
+					}
+				} else {
+					mutateHookCommand(entry);
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -30,9 +30,12 @@ import { ChatConfiguration } from '../constants.js';
 import { parseCopilotHooks } from '../promptSyntax/hookCompatibility.js';
 import { parseClaudeHooks } from '../promptSyntax/hookClaudeCompat.js';
 import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginCommand, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from './agentPluginService.js';
-import { cloneAndChange } from '../../../../../base/common/objects.js';
+import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
 import { IPluginInstallService } from './pluginInstallService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
+import { Mutable } from '../../../../../base/common/types.js';
+import { IHookCommand } from '../promptSyntax/hookSchema.js';
+import { cloneAndChange } from '../../../../../base/common/objects.js';
 
 const COMMAND_FILE_SUFFIX = '.md';
 
@@ -53,34 +56,123 @@ function mapParsedHooks(parsed: Map<IAgentPluginHook['type'], { hooks: IAgentPlu
 	return [...parsed.entries()].map(([type, { hooks, originalId }]) => ({ type, hooks, originalId }));
 }
 
-const copilotPluginFormatAdapter: IAgentPluginFormatAdapter = {
-	format: AgentPluginFormat.Copilot,
-	manifestPaths: ['plugin.json'],
-	hookConfigPaths: ['hooks.json'],
-	hookWatchPaths: ['hooks.json'],
-	parseHooks: (json, pluginUri, userHome) => mapParsedHooks(parseCopilotHooks(json, pluginUri, userHome)),
-};
+/**
+ * Resolves the workspace folder that contains the plugin URI for cwd resolution,
+ * falling back to the first workspace folder for plugins outside the workspace.
+ */
+function resolveWorkspaceRoot(pluginUri: URI, workspaceContextService: IWorkspaceContextService): URI | undefined {
+	const defaultFolder = workspaceContextService.getWorkspace().folders[0];
+	const folder = workspaceContextService.getWorkspaceFolder(pluginUri) ?? defaultFolder;
+	return folder?.uri;
+}
 
-const claudePluginFormatAdapter: IAgentPluginFormatAdapter = {
-	format: AgentPluginFormat.Claude,
-	manifestPaths: ['.claude-plugin/plugin.json'],
-	hookConfigPaths: ['hooks/hooks.json'],
-	hookWatchPaths: ['hooks'],
-	parseHooks: (json, pluginUri, userHome) => {
+class CopilotPluginFormatAdapter implements IAgentPluginFormatAdapter {
+	readonly format = AgentPluginFormat.Copilot;
+	readonly manifestPaths = ['plugin.json'];
+	readonly hookConfigPaths = ['hooks.json'];
+	readonly hookWatchPaths = ['hooks.json'];
+
+	constructor(
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[] {
+		const workspaceRoot = resolveWorkspaceRoot(pluginUri, this._workspaceContextService);
+		return mapParsedHooks(parseCopilotHooks(json, workspaceRoot, userHome));
+	}
+}
+
+/**
+ * Characters in a file path that require shell quoting to prevent
+ * word splitting or interpretation by common shells (bash, zsh, cmd, PowerShell).
+ */
+const shellUnsafeChars = /[\s&|<>()^;!`"']/;
+
+/**
+ * Replaces `${CLAUDE_PLUGIN_ROOT}` in a shell command string with the
+ * given fsPath. If the path contains characters that would break shell
+ * parsing (e.g. spaces), occurrences are wrapped in double-quotes.
+ *
+ * The token may be followed by additional path segments like
+ * `${CLAUDE_PLUGIN_ROOT}/scripts/run.sh`; the entire resulting path
+ * (including suffix) is quoted as one unit.
+ *
+ */
+export function shellQuotePluginRootInCommand(command: string, fsPath: string, token: string = '${CLAUDE_PLUGIN_ROOT}'): string {
+	if (!command.includes(token)) {
+		return command;
+	}
+
+	if (!shellUnsafeChars.test(fsPath)) {
+		// Path is shell-safe; plain replacement is fine.
+		return command.replaceAll(token, fsPath);
+	}
+
+	// Replace each token occurrence (plus any trailing path chars that form
+	// a single filesystem argument) with a properly double-quoted expansion.
+	const escapedToken = escapeRegExpCharacters(token);
+	const pattern = new RegExp(
+		// Capture an optional leading quote so we know if it's already quoted
+		`(["']?)` + escapedToken + `([^\\s"']*)`,
+		'g',
+	);
+
+	return command.replace(pattern, (_match, leadingQuote: string, suffix: string) => {
+		const fullPath = fsPath + suffix;
+		if (leadingQuote) {
+			// Already inside quotes — don't add more, just expand.
+			return leadingQuote + fullPath;
+		}
+		// Wrap in double quotes, escaping any embedded double-quote chars.
+		return '"' + fullPath.replace(/"/g, '\\"') + '"';
+	});
+}
+
+class ClaudePluginFormatAdapter implements IAgentPluginFormatAdapter {
+	readonly format = AgentPluginFormat.Claude;
+	readonly manifestPaths = ['.claude-plugin/plugin.json'];
+	readonly hookConfigPaths = ['hooks/hooks.json'];
+	readonly hookWatchPaths = ['hooks'];
+
+	constructor(
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+	) { }
+
+	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[] {
+		const token = '${CLAUDE_PLUGIN_ROOT}';
+		const fsPath = pluginUri.fsPath;
+		const typedJson = json as { hooks?: Record<string, { hooks: Mutable<IHookCommand>[]; originalId: string }[]> };
+
+		for (const lifecycle of Object.values(typedJson.hooks ?? {})) {
+			for (const { hooks } of lifecycle) {
+				for (const hook of hooks || []) {
+					for (const field of ['command', 'windows', 'linux', 'osx'] as const) {
+						if (typeof hook[field] === 'string') {
+							hook[field] = shellQuotePluginRootInCommand(hook[field], fsPath, token);
+						}
+					}
+
+					hook.env ??= {};
+					hook.env.CLAUDE_PLUGIN_ROOT = fsPath;
+				}
+			}
+		}
+
 		const replacer = (v: unknown): unknown => {
 			return typeof v === 'string'
 				? v.replaceAll('${CLAUDE_PLUGIN_ROOT}', pluginUri.fsPath)
 				: undefined;
 		};
 
-		const { hooks, disabledAllHooks } = parseClaudeHooks(cloneAndChange(json, replacer), pluginUri, userHome);
+		const workspaceRoot = resolveWorkspaceRoot(pluginUri, this._workspaceContextService);
+		const { hooks, disabledAllHooks } = parseClaudeHooks(cloneAndChange(json, replacer), workspaceRoot, userHome);
 		if (disabledAllHooks) {
 			return [];
 		}
 
 		return mapParsedHooks(hooks);
-	},
-};
+	}
+}
 
 export class AgentPluginService extends Disposable implements IAgentPluginService {
 
@@ -164,6 +256,7 @@ export class ConfiguredAgentPluginDiscovery extends Disposable implements IAgent
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IPathService private readonly _pathService: IPathService,
 		@ILogService private readonly _logService: ILogService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 		this._pluginPathsConfig = observableConfigValue<Record<string, boolean>>(ChatConfiguration.PluginPaths, {}, _configurationService);
@@ -303,10 +396,10 @@ export class ConfiguredAgentPluginDiscovery extends Disposable implements IAgent
 	private async _detectPluginFormatAdapter(pluginUri: URI): Promise<IAgentPluginFormatAdapter> {
 		const isInClaudeDirectory = pluginUri.path.split('/').includes('.claude');
 		if (isInClaudeDirectory || await this._pathExists(joinPath(pluginUri, '.claude-plugin', 'plugin.json'))) {
-			return claudePluginFormatAdapter;
+			return this._instantiationService.createInstance(ClaudePluginFormatAdapter);
 		}
 
-		return copilotPluginFormatAdapter;
+		return this._instantiationService.createInstance(CopilotPluginFormatAdapter);
 	}
 
 	private async _pathExists(resource: URI): Promise<boolean> {
@@ -521,7 +614,11 @@ export class ConfiguredAgentPluginDiscovery extends Disposable implements IAgent
 		for (const hooksUri of adapter.hookConfigPaths.map(path => joinPath(pluginUri, path))) {
 			const json = await this._readJsonFile(hooksUri);
 			if (json) {
-				return adapter.parseHooks(json, pluginUri, userHome);
+				try {
+					return adapter.parseHooks(json, pluginUri, userHome);
+				} catch (e) {
+					this._logService.info(`[ConfiguredAgentPluginDiscovery] Failed to parse hooks from ${hooksUri.toString()}:`, e);
+				}
 			}
 		}
 
@@ -530,7 +627,11 @@ export class ConfiguredAgentPluginDiscovery extends Disposable implements IAgent
 			if (manifest && typeof manifest === 'object') {
 				const hooks = (manifest as Record<string, unknown>)['hooks'];
 				if (hooks && typeof hooks === 'object') {
-					return adapter.parseHooks({ hooks }, pluginUri, userHome);
+					try {
+						return adapter.parseHooks({ hooks }, pluginUri, userHome);
+					} catch (e) {
+						this._logService.info(`[ConfiguredAgentPluginDiscovery] Failed to parse hooks from manifest ${manifestPath.toString()}:`, e);
+					}
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/chat/test/common/plugins/shellQuotePluginRootInCommand.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/shellQuotePluginRootInCommand.test.ts
@@ -82,6 +82,13 @@ suite('shellQuotePluginRootInCommand', () => {
 		);
 	});
 
+	test('does not consume shell operators adjacent to token', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('cd ${PLUGIN_ROOT}&& echo ok', '/my dir', TOKEN),
+			'cd "/my dir"&& echo ok',
+		);
+	});
+
 	test('handles token at start, middle and end of command', () => {
 		assert.strictEqual(
 			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/a ${PLUGIN_ROOT}/b ${PLUGIN_ROOT}/c', '/sp ace', TOKEN),

--- a/src/vs/workbench/contrib/chat/test/common/plugins/shellQuotePluginRootInCommand.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/shellQuotePluginRootInCommand.test.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { shellQuotePluginRootInCommand } from '../../../common/plugins/agentPluginServiceImpl.js';
+
+suite('shellQuotePluginRootInCommand', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const TOKEN = '${PLUGIN_ROOT}';
+
+	test('returns command unchanged when token is not present', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('echo hello', '/safe/path', TOKEN),
+			'echo hello',
+		);
+	});
+
+	test('plain replacement when path has no special characters', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/run.sh', '/safe/path', TOKEN),
+			'/safe/path/run.sh',
+		);
+	});
+
+	test('plain replacement for multiple occurrences with safe path', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/a && ${PLUGIN_ROOT}/b', '/safe', TOKEN),
+			'/safe/a && /safe/b',
+		);
+	});
+
+	test('quotes path with spaces', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/run.sh', '/path with spaces', TOKEN),
+			'"/path with spaces/run.sh"',
+		);
+	});
+
+	test('quotes path with ampersand', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/run.sh', '/path&dir', TOKEN),
+			'"/path&dir/run.sh"',
+		);
+	});
+
+	test('quotes multiple occurrences with unsafe path', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/a && ${PLUGIN_ROOT}/b', '/my dir', TOKEN),
+			'"/my dir/a" && "/my dir/b"',
+		);
+	});
+
+	test('does not double-quote when already in double quotes', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('"${PLUGIN_ROOT}/run.sh"', '/my dir', TOKEN),
+			'"/my dir/run.sh"',
+		);
+	});
+
+	test('does not double-quote when already in single quotes', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand(`'\${PLUGIN_ROOT}/run.sh'`, '/my dir', TOKEN),
+			`'/my dir/run.sh'`,
+		);
+	});
+
+	test('escapes embedded double-quote characters in path', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/run.sh', '/path"with"quotes', TOKEN),
+			'"/path\\"with\\"quotes/run.sh"',
+		);
+	});
+
+	test('handles token without trailing path suffix', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('cd ${PLUGIN_ROOT} && run', '/my dir', TOKEN),
+			'cd "/my dir" && run',
+		);
+	});
+
+	test('handles token at start, middle and end of command', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/a ${PLUGIN_ROOT}/b ${PLUGIN_ROOT}/c', '/sp ace', TOKEN),
+			'"/sp ace/a" "/sp ace/b" "/sp ace/c"',
+		);
+	});
+
+	test('uses default CLAUDE_PLUGIN_ROOT token when not specified', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${CLAUDE_PLUGIN_ROOT}/run.sh', '/safe/path'),
+			'/safe/path/run.sh',
+		);
+	});
+
+	test('uses default CLAUDE_PLUGIN_ROOT token with quoting', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${CLAUDE_PLUGIN_ROOT}/run.sh', '/my dir'),
+			'"/my dir/run.sh"',
+		);
+	});
+
+	test('handles Windows-style paths with spaces', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}\\scripts\\run.bat', 'C:\\Program Files\\plugin', TOKEN),
+			'"C:\\Program Files\\plugin\\scripts\\run.bat"',
+		);
+	});
+
+	test('handles path with parentheses', () => {
+		assert.strictEqual(
+			shellQuotePluginRootInCommand('${PLUGIN_ROOT}/run.sh', '/path(1)', TOKEN),
+			'"/path(1)/run.sh"',
+		);
+	});
+});


### PR DESCRIPTION
Refactors agent plugin format adapters to use dependency injection and
correctly resolve workspace root URIs for hook cwd resolution, matching
the pattern from PromptsService. Also uses IInstantiationService for
creating adapter instances instead of manual construction.

- Converts CopilotPluginFormatAdapter and ClaudePluginFormatAdapter from
  const objects to proper classes with @IWorkspaceContextService injection
- Adds resolveWorkspaceRoot helper that mirrors PromptsService logic to
  resolve the workspace folder containing the plugin, falling back to the
  first workspace folder for plugins outside the workspace
- Fixes workspace root passed to parseCopilotHooks and parseClaudeHooks
  (was incorrectly passing pluginUri instead of the workspace folder URI)
- Updates _detectPluginFormatAdapter to use _instantiationService
  .createInstance instead of manual constructor calls

(Commit message generated by Copilot)