### PR TITLE
sessions: tweaks to customizations

### DIFF
--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+	"version": 1,
+	"hooks": {
+		"sessionStart": [
+			{
+				"type": "command",
+				"bash": "if [ -f ~/.vscode-worktree-setup ]; then nohup npm ci > /tmp/npm-ci-$(date +%Y-%m-%d_%H-%M-%S).log 2>&1 & fi"
+			}
+		],
+		"userPromptSubmitted": [
+			{
+				"type": "command",
+				"bash": ""
+			}
+		],
+		"preToolUse": [
+			{
+				"type": "command",
+				"bash": ""
+			}
+		],
+		"postToolUse": [
+			{
+				"type": "command",
+				"bash": ""
+			}
+		]
+	}
+}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -27,7 +27,7 @@ import { AICustomizationManagementEditor } from '../../../../workbench/contrib/c
 import { agentIcon, instructionsIcon, promptIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP } from '../../../../workbench/services/editor/common/editorService.js';
 
 const $ = DOM.$;
 
@@ -187,7 +187,7 @@ export class AICustomizationOverviewView extends ViewPane {
 
 	private async openSection(sectionId: AICustomizationManagementSection): Promise<void> {
 		const input = AICustomizationManagementEditorInput.getOrCreate();
-		const editor = await this.editorService.openEditor(input, { pinned: true });
+		const editor = await this.editorService.openEditor(input, { pinned: true }, MODAL_GROUP);
 
 		// Deep-link to the section
 		if (editor instanceof AICustomizationManagementEditor) {

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -249,6 +249,10 @@ export class AgenticSessionsViewPane extends ViewPane {
 			this.mcpService.servers.read(reader);
 			updateHeaderTotalCount();
 		}));
+		this._register(autorun(reader => {
+			this.workspaceService.activeProjectRoot.read(reader);
+			updateHeaderTotalCount();
+		}));
 		updateHeaderTotalCount();
 
 		// Toggle collapse on header click

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -43,7 +43,10 @@ import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js';
 import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
-import { HOOK_TYPES } from '../../common/promptSyntax/hookSchema.js';
+import { HOOK_TYPES, formatHookCommandLabel } from '../../common/promptSyntax/hookSchema.js';
+import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { OS } from '../../../../../base/common/platform.js';
 
 const $ = DOM.$;
 
@@ -823,13 +826,14 @@ export class AICustomizationListWidget extends Disposable {
 			// Try to parse individual hooks from each file; fall back to showing the file itself
 			const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
 			const activeRoot = this.workspaceService.getActiveProjectRoot();
-			const userHome = this.pathService.userHome({ preferLocal: true }).fsPath;
+			const userHomeUri = await this.pathService.userHome();
+			const userHome = userHomeUri.scheme === Schemas.file ? userHomeUri.fsPath : userHomeUri.path;
 
 			for (const hookFile of hookFiles) {
 				let parsedHooks = false;
 				try {
 					const content = await this.fileService.readFile(hookFile.uri);
-					const json = JSON.parse(content.value.toString());
+					const json = parseJSONC(content.value.toString());
 					const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
 
 					if (hooks.size > 0) {
@@ -838,8 +842,8 @@ export class AICustomizationListWidget extends Disposable {
 							const hookMeta = HOOK_TYPES.find(h => h.id === hookType);
 							for (let i = 0; i < entry.hooks.length; i++) {
 								const hook = entry.hooks[i];
-								const cmd = hook.command || hook.osx || hook.linux || hook.windows || '';
-								const truncatedCmd = cmd.length > 60 ? cmd.substring(0, 57) + '...' : cmd;
+								const cmdLabel = formatHookCommandLabel(hook, OS);
+								const truncatedCmd = cmdLabel.length > 60 ? cmdLabel.substring(0, 57) + '...' : cmdLabel;
 								items.push({
 									id: `${hookFile.uri.toString()}#${entry.originalId}[${i}]`,
 									uri: hookFile.uri,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -39,7 +39,11 @@ import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { ISCMService } from '../../../scm/common/scm.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
 import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js';
+import { parseHooksFromFile } from '../../common/promptSyntax/hookCompatibility.js';
+import { HOOK_TYPES } from '../../common/promptSyntax/hookSchema.js';
 
 const $ = DOM.$;
 
@@ -367,6 +371,8 @@ export class AICustomizationListWidget extends Disposable {
 		@IClipboardService private readonly clipboardService: IClipboardService,
 		@ISCMService private readonly scmService: ISCMService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IFileService private readonly fileService: IFileService,
+		@IPathService private readonly pathService: IPathService,
 	) {
 		super();
 		this.element = $('.ai-customization-list-widget');
@@ -814,18 +820,53 @@ export class AICustomizationListWidget extends Disposable {
 				});
 			}
 		} else if (promptType === PromptsType.hook) {
-			// Show hook files (not individual hooks) so users can open and edit them
+			// Try to parse individual hooks from each file; fall back to showing the file itself
 			const hookFiles = await this.promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
+			const activeRoot = this.workspaceService.getActiveProjectRoot();
+			const userHome = this.pathService.userHome({ preferLocal: true }).fsPath;
+
 			for (const hookFile of hookFiles) {
-				const filename = basename(hookFile.uri);
-				items.push({
-					id: hookFile.uri.toString(),
-					uri: hookFile.uri,
-					name: this.getFriendlyName(filename),
-					filename,
-					storage: hookFile.storage,
-					promptType,
-				});
+				let parsedHooks = false;
+				try {
+					const content = await this.fileService.readFile(hookFile.uri);
+					const json = JSON.parse(content.value.toString());
+					const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, userHome);
+
+					if (hooks.size > 0) {
+						parsedHooks = true;
+						for (const [hookType, entry] of hooks) {
+							const hookMeta = HOOK_TYPES.find(h => h.id === hookType);
+							for (let i = 0; i < entry.hooks.length; i++) {
+								const hook = entry.hooks[i];
+								const cmd = hook.command || hook.osx || hook.linux || hook.windows || '';
+								const truncatedCmd = cmd.length > 60 ? cmd.substring(0, 57) + '...' : cmd;
+								items.push({
+									id: `${hookFile.uri.toString()}#${entry.originalId}[${i}]`,
+									uri: hookFile.uri,
+									name: hookMeta?.label ?? entry.originalId,
+									filename: basename(hookFile.uri),
+									description: truncatedCmd || localize('hookUnset', "(unset)"),
+									storage: hookFile.storage,
+									promptType,
+								});
+							}
+						}
+					}
+				} catch {
+					// Parse failed — fall through to show raw file
+				}
+
+				if (!parsedHooks) {
+					const filename = basename(hookFile.uri);
+					items.push({
+						id: hookFile.uri.toString(),
+						uri: hookFile.uri,
+						name: this.getFriendlyName(filename),
+						filename,
+						storage: hookFile.storage,
+						promptType,
+					});
+				}
 			}
 		} else {
 			// For instructions, fetch prompt files and group by storage

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/hookSchema.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/hookSchema.ts
@@ -523,13 +523,6 @@ export function formatHookCommandLabel(hook: IHookCommand, os: OperatingSystem):
 	if (!command) {
 		return '';
 	}
-
-	// Add platform badge if using platform-specific override
-	if (isUsingPlatformOverride(hook, os)) {
-		const platformLabel = getPlatformLabel(os);
-		return `[${platformLabel}] ${command}`;
-	}
-
 	return command;
 }
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/hookSchema.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/hookSchema.test.ts
@@ -461,7 +461,7 @@ suite('HookSchema', () => {
 			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Windows), '');
 		});
 
-		test('applies platform override for display with platform badge', () => {
+		test('applies platform override for display', () => {
 			const hook: IHookCommand = {
 				type: 'command',
 				command: 'default-command',
@@ -469,10 +469,10 @@ suite('HookSchema', () => {
 				linux: 'linux-command',
 				osx: 'osx-command'
 			};
-			// Should include platform badge when using platform-specific override
-			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Windows), '[Windows] win-command');
-			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Macintosh), '[macOS] osx-command');
-			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Linux), '[Linux] linux-command');
+			// Should resolve to platform-specific command
+			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Windows), 'win-command');
+			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Macintosh), 'osx-command');
+			assert.strictEqual(formatHookCommandLabel(hook, OperatingSystem.Linux), 'linux-command');
 		});
 
 		test('no platform badge when falling back to default command', () => {


### PR DESCRIPTION
- selectSectionById: inline all state updates to avoid race with onDidChangeSelection
- goBackToList: refresh list to show newly created files
- goBackToList: only auto-commit if editor content was actually modified
- Hooks: parse individual hooks from files, show hook type labels and commands
- Hooks: show (unset) for empty hook commands
- Toolbar: use MODAL_GROUP when opening editor in sessions
- Overview: use MODAL_GROUP when opening editor in sessions
- Toolbar: add _updateCountsRequestId guard to prevent stale count renders
- SessionsViewPane: subscribe to activeProjectRoot for total count updates
- List widget: add IFileService + IPathService for hook file parsing