### PR TITLE
Debug panel fixes

### DIFF
--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -197,13 +197,14 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 				};
 			}
 			default: {
-				// Final fallback: treat as generic
 				const generic = event as vscode.ChatDebugGenericEvent;
+				const rawName = generic.name;
+				const rawDetails = generic.details;
 				return {
 					...base,
 					kind: 'generic',
-					name: generic.name ?? '',
-					details: generic.details,
+					name: typeof rawName === 'string' ? rawName : '',
+					details: typeof rawDetails === 'string' ? rawDetails : undefined,
 					level: generic.level ?? 1,
 					category: generic.category,
 				};

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventList.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventList.ts
@@ -12,6 +12,14 @@ import { safeIntl } from '../../../../../base/common/date.js';
 
 const $ = DOM.$;
 
+/** Coerce a value to a string, returning a fallback for null/undefined/non-strings. */
+function safeStr(value: string | undefined | null, fallback: string = ''): string {
+	if (value === null || value === undefined || typeof value !== 'string') {
+		return fallback;
+	}
+	return value;
+}
+
 const dateFormatter = safeIntl.DateTimeFormat(undefined, {
 	month: 'short',
 	day: 'numeric',
@@ -32,30 +40,30 @@ function renderEventToTemplate(element: IChatDebugEvent, templateData: IChatDebu
 
 	switch (element.kind) {
 		case 'toolCall':
-			templateData.name.textContent = element.toolName;
-			templateData.details.textContent = element.result ?? '';
+			templateData.name.textContent = safeStr(element.toolName, localize('chatDebug.unknownEvent', "(unknown)"));
+			templateData.details.textContent = safeStr(element.result);
 			break;
 		case 'modelTurn':
-			templateData.name.textContent = element.model ?? localize('chatDebug.modelTurn', "Model Turn");
+			templateData.name.textContent = safeStr(element.model) || localize('chatDebug.modelTurn', "Model Turn");
 			templateData.details.textContent = element.totalTokens !== undefined
 				? localize('chatDebug.tokens', "{0} tokens", element.totalTokens)
 				: '';
 			break;
 		case 'generic':
-			templateData.name.textContent = element.name;
-			templateData.details.textContent = element.details ?? '';
+			templateData.name.textContent = safeStr(element.name, localize('chatDebug.unknownEvent', "(unknown)"));
+			templateData.details.textContent = safeStr(element.details);
 			break;
 		case 'subagentInvocation':
-			templateData.name.textContent = element.agentName;
-			templateData.details.textContent = element.description ?? (element.status ?? '');
+			templateData.name.textContent = safeStr(element.agentName, localize('chatDebug.unknownEvent', "(unknown)"));
+			templateData.details.textContent = safeStr(element.description) || safeStr(element.status);
 			break;
 		case 'userMessage':
 			templateData.name.textContent = localize('chatDebug.userMessage', "User Message");
-			templateData.details.textContent = element.message;
+			templateData.details.textContent = safeStr(element.message);
 			break;
 		case 'agentResponse':
 			templateData.name.textContent = localize('chatDebug.agentResponse', "Agent Response");
-			templateData.details.textContent = element.message;
+			templateData.details.textContent = safeStr(element.message);
 			break;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -98,7 +98,11 @@ export class ChatDebugHomeView extends Disposable {
 				DOM.append(item, $(`span${ThemeIcon.asCSSSelector(Codicon.comment)}`));
 
 				const titleSpan = DOM.append(item, $('span.chat-debug-home-session-item-title'));
-				const isShimmering = isUUID(sessionTitle);
+				// Only show shimmer when the title is a UUID AND the model is not
+				// yet loaded. A live session with no requests yet has an empty title but its model exists — show a
+				// placeholder instead of an indefinite spinner.
+				const hasLiveModel = !!this.chatService.getSession(sessionResource);
+				const isShimmering = isUUID(sessionTitle) && !hasLiveModel;
 				if (isShimmering) {
 					titleSpan.classList.add('chat-debug-home-session-item-shimmer');
 					item.disabled = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/6905, https://github.com/microsoft/vscode-internalbacklog/issues/6862


**Fix 1: [object Object] in debug panel** 
extHostChatDebug.ts — typeof checks in the default fallback of _serializeEvent() to drop non-string name/details
chatDebugEventList.ts — safeStr() helper that returns '' for non-strings, with '(unknown)' fallback for name fields

**Fix 2: Indefinite spinner for new sessions on home page**
chatDebugHomeView.ts — Only show shimmer when the title is a UUID and no live model exists, not for new sessions that simply have no requests yet