### PR TITLE
chore: switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,7 @@ import stylisticTs from '@stylistic/eslint-plugin-ts';
 import * as pluginLocal from './.eslint-plugin-local/index.ts';
 import pluginJsdoc from 'eslint-plugin-jsdoc';
 
-import pluginHeader from 'eslint-plugin-header';
-pluginHeader.rules.header.meta.schema = false;
+import pluginHeader from '@tony.ganchev/eslint-plugin-header';
 
 const ignores = fs.readFileSync(path.join(import.meta.dirname, '.eslint-ignore'), 'utf8')
 	.toString()
@@ -121,13 +120,17 @@ export default tseslint.config(
 			],
 			'header/header': [
 				2,
-				'block',
-				[
-					'---------------------------------------------------------------------------------------------',
-					' *  Copyright (c) Microsoft Corporation. All rights reserved.',
-					' *  Licensed under the MIT License. See License.txt in the project root for license information.',
-					' *--------------------------------------------------------------------------------------------'
-				]
+				{
+					header: {
+						commentType: 'block',
+						lines: [
+							'---------------------------------------------------------------------------------------------',
+							' *  Copyright (c) Microsoft Corporation. All rights reserved.',
+							' *  Licensed under the MIT License. See License.txt in the project root for license information.',
+							' *--------------------------------------------------------------------------------------------'
+						]
+					}
+				}
 			]
 		},
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "devDependencies": {
         "@playwright/test": "^1.56.1",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
+        "@tony.ganchev/eslint-plugin-header": "^3.2.4",
         "@types/cookie": "^0.3.3",
         "@types/debug": "^4.1.5",
         "@types/eslint": "^9.6.1",
@@ -106,7 +107,6 @@
         "electron": "39.6.0",
         "eslint": "^9.36.0",
         "eslint-formatter-compact": "^8.40.0",
-        "eslint-plugin-header": "3.1.1",
         "eslint-plugin-jsdoc": "^50.3.1",
         "event-stream": "3.3.4",
         "fancy-log": "^1.3.3",
@@ -2271,6 +2271,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.2.4.tgz",
+      "integrity": "sha512-zqMKTW/KQmqKGINkhwEPoJFcJ0ewUkUAmvzHLB5N+n/6bsk7D/xkQ50VhUakG2P4JHHtqsncaXrPxgSeuBPmOw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -7159,15 +7169,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "devDependencies": {
     "@playwright/test": "^1.56.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
+    "@tony.ganchev/eslint-plugin-header": "^3.2.4",
     "@types/cookie": "^0.3.3",
     "@types/debug": "^4.1.5",
     "@types/eslint": "^9.6.1",
@@ -175,7 +176,6 @@
     "electron": "39.6.0",
     "eslint": "^9.36.0",
     "eslint-formatter-compact": "^8.40.0",
-    "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^50.3.1",
     "event-stream": "3.3.4",
     "fancy-log": "^1.3.3",


### PR DESCRIPTION
Reasons
- Supports ESLint 9 without hacks.
- TypeScript bindings.
- Proper Windows support.
- In active development.
- More informative error messages, not just all or nothing.

Note: I switched the rule config to the plugins modern object-oriented format but this can be reverted.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
