### PR TITLE
Revert "Merge pull request #295188 from microsoft/mrleemurray/distinguished-apricot-eel"

### DIFF
--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -11,7 +11,6 @@ import { ConfigurationTarget } from '../../../../platform/configuration/common/c
 import { isBoolean, isString } from '../../../../base/common/types.js';
 import { IconContribution, IconDefinition } from '../../../../platform/theme/common/iconRegistry.js';
 import { ColorScheme, ThemeTypeSelector } from '../../../../platform/theme/common/theme.js';
-import product from '../../../../platform/product/common/product.js';
 
 export const IWorkbenchThemeService = refineServiceDecorator<IThemeService, IWorkbenchThemeService>(IThemeService);
 
@@ -39,19 +38,17 @@ export enum ThemeSettings {
 	SYSTEM_COLOR_THEME = 'window.systemColorTheme'
 }
 
-const isOSS = !product.quality;
+export enum ThemeSettingDefaults {
+	COLOR_THEME_DARK = 'Default Dark Modern',
+	COLOR_THEME_LIGHT = 'Default Light Modern',
+	COLOR_THEME_HC_DARK = 'Default High Contrast',
+	COLOR_THEME_HC_LIGHT = 'Default High Contrast Light',
 
-export namespace ThemeSettingDefaults {
-	export const COLOR_THEME_DARK = isOSS ? 'Experimental Dark' : 'Default Dark Modern';
-	export const COLOR_THEME_LIGHT = isOSS ? 'Experimental Light' : 'Default Light Modern';
-	export const COLOR_THEME_HC_DARK = 'Default High Contrast';
-	export const COLOR_THEME_HC_LIGHT = 'Default High Contrast Light';
+	COLOR_THEME_DARK_OLD = 'Default Dark+',
+	COLOR_THEME_LIGHT_OLD = 'Default Light+',
 
-	export const COLOR_THEME_DARK_OLD = 'Default Dark+';
-	export const COLOR_THEME_LIGHT_OLD = 'Default Light+';
-
-	export const FILE_ICON_THEME = 'vs-seti';
-	export const PRODUCT_ICON_THEME = 'Default';
+	FILE_ICON_THEME = 'vs-seti',
+	PRODUCT_ICON_THEME = 'Default',
 }
 
 export const COLOR_THEME_DARK_INITIAL_COLORS = {


### PR DESCRIPTION
This reverts commit d752c031a29e71103b28f1d566eca955747d12fe, reversing changes made to 8df7a1f66f098ee9bbd187e1b32f536815315015.

Due to CI failures:

```
[color-contrast] Elements must meet minimum color contrast ratio thresholds (serious)
  Help URL: https://dequeuniversity.com/rules/axe/4.11/color-contrast?application=axeAPI
  Element: .chat-welcome-view-disclaimer > .rendered-markdown > p
    Class: no class
    HTML: <p><a href="" title="command:workbench.action.chat.generateAgentInstructions" draggable="false" data-href="command:workbench.action.chat.generateAgentInstructions">Generate Agent Instructions</a> to onboard AI onto your codebase.</p>
    Issue: Fix any of the following:
  Element has insufficient color contrast of 3.89 (foreground color: #777777, background color: #191a1b, font size: 9.0pt (12px), font weight: normal). Expected contrast ratio of 4.5:1
```

cc @mrleemurray