### PR TITLE
Align chat context and code block pill spacing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatCodeBlockPill.css
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 .interactive-item-container.interactive-response .value .chat-markdown-part.rendered-markdown .code:has(.chat-codeblock-pill-container) {
-	margin-bottom: 8px;
+	margin-bottom: 16px;
 }
 
 .chat-markdown-part.rendered-markdown .code .chat-codeblock-pill-container {
 	display: flex;
 	align-items: center;
 	gap: 5px;
-	margin: 0 0 6px 0px;
 	font-size: var(--vscode-chat-font-size-body-s);
 	color: var(--vscode-descriptionForeground);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -282,7 +282,7 @@
 }
 
 .interactive-item-container > .value .chat-used-context {
-	margin-bottom: 10px;
+	margin-bottom: 16px;
 }
 
 .interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -285,6 +285,10 @@
 	margin-bottom: 16px;
 }
 
+.interactive-item-container > .value .chat-used-context .chat-used-context-list {
+	margin-bottom: 0;
+}
+
 .interactive-item-container .value .rendered-markdown:not(:has(.chat-extensions-content-part)) {
 	.codicon {
 		font-size: inherit;


### PR DESCRIPTION
This updates chat response spacing to improve visual consistency between used-context metadata and code blocks that render the code block pill. The previous mixed margins created uneven vertical rhythm in responses.

### What changed
- Increased bottom margin for used-context content in `chat.css` from `10px` to `16px`.
- Increased bottom margin for code blocks containing a code-block pill from `8px` to `16px`.
- Removed the extra bottom margin from `.chat-codeblock-pill-container` so spacing is controlled by the parent code block rule.