### PR TITLE
Include ready remote extension hosts in immediate activation

### DIFF
--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -1024,9 +1024,13 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		let managers: IExtensionHostManager[];
 		if (activationKind === ActivationKind.Immediate) {
 			// For immediate activation, only activate on local extension hosts
-			// and defer remote activation until the remote host is ready
+			// and on remote extension hosts that are already ready.
+			// Defer activation for remote hosts that are not yet ready to avoid
+			// blocking (e.g. during remote authority resolution).
 			managers = this._extensionHostManagers.filter(
-				extHostManager => extHostManager.kind === ExtensionHostKind.LocalProcess || extHostManager.kind === ExtensionHostKind.LocalWebWorker
+				extHostManager => extHostManager.kind === ExtensionHostKind.LocalProcess
+					|| extHostManager.kind === ExtensionHostKind.LocalWebWorker
+					|| extHostManager.isReady
 			);
 			this._pendingRemoteActivationEvents.add(activationEvent);
 		} else {

--- a/src/vs/workbench/services/extensions/common/extensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManager.ts
@@ -71,6 +71,7 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 	private readonly _customers: IDisposable[];
 	private readonly _extensionHost: IExtensionHost;
 	private _proxy: Promise<IExtensionHostProxy | null> | null;
+	private _hasStarted: boolean = false;
 
 	public get pid(): number | null {
 		return this._extensionHost.pid;
@@ -152,6 +153,7 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 			}
 		);
 		this._proxy.then(() => {
+			this._hasStarted = true;
 			initialActivationEvents.forEach((activationEvent) => this.activateByEvent(activationEvent, ActivationKind.Normal));
 			this._register(registerLatencyTestProvider({
 				measure: () => this.measure()
@@ -194,6 +196,10 @@ export class ExtensionHostManager extends Disposable implements IExtensionHostMa
 			down,
 			up
 		};
+	}
+
+	public get isReady(): boolean {
+		return this._hasStarted;
 	}
 
 	public async ready(): Promise<void> {

--- a/src/vs/workbench/services/extensions/common/extensionHostManagers.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostManagers.ts
@@ -22,6 +22,7 @@ export interface IExtensionHostManager {
 	readonly onDidChangeResponsiveState: Event<ResponsiveState>;
 	disconnect(): Promise<void>;
 	dispose(): void;
+	readonly isReady: boolean;
 	ready(): Promise<void>;
 	representsRunningLocation(runningLocation: ExtensionRunningLocation): boolean;
 	deltaExtensions(extensionsDelta: IExtensionDescriptionDelta): Promise<void>;

--- a/src/vs/workbench/services/extensions/common/lazyCreateExtensionHostManager.ts
+++ b/src/vs/workbench/services/extensions/common/lazyCreateExtensionHostManager.ts
@@ -90,6 +90,10 @@ export class LazyCreateExtensionHostManager extends Disposable implements IExten
 		return actual;
 	}
 
+	public get isReady(): boolean {
+		return this._startCalled.isOpen() && (this._actual?.isReady ?? false);
+	}
+
 	public async ready(): Promise<void> {
 		await this._startCalled.wait();
 		if (this._actual) {


### PR DESCRIPTION
Fixes #297019

When `activateByEvent` is called with `ActivationKind.Immediate`, remote extension hosts were unconditionally excluded to avoid blocking during remote authority resolution. This caused extensions that only run on the remote host (e.g. microsoft-authentication in web Codespaces) to never get activated within the 5-second timeout window.

Add a synchronous `isReady` property to `IExtensionHostManager` so that `_activateByEvent` can include remote hosts that are already connected while still deferring those that aren't. Not-ready remote hosts continue to be replayed via `_pendingRemoteActivationEvents` after initialization.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
