### PR TITLE
Polish model picker filter input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -596,6 +596,11 @@ export class ModelPickerWidget extends Disposable {
 			getModelPickerAccessibilityProvider(),
 			listOptions
 		);
+
+		const activeElement = dom.getActiveElement();
+		if (dom.isHTMLInputElement(activeElement) && activeElement.classList.contains('action-list-filter-input')) {
+			activeElement.classList.add('chat-model-picker-filter-input');
+		}
 	}
 
 	private _updateBadge(): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1436,6 +1436,13 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	color: var(--vscode-textLink-activeForeground);
 }
 
+.action-widget .action-list-filter-input.chat-model-picker-filter-input,
+.action-widget .action-list-filter-input.chat-model-picker-filter-input:focus {
+	outline: none;
+	box-shadow: none;
+	border-color: transparent;
+}
+
 .interactive-session .chat-input-toolbars .codicon-debug-stop {
 	color: var(--vscode-icon-foreground) !important;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/298185

Hides the focus outline/border on the model picker's filter input regardless of focus state.

**Changes:**
- **chatModelPicker.ts** – Tags the filter input with `chat-model-picker-filter-input` after the action widget opens, so the CSS override stays scoped to the chat model picker only.
- **chat.css** – Adds a rule to suppress `outline`, `box-shadow`, and `border-color` on that tagged input in both normal and `:focus` states.