### PR TITLE
mcp: add error handling to mcpStdioStateHandler test

### DIFF
--- a/src/vs/workbench/contrib/mcp/test/node/mcpStdioStateHandler.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/node/mcpStdioStateHandler.test.ts
@@ -26,7 +26,7 @@ suite('McpStdioStateHandler', () => {
 			processId: new Promise<number>((resolve) => {
 				child.on('spawn', () => resolve(child.pid!));
 			}),
-			output: new Promise<string>((resolve) => {
+			output: new Promise<string>((resolve, reject) => {
 				let output = '';
 				child.stderr.setEncoding('utf-8').on('data', (data) => {
 					output += data.toString();
@@ -34,6 +34,7 @@ suite('McpStdioStateHandler', () => {
 				child.stdout.setEncoding('utf-8').on('data', (data) => {
 					output += data.toString();
 				});
+				child.on('error', reject);
 				child.on('close', () => resolve(output));
 			}),
 		};


### PR DESCRIPTION
Adds proper error handling to the output promise in the mcpStdioStateHandler test by:

- Adding reject parameter to the Promise constructor
- Forwarding child process errors as promise rejections

This ensures that child process errors are properly handled and prevents potential unhandled rejection warnings.

Fixes https://github.com/microsoft/vscode/issues/297237

(Commit message generated by Copilot)