### PR TITLE
Shared approval for URLs in `openBrowserPage`, `navigatePage`, and `fetch` tools

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
@@ -68,8 +68,8 @@ class BrowserChatAgentToolsContribution extends Disposable implements IWorkbench
 		}));
 
 		// Register URL-based confirmation contributions for open and navigate tools.
-		// This enables shared origin approvals: approving a call to open_browser_page
-		// also auto-approves navigate_page calls to the same origin, and vice versa.
+		// This confirmation will be stored in settings and shared with other tools that
+		// register ChatUrlFetchingConfirmationContribution, such as the `fetch` tool.
 		this._register(confirmationService.registerConfirmationContribution(
 			OpenBrowserToolData.id,
 			instantiationService.createInstance(

--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/browserTools.contribution.ts
@@ -12,6 +12,8 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { registerWorkbenchContribution2, WorkbenchPhase, type IWorkbenchContribution } from '../../../../common/contributions.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IChatContextService } from '../../../chat/browser/contextContrib/chatContextService.js';
+import { ChatUrlFetchingConfirmationContribution } from '../../../chat/common/tools/builtinTools/chatUrlFetchingConfirmation.js';
+import { ILanguageModelToolsConfirmationService } from '../../../chat/common/tools/languageModelToolsConfirmationService.js';
 import { ILanguageModelToolsService, ToolDataSource, ToolSet } from '../../../chat/common/tools/languageModelToolsService.js';
 import { BrowserEditorInput } from '../browserEditorInput.js';
 import { ClickBrowserTool, ClickBrowserToolData } from './clickBrowserTool.js';
@@ -43,6 +45,7 @@ class BrowserChatAgentToolsContribution extends Disposable implements IWorkbench
 		@IPlaywrightService private readonly playwrightService: IPlaywrightService,
 		@IChatContextService private readonly chatContextService: IChatContextService,
 		@IEditorService private readonly editorService: IEditorService,
+		@ILanguageModelToolsConfirmationService confirmationService: ILanguageModelToolsConfirmationService,
 	) {
 		super();
 
@@ -63,6 +66,30 @@ class BrowserChatAgentToolsContribution extends Disposable implements IWorkbench
 				this._updateToolRegistrations();
 			}
 		}));
+
+		// Register URL-based confirmation contributions for open and navigate tools.
+		// This enables shared origin approvals: approving a call to open_browser_page
+		// also auto-approves navigate_page calls to the same origin, and vice versa.
+		this._register(confirmationService.registerConfirmationContribution(
+			OpenBrowserToolData.id,
+			instantiationService.createInstance(
+				ChatUrlFetchingConfirmationContribution,
+				(params: unknown) => {
+					const url = (params as { url?: string }).url;
+					return url ? [url] : undefined;
+				}
+			)
+		));
+		this._register(confirmationService.registerConfirmationContribution(
+			NavigateBrowserToolData.id,
+			instantiationService.createInstance(
+				ChatUrlFetchingConfirmationContribution,
+				(params: unknown) => {
+					const p = params as { type?: string; url?: string };
+					return (!p.type || p.type === 'url') && p.url ? [p.url] : undefined;
+				}
+			)
+		));
 	}
 
 	private _updateToolRegistrations(): void {


### PR DESCRIPTION
* Closes https://github.com/microsoft/vscode/issues/298034

Validation:
* Prompt `Open wikipedia.org and navigate to the English wikipedia page`
* Dialog:
  <img width="485" height="223" alt="image" src="https://github.com/user-attachments/assets/49a467e8-4fae-4a1c-8545-2d2fc013f1cc" />
* Select "Allow Requsts to en.wikipedia.org"
* Now your VS Code settings will have the entry:
  ```
    "chat.tools.urls.autoApprove": {
        
        "https://en.wikipedia.org": {
            "approveRequest": true,
            "approveResponse": false
        }
    },
  ```
* From now on, every `openBrowserPage`, `navigatePage`, or even `fetch` Tool uses will be allowed for en.wikipedia.org