### PR TITLE
Update Copilot usage widget when overages are enabled 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatUsageWidget.ts
@@ -68,12 +68,12 @@ export class ChatUsageWidget extends Disposable {
 
 			// Premium requests
 			if (premiumChatQuota) {
-				this.renderQuotaItem(this.usageSection, localize('plan.premiumRequests', 'Premium requests'), premiumChatQuota);
+				const premiumLabel = premiumChatQuota.overageEnabled ? localize('plan.includedPremiumRequests', 'Included premium requests') : localize('plan.premiumRequests', 'Premium requests');
+				this.renderQuotaItem(this.usageSection, premiumLabel, premiumChatQuota, premiumChatQuota.overageEnabled);
 
-				// Additional overage message
-				if (premiumChatQuota.overageEnabled) {
+				if (premiumChatQuota.overageEnabled && !premiumChatQuota.unlimited) {
 					const overageMessage = DOM.append(this.usageSection, $('.overage-message'));
-					overageMessage.textContent = localize('plan.additionalPaidEnabled', 'Additional paid premium requests enabled.');
+					overageMessage.textContent = localize('plan.overageApproved', 'Additional premium requests approved after 100%.');
 				}
 			}
 
@@ -89,7 +89,7 @@ export class ChatUsageWidget extends Disposable {
 		this._onDidChangeContentHeight.fire(height);
 	}
 
-	private renderQuotaItem(container: HTMLElement, label: string, quota: IQuotaSnapshot): void {
+	private renderQuotaItem(container: HTMLElement, label: string, quota: IQuotaSnapshot, overageEnabled: boolean = false): void {
 		const quotaItem = DOM.append(container, $('.quota-item'));
 
 		const quotaItemHeader = DOM.append(quotaItem, $('.quota-item-header'));
@@ -109,10 +109,10 @@ export class ChatUsageWidget extends Disposable {
 		const percentageUsed = this.getQuotaPercentageUsed(quota);
 		progressBar.style.width = percentageUsed + '%';
 
-		// Apply warning/error classes based on usage
-		if (percentageUsed >= 90) {
+		// Apply warning/error classes based on usage (don't show error/warning if overage is enabled)
+		if (percentageUsed >= 90 && !overageEnabled) {
 			quotaItem.classList.add('error');
-		} else if (percentageUsed >= 75) {
+		} else if (percentageUsed >= 75 && !overageEnabled) {
 			quotaItem.classList.add('warning');
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatUsageWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatUsageWidget.ts
@@ -73,7 +73,9 @@ export class ChatUsageWidget extends Disposable {
 
 				if (premiumChatQuota.overageEnabled && !premiumChatQuota.unlimited) {
 					const overageMessage = DOM.append(this.usageSection, $('.overage-message'));
-					overageMessage.textContent = localize('plan.overageApproved', 'Additional premium requests approved after 100%.');
+					overageMessage.append(localize('plan.overageApprovedLine1', "Additional premium requests approved."));
+					DOM.append(overageMessage, $('br'));
+					overageMessage.append(localize('plan.overageApprovedLine2', "You can continue after included premium requests limit reaches 100%."));
 				}
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -179,7 +179,8 @@ export class ChatStatusDashboard extends DomWidget {
 
 			const completionsQuotaIndicator = completionsQuota && (completionsQuota.total > 0 || completionsQuota.unlimited) ? this.createQuotaIndicator(this.element, this._store, completionsQuota, localize('completionsLabel', "Inline Suggestions"), false) : undefined;
 			const chatQuotaIndicator = chatQuota && (chatQuota.total > 0 || chatQuota.unlimited) ? this.createQuotaIndicator(this.element, this._store, chatQuota, localize('chatsLabel', "Chat messages"), false) : undefined;
-			const premiumChatQuotaIndicator = premiumChatQuota && (premiumChatQuota.total > 0 || premiumChatQuota.unlimited) ? this.createQuotaIndicator(this.element, this._store, premiumChatQuota, localize('premiumChatsLabel', "Premium requests"), true) : undefined;
+			const premiumChatLabel = premiumChatQuota?.overageEnabled && !premiumChatQuota?.unlimited ? localize('includedPremiumChatsLabel', "Included premium requests") : localize('premiumChatsLabel', "Premium requests");
+			const premiumChatQuotaIndicator = premiumChatQuota && (premiumChatQuota.total > 0 || premiumChatQuota.unlimited) ? this.createQuotaIndicator(this.element, this._store, premiumChatQuota, premiumChatLabel, true) : undefined;
 
 			if (resetDate) {
 				this.element.appendChild($('div.description', undefined, localize('limitQuota', "Allowance resets {0}.", resetDateHasTime ? this.dateTimeFormatter.value.format(new Date(resetDate)) : this.dateFormatter.value.format(new Date(resetDate)))));
@@ -528,15 +529,18 @@ export class ChatStatusDashboard extends DomWidget {
 
 			quotaBit.style.width = `${usedPercentage}%`;
 
-			if (usedPercentage >= 90) {
+			const overageEnabled = supportsOverage && typeof quota !== 'string' && quota?.overageEnabled;
+			if (usedPercentage >= 90 && !overageEnabled) {
 				quotaIndicator.classList.add('error');
-			} else if (usedPercentage >= 75) {
+			} else if (usedPercentage >= 75 && !overageEnabled) {
 				quotaIndicator.classList.add('warning');
 			}
 
 			if (supportsOverage) {
-				if (typeof quota !== 'string' && quota?.overageEnabled) {
-					overageLabel.textContent = localize('additionalUsageEnabled', "Additional paid premium requests enabled.");
+				if (typeof quota !== 'string' && quota.unlimited) {
+					overageLabel.textContent = '';
+				} else if (typeof quota !== 'string' && quota?.overageEnabled) {
+					overageLabel.textContent = localize('additionalUsageApproved', "Additional premium requests approved after 100%.");
 				} else {
 					overageLabel.textContent = localize('additionalUsageDisabled', "Additional paid premium requests disabled.");
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -540,7 +540,11 @@ export class ChatStatusDashboard extends DomWidget {
 				if (typeof quota !== 'string' && quota.unlimited) {
 					overageLabel.textContent = '';
 				} else if (typeof quota !== 'string' && quota?.overageEnabled) {
-					overageLabel.textContent = localize('additionalUsageApproved', "Additional premium requests approved after 100%.");
+					overageLabel.replaceChildren(
+						localize('additionalUsageApprovedLine1', "Additional premium requests approved."),
+						$('br'),
+						localize('additionalUsageApprovedLine2', "You can continue after the included premium requests limit reaches 100%.")
+					);
 				} else {
 					overageLabel.textContent = localize('additionalUsageDisabled', "Additional paid premium requests disabled.");
 				}


### PR DESCRIPTION
UI for when overages are disabled. 
<img width="408" height="608" alt="image" src="https://github.com/user-attachments/assets/28acc732-b3a5-4d15-8492-d01360601374" />

Overages enabled (usage bar stays blue with updated text below to encourage continued usage) 

<img width="573" height="698" alt="image" src="https://github.com/user-attachments/assets/aced2da9-acbe-4491-b00b-b424b07d2dba" />

