### PR TITLE
include debug extension host env in shell env (#241078)

### DIFF
--- a/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
@@ -300,7 +300,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 
 		// If running in the context of an extension development host, include the environment derived from the launch configuration
 		if (this._environmentService.debugExtensionHost.env) {
-			Object.assign(env, this._environmentService.debugExtensionHost.env);
+			terminalEnvironment.mergeEnvironments(env, this._environmentService.debugExtensionHost.env);
 		}
 
 		return env;

--- a/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
@@ -296,7 +296,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 
 	@memoize
 	async getShellEnvironment(): Promise<IProcessEnvironment> {
-		const env = await this._shellEnvironmentService.getShellEnv();
+		const env = { ... await this._shellEnvironmentService.getShellEnv() };
 
 		// If running in the context of an extension development host, include the environment derived from the launch configuration
 		if (this._environmentService.debugExtensionHost.env) {

--- a/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/localTerminalBackend.ts
@@ -37,6 +37,7 @@ import { IStatusbarService } from '../../../services/statusbar/browser/statusbar
 import { memoize } from '../../../../base/common/decorators.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
+import { INativeWorkbenchEnvironmentService } from '../../../services/environment/electron-browser/environmentService.js';
 import { shouldUseEnvironmentVariableCollection } from '../../../../platform/terminal/common/terminalEnvironment.js';
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 
@@ -95,6 +96,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		@INativeHostService private readonly _nativeHostService: INativeHostService,
 		@IStatusbarService statusBarService: IStatusbarService,
 		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
+		@INativeWorkbenchEnvironmentService private readonly _environmentService: INativeWorkbenchEnvironmentService,
 	) {
 		super(_localPtyService, logService, historyService, _configurationResolverService, statusBarService, workspaceContextService);
 
@@ -294,7 +296,14 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 
 	@memoize
 	async getShellEnvironment(): Promise<IProcessEnvironment> {
-		return this._shellEnvironmentService.getShellEnv();
+		const env = await this._shellEnvironmentService.getShellEnv();
+
+		// If running in the context of an extension development host, include the environment derived from the launch configuration
+		if (this._environmentService.debugExtensionHost.env) {
+			Object.assign(env, this._environmentService.debugExtensionHost.env);
+		}
+
+		return env;
 	}
 
 	async getWslPath(original: string, direction: 'unix-to-win' | 'win-to-unix'): Promise<string> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR proposes a fix for #241078 .

With some investigation and some help from AI, I managed to produce this fix which includes adds the debug extension host environment to the terminal environment.

With that I was able to observe that environment variables added in the `env` property of a launch configuration or through an env file and the `envFile`, are correctly inherited into terminals spawned by the debugged instance.

More specifically, tasks now inherit the environment provided by the debug launch configuration.

Given my little experience with the codebase, I'm not sure this works in all configurations (web, electron, remote, etc) so guidance would be appreciated to steer this in the right direction.

Thanks!