### PR TITLE
improve chat terminal progress part

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -57,8 +57,35 @@ import { PANEL_BACKGROUND } from '../../../../../../common/theme.js';
 import { editorBackground } from '../../../../../../../platform/theme/common/colorRegistry.js';
 import { IThemeService } from '../../../../../../../platform/theme/common/themeService.js';
 
+/**
+ * Minimum number of rows to display in the terminal output view.
+ */
 const MIN_OUTPUT_ROWS = 1;
+
+/**
+ * Maximum number of rows to display in the terminal output view before scrolling.
+ */
 const MAX_OUTPUT_ROWS = 10;
+
+/**
+ * Maximum number of characters to display in the command title before truncating.
+ */
+const MAX_COMMAND_TITLE_LENGTH = 50;
+
+/**
+ * Maximum number of retries when waiting for terminal output to appear.
+ */
+const MAX_OUTPUT_POLL_RETRIES = 10;
+
+/**
+ * Delay between retries when polling for terminal output (in milliseconds).
+ */
+const OUTPUT_POLL_DELAY_MS = 100;
+
+/**
+ * Minimum number of data events that indicate real output (vs shell integration sequences).
+ */
+const MIN_DATA_EVENTS_FOR_REAL_OUTPUT = 2;
 
 /**
  * Remembers whether a tool invocation was last expanded so state survives virtualization re-renders.
@@ -196,6 +223,25 @@ class TerminalCommandDecoration extends Disposable {
 	}
 }
 
+/**
+ * A chat content part that displays terminal tool invocation progress.
+ *
+ * This component shows:
+ * - The command being executed with syntax highlighting
+ * - A status decoration indicating success/failure/running state
+ * - Expandable terminal output with live streaming support
+ * - Actions to focus the terminal, show/hide output, and continue in background
+ *
+ * The component supports two rendering modes:
+ * - Standard mode: Shows full progress with status indicators
+ * - Collapsible wrapper mode: For thinking containers with simplified UI
+ *
+ * Output auto-expansion behavior:
+ * - Long-running commands with output auto-expand after a short delay
+ * - Fast commands that complete quickly don't auto-expand (prevents flickering)
+ * - Failed commands can be configured to auto-expand via settings
+ * - Successful commands auto-collapse if output was auto-expanded
+ */
 export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart implements IChatTerminalToolProgressPart {
 	public readonly domNode: HTMLElement;
 
@@ -393,9 +439,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 
 	private _createCollapsibleWrapper(contentElement: HTMLElement, commandText: string, toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, context: IChatContentPartRenderContext): HTMLElement {
 		// truncate header when it's too long
-		const maxCommandLength = 50;
-		const truncatedCommand = commandText.length > maxCommandLength
-			? commandText.substring(0, maxCommandLength) + '...'
+		const truncatedCommand = commandText.length > MAX_COMMAND_TITLE_LENGTH
+			? commandText.substring(0, MAX_COMMAND_TITLE_LENGTH) + '...'
 			: commandText;
 
 		const isComplete = IChatToolInvocation.isComplete(toolInvocation);
@@ -597,6 +642,27 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 		this._decoration.update();
 	}
 
+	/**
+	 * Determines whether the terminal output should auto-expand.
+	 * Returns false if already expanded, user has manually toggled, component is disposed,
+	 * or if the invocation was previously expanded (to preserve state across re-renders).
+	 */
+	private _shouldAutoExpand(): boolean {
+		return !this._outputView.isExpanded &&
+			!this._userToggledOutput &&
+			!this._store.isDisposed &&
+			!expandedStateByInvocation.get(this.toolInvocation);
+	}
+
+	/**
+	 * Registers event listeners on the terminal instance to track command execution,
+	 * manage auto-expansion of output, and handle command completion.
+	 *
+	 * This method sets up:
+	 * - Command detection listeners for tracking command lifecycle
+	 * - Auto-expand logic based on command output and duration
+	 * - Instance disposal handling to clean up actions and state
+	 */
 	private _registerInstanceListener(terminalInstance: ITerminalInstance): void {
 		const commandDetectionListener = this._register(new MutableDisposable<IDisposable>());
 		const tryResolveCommand = async (): Promise<ITerminalCommand | undefined> => {
@@ -637,14 +703,14 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				// hasn't moved past the marker (e.g., progress bars updating on same line)
 				// Shell integration sequences fire a couple times per command (PromptStart, CommandStart,
 				// CommandExecuted), so we need a small threshold to filter those out
-				return receivedDataCount > 2;
+				return receivedDataCount > MIN_DATA_EVENTS_FOR_REAL_OUTPUT;
 			};
 
 			// Use the extracted auto-expand logic
 			const autoExpand = store.add(new TerminalToolAutoExpand({
 				commandDetection,
 				onWillData: terminalInstance.onWillData,
-				shouldAutoExpand: () => !this._outputView.isExpanded && !this._userToggledOutput && !this._store.isDisposed && !expandedStateByInvocation.get(this.toolInvocation),
+				shouldAutoExpand: () => this._shouldAutoExpand(),
 				hasRealOutput,
 			}));
 			store.add(autoExpand.onDidRequestExpand(() => {
@@ -667,18 +733,8 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 				this._addActions(terminalInstance, this._terminalData.terminalToolSessionId);
 				const resolvedCommand = this._getResolvedCommand(terminalInstance);
 
-				// update title
-				this.markCollapsibleWrapperComplete();
+				this._handleCommandCompletion(resolvedCommand);
 
-				// Auto-collapse on success
-				if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput) {
-					this._toggleOutput(false);
-				}
-				// keep outer wrapper expanded on error
-				const autoExpandFailures = this._configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures);
-				if (autoExpandFailures && resolvedCommand?.exitCode !== undefined && resolvedCommand.exitCode !== 0 && this._thinkingCollapsibleWrapper) {
-					this.expandCollapsibleWrapper();
-				}
 				if (resolvedCommand?.endMarker) {
 					commandDetectionListener.clear();
 				}
@@ -688,17 +744,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			const resolvedImmediately = await tryResolveCommand();
 			if (resolvedImmediately?.endMarker) {
 				commandDetectionListener.clear();
-				// update title
-				this.markCollapsibleWrapperComplete();
-				// Auto-collapse on success
-				if (resolvedImmediately.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput) {
-					this._toggleOutput(false);
-				}
-				// keep outer wrapper expanded on error
-				const autoExpandFailures = this._configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures);
-				if (autoExpandFailures && resolvedImmediately.exitCode !== undefined && resolvedImmediately.exitCode !== 0 && this._thinkingCollapsibleWrapper) {
-					this.expandCollapsibleWrapper();
-				}
+				this._handleCommandCompletion(resolvedImmediately);
 				return;
 			}
 		};
@@ -751,6 +797,29 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 			}
 		}
 		this._continueInBackgroundAction.clear();
+	}
+
+	/**
+	 * Handles the completion of a terminal command by updating the UI state.
+	 * This includes marking the collapsible wrapper as complete, auto-collapsing
+	 * successful commands, and keeping failed commands expanded.
+	 *
+	 * @param resolvedCommand The completed terminal command with exit code information.
+	 */
+	private _handleCommandCompletion(resolvedCommand: ITerminalCommand | undefined): void {
+		// Update title to show completion state
+		this.markCollapsibleWrapperComplete();
+
+		// Auto-collapse on success (exit code 0)
+		if (resolvedCommand?.exitCode === 0 && this._outputView.isExpanded && !this._userToggledOutput) {
+			this._toggleOutput(false);
+		}
+
+		// Keep outer wrapper expanded on error for visibility
+		const autoExpandFailures = this._configurationService.getValue<boolean>(ChatConfiguration.AutoExpandToolFailures);
+		if (autoExpandFailures && resolvedCommand?.exitCode !== undefined && resolvedCommand.exitCode !== 0 && this._thinkingCollapsibleWrapper) {
+			this.expandCollapsibleWrapper();
+		}
 	}
 
 	private async _toggleOutput(expanded: boolean): Promise<boolean> {
@@ -877,6 +946,21 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	}
 }
 
+/**
+ * A component that displays terminal command output in an expandable/collapsible section.
+ *
+ * This component supports two modes of displaying output:
+ * - **Live output**: Mirrors the output from a running terminal instance in real-time,
+ *   supporting streaming updates, scroll-lock behavior, and user input forwarding.
+ * - **Snapshot output**: Displays a static snapshot of previously captured terminal output,
+ *   useful for serialized/restored chat sessions.
+ *
+ * Features:
+ * - Automatic height calculation based on line count (min/max row limits)
+ * - Scroll-lock behavior: stays at bottom during streaming, respects user scroll position
+ * - Accessibility: proper ARIA labels and accessible view support
+ * - Theme-aware background color that adapts to panel vs editor context
+ */
 class ChatTerminalToolOutputSection extends Disposable {
 	public readonly domNode: HTMLElement;
 
@@ -1130,9 +1214,8 @@ class ChatTerminalToolOutputSection extends Disposable {
 		// 1. Command is running but executedMarker isn't set yet (renderCommand returns undefined)
 		// 2. Command finished quickly but buffer isn't ready yet
 		if (!hasOutput) {
-			const maxRetries = 10;
-			for (let retry = 0; retry < maxRetries && !hasOutput; retry++) {
-				await timeout(100);
+			for (let retry = 0; retry < MAX_OUTPUT_POLL_RETRIES && !hasOutput; retry++) {
+				await timeout(OUTPUT_POLL_DELAY_MS);
 				if (this._store.isDisposed) {
 					return true;
 				}


### PR DESCRIPTION
while verifying someone's issue was fixed for endgame, made this PR

- Extracted magic numbers to documented constants (MAX_COMMAND_TITLE_LENGTH, MAX_OUTPUT_POLL_RETRIES, OUTPUT_POLL_DELAY_MS, MIN_DATA_EVENTS_FOR_REAL_OUTPUT)
- Added `_handleCommandCompletion()` method to deduplicate command completion logic (auto-collapse on success, expand on error)
- Added `_shouldAutoExpand()` helper method for cleaner condition checking
- Added JSDoc documentation to ChatTerminalToolProgressPart and ChatTerminalToolOutputSection classes
- Added JSDoc to key methods explaining their purpose