### PR TITLE
rm duplicate `askQuestions` tool from picker, use correct name in prompt validator

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptValidator.ts
@@ -901,7 +901,7 @@ export const knownClaudeTools = [
 	{ name: 'Skill', description: localize('claude.skill', 'Execute skills'), toolEquivalent: [] },
 	{ name: 'LSP', description: localize('claude.lsp', 'Code intelligence (requires plugin)'), toolEquivalent: [] },
 	{ name: 'NotebookEdit', description: localize('claude.notebookEdit', 'Modify Jupyter notebooks'), toolEquivalent: ['edit/editNotebook'] },
-	{ name: 'AskUserQuestion', description: localize('claude.askUserQuestion', 'Ask multiple-choice questions'), toolEquivalent: ['vscode/askQuestions'] },
+	{ name: 'AskUserQuestion', description: localize('claude.askUserQuestion', 'Ask multiple-choice questions'), toolEquivalent: ['agent/askQuestions'] },
 	{ name: 'MCPSearch', description: localize('claude.mcpSearch', 'Searches for MCP tools when tool search is enabled'), toolEquivalent: [] }
 ];
 

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
@@ -145,7 +145,8 @@ export function createAskQuestionsToolData(): IToolData {
 	return {
 		id: AskQuestionsToolId,
 		toolReferenceName: 'askQuestions',
-		canBeReferencedInPrompt: true,
+		legacyToolReferenceFullNames: [AskQuestionsToolId, 'vscode/askQuestions'],
+		canBeReferencedInPrompt: false,
 		icon: ThemeIcon.fromId(Codicon.question.id),
 		displayName: localize('tool.askQuestions.displayName', 'Ask Clarifying Questions'),
 		userDescription: localize('tool.askQuestions.userDescription', 'Ask structured clarifying questions using single select, multi-select, or freeform inputs to collect task requirements before proceeding.'),


### PR DESCRIPTION
fix #297978
fix https://github.com/microsoft/vscode/issues/288961

<img width="649" height="295" alt="Screenshot 2026-02-26 at 12 12 15 PM" src="https://github.com/user-attachments/assets/24832f96-59d0-443d-90d3-9e657b4d89bc" />
