### PR TITLE
Add property `allowIntegratedBrowserOpener` to `OpenExternalOptions`

### DIFF
--- a/src/vs/platform/markdown/browser/markdownRenderer.ts
+++ b/src/vs/platform/markdown/browser/markdownRenderer.ts
@@ -91,6 +91,7 @@ export async function openLinkFromMarkdown(openerService: IOpenerService, link: 
 		return await openerService.open(link, {
 			fromUserGesture: true,
 			allowContributedOpeners: true,
+			allowIntegratedBrowserOpener: true,
 			allowCommands: toAllowCommandsOption(isTrusted),
 			skipValidation
 		});

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -42,6 +42,7 @@ export type OpenExternalOptions = {
 	readonly openExternal?: boolean;
 	readonly allowTunneling?: boolean;
 	readonly allowContributedOpeners?: boolean | string;
+	readonly allowIntegratedBrowserOpener?: boolean;
 	readonly fromWorkspace?: boolean;
 	readonly skipValidation?: boolean;
 };

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -117,7 +117,11 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 		this._register(openerService.registerOpener(this));
 	}
 
-	async open(resource: URI | string, _options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+	async open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+		if (!(options as OpenExternalOptions | undefined)?.allowIntegratedBrowserOpener) {
+			return false;
+		}
+
 		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -308,6 +308,7 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		this._openerService.open(link.text, {
 			allowTunneling: this._isRemote && this._configurationService.getValue('remote.forwardOnOpen'),
 			allowContributedOpeners: true,
+			allowIntegratedBrowserOpener: true,
 			openExternal: true
 		});
 	}
@@ -348,6 +349,7 @@ export class TerminalUrlLinkOpener implements ITerminalLinkOpener {
 		this._openerService.open(link.text, {
 			allowTunneling: this._isRemote && this._configurationService.getValue('remote.forwardOnOpen'),
 			allowContributedOpeners: true,
+			allowIntegratedBrowserOpener: true,
 			openExternal: true
 		});
 	}


### PR DESCRIPTION
Allowlist approach, by default it blocks Integrated Browser from handling links, unless explicitly allowed.

In this PR, we only allow Integrated Browser for links in Terminal and Chat Markdown