### PR TITLE
Fix Integrated Browser Localhost Opener triggering in too many cases

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -117,7 +117,11 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 		this._register(openerService.registerOpener(this));
 	}
 
-	async open(resource: URI | string, _options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+	async open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+		if (!(options as OpenExternalOptions | undefined)?.allowContributedOpeners) {
+			return false;
+		}
+
 		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
 			return false;
 		}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -21,12 +21,13 @@ import { Schemas } from '../../../../base/common/network.js';
 import { IBrowserViewWorkbenchService } from '../common/browserView.js';
 import { BrowserViewWorkbenchService } from './browserViewWorkbenchService.js';
 import { BrowserViewStorageScope } from '../../../../platform/browserView/common/browserView.js';
-import { IOpenerService, IOpener, OpenInternalOptions, OpenExternalOptions } from '../../../../platform/opener/common/opener.js';
+import { IExternalOpener, IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { isLocalhostAuthority } from '../../../../platform/url/common/trustedDomains.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { PolicyCategory } from '../../../../base/common/policy.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { logBrowserOpen } from '../../../../platform/browserView/common/browserViewTelemetry.js';
@@ -103,7 +104,7 @@ registerWorkbenchContribution2(BrowserEditorResolverContribution.ID, BrowserEdit
 /**
  * Opens localhost URLs in the Integrated Browser when the setting is enabled.
  */
-class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchContribution, IOpener {
+class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchContribution, IExternalOpener {
 	static readonly ID = 'workbench.contrib.localhostLinkOpener';
 
 	constructor(
@@ -114,21 +115,16 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 	) {
 		super();
 
-		this._register(openerService.registerOpener(this));
+		this._register(openerService.registerExternalOpener(this));
 	}
 
-	async open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
-		if (!(options as OpenExternalOptions | undefined)?.allowContributedOpeners) {
-			return false;
-		}
-
+	async openExternal(href: string, _ctx: { sourceUri: URI; preferredOpenerId?: string }, _token: CancellationToken): Promise<boolean> {
 		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
 			return false;
 		}
 
-		const url = typeof resource === 'string' ? resource : resource.toString(true);
 		try {
-			const parsed = new URL(url);
+			const parsed = new URL(href);
 			if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
 				return false;
 			}
@@ -141,7 +137,7 @@ class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchCo
 
 		logBrowserOpen(this.telemetryService, 'localhostLinkOpener');
 
-		const browserUri = BrowserViewUri.forUrl(url);
+		const browserUri = BrowserViewUri.forUrl(href);
 		await this.editorService.openEditor({ resource: browserUri, options: { pinned: true } });
 		return true;
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -338,7 +338,7 @@ class OpenInExternalBrowserAction extends Action2 {
 			const url = browserEditor.getUrl();
 			if (url) {
 				const openerService = accessor.get(IOpenerService);
-				await openerService.open(url, { openExternal: true });
+				await openerService.open(url, { openExternal: true, allowContributedOpeners: false });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -341,7 +341,7 @@ class OpenInExternalBrowserAction extends Action2 {
 				await openerService.open(url, {
 					// ensures that VS Code itself doesn't try to open the URL, even for non-"http(s):" scheme URLs.
 					openExternal: true,
-					// ensures that the link isn't opened in Integrated Browser or other contributed external openers.
+					// ensures that the link isn't opened in Integrated Browser or other contributed external openers. False it the default but just being explicit here.
 					allowContributedOpeners: false
 				});
 			}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -341,7 +341,7 @@ class OpenInExternalBrowserAction extends Action2 {
 				await openerService.open(url, {
 					// ensures that VS Code itself doesn't try to open the URL, even for non-"http(s):" scheme URLs.
 					openExternal: true,
-					// ensures that the link isn't opened in Integrated Browser or other contributed external openers. False it the default but just being explicit here.
+					// ensures that the link isn't opened in Integrated Browser or other contributed external openers. False is the default, but just being explicit here.
 					allowContributedOpeners: false
 				});
 			}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -338,9 +338,12 @@ class OpenInExternalBrowserAction extends Action2 {
 			const url = browserEditor.getUrl();
 			if (url) {
 				const openerService = accessor.get(IOpenerService);
-				// `openExternal: true` ensures that VS Code itself doesn't try to open the URL, even for non-"http(s):" scheme URLs.
-				// `allowContributedOpeners: false` (implicit default) ensures that the link isn't opened in Integrated Browser or other contributed external openers.
-				await openerService.open(url, { openExternal: true });
+				await openerService.open(url, {
+					// ensures that VS Code itself doesn't try to open the URL, even for non-"http(s):" scheme URLs.
+					openExternal: true,
+					// ensures that the link isn't opened in Integrated Browser or other contributed external openers.
+					allowContributedOpeners: false
+				});
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -338,7 +338,9 @@ class OpenInExternalBrowserAction extends Action2 {
 			const url = browserEditor.getUrl();
 			if (url) {
 				const openerService = accessor.get(IOpenerService);
-				await openerService.open(url, { openExternal: true, allowContributedOpeners: false });
+				// `openExternal: true` ensures that VS Code itself doesn't try to open the URL, even for non-"http(s):" scheme URLs.
+				// `allowContributedOpeners: false` (implicit default) ensures that the link isn't opened in Integrated Browser or other contributed external openers.
+				await openerService.open(url, { openExternal: true });
 			}
 		}
 	}


### PR DESCRIPTION
* Fixes #293015

Turn the Localhost Opener into an external opener, which implicitly is gated by the `allowContributedOpeners` flag