### PR TITLE
chat: fix dropdown action order to match default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -208,7 +208,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			}
 		};
 
-		return [queueAction, steerAction, sendAction];
+		return [sendAction, queueAction, steerAction];
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -159,11 +159,14 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 	}
 
 	private _getDropdownActions(): IActionWidgetDropdownAction[] {
+		const isSteerDefault = this._isSteerDefault();
+
 		const queueAction: IActionWidgetDropdownAction = {
 			id: ChatQueueMessageAction.ID,
 			label: localize('chat.queueMessage', "Add to Queue"),
 			tooltip: '',
 			enabled: true,
+			checked: !isSteerDefault,
 			icon: Codicon.add,
 			class: undefined,
 			hover: {
@@ -179,6 +182,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			label: localize('chat.steerWithMessage', "Steer with Message"),
 			tooltip: '',
 			enabled: true,
+			checked: isSteerDefault,
 			icon: Codicon.arrowRight,
 			class: undefined,
 			hover: {
@@ -204,7 +208,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			}
 		};
 
-		return [sendAction, queueAction, steerAction];
+		return [queueAction, steerAction, sendAction];
 	}
 }
 


### PR DESCRIPTION
- Reorders dropdown actions to show queue/steer (the default actions) before stop and send (destructive action)
- Marks the configured default action as checked so it's focused when the dropdown opens with keyboard
- This ensures the dropdown pre-selection matches the action that would be triggered by pressing Enter

Fixes #297559

(Commit message generated by Copilot)