### PR TITLE
Rename background agent display name to "Copilot CLI"

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -46,7 +46,7 @@ export function getAgentSessionProvider(sessionResource: URI | string): AgentSes
  * Observable holding the display name for the background agent session provider.
  * Updated via experiment treatment to allow A/B testing of the display name.
  */
-export const backgroundAgentDisplayName = observableValue<string>('backgroundAgentDisplayName', localize('chat.session.providerLabel.background', "Background"));
+export const backgroundAgentDisplayName = observableValue<string>('backgroundAgentDisplayName', localize('chat.session.providerLabel.background', "Copilot CLI"));
 
 export function getAgentSessionProviderName(provider: AgentSessionProviders): string {
 	switch (provider) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -108,6 +108,7 @@ import { IAccessibilityService } from '../../../../../platform/accessibility/com
 import { ChatHookContentPart } from './chatContentParts/chatHookContentPart.js';
 import { ChatPendingDragController } from './chatPendingDragAndDrop.js';
 import { HookType } from '../../common/promptSyntax/hookSchema.js';
+import { AgentSessionProviders, backgroundAgentDisplayName } from '../agentSessions/agentSessions.js';
 import { ChatQuestionCarouselAutoReply } from './chatQuestionCarouselAutoReply.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 
@@ -738,7 +739,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			this.renderAvatar(element, templateData);
 		}
 
-		templateData.username.textContent = element.username;
+		const isBackgroundSession = isResponseVM(element) && getChatSessionType(element.sessionResource) === AgentSessionProviders.Background;
+		templateData.username.textContent = isBackgroundSession ? backgroundAgentDisplayName.get() : element.username;
 		templateData.username.classList.toggle('hidden', element.username === COPILOT_USERNAME || this.environmentService.isSessionsWindow);
 		templateData.avatarContainer.classList.toggle('hidden', element.username === COPILOT_USERNAME || this.environmentService.isSessionsWindow);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -96,7 +96,7 @@ import { IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { ChatHistoryNavigator } from '../../../common/widget/chatWidgetHistoryService.js';
 import { ChatSessionPrimaryPickerAction, ChatSubmitAction, IChatExecuteActionContext, OpenDelegationPickerAction, OpenModelPickerAction, OpenModePickerAction, OpenSessionTargetPickerAction, OpenWorkspacePickerAction } from '../../actions/chatExecuteActions.js';
-import { AgentSessionProviders, getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
+import { AgentSessionProviders, getAgentSessionProvider, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
 import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
 import { IChatAttachmentWidgetRegistry } from '../../attachments/chatAttachmentWidgetRegistry.js';
@@ -1825,7 +1825,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		const contribution = this.chatSessionsService.getChatSessionContribution(sessionType);
 		if (contribution) {
-			this._widget?.lockToCodingAgent(contribution.name, contribution.displayName, contribution.type);
+			const knownProvider = getAgentSessionProvider(contribution.type);
+			const displayName = knownProvider ? getAgentSessionProviderName(knownProvider) : contribution.displayName;
+			this._widget?.lockToCodingAgent(contribution.name, displayName, contribution.type);
 		} else {
 			this._widget?.unlockFromCodingAgent();
 		}

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -31,6 +31,7 @@ import { IChatModel, IChatModelInputState, IExportableChatData, ISerializableCha
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
+import { getAgentSessionProvider, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
 import { clearChatEditor } from '../../actions/chatClear.js';
 import { ChatEditorInput } from './chatEditorInput.js';
 import { ChatWidget } from '../../widget/chatWidget.js';
@@ -223,7 +224,9 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 				const contributions = this.chatSessionsService.getAllChatSessionContributions();
 				const contribution = contributions.find(c => c.type === chatSessionType);
 				if (contribution) {
-					this.widget.lockToCodingAgent(contribution.name, contribution.displayName, contribution.type);
+					const knownProvider = getAgentSessionProvider(contribution.type);
+					const displayName = knownProvider ? getAgentSessionProviderName(knownProvider) : contribution.displayName;
+					this.widget.lockToCodingAgent(contribution.name, displayName, contribution.type);
 					isContributedChatSession = true;
 				} else {
 					this.widget.unlockFromCodingAgent();

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane.ts
@@ -54,7 +54,7 @@ import { ChatWidget } from '../../widget/chatWidget.js';
 import { ChatViewWelcomeController, IViewWelcomeDelegate } from '../../viewsWelcome/chatViewWelcomeController.js';
 import { IChatViewsWelcomeDescriptor } from '../../viewsWelcome/chatViewsWelcome.js';
 import { IWorkbenchLayoutService, LayoutSettings, Position } from '../../../../../services/layout/browser/layoutService.js';
-import { AgentSessionsViewerOrientation, AgentSessionsViewerPosition } from '../../agentSessions/agentSessions.js';
+import { AgentSessionsViewerOrientation, AgentSessionsViewerPosition, getAgentSessionProvider, getAgentSessionProviderName } from '../../agentSessions/agentSessions.js';
 import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
 import { ChatViewId } from '../../chat.js';
 import { IActivityService, ProgressBadge } from '../../../../../services/activity/common/activity.js';
@@ -749,7 +749,9 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 		const contribution = this.chatSessionsService.getChatSessionContribution(sessionType);
 		if (contribution) {
-			this._widget.lockToCodingAgent(contribution.name, contribution.displayName, contribution.type);
+			const knownProvider = getAgentSessionProvider(contribution.type);
+			const displayName = knownProvider ? getAgentSessionProviderName(knownProvider) : contribution.displayName;
+			this._widget.lockToCodingAgent(contribution.name, displayName, contribution.type);
 		} else {
 			this._widget.unlockFromCodingAgent();
 		}


### PR DESCRIPTION
Change the default display name for the background agent session provider from "Background" to "Copilot CLI" in the chat timeline, to better communicate what the agent actually is.