### PR TITLE
Add property `skipIntegratedBrowserOpener` to `OpenExternalOptions`

### DIFF
--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -44,6 +44,7 @@ export type OpenExternalOptions = {
 	readonly allowContributedOpeners?: boolean | string;
 	readonly fromWorkspace?: boolean;
 	readonly skipValidation?: boolean;
+	readonly skipIntegratedBrowser?: boolean;
 };
 
 export type OpenOptions = OpenInternalOptions & OpenExternalOptions;

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -42,9 +42,9 @@ export type OpenExternalOptions = {
 	readonly openExternal?: boolean;
 	readonly allowTunneling?: boolean;
 	readonly allowContributedOpeners?: boolean | string;
+	readonly skipIntegratedBrowserOpener?: boolean;
 	readonly fromWorkspace?: boolean;
 	readonly skipValidation?: boolean;
-	readonly skipIntegratedBrowser?: boolean;
 };
 
 export type OpenOptions = OpenInternalOptions & OpenExternalOptions;

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -117,7 +117,11 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 		this._register(openerService.registerOpener(this));
 	}
 
-	async open(resource: URI | string, _options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+	async open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+		if ((options as OpenExternalOptions | undefined)?.skipIntegratedBrowser) {
+			return false;
+		}
+
 		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -118,7 +118,7 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 	}
 
 	async open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
-		if ((options as OpenExternalOptions | undefined)?.skipIntegratedBrowser) {
+		if ((options as OpenExternalOptions | undefined)?.skipIntegratedBrowserOpener) {
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -338,7 +338,7 @@ class OpenInExternalBrowserAction extends Action2 {
 			const url = browserEditor.getUrl();
 			if (url) {
 				const openerService = accessor.get(IOpenerService);
-				await openerService.open(url, { openExternal: true, skipIntegratedBrowser: true });
+				await openerService.open(url, { openExternal: true, skipIntegratedBrowserOpener: true });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -338,7 +338,7 @@ class OpenInExternalBrowserAction extends Action2 {
 			const url = browserEditor.getUrl();
 			if (url) {
 				const openerService = accessor.get(IOpenerService);
-				await openerService.open(url, { openExternal: true });
+				await openerService.open(url, { openExternal: true, skipIntegratedBrowser: true });
 			}
 		}
 	}


### PR DESCRIPTION
Blocklist approach, by default it allows Integrated Browser to handle links if applicable and settings like Open Localhost Links say so, but you can set `skipIntegratedBrowser: false` to prevent Internal Browser from opening the link.