### PR TITLE
Revert "Bump hono from 4.12.0 to 4.12.3 in /test/mcp"

### DIFF
--- a/test/mcp/package-lock.json
+++ b/test/mcp/package-lock.json
@@ -702,9 +702,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Reverts microsoft/vscode#298076

Fixes https://dev.azure.com/monacotools/Monaco/_build/results?buildId=412708&view=logs&j=a1a226c6-d859-5ac0-b784-63d47497f266&t=e8e681d6-5d09-5e02-96fd-530cbfcd695a