### PR TITLE
Add border radius to debug view title for improved aesthetics

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -57,6 +57,7 @@
 	line-height: inherit;
 	padding-top: 0;
 	padding-bottom: 0;
+	border-radius: 0 var(--vscode-cornerRadius-small) var(--vscode-cornerRadius-small) 0;
 
 	/* The debug view title is crowded, let this one get narrower than others */
 	min-width: 90px;


### PR DESCRIPTION
Enhance the visual appeal of the debug view title by adding a border radius. This change improves the overall aesthetics of the interface. Testing can be done by reviewing the debug view in the application to observe the updated styling.

