### PR TITLE
fix: set 'u' query parameter to 'none' if internalOrg is not provided

### DIFF
--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -30,9 +30,7 @@ export function createUpdateURL(baseUpdateUrl: string, platform: string, quality
 		url.searchParams.set('bg', 'true');
 	}
 
-	if (options?.internalOrg) {
-		url.searchParams.set('org', options.internalOrg);
-	}
+	url.searchParams.set('u', options?.internalOrg ?? 'none');
 
 	return url.toString();
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
