### PR TITLE
exp-enable chat.implicitContext.enabled

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -266,6 +266,7 @@ configurationRegistry.registerConfiguration({
 			default: {
 				'panel': 'always',
 			},
+			tags: ['experimental'],
 			experiment: {
 				mode: 'startup'
 			}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -265,6 +265,9 @@ configurationRegistry.registerConfiguration({
 			},
 			default: {
 				'panel': 'always',
+			},
+			experiment: {
+				mode: 'startup'
 			}
 		},
 		'chat.implicitContext.suggestedContext': {


### PR DESCRIPTION
## Summary
- add experiment metadata to chat.implicitContext.enabled
- use `mode: 'startup'` so the setting can be controlled by assignment on startup
- keep existing default value unchanged (`{ panel: 'always' }`)
