### PR TITLE
improve tip service

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipCatalog.ts
@@ -1,0 +1,363 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { localize } from '../../../../nls.js';
+import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
+import { ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { localChatSessionType } from '../common/chatSessionsService.js';
+import { ITipExclusionConfig } from './chatTipEligibilityTracker.js';
+import { TipTrackingCommands } from './chatTipStorageKeys.js';
+import {
+	GENERATE_AGENT_COMMAND_ID,
+	GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID,
+	GENERATE_PROMPT_COMMAND_ID,
+	GENERATE_SKILL_COMMAND_ID,
+} from './actions/chatActions.js';
+
+/**
+ * Context provided to tip builders for dynamic message construction.
+ */
+export interface ITipBuildContext {
+	/**
+	 * Keybinding service for looking up keyboard shortcuts.
+	 */
+	readonly keybindingService: IKeybindingService;
+}
+
+/**
+ * Gets the display label for a command, looking it up from MenuRegistry.
+ * Falls back to extracting a readable name from the command ID.
+ */
+export function getCommandLabel(commandId: string): string {
+	const command = MenuRegistry.getCommand(commandId);
+	if (command?.title) {
+		// Handle both string and ILocalizedString formats
+		return typeof command.title === 'string' ? command.title : command.title.value;
+	}
+	// Fallback: extract readable name from command ID
+	// e.g., 'workbench.action.chat.openEditSession' -> 'openEditSession'
+	const parts = commandId.split('.');
+	return parts[parts.length - 1];
+}
+
+/**
+ * Formats a keybinding for display in a tip message.
+ * Returns empty string if no keybinding is bound.
+ */
+function formatKeybinding(ctx: ITipBuildContext, commandId: string): string {
+	const kb = ctx.keybindingService.lookupKeybinding(commandId);
+	return kb ? ` (${kb.getLabel()})` : '';
+}
+
+/**
+ * Extracts command IDs from command: links in a markdown string.
+ * Used to automatically populate enabledCommands for trusted markdown.
+ */
+export function extractCommandIds(markdown: string): string[] {
+	const commandPattern = /\[.*?\]\(command:([^?\s)]+)/g;
+	const commands = new Set<string>();
+	let match;
+	while ((match = commandPattern.exec(markdown)) !== null) {
+		commands.add(match[1]);
+	}
+	return [...commands];
+}
+
+/**
+ * Interface for tip definitions in the catalog.
+ */
+export interface ITipDefinition extends ITipExclusionConfig {
+	readonly id: string;
+	/**
+	 * Builds the tip message dynamically at runtime.
+	 * This enables keybindings and command labels to be looked up fresh.
+	 * The returned MarkdownString should NOT include the "Tip:" prefix.
+	 */
+	buildMessage(ctx: ITipBuildContext): MarkdownString;
+	/**
+	 * When clause expression that determines if this tip is eligible to be shown.
+	 */
+	readonly when?: ContextKeyExpression;
+	/**
+	 * Chat model IDs for which this tip is eligible (lowercase).
+	 */
+	readonly onlyWhenModelIds?: readonly string[];
+	/**
+	 * Setting keys that, if changed from default, make this tip ineligible.
+	 */
+	readonly excludeWhenSettingsChanged?: readonly string[];
+	/**
+	 * Command IDs that dismiss this tip when clicked from the tip markdown.
+	 */
+	readonly dismissWhenCommandsClicked?: readonly string[];
+}
+
+// -----------------------------------------------------------------------------
+// Tip Catalog
+// -----------------------------------------------------------------------------
+
+/**
+ * Static catalog of tips. Tips are built dynamically at runtime to enable
+ * keybindings and command labels to be resolved fresh.
+ */
+export const TIP_CATALOG: readonly ITipDefinition[] = [
+	{
+		id: 'tip.switchToAuto',
+		buildMessage(ctx) {
+			const label = getCommandLabel('workbench.action.chat.openModelPicker');
+			const kb = formatKeybinding(ctx, 'workbench.action.chat.openModelPicker');
+			return new MarkdownString(
+				localize(
+					'tip.switchToAuto',
+					"Using gpt-4.1? Try switching to [{0}](command:workbench.action.chat.openModelPicker){1} for better coding performance.",
+					label,
+					kb
+				)
+			);
+		},
+		onlyWhenModelIds: ['gpt-4.1'],
+	},
+	{
+		id: 'tip.createInstruction',
+		buildMessage(ctx) {
+			const kb = formatKeybinding(ctx, GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID);
+			return new MarkdownString(
+				localize(
+					'tip.createInstruction',
+					"Use [{0}](command:{1}){2} to generate an on-demand instructions file with the agent.",
+					'/create-instructions',
+					GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID,
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+		excludeWhenCommandsExecuted: [
+			GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID,
+			TipTrackingCommands.CreateAgentInstructionsUsed,
+		],
+	},
+	{
+		id: 'tip.createPrompt',
+		buildMessage(ctx) {
+			const kb = formatKeybinding(ctx, GENERATE_PROMPT_COMMAND_ID);
+			return new MarkdownString(
+				localize(
+					'tip.createPrompt',
+					"Use [{0}](command:{1}){2} to generate a reusable prompt file with the agent.",
+					'/create-prompt',
+					GENERATE_PROMPT_COMMAND_ID,
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+		excludeWhenCommandsExecuted: [
+			GENERATE_PROMPT_COMMAND_ID,
+			TipTrackingCommands.CreatePromptUsed,
+		],
+	},
+	{
+		id: 'tip.createAgent',
+		buildMessage(ctx) {
+			const kb = formatKeybinding(ctx, GENERATE_AGENT_COMMAND_ID);
+			return new MarkdownString(
+				localize(
+					'tip.createAgent',
+					"Use [{0}](command:{1}){2} to scaffold a custom agent for your workflow.",
+					'/create-agent',
+					GENERATE_AGENT_COMMAND_ID,
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+		excludeWhenCommandsExecuted: [
+			GENERATE_AGENT_COMMAND_ID,
+			TipTrackingCommands.CreateAgentUsed,
+		],
+	},
+	{
+		id: 'tip.createSkill',
+		buildMessage(ctx) {
+			const kb = formatKeybinding(ctx, GENERATE_SKILL_COMMAND_ID);
+			return new MarkdownString(
+				localize(
+					'tip.createSkill',
+					"Use [{0}](command:{1}){2} to create a skill the agent can load when relevant.",
+					'/create-skill',
+					GENERATE_SKILL_COMMAND_ID,
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+		excludeWhenCommandsExecuted: [
+			GENERATE_SKILL_COMMAND_ID,
+			TipTrackingCommands.CreateSkillUsed,
+		],
+	},
+	{
+		id: 'tip.agentMode',
+		buildMessage(ctx) {
+			const label = getCommandLabel('workbench.action.chat.openEditSession');
+			const kb = formatKeybinding(ctx, 'workbench.action.chat.openEditSession');
+			return new MarkdownString(
+				localize(
+					'tip.agentMode',
+					"Try [{0}](command:workbench.action.chat.openEditSession){1} to make edits across your project and run commands.",
+					label,
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatModeKind.notEqualsTo(ChatModeKind.Agent),
+		excludeWhenModesUsed: [ChatModeKind.Agent],
+	},
+	{
+		id: 'tip.planMode',
+		buildMessage(ctx) {
+			const kb = formatKeybinding(ctx, 'workbench.action.chat.openPlan');
+			return new MarkdownString(
+				localize(
+					'tip.planMode',
+					"Try the [{0}](command:workbench.action.chat.openPlan){1} to research and plan before implementing changes.",
+					'Plan agent',
+					kb
+				)
+			);
+		},
+		when: ChatContextKeys.chatModeName.notEqualsTo('Plan'),
+		excludeWhenCommandsExecuted: ['workbench.action.chat.openPlan'],
+		excludeWhenModesUsed: ['Plan'],
+	},
+	{
+		id: 'tip.attachFiles',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.attachFiles', "Reference files or folders with # to give the agent more context about the task.")
+			);
+		},
+		excludeWhenCommandsExecuted: [
+			'workbench.action.chat.attachContext',
+			'workbench.action.chat.attachFile',
+			'workbench.action.chat.attachFolder',
+			'workbench.action.chat.attachSelection',
+			TipTrackingCommands.AttachFilesReferenceUsed,
+		],
+	},
+	{
+		id: 'tip.codeActions',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.codeActions', "Select a code block in the editor and right-click to access more AI actions.")
+			);
+		},
+		excludeWhenCommandsExecuted: ['inlineChat.start'],
+	},
+	{
+		id: 'tip.undoChanges',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.undoChanges', "Select \"Restore Checkpoint\" to undo changes after that point in the chat conversation.")
+			);
+		},
+		when: ContextKeyExpr.and(
+			ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
+			ContextKeyExpr.or(
+				ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+				ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Edit),
+			),
+		),
+		excludeWhenCommandsExecuted: ['workbench.action.chat.restoreCheckpoint', 'workbench.action.chat.restoreLastCheckpoint'],
+	},
+	{
+		id: 'tip.messageQueueing',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.messageQueueing', "Steer the agent mid-task by sending follow-up messages. They queue and apply in order.")
+			);
+		},
+		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+		excludeWhenCommandsExecuted: ['workbench.action.chat.queueMessage', 'workbench.action.chat.steerWithMessage'],
+	},
+	{
+		id: 'tip.yoloMode',
+		buildMessage() {
+			return new MarkdownString(
+				localize(
+					'tip.yoloMode',
+					"Enable [{0}](command:workbench.action.openSettings?%5B%22{1}%22%5D) to give the agent full control without manual confirmation.",
+					'auto approve',
+					ChatConfiguration.GlobalAutoApprove
+				)
+			);
+		},
+		when: ContextKeyExpr.and(
+			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+			ContextKeyExpr.notEquals('config.chat.tools.global.autoApprove', true),
+		),
+		excludeWhenSettingsChanged: [ChatConfiguration.GlobalAutoApprove],
+		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
+	},
+	{
+		id: 'tip.agenticBrowser',
+		buildMessage() {
+			return new MarkdownString(
+				localize(
+					'tip.agenticBrowser',
+					"Enable [{0}](command:workbench.action.openSettings?%5B%22workbench.browser.enableChatTools%22%5D) to let the agent open and interact with pages in the Integrated Browser.",
+					'agentic browser integration'
+				)
+			);
+		},
+		when: ContextKeyExpr.and(
+			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+			ContextKeyExpr.notEquals('config.workbench.browser.enableChatTools', true),
+		),
+		excludeWhenSettingsChanged: ['workbench.browser.enableChatTools'],
+		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
+	},
+	{
+		id: 'tip.mermaid',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.mermaid', "Ask the agent to draw an architectural diagram or flow chart; it can render Mermaid diagrams directly in chat.")
+			);
+		},
+		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+		excludeWhenToolsInvoked: ['renderMermaidDiagram'],
+	},
+	{
+		id: 'tip.subagents',
+		buildMessage() {
+			return new MarkdownString(
+				localize('tip.subagents', "Ask the agent to work in parallel to complete large tasks faster.")
+			);
+		},
+		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+		excludeWhenToolsInvoked: ['runSubagent'],
+	},
+	{
+		id: 'tip.thinkingPhrases',
+		buildMessage() {
+			return new MarkdownString(
+				localize(
+					'tip.thinkingPhrases',
+					"Customize the loading messages shown while the agent works with [{0}](command:workbench.action.openSettings?%5B%22{1}%22%5D).",
+					'thinking phrases',
+					ChatConfiguration.ThinkingPhrases
+				)
+			);
+		},
+		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
+		excludeWhenSettingsChanged: [ChatConfiguration.ThinkingPhrases],
+		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
+	},
+];

--- a/src/vs/workbench/contrib/chat/browser/chatTipEligibilityTracker.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipEligibilityTracker.ts
@@ -1,0 +1,327 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
+import { AgentFileType, IPromptsService } from '../common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../common/promptSyntax/promptTypes.js';
+import { ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
+import { TipEligibilityStorageKeys } from './chatTipStorageKeys.js';
+
+/**
+ * Interface for tip definitions that have exclusion criteria tracked by this class.
+ * This subset is all TipEligibilityTracker needs to know about tip definitions.
+ */
+export interface ITipExclusionConfig {
+	readonly id: string;
+	/** Command IDs that, if ever executed, make this tip ineligible. */
+	readonly excludeWhenCommandsExecuted?: readonly string[];
+	/** Chat mode names that, if ever used, make this tip ineligible. */
+	readonly excludeWhenModesUsed?: readonly string[];
+	/** Tool IDs that, if ever invoked, make this tip ineligible. */
+	readonly excludeWhenToolsInvoked?: readonly string[];
+	/** File-based exclusion configuration. */
+	readonly excludeWhenPromptFilesExist?: {
+		readonly promptType: PromptsType;
+		readonly agentFileType?: AgentFileType;
+		readonly excludeUntilChecked?: boolean;
+	};
+}
+
+/**
+ * Tracks user-level signals that determine whether certain tips should be
+ * excluded. Persists state to application storage and disposes listeners once all
+ * signals of interest have been observed.
+ */
+export class TipEligibilityTracker extends Disposable {
+
+	private readonly _executedCommands: Set<string>;
+	private readonly _usedModes: Set<string>;
+	private readonly _invokedTools: Set<string>;
+
+	private readonly _pendingCommands: Set<string>;
+	private readonly _pendingModes: Set<string>;
+	private readonly _pendingTools: Set<string>;
+
+	private readonly _commandListener = this._register(new MutableDisposable());
+	private readonly _toolListener = this._register(new MutableDisposable());
+
+	/**
+	 * Tip IDs excluded because prompt files of the required type exist in the workspace.
+	 * Tips with `excludeUntilChecked` are pre-added and removed if no files are found.
+	 */
+	private readonly _excludedByFiles = new Set<string>();
+
+	/** Tips that have file-based exclusions, kept for re-checks. */
+	private readonly _tipsWithFileExclusions: readonly ITipExclusionConfig[];
+
+	/** Generation counter per tip ID to discard stale async file-check results. */
+	private readonly _fileCheckGeneration = new Map<string, number>();
+	private readonly _fileChecksInFlight = new Map<string, Promise<void>>();
+
+	constructor(
+		tips: readonly ITipExclusionConfig[],
+		@ICommandService commandService: ICommandService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IPromptsService private readonly _promptsService: IPromptsService,
+		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+
+		// --- Restore persisted state -------------------------------------------
+
+		const storedCmds = this._readApplicationWithProfileFallback(TipEligibilityStorageKeys.ExecutedCommands);
+		this._executedCommands = new Set<string>(storedCmds ? JSON.parse(storedCmds) : []);
+
+		const storedModes = this._readApplicationWithProfileFallback(TipEligibilityStorageKeys.UsedModes);
+		this._usedModes = new Set<string>(storedModes ? JSON.parse(storedModes) : []);
+
+		const storedTools = this._readApplicationWithProfileFallback(TipEligibilityStorageKeys.InvokedTools);
+		this._invokedTools = new Set<string>(storedTools ? JSON.parse(storedTools) : []);
+
+		// --- Derive what still needs tracking ----------------------------------
+
+		this._pendingCommands = new Set<string>();
+		for (const tip of tips) {
+			for (const cmd of tip.excludeWhenCommandsExecuted ?? []) {
+				if (!this._executedCommands.has(cmd)) {
+					this._pendingCommands.add(cmd);
+				}
+			}
+		}
+
+		this._pendingModes = new Set<string>();
+		for (const tip of tips) {
+			for (const mode of tip.excludeWhenModesUsed ?? []) {
+				if (!this._usedModes.has(mode)) {
+					this._pendingModes.add(mode);
+				}
+			}
+		}
+
+		this._pendingTools = new Set<string>();
+		for (const tip of tips) {
+			for (const toolId of tip.excludeWhenToolsInvoked ?? []) {
+				if (!this._invokedTools.has(toolId)) {
+					this._pendingTools.add(toolId);
+				}
+			}
+		}
+
+		// --- Set up command listener (auto-disposes when all seen) --------------
+
+		if (this._pendingCommands.size > 0) {
+			this._commandListener.value = commandService.onDidExecuteCommand(e => {
+				this.recordCommandExecuted(e.commandId);
+			});
+		}
+
+		// --- Set up tool listener (auto-disposes when all seen) -----------------
+
+		if (this._pendingTools.size > 0) {
+			this._toolListener.value = this._languageModelToolsService.onDidInvokeTool(e => {
+				// Track explicit tool IDs
+				if (this._pendingTools.has(e.toolId)) {
+					this._invokedTools.add(e.toolId);
+					this._pendingTools.delete(e.toolId);
+
+					this._persistSet(TipEligibilityStorageKeys.InvokedTools, this._invokedTools);
+				}
+
+				if (this._pendingTools.size === 0) {
+					this._toolListener.clear();
+				}
+			});
+		}
+
+		// --- Async file checks -------------------------------------------------
+
+		this._tipsWithFileExclusions = tips.filter(t => t.excludeWhenPromptFilesExist);
+		for (const tip of this._tipsWithFileExclusions) {
+			if (tip.excludeWhenPromptFilesExist!.excludeUntilChecked) {
+				this._excludedByFiles.add(tip.id);
+			}
+			this._checkForPromptFiles(tip);
+		}
+
+		// Re-check agent file exclusions when custom agents change (covers late discovery)
+		this._register(this._promptsService.onDidChangeCustomAgents(() => {
+			for (const tip of this._tipsWithFileExclusions) {
+				if (tip.excludeWhenPromptFilesExist!.promptType === PromptsType.agent) {
+					this._checkForPromptFiles(tip);
+				}
+			}
+		}));
+	}
+
+	recordCommandExecuted(commandId: string): void {
+		if (!this._pendingCommands.has(commandId)) {
+			return;
+		}
+
+		this._executedCommands.add(commandId);
+		this._persistSet(TipEligibilityStorageKeys.ExecutedCommands, this._executedCommands);
+		this._pendingCommands.delete(commandId);
+
+		if (this._pendingCommands.size === 0) {
+			this._commandListener.clear();
+		}
+	}
+
+	/**
+	 * Records the current chat mode (kind + name) so future tip eligibility
+	 * checks can exclude mode-related tips. No-ops once all tracked modes
+	 * have been observed.
+	 */
+	recordCurrentMode(contextKeyService: IContextKeyService): void {
+		if (this._pendingModes.size === 0) {
+			return;
+		}
+
+		let changed = false;
+		const kind = contextKeyService.getContextKeyValue<string>(ChatContextKeys.chatModeKind.key);
+		if (kind && !this._usedModes.has(kind)) {
+			this._usedModes.add(kind);
+			this._pendingModes.delete(kind);
+			changed = true;
+		}
+		const name = contextKeyService.getContextKeyValue<string>(ChatContextKeys.chatModeName.key);
+		if (name && !this._usedModes.has(name)) {
+			this._usedModes.add(name);
+			this._pendingModes.delete(name);
+			changed = true;
+		}
+		if (changed) {
+			this._persistSet(TipEligibilityStorageKeys.UsedModes, this._usedModes);
+		}
+	}
+
+	/**
+	 * Returns `true` when the tip should be **excluded** from the eligible set.
+	 */
+	isExcluded(tip: ITipExclusionConfig): boolean {
+		if (tip.excludeWhenCommandsExecuted) {
+			for (const cmd of tip.excludeWhenCommandsExecuted) {
+				if (this._executedCommands.has(cmd)) {
+					this._logService.debug('#ChatTips: tip excluded because command was executed', tip.id, cmd);
+					return true;
+				}
+			}
+		}
+		if (tip.excludeWhenModesUsed) {
+			for (const mode of tip.excludeWhenModesUsed) {
+				if (this._usedModes.has(mode)) {
+					this._logService.debug('#ChatTips: tip excluded because mode was used', tip.id, mode);
+					return true;
+				}
+			}
+		}
+		if (tip.excludeWhenToolsInvoked) {
+			for (const toolId of tip.excludeWhenToolsInvoked) {
+				if (this._invokedTools.has(toolId)) {
+					this._logService.debug('#ChatTips: tip excluded because tool was invoked', tip.id, toolId);
+					return true;
+				}
+			}
+		}
+		if (tip.excludeWhenPromptFilesExist && this._excludedByFiles.has(tip.id)) {
+			this._logService.debug('#ChatTips: tip excluded because prompt files exist', tip.id);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Revalidates all file-based tip exclusions. Tips with `excludeUntilChecked`
+	 * are conservatively hidden until the re-check completes.
+	 */
+	refreshPromptFileExclusions(): void {
+		for (const tip of this._tipsWithFileExclusions) {
+			if (tip.excludeWhenPromptFilesExist!.excludeUntilChecked) {
+				this._excludedByFiles.add(tip.id);
+			}
+			this._checkForPromptFiles(tip);
+		}
+	}
+
+	private async _checkForPromptFiles(tip: ITipExclusionConfig): Promise<void> {
+		const inFlight = this._fileChecksInFlight.get(tip.id);
+		if (inFlight) {
+			await inFlight;
+			return;
+		}
+
+		const checkPromise = this._doCheckForPromptFiles(tip);
+		this._fileChecksInFlight.set(tip.id, checkPromise);
+		try {
+			await checkPromise;
+		} finally {
+			if (this._fileChecksInFlight.get(tip.id) === checkPromise) {
+				this._fileChecksInFlight.delete(tip.id);
+			}
+		}
+	}
+
+	private async _doCheckForPromptFiles(tip: ITipExclusionConfig): Promise<void> {
+		const config = tip.excludeWhenPromptFilesExist!;
+		const generation = (this._fileCheckGeneration.get(tip.id) ?? 0) + 1;
+		this._fileCheckGeneration.set(tip.id, generation);
+
+		try {
+			const [promptFiles, agentInstructions] = await Promise.all([
+				this._promptsService.listPromptFiles(config.promptType, CancellationToken.None),
+				config.agentFileType ? this._promptsService.listAgentInstructions(CancellationToken.None) : Promise.resolve([]),
+			]);
+
+			// Discard stale result if a newer check was started while we were awaiting
+			if (this._fileCheckGeneration.get(tip.id) !== generation) {
+				return;
+			}
+
+			const hasPromptFiles = promptFiles.length > 0;
+			const hasAgentFile = config.agentFileType
+				? agentInstructions.some(f => f.type === config.agentFileType)
+				: false;
+			const hasPromptFilesOrAgentFile = hasPromptFiles || hasAgentFile;
+
+			if (hasPromptFilesOrAgentFile) {
+				this._excludedByFiles.add(tip.id);
+			} else {
+				this._excludedByFiles.delete(tip.id);
+			}
+		} catch {
+			if (this._fileCheckGeneration.get(tip.id) !== generation) {
+				return;
+			}
+			if (config.excludeUntilChecked) {
+				this._excludedByFiles.add(tip.id);
+			}
+		}
+	}
+
+	private _persistSet(key: string, set: Set<string>): void {
+		this._storageService.store(key, JSON.stringify([...set]), StorageScope.APPLICATION, StorageTarget.MACHINE);
+	}
+
+	private _readApplicationWithProfileFallback(key: string): string | undefined {
+		const applicationValue = this._storageService.get(key, StorageScope.APPLICATION);
+		if (applicationValue) {
+			return applicationValue;
+		}
+
+		const profileValue = this._storageService.get(key, StorageScope.PROFILE);
+		if (profileValue) {
+			this._storageService.store(key, profileValue, StorageScope.APPLICATION, StorageTarget.MACHINE);
+		}
+
+		return profileValue;
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/chatTipService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipService.ts
@@ -5,28 +5,26 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
-import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
-import { ChatAgentLocation, ChatConfiguration, ChatModeKind } from '../common/constants.js';
+import { ChatAgentLocation, ChatConfiguration } from '../common/constants.js';
 import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
-import { AgentFileType, IPromptsService } from '../common/promptSyntax/service/promptsService.js';
-import { PromptsType } from '../common/promptSyntax/promptTypes.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
-import { localChatSessionType } from '../common/chatSessionsService.js';
 import { IChatService } from '../common/chatService/chatService.js';
 import { CreateSlashCommandsUsageTracker } from './createSlashCommandsUsageTracker.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { ChatRequestDynamicVariablePart, ChatRequestSlashCommandPart, IParsedChatRequest } from '../common/requestParser/chatParserTypes.js';
-import { GENERATE_AGENT_COMMAND_ID, GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID, GENERATE_PROMPT_COMMAND_ID, GENERATE_SKILL_COMMAND_ID } from './actions/chatActions.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { TipEligibilityTracker } from './chatTipEligibilityTracker.js';
+import { extractCommandIds, ITipBuildContext, ITipDefinition, TIP_CATALOG } from './chatTipCatalog.js';
+import { ChatTipStorageKeys, TipTrackingCommands } from './chatTipStorageKeys.js';
 
 type ChatTipEvent = {
 	tipId: string;
@@ -42,11 +40,20 @@ type ChatTipClassification = {
 	comment: 'Tracks user interactions with chat tips to understand which tips resonate and which are dismissed.';
 };
 
-export const ATTACH_FILES_REFERENCE_TRACKING_COMMAND = 'chat.tips.attachFiles.referenceUsed';
-export const CREATE_AGENT_INSTRUCTIONS_TRACKING_COMMAND = 'chat.tips.createAgentInstructions.commandUsed';
-export const CREATE_PROMPT_TRACKING_COMMAND = 'chat.tips.createPrompt.commandUsed';
-export const CREATE_AGENT_TRACKING_COMMAND = 'chat.tips.createAgent.commandUsed';
-export const CREATE_SKILL_TRACKING_COMMAND = 'chat.tips.createSkill.commandUsed';
+// Re-export tracking commands for backwards compatibility
+export {
+	TipTrackingCommands,
+};
+/** @deprecated Use TipTrackingCommands.AttachFilesReferenceUsed */
+export const ATTACH_FILES_REFERENCE_TRACKING_COMMAND = TipTrackingCommands.AttachFilesReferenceUsed;
+/** @deprecated Use TipTrackingCommands.CreateAgentInstructionsUsed */
+export const CREATE_AGENT_INSTRUCTIONS_TRACKING_COMMAND = TipTrackingCommands.CreateAgentInstructionsUsed;
+/** @deprecated Use TipTrackingCommands.CreatePromptUsed */
+export const CREATE_PROMPT_TRACKING_COMMAND = TipTrackingCommands.CreatePromptUsed;
+/** @deprecated Use TipTrackingCommands.CreateAgentUsed */
+export const CREATE_AGENT_TRACKING_COMMAND = TipTrackingCommands.CreateAgentUsed;
+/** @deprecated Use TipTrackingCommands.CreateSkillUsed */
+export const CREATE_SKILL_TRACKING_COMMAND = TipTrackingCommands.CreateSkillUsed;
 
 export const IChatTipService = createDecorator<IChatTipService>('chatTipService');
 
@@ -119,6 +126,12 @@ export interface IChatTipService {
 	navigateToPreviousTip(): IChatTip | undefined;
 
 	/**
+	 * Gets the next eligible tip after the current one, without requiring multiple tips.
+	 * Used after dismissing a tip to show the next available tip (even if it's the only one left).
+	 */
+	getNextEligibleTip(): IChatTip | undefined;
+
+	/**
 	 * Returns whether there are multiple eligible tips for navigation.
 	 */
 	hasMultipleTips(): boolean;
@@ -129,508 +142,9 @@ export interface IChatTipService {
 	clearDismissedTips(): void;
 }
 
-export interface ITipDefinition {
-	readonly id: string;
-	readonly message: string;
-	/**
-	 * When clause expression that determines if this tip is eligible to be shown.
-	 * If undefined, the tip is always eligible.
-	 */
-	readonly when?: ContextKeyExpression;
-	/**
-	 * Command IDs that are allowed to be executed from this tip's markdown.
-	 */
-	readonly enabledCommands?: string[];
-	/**
-	 * Chat model IDs for which this tip is eligible.
-	 * Compared against the lowercased `chatModelId` context key.
-	 */
-	readonly onlyWhenModelIds?: readonly string[];
-	/**
-	 * Command IDs that, if ever executed in this workspace, make this tip ineligible.
-	 * The tip won't be shown if the user has already performed the action it suggests.
-	 */
-	readonly excludeWhenCommandsExecuted?: string[];
-	/**
-	 * Chat mode names that, if ever used in this workspace, make this tip ineligible.
-	 * The tip won't be shown if the user has already used the mode it suggests.
-	 * Matches against both mode kind (e.g. 'agent') and mode name (e.g. 'Plan').
-	 */
-	readonly excludeWhenModesUsed?: string[];
-	/**
-	 * Tool IDs that, if ever invoked in this workspace, make this tip ineligible.
-	 * The tip won't be shown if the tool it describes has already been used.
-	 */
-	readonly excludeWhenToolsInvoked?: string[];
-	/**
-	 * If set, exclude this tip when prompt files of the specified type exist in the workspace.
-	 */
-	readonly excludeWhenPromptFilesExist?: {
-		readonly promptType: PromptsType;
-		/** Also check for this specific agent instruction file type. */
-		readonly agentFileType?: AgentFileType;
-		/** If true, exclude the tip until the async file check completes. Default: false. */
-		readonly excludeUntilChecked?: boolean;
-	};
-	/**
-	 * Setting keys that, if changed from their default value, make this tip ineligible.
-	 * The tip won't be shown if the user has already customized the setting it describes.
-	 */
-	readonly excludeWhenSettingsChanged?: string[];
-	/**
-	 * Command IDs that dismiss this tip when clicked from the tip markdown
-	 * while the tip is currently shown.
-	 */
-	readonly dismissWhenCommandsClicked?: string[];
-}
-
-/**
- * Static catalog of tips. Each tip has an optional when clause for eligibility.
- */
-const TIP_CATALOG: ITipDefinition[] = [
-	{
-		id: 'tip.switchToAuto',
-		message: localize('tip.switchToAuto', "Tip: Using gpt-4.1? Try switching to [Auto](command:workbench.action.chat.openModelPicker) in the model picker for better coding performance."),
-		enabledCommands: ['workbench.action.chat.openModelPicker'],
-		onlyWhenModelIds: ['gpt-4.1'],
-	},
-	{
-		id: 'tip.createInstruction',
-		message: localize(
-			'tip.createInstruction',
-			"Tip: Use [/create-instructions](command:{0}) to generate an on-demand instructions file with the agent.",
-			GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID
-		),
-		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-		enabledCommands: [GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID],
-		excludeWhenCommandsExecuted: [
-			GENERATE_ON_DEMAND_INSTRUCTIONS_COMMAND_ID,
-			CREATE_AGENT_INSTRUCTIONS_TRACKING_COMMAND,
-		],
-	},
-	{
-		id: 'tip.createPrompt',
-		message: localize(
-			'tip.createPrompt',
-			"Tip: Use [/create-prompt](command:{0}) to generate a reusable prompt file with the agent.",
-			GENERATE_PROMPT_COMMAND_ID
-		),
-		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-		enabledCommands: [GENERATE_PROMPT_COMMAND_ID],
-		excludeWhenCommandsExecuted: [
-			GENERATE_PROMPT_COMMAND_ID,
-			CREATE_PROMPT_TRACKING_COMMAND,
-		],
-	},
-	{
-		id: 'tip.createAgent',
-		message: localize(
-			'tip.createAgent',
-			"Tip: Use [/create-agent](command:{0}) to scaffold a custom agent for your workflow.",
-			GENERATE_AGENT_COMMAND_ID
-		),
-		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-		enabledCommands: [GENERATE_AGENT_COMMAND_ID],
-		excludeWhenCommandsExecuted: [
-			GENERATE_AGENT_COMMAND_ID,
-			CREATE_AGENT_TRACKING_COMMAND,
-		],
-	},
-	{
-		id: 'tip.createSkill',
-		message: localize(
-			'tip.createSkill',
-			"Tip: Use [/create-skill](command:{0}) to create a skill the agent can load when relevant.",
-			GENERATE_SKILL_COMMAND_ID
-		),
-		when: ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-		enabledCommands: [GENERATE_SKILL_COMMAND_ID],
-		excludeWhenCommandsExecuted: [
-			GENERATE_SKILL_COMMAND_ID,
-			CREATE_SKILL_TRACKING_COMMAND,
-		],
-	},
-	{
-		id: 'tip.agentMode',
-		message: localize('tip.agentMode', "Tip: Try [Agents](command:workbench.action.chat.openEditSession) to make edits across your project and run commands."),
-		when: ChatContextKeys.chatModeKind.notEqualsTo(ChatModeKind.Agent),
-		enabledCommands: ['workbench.action.chat.openEditSession'],
-		excludeWhenModesUsed: [ChatModeKind.Agent],
-	},
-	{
-		id: 'tip.planMode',
-		message: localize('tip.planMode', "Tip: Try the [Plan agent](command:workbench.action.chat.openPlan) to research and plan before implementing changes."),
-		when: ChatContextKeys.chatModeName.notEqualsTo('Plan'),
-		enabledCommands: ['workbench.action.chat.openPlan'],
-		excludeWhenCommandsExecuted: ['workbench.action.chat.openPlan'],
-		excludeWhenModesUsed: ['Plan'],
-	},
-	{
-		id: 'tip.attachFiles',
-		message: localize('tip.attachFiles', "Tip: Reference files or folders with # to give the agent more context about the task."),
-		excludeWhenCommandsExecuted: ['workbench.action.chat.attachContext', 'workbench.action.chat.attachFile', 'workbench.action.chat.attachFolder', 'workbench.action.chat.attachSelection', ATTACH_FILES_REFERENCE_TRACKING_COMMAND],
-	},
-	{
-		id: 'tip.codeActions',
-		message: localize('tip.codeActions', "Tip: Select a code block in the editor and right-click to access more AI actions."),
-		excludeWhenCommandsExecuted: ['inlineChat.start'],
-	},
-	{
-		id: 'tip.undoChanges',
-		message: localize('tip.undoChanges', "Tip: Select \"Restore Checkpoint\" to undo changes after that point in the chat conversation."),
-		when: ContextKeyExpr.and(
-			ChatContextKeys.chatSessionType.isEqualTo(localChatSessionType),
-			ContextKeyExpr.or(
-				ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-				ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Edit),
-			),
-		),
-		excludeWhenCommandsExecuted: ['workbench.action.chat.restoreCheckpoint', 'workbench.action.chat.restoreLastCheckpoint'],
-	},
-	{
-		id: 'tip.messageQueueing',
-		message: localize('tip.messageQueueing', "Tip: Steer the agent mid-task by sending follow-up messages. They queue and apply in order."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		excludeWhenCommandsExecuted: ['workbench.action.chat.queueMessage', 'workbench.action.chat.steerWithMessage'],
-	},
-	{
-		id: 'tip.yoloMode',
-		message: localize('tip.yoloMode', "Tip: Enable [auto approve](command:workbench.action.openSettings?%5B%22chat.tools.global.autoApprove%22%5D) to give the agent full control without manual confirmation."),
-		when: ContextKeyExpr.and(
-			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-			ContextKeyExpr.notEquals('config.chat.tools.global.autoApprove', true),
-		),
-		enabledCommands: ['workbench.action.openSettings'],
-		excludeWhenSettingsChanged: [ChatConfiguration.GlobalAutoApprove],
-		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
-	},
-	{
-		id: 'tip.agenticBrowser',
-		message: localize('tip.agenticBrowser', "Tip: Enable [agentic browser integration](command:workbench.action.openSettings?%5B%22workbench.browser.enableChatTools%22%5D) to let the agent open and interact with pages in the Integrated Browser."),
-		when: ContextKeyExpr.and(
-			ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-			ContextKeyExpr.notEquals('config.workbench.browser.enableChatTools', true),
-		),
-		enabledCommands: ['workbench.action.openSettings'],
-		excludeWhenSettingsChanged: ['workbench.browser.enableChatTools'],
-		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
-	},
-	{
-		id: 'tip.mermaid',
-		message: localize('tip.mermaid', "Tip: Ask the agent to draw an architectural diagram or flow chart; it can render Mermaid diagrams directly in chat."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		excludeWhenToolsInvoked: ['renderMermaidDiagram'],
-	},
-	{
-		id: 'tip.subagents',
-		message: localize('tip.subagents', "Tip: Ask the agent to work in parallel to complete large tasks faster."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		excludeWhenToolsInvoked: ['runSubagent'],
-	},
-	{
-		id: 'tip.thinkingPhrases',
-		message: localize('tip.thinkingPhrases', "Tip: Customize the loading messages shown while the agent works with [thinking phrases](command:workbench.action.openSettings?%5B%22chat.agent.thinking.phrases%22%5D)."),
-		when: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-		enabledCommands: ['workbench.action.openSettings'],
-		excludeWhenSettingsChanged: ['chat.agent.thinking.phrases'],
-		dismissWhenCommandsClicked: ['workbench.action.openSettings'],
-	},
-];
-
-/**
- * Tracks user-level signals that determine whether certain tips should be
- * excluded. Persists state to application storage and disposes listeners once all
- * signals of interest have been observed.
- */
-export class TipEligibilityTracker extends Disposable {
-
-	private static readonly _COMMANDS_STORAGE_KEY = 'chat.tips.executedCommands';
-	private static readonly _MODES_STORAGE_KEY = 'chat.tips.usedModes';
-	private static readonly _TOOLS_STORAGE_KEY = 'chat.tips.invokedTools';
-
-	private readonly _executedCommands: Set<string>;
-	private readonly _usedModes: Set<string>;
-	private readonly _invokedTools: Set<string>;
-
-	private readonly _pendingCommands: Set<string>;
-	private readonly _pendingModes: Set<string>;
-	private readonly _pendingTools: Set<string>;
-
-	private readonly _commandListener = this._register(new MutableDisposable());
-	private readonly _toolListener = this._register(new MutableDisposable());
-
-	/**
-	 * Tip IDs excluded because prompt files of the required type exist in the workspace.
-	 * Tips with `excludeUntilChecked` are pre-added and removed if no files are found.
-	 */
-	private readonly _excludedByFiles = new Set<string>();
-
-	/** Tips that have file-based exclusions, kept for re-checks. */
-	private readonly _tipsWithFileExclusions: readonly ITipDefinition[];
-
-	/** Generation counter per tip ID to discard stale async file-check results. */
-	private readonly _fileCheckGeneration = new Map<string, number>();
-	private readonly _fileChecksInFlight = new Map<string, Promise<void>>();
-
-	constructor(
-		tips: readonly ITipDefinition[],
-		@ICommandService commandService: ICommandService,
-		@IStorageService private readonly _storageService: IStorageService,
-		@IPromptsService private readonly _promptsService: IPromptsService,
-		@ILanguageModelToolsService private readonly _languageModelToolsService: ILanguageModelToolsService,
-		@ILogService private readonly _logService: ILogService,
-	) {
-		super();
-
-		// --- Restore persisted state -------------------------------------------
-
-		const storedCmds = this._readApplicationWithProfileFallback(TipEligibilityTracker._COMMANDS_STORAGE_KEY);
-		this._executedCommands = new Set<string>(storedCmds ? JSON.parse(storedCmds) : []);
-
-		const storedModes = this._readApplicationWithProfileFallback(TipEligibilityTracker._MODES_STORAGE_KEY);
-		this._usedModes = new Set<string>(storedModes ? JSON.parse(storedModes) : []);
-
-		const storedTools = this._readApplicationWithProfileFallback(TipEligibilityTracker._TOOLS_STORAGE_KEY);
-		this._invokedTools = new Set<string>(storedTools ? JSON.parse(storedTools) : []);
-
-		// --- Derive what still needs tracking ----------------------------------
-
-		this._pendingCommands = new Set<string>();
-		for (const tip of tips) {
-			for (const cmd of tip.excludeWhenCommandsExecuted ?? []) {
-				if (!this._executedCommands.has(cmd)) {
-					this._pendingCommands.add(cmd);
-				}
-			}
-		}
-
-		this._pendingModes = new Set<string>();
-		for (const tip of tips) {
-			for (const mode of tip.excludeWhenModesUsed ?? []) {
-				if (!this._usedModes.has(mode)) {
-					this._pendingModes.add(mode);
-				}
-			}
-		}
-
-		this._pendingTools = new Set<string>();
-		for (const tip of tips) {
-			for (const toolId of tip.excludeWhenToolsInvoked ?? []) {
-				if (!this._invokedTools.has(toolId)) {
-					this._pendingTools.add(toolId);
-				}
-			}
-		}
-
-		// --- Set up command listener (auto-disposes when all seen) --------------
-
-		if (this._pendingCommands.size > 0) {
-			this._commandListener.value = commandService.onDidExecuteCommand(e => {
-				this.recordCommandExecuted(e.commandId);
-			});
-		}
-
-		// --- Set up tool listener (auto-disposes when all seen) -----------------
-
-		if (this._pendingTools.size > 0) {
-			this._toolListener.value = this._languageModelToolsService.onDidInvokeTool(e => {
-				// Track explicit tool IDs
-				if (this._pendingTools.has(e.toolId)) {
-					this._invokedTools.add(e.toolId);
-					this._pendingTools.delete(e.toolId);
-
-					this._persistSet(TipEligibilityTracker._TOOLS_STORAGE_KEY, this._invokedTools);
-				}
-
-				if (this._pendingTools.size === 0) {
-					this._toolListener.clear();
-				}
-			});
-		}
-
-		// --- Async file checks -------------------------------------------------
-
-		this._tipsWithFileExclusions = tips.filter(t => t.excludeWhenPromptFilesExist);
-		for (const tip of this._tipsWithFileExclusions) {
-			if (tip.excludeWhenPromptFilesExist!.excludeUntilChecked) {
-				this._excludedByFiles.add(tip.id);
-			}
-			this._checkForPromptFiles(tip);
-		}
-
-		// Re-check agent file exclusions when custom agents change (covers late discovery)
-		this._register(this._promptsService.onDidChangeCustomAgents(() => {
-			for (const tip of this._tipsWithFileExclusions) {
-				if (tip.excludeWhenPromptFilesExist!.promptType === PromptsType.agent) {
-					this._checkForPromptFiles(tip);
-				}
-			}
-		}));
-	}
-
-	recordCommandExecuted(commandId: string): void {
-		if (!this._pendingCommands.has(commandId)) {
-			return;
-		}
-
-		this._executedCommands.add(commandId);
-		this._persistSet(TipEligibilityTracker._COMMANDS_STORAGE_KEY, this._executedCommands);
-		this._pendingCommands.delete(commandId);
-
-		if (this._pendingCommands.size === 0) {
-			this._commandListener.clear();
-		}
-	}
-
-	/**
-	 * Records the current chat mode (kind + name) so future tip eligibility
-	 * checks can exclude mode-related tips. No-ops once all tracked modes
-	 * have been observed.
-	 */
-	recordCurrentMode(contextKeyService: IContextKeyService): void {
-		if (this._pendingModes.size === 0) {
-			return;
-		}
-
-		let changed = false;
-		const kind = contextKeyService.getContextKeyValue<string>(ChatContextKeys.chatModeKind.key);
-		if (kind && !this._usedModes.has(kind)) {
-			this._usedModes.add(kind);
-			this._pendingModes.delete(kind);
-			changed = true;
-		}
-		const name = contextKeyService.getContextKeyValue<string>(ChatContextKeys.chatModeName.key);
-		if (name && !this._usedModes.has(name)) {
-			this._usedModes.add(name);
-			this._pendingModes.delete(name);
-			changed = true;
-		}
-		if (changed) {
-			this._persistSet(TipEligibilityTracker._MODES_STORAGE_KEY, this._usedModes);
-		}
-	}
-
-	/**
-	 * Returns `true` when the tip should be **excluded** from the eligible set.
-	 */
-	isExcluded(tip: ITipDefinition): boolean {
-		if (tip.excludeWhenCommandsExecuted) {
-			for (const cmd of tip.excludeWhenCommandsExecuted) {
-				if (this._executedCommands.has(cmd)) {
-					this._logService.debug('#ChatTips: tip excluded because command was executed', tip.id, cmd);
-					return true;
-				}
-			}
-		}
-		if (tip.excludeWhenModesUsed) {
-			for (const mode of tip.excludeWhenModesUsed) {
-				if (this._usedModes.has(mode)) {
-					this._logService.debug('#ChatTips: tip excluded because mode was used', tip.id, mode);
-					return true;
-				}
-			}
-		}
-		if (tip.excludeWhenToolsInvoked) {
-			for (const toolId of tip.excludeWhenToolsInvoked) {
-				if (this._invokedTools.has(toolId)) {
-					this._logService.debug('#ChatTips: tip excluded because tool was invoked', tip.id, toolId);
-					return true;
-				}
-			}
-		}
-		if (tip.excludeWhenPromptFilesExist && this._excludedByFiles.has(tip.id)) {
-			this._logService.debug('#ChatTips: tip excluded because prompt files exist', tip.id);
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Revalidates all file-based tip exclusions. Tips with `excludeUntilChecked`
-	 * are conservatively hidden until the re-check completes.
-	 */
-	refreshPromptFileExclusions(): void {
-		for (const tip of this._tipsWithFileExclusions) {
-			if (tip.excludeWhenPromptFilesExist!.excludeUntilChecked) {
-				this._excludedByFiles.add(tip.id);
-			}
-			this._checkForPromptFiles(tip);
-		}
-	}
-
-	private async _checkForPromptFiles(tip: ITipDefinition): Promise<void> {
-		const inFlight = this._fileChecksInFlight.get(tip.id);
-		if (inFlight) {
-			await inFlight;
-			return;
-		}
-
-		const checkPromise = this._doCheckForPromptFiles(tip);
-		this._fileChecksInFlight.set(tip.id, checkPromise);
-		try {
-			await checkPromise;
-		} finally {
-			if (this._fileChecksInFlight.get(tip.id) === checkPromise) {
-				this._fileChecksInFlight.delete(tip.id);
-			}
-		}
-	}
-
-	private async _doCheckForPromptFiles(tip: ITipDefinition): Promise<void> {
-		const config = tip.excludeWhenPromptFilesExist!;
-		const generation = (this._fileCheckGeneration.get(tip.id) ?? 0) + 1;
-		this._fileCheckGeneration.set(tip.id, generation);
-
-		try {
-			const [promptFiles, agentInstructions] = await Promise.all([
-				this._promptsService.listPromptFiles(config.promptType, CancellationToken.None),
-				config.agentFileType ? this._promptsService.listAgentInstructions(CancellationToken.None) : Promise.resolve([]),
-			]);
-
-			// Discard stale result if a newer check was started while we were awaiting
-			if (this._fileCheckGeneration.get(tip.id) !== generation) {
-				return;
-			}
-
-			const hasPromptFiles = promptFiles.length > 0;
-			const hasAgentFile = config.agentFileType
-				? agentInstructions.some(f => f.type === config.agentFileType)
-				: false;
-			const hasPromptFilesOrAgentFile = hasPromptFiles || hasAgentFile;
-
-			if (hasPromptFilesOrAgentFile) {
-				this._excludedByFiles.add(tip.id);
-			} else {
-				this._excludedByFiles.delete(tip.id);
-			}
-		} catch {
-			if (this._fileCheckGeneration.get(tip.id) !== generation) {
-				return;
-			}
-			if (config.excludeUntilChecked) {
-				this._excludedByFiles.add(tip.id);
-			}
-		}
-	}
-
-	private _persistSet(key: string, set: Set<string>): void {
-		this._storageService.store(key, JSON.stringify([...set]), StorageScope.APPLICATION, StorageTarget.MACHINE);
-	}
-
-	private _readApplicationWithProfileFallback(key: string): string | undefined {
-		const applicationValue = this._storageService.get(key, StorageScope.APPLICATION);
-		if (applicationValue) {
-			return applicationValue;
-		}
-
-		const profileValue = this._storageService.get(key, StorageScope.PROFILE);
-		if (profileValue) {
-			this._storageService.store(key, profileValue, StorageScope.APPLICATION, StorageTarget.MACHINE);
-		}
-
-		return profileValue;
-	}
-}
+// Re-export types for backwards compatibility
+export type { ITipDefinition } from './chatTipCatalog.js';
+export { TipEligibilityTracker } from './chatTipEligibilityTracker.js';
 
 export class ChatTipService extends Disposable implements IChatTipService {
 	readonly _serviceBrand: undefined;
@@ -664,10 +178,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	 */
 	private _contextKeyService: IContextKeyService | undefined;
 
-	private static readonly _DISMISSED_TIP_KEY = 'chat.tip.dismissed';
-	private static readonly _LAST_TIP_ID_KEY = 'chat.tip.lastTipId';
-	private static readonly _YOLO_EVER_ENABLED_KEY = 'chat.tip.yoloModeEverEnabled';
-	private static readonly _THINKING_PHRASES_EVER_MODIFIED_KEY = 'chat.tip.thinkingPhrasesEverModified';
+
 	private readonly _tracker: TipEligibilityTracker;
 	private readonly _createSlashCommandsUsageTracker: CreateSlashCommandsUsageTracker;
 	private _yoloModeEverEnabled: boolean;
@@ -684,6 +195,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		@IChatEntitlementService private readonly _chatEntitlementService: IChatEntitlementService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 	) {
 		super();
 		this._tracker = this._register(instantiationService.createInstance(TipEligibilityTracker, TIP_CATALOG));
@@ -701,7 +213,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 			}
 
 			if (this._hasFileOrFolderReference(message)) {
-				this._tracker.recordCommandExecuted(ATTACH_FILES_REFERENCE_TRACKING_COMMAND);
+				this._tracker.recordCommandExecuted(TipTrackingCommands.AttachFilesReferenceUsed);
 			}
 
 			const createCommandTrackingId = this._getCreateSlashCommandTrackingId(message);
@@ -711,10 +223,10 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		}));
 
 		// Track whether yolo mode was ever enabled
-		this._yoloModeEverEnabled = this._storageService.getBoolean(ChatTipService._YOLO_EVER_ENABLED_KEY, StorageScope.APPLICATION, false);
+		this._yoloModeEverEnabled = this._storageService.getBoolean(ChatTipStorageKeys.YoloModeEverEnabled, StorageScope.APPLICATION, false);
 		if (!this._yoloModeEverEnabled && this._configurationService.getValue<boolean>(ChatConfiguration.GlobalAutoApprove)) {
 			this._yoloModeEverEnabled = true;
-			this._storageService.store(ChatTipService._YOLO_EVER_ENABLED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			this._storageService.store(ChatTipStorageKeys.YoloModeEverEnabled, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		if (!this._yoloModeEverEnabled) {
 			const configListener = this._register(new MutableDisposable());
@@ -722,23 +234,23 @@ export class ChatTipService extends Disposable implements IChatTipService {
 				if (e.affectsConfiguration(ChatConfiguration.GlobalAutoApprove)) {
 					if (this._configurationService.getValue<boolean>(ChatConfiguration.GlobalAutoApprove)) {
 						this._yoloModeEverEnabled = true;
-						this._storageService.store(ChatTipService._YOLO_EVER_ENABLED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+						this._storageService.store(ChatTipStorageKeys.YoloModeEverEnabled, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 						configListener.clear();
 					}
 				}
 			});
 		}
 
-		this._thinkingPhrasesEverModified = this._storageService.getBoolean(ChatTipService._THINKING_PHRASES_EVER_MODIFIED_KEY, StorageScope.APPLICATION, false);
+		this._thinkingPhrasesEverModified = this._storageService.getBoolean(ChatTipStorageKeys.ThinkingPhrasesEverModified, StorageScope.APPLICATION, false);
 		if (!this._thinkingPhrasesEverModified && this._isSettingModified(ChatConfiguration.ThinkingPhrases)) {
 			this._thinkingPhrasesEverModified = true;
-			this._storageService.store(ChatTipService._THINKING_PHRASES_EVER_MODIFIED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+			this._storageService.store(ChatTipStorageKeys.ThinkingPhrasesEverModified, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		if (!this._thinkingPhrasesEverModified) {
 			this._register(this._configurationService.onDidChangeConfiguration(e => {
 				if (e.affectsConfiguration(ChatConfiguration.ThinkingPhrases)) {
 					this._thinkingPhrasesEverModified = true;
-					this._storageService.store(ChatTipService._THINKING_PHRASES_EVER_MODIFIED_KEY, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
+					this._storageService.store(ChatTipStorageKeys.ThinkingPhrasesEverModified, true, StorageScope.APPLICATION, StorageTarget.MACHINE);
 				}
 			}));
 		}
@@ -794,7 +306,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 			this._logTipTelemetry(this._shownTip.id, 'dismissed');
 			const dismissed = new Set(this._getDismissedTipIds());
 			dismissed.add(this._shownTip.id);
-			this._storageService.store(ChatTipService._DISMISSED_TIP_KEY, JSON.stringify([...dismissed]), StorageScope.APPLICATION, StorageTarget.MACHINE);
+			this._storageService.store(ChatTipStorageKeys.DismissedTips, JSON.stringify([...dismissed]), StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		// Keep the current tip reference so callers can navigate relative to it
 		// (for example, dismiss -> next should mirror next/previous behavior).
@@ -803,8 +315,8 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	clearDismissedTips(): void {
-		this._storageService.remove(ChatTipService._DISMISSED_TIP_KEY, StorageScope.APPLICATION);
-		this._storageService.remove(ChatTipService._DISMISSED_TIP_KEY, StorageScope.PROFILE);
+		this._storageService.remove(ChatTipStorageKeys.DismissedTips, StorageScope.APPLICATION);
+		this._storageService.remove(ChatTipStorageKeys.DismissedTips, StorageScope.PROFILE);
 		this._shownTip = undefined;
 		this._tipRequestId = undefined;
 		this._contextKeyService = undefined;
@@ -812,7 +324,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	private _getDismissedTipIds(): string[] {
-		const raw = this._readApplicationWithProfileFallback(ChatTipService._DISMISSED_TIP_KEY);
+		const raw = this._readApplicationWithProfileFallback(ChatTipStorageKeys.DismissedTips);
 		if (!raw) {
 			return [];
 		}
@@ -898,7 +410,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 				const nextTip = this._findNextEligibleTip(this._shownTip.id, contextKeyService);
 				if (nextTip) {
 					this._shownTip = nextTip;
-					this._storageService.store(ChatTipService._LAST_TIP_ID_KEY, nextTip.id, StorageScope.APPLICATION, StorageTarget.USER);
+					this._storageService.store(ChatTipStorageKeys.LastTipId, nextTip.id, StorageScope.APPLICATION, StorageTarget.USER);
 					const tip = this._createTip(nextTip);
 					this._onDidNavigateTip.fire(tip);
 					return tip;
@@ -940,7 +452,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		let selectedTip: ITipDefinition | undefined;
 
 		// Determine where to start in the catalog based on the last-shown tip.
-		const lastTipId = this._readApplicationWithProfileFallback(ChatTipService._LAST_TIP_ID_KEY);
+		const lastTipId = this._readApplicationWithProfileFallback(ChatTipStorageKeys.LastTipId);
 		const lastCatalogIndex = lastTipId ? TIP_CATALOG.findIndex(tip => tip.id === lastTipId) : -1;
 		const startIndex = lastCatalogIndex === -1 ? 0 : (lastCatalogIndex + 1) % TIP_CATALOG.length;
 
@@ -960,7 +472,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 		}
 
 		// Persist the selected tip id so the next use advances to the following one.
-		this._storageService.store(ChatTipService._LAST_TIP_ID_KEY, selectedTip.id, StorageScope.APPLICATION, StorageTarget.USER);
+		this._storageService.store(ChatTipStorageKeys.LastTipId, selectedTip.id, StorageScope.APPLICATION, StorageTarget.USER);
 
 		// Record that we've shown a tip this session
 		this._tipRequestId = sourceId;
@@ -984,6 +496,35 @@ export class ChatTipService extends Disposable implements IChatTipService {
 			return undefined;
 		}
 		return this._navigateTip(-1, this._contextKeyService);
+	}
+
+	getNextEligibleTip(): IChatTip | undefined {
+		if (!this._contextKeyService || !this._shownTip) {
+			return undefined;
+		}
+
+		this._createSlashCommandsUsageTracker.syncContextKey(this._contextKeyService);
+		const currentIndex = TIP_CATALOG.findIndex(t => t.id === this._shownTip!.id);
+		if (currentIndex === -1) {
+			return undefined;
+		}
+
+		const dismissedIds = new Set(this._getDismissedTipIds());
+		for (let i = 1; i < TIP_CATALOG.length; i++) {
+			const idx = (currentIndex + i) % TIP_CATALOG.length;
+			const candidate = TIP_CATALOG[idx];
+			if (!dismissedIds.has(candidate.id) && this._isEligible(candidate, this._contextKeyService)) {
+				// Found the next eligible tip - update state and return it
+				this._shownTip = candidate;
+				this._tipRequestId = 'welcome';
+				this._storageService.store(ChatTipStorageKeys.LastTipId, candidate.id, StorageScope.APPLICATION, StorageTarget.USER);
+				this._logTipTelemetry(candidate.id, 'shown');
+				this._trackTipCommandClicks(candidate);
+				return this._createTip(candidate);
+			}
+		}
+
+		return undefined;
 	}
 
 	hasMultipleTips(): boolean {
@@ -1011,7 +552,7 @@ export class ChatTipService extends Disposable implements IChatTipService {
 			this._logTipTelemetry(this._shownTip.id, direction === 1 ? 'navigateNext' : 'navigatePrevious');
 			this._shownTip = candidate;
 			this._tipRequestId = 'welcome';
-			this._storageService.store(ChatTipService._LAST_TIP_ID_KEY, candidate.id, StorageScope.APPLICATION, StorageTarget.USER);
+			this._storageService.store(ChatTipStorageKeys.LastTipId, candidate.id, StorageScope.APPLICATION, StorageTarget.USER);
 			this._logTipTelemetry(candidate.id, 'shown');
 			this._trackTipCommandClicks(candidate);
 			const tip = this._createTip(candidate);
@@ -1161,13 +702,23 @@ export class ChatTipService extends Disposable implements IChatTipService {
 	}
 
 	private _createTip(tipDef: ITipDefinition): IChatTip {
-		const markdown = new MarkdownString(tipDef.message, {
-			isTrusted: tipDef.enabledCommands ? { enabledCommands: tipDef.enabledCommands } : false,
+		// Build the tip message with dynamic keybindings and command labels
+		const ctx: ITipBuildContext = { keybindingService: this._keybindingService };
+		const rawMessage = tipDef.buildMessage(ctx);
+
+		// Add "Tip:" prefix once here, avoiding duplication in individual tip definitions
+		const prefixedMessage = localize('tipPrefix', "**Tip:** {0}", rawMessage.value);
+
+		// Auto-extract enabled commands from the built message
+		const enabledCommands = extractCommandIds(prefixedMessage);
+
+		const markdown = new MarkdownString(prefixedMessage, {
+			isTrusted: enabledCommands.length > 0 ? { enabledCommands } : false,
 		});
 		return {
 			id: tipDef.id,
 			content: markdown,
-			enabledCommands: tipDef.enabledCommands,
+			enabledCommands,
 		};
 	}
 
@@ -1181,10 +732,16 @@ export class ChatTipService extends Disposable implements IChatTipService {
 
 	private _trackTipCommandClicks(tip: ITipDefinition): void {
 		this._tipCommandListener.clear();
-		if (!tip.enabledCommands?.length) {
+
+		// Build message to extract enabled commands dynamically
+		const ctx: ITipBuildContext = { keybindingService: this._keybindingService };
+		const rawMessage = tip.buildMessage(ctx);
+		const enabledCommands = extractCommandIds(rawMessage.value);
+
+		if (!enabledCommands.length) {
 			return;
 		}
-		const enabledCommandSet = new Set(tip.enabledCommands);
+		const enabledCommandSet = new Set(enabledCommands);
 		const dismissCommandSet = new Set(tip.dismissWhenCommandsClicked);
 		this._tipCommandListener.value = this._commandService.onDidExecuteCommand(e => {
 			if (enabledCommandSet.has(e.commandId) && this._shownTip?.id === tip.id) {

--- a/src/vs/workbench/contrib/chat/browser/chatTipStorageKeys.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatTipStorageKeys.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Storage keys used by ChatTipService for persisting tip state.
+ */
+export const ChatTipStorageKeys = {
+	/** IDs of tips that have been permanently dismissed by the user. */
+	DismissedTips: 'chat.tip.dismissed',
+	/** The ID of the last tip that was shown, for round-robin selection. */
+	LastTipId: 'chat.tip.lastTipId',
+	/** Whether the user has ever enabled global auto-approve (yolo mode). */
+	YoloModeEverEnabled: 'chat.tip.yoloModeEverEnabled',
+	/** Whether the user has ever modified the thinking phrases setting. */
+	ThinkingPhrasesEverModified: 'chat.tip.thinkingPhrasesEverModified',
+};
+
+/**
+ * Storage keys used by TipEligibilityTracker for tracking user signals.
+ */
+export const TipEligibilityStorageKeys = {
+	/** Command IDs that have been executed (for excludeWhenCommandsExecuted). */
+	ExecutedCommands: 'chat.tips.executedCommands',
+	/** Chat modes that have been used (for excludeWhenModesUsed). */
+	UsedModes: 'chat.tips.usedModes',
+	/** Tool IDs that have been invoked (for excludeWhenToolsInvoked). */
+	InvokedTools: 'chat.tips.invokedTools',
+};
+
+/**
+ * Synthetic command IDs used to track user actions that don't have real commands.
+ * These are recorded when the user performs the action, allowing tips to be excluded
+ * via excludeWhenCommandsExecuted.
+ */
+export const TipTrackingCommands = {
+	/** Tracked when user attaches a file/folder reference with #. */
+	AttachFilesReferenceUsed: 'chat.tips.attachFiles.referenceUsed',
+	/** Tracked when user executes /create-instructions. */
+	CreateAgentInstructionsUsed: 'chat.tips.createAgentInstructions.commandUsed',
+	/** Tracked when user executes /create-prompt. */
+	CreatePromptUsed: 'chat.tips.createPrompt.commandUsed',
+	/** Tracked when user executes /create-agent. */
+	CreateAgentUsed: 'chat.tips.createAgent.commandUsed',
+	/** Tracked when user executes /create-skill. */
+	CreateSkillUsed: 'chat.tips.createSkill.commandUsed',
+} as const;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart.ts
@@ -74,7 +74,9 @@ export class ChatTipContentPart extends Disposable {
 		this._renderTip(tip);
 
 		this._register(this._chatTipService.onDidDismissTip(() => {
-			const nextTip = this._chatTipService.navigateToNextTip();
+			// Use getNextEligibleTip instead of navigateToNextTip to show the next
+			// available tip even if it's the only one left (no multiple-tip requirement)
+			const nextTip = this._chatTipService.getNextEligibleTip();
 			if (nextTip) {
 				this._renderTip(nextTip);
 				dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(this.domNode), () => this.focus());


### PR DESCRIPTION
Fixes #295915
Fixes #297131
Fixes #298195

- Separates tip definitions (catalog) from eligibility logic (tracker) from orchestration (service)
- Tips build messages dynamically so keybindings are always current
- Storage key constants consolidated in one place
- Auto-disposes listeners when all relevant signals are observed