### PR TITLE
Browser: trim() selected text before checking if it has newlines in showFind method

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -717,7 +717,7 @@ export class BrowserEditor extends EditorPane {
 	 */
 	async showFind(): Promise<void> {
 		// Get selected text from the browser view to pre-populate the search box.
-		const selectedText = await this._model?.getSelectedText()?.trim();
+		const selectedText = (await this._model?.getSelectedText())?.trim();
 
 		// Only use the selected text if it doesn't contain newlines (single line selection)
 		const textToReveal = selectedText && !/[\r\n]/.test(selectedText) ? selectedText : undefined;

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -717,7 +717,7 @@ export class BrowserEditor extends EditorPane {
 	 */
 	async showFind(): Promise<void> {
 		// Get selected text from the browser view to pre-populate the search box.
-		const selectedText = await this._model?.getSelectedText();
+		const selectedText = await this._model?.getSelectedText()?.trim();
 
 		// Only use the selected text if it doesn't contain newlines (single line selection)
 		const textToReveal = selectedText && !/[\r\n]/.test(selectedText) ? selectedText : undefined;


### PR DESCRIPTION
- Fixes https://github.com/microsoft/vscode/issues/297803
- Fixes https://github.com/microsoft/vscode/issues/291378#issuecomment-3954672491