### PR TITLE
Reduce agent session title row gap

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -139,7 +139,7 @@
 
 		.agent-session-title-row {
 			line-height: 17px;
-			padding-bottom: 6px;
+			padding-bottom: 4px;
 		}
 
 		.agent-session-details-row {


### PR DESCRIPTION
This adjusts spacing in the Agent Sessions list so the title row has a tighter separation from the details row, matching the requested visual balance without changing overall row height.

### What changed
- Reduced `.agent-session-title-row` bottom padding from `6px` to `4px` in `agentsessionsviewer.css`.
- Kept list item height at `54px`, preserving the existing vertical footprint and surrounding layout behavior.

### Notes
- The merge-base diff against `main` contains only this single CSS tweak.
- No welcome-view layout changes are included in this PR.