### PR TITLE
mcp: surface task statusMessage notifications in chat progress

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -1087,7 +1087,7 @@ export class McpTool implements IMcpTool {
 					arguments: params,
 					task: shouldUseTask ? {} : undefined,
 					_meta: meta,
-				}, token);
+				}, token, progress ? (message) => progress.report({ message }) : undefined);
 
 				// Wait for tools to refresh for dynamic servers (#261611)
 				await this._server.awaitToolRefresh();


### PR DESCRIPTION
- When a tool call returns a CreateTaskResult, the MCP server now forwards
  task statusMessage from notifications/tasks/status into the chat progress
  stream via the ToolProgress callback
- Adds onStatusMessage optional callback to McpTask constructor to report
  status messages as they come in from server notifications
- Updates callTool method signature to accept onStatusMessage callback,
  passed from _callWithProgress in mcpServer.ts
- This allows task-mode MCP tools to communicate progress through the
  established progress channel without requiring duplicate progress
  notifications

Fixes #298013