### PR TITLE
Move status entry to the right and make it more subtle

### DIFF
--- a/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateStatusBarEntry.css
@@ -3,6 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.monaco-workbench .part.statusbar > .items-container > #status\.update > a > span {
+	color: var(--vscode-button-background);
+	font-size: 16px;
+}
+
 .update-status-tooltip {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateStatusBarEntry.ts
@@ -77,7 +77,6 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 			return;
 		}
 
-		const productIcon = this.productService.quality === 'insider' ? '$(vscode-insiders)' : '$(vscode)';
 		switch (state.type) {
 			case StateType.Uninitialized:
 			case StateType.Idle:
@@ -97,9 +96,8 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 
 			case StateType.AvailableForDownload:
 				this.updateStatusBarEntry({
-					kind: 'prominent',
 					name: UpdateStatusBarEntryContribution.NAME,
-					text: nls.localize('updateStatus.updateAvailableStatus', "{0} Update available, click to download.", productIcon),
+					text: nls.localize('updateStatus.updateAvailableStatus', "$(circle-filled) Update available, click to download."),
 					ariaLabel: nls.localize('updateStatus.updateAvailableAria', "Update available, click to download."),
 					tooltip: this.getAvailableTooltip(state.update),
 					command: 'update.downloadNow'
@@ -118,9 +116,8 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 
 			case StateType.Downloaded:
 				this.updateStatusBarEntry({
-					kind: 'prominent',
 					name: UpdateStatusBarEntryContribution.NAME,
-					text: nls.localize('updateStatus.updateReadyStatus', "{0} Update downloaded, click to install.", productIcon),
+					text: nls.localize('updateStatus.updateReadyStatus', "$(circle-filled) Update downloaded, click to install."),
 					ariaLabel: nls.localize('updateStatus.updateReadyAria', "Update downloaded, click to install."),
 					tooltip: this.getReadyToInstallTooltip(state.update),
 					command: 'update.install'
@@ -140,9 +137,8 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 			case StateType.Ready: {
 
 				this.updateStatusBarEntry({
-					kind: 'prominent',
 					name: UpdateStatusBarEntryContribution.NAME,
-					text: nls.localize('updateStatus.restartToUpdateStatus', "{0} Update is ready, click to restart.", productIcon),
+					text: nls.localize('updateStatus.restartToUpdateStatus', "$(circle-filled) Update is ready, click to restart."),
 					ariaLabel: nls.localize('updateStatus.restartToUpdateAria', "Update is ready, click to restart."),
 					tooltip: this.getRestartToUpdateTooltip(state.update),
 					command: 'update.restart'
@@ -170,10 +166,7 @@ export class UpdateStatusBarEntryContribution extends Disposable implements IWor
 				entry,
 				'status.update',
 				StatusbarAlignment.LEFT,
-				{
-					location: { id: 'status.host', priority: Number.MAX_VALUE },
-					alignment: StatusbarAlignment.LEFT
-				}
+				-Number.MAX_VALUE
 			);
 		}
 	}


### PR DESCRIPTION
Fixes #295925

**Changes**
Moved status bar item back to its original position on the right of the left side.
Replaced prominent background with a filled circle.

**Notes**
This is based on feedback so far.
This entry will likely be replaced by a title bar affordance in March.
