### PR TITLE
Align tool invocation spacing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -616,7 +616,7 @@
 	}
 
 	&:not(:last-child) {
-		margin-bottom: 12px;
+		margin-bottom: 16px;
 	}
 }
 


### PR DESCRIPTION
- align tool invocation item spacing by increasing the non-last child margin from 12px to 16px in chat tool invocation content
- keeps spacing consistent with adjacent confirmation-style items