### PR TITLE
Update @vscode/codicons to version 0.0.45-11 and add 'new-session' icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-10",
+        "@vscode/codicons": "^0.0.45-11",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -3059,9 +3059,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-10",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-10.tgz",
-      "integrity": "sha512-05CYIpwSYKEQN0qBnfmLC/5VcasOwmeLsl3SGj944UyJ1/vJQpqL153A+0xh4geYEeqcOtIc42emmCizsCzf0Q==",
+      "version": "0.0.45-11",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-11.tgz",
+      "integrity": "sha512-fLjx4i7pfSYJJzzmQ6tZnshWWSLYUfg8Ru6xNRBWRSFj8yZkuuXEZGMxju4mt/tuu8Y/gjhEGmIVmVC16fg+yQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-10",
+    "@vscode/codicons": "^0.0.45-11",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-10",
+        "@vscode/codicons": "^0.0.45-11",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-10",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-10.tgz",
-      "integrity": "sha512-05CYIpwSYKEQN0qBnfmLC/5VcasOwmeLsl3SGj944UyJ1/vJQpqL153A+0xh4geYEeqcOtIc42emmCizsCzf0Q==",
+      "version": "0.0.45-11",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-11.tgz",
+      "integrity": "sha512-fLjx4i7pfSYJJzzmQ6tZnshWWSLYUfg8Ru6xNRBWRSFj8yZkuuXEZGMxju4mt/tuu8Y/gjhEGmIVmVC16fg+yQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-10",
+    "@vscode/codicons": "^0.0.45-11",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -655,4 +655,5 @@ export const codiconsLibrary = {
 	openai: register('openai', 0xec81),
 	claude: register('claude', 0xec82),
 	openInWindow: register('open-in-window', 0xec83),
+	newSession: register('new-session', 0xec84),
 } as const;


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.45-11 and introduce a new 'new-session' icon for enhanced functionality. Testing can be done by verifying the availability of the new icon in the codicons library.

