### PR TITLE
Fix session resource aliasing in chat sessions

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -207,6 +207,22 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 							if (newItem) {
 								chatSessionResource = newItem.resource;
 								isUntitled = false;
+
+								// Update the model's contributed session with the resolved resource
+								// so subsequent requests don't re-invoke newChatSessionItemHandler
+								// and getChatSessionFromInternalUri returns the real resource.
+								chatSession?.setContributedChatSession({
+									chatSessionType: contributedSession.chatSessionType,
+									chatSessionResource,
+									isUntitled: false,
+									initialSessionOptions: contributedSession.initialSessionOptions,
+								});
+
+								// Register alias so session-option lookups work with the new resource
+								this._chatSessionService.registerSessionResourceAlias(
+									contributedSession.chatSessionResource,
+									chatSessionResource
+								);
 							}
 						}
 

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -306,6 +306,12 @@ export interface IChatSessionsService {
 	 * Returns undefined if the controller doesn't have a handler or if no controller is registered.
 	 */
 	createNewChatSessionItem(chatSessionType: string, request: IChatAgentRequest, token: CancellationToken): Promise<IChatSessionItem | undefined>;
+
+	/**
+	 * Registers an alias so that session-option lookups by the real resource
+	 * are redirected to the canonical (untitled) resource in the internal session map.
+	 */
+	registerSessionResourceAlias(untitledResource: URI, realResource: URI): void;
 }
 
 export function isSessionInProgressStatus(state: ChatSessionStatus): boolean {

--- a/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatSessionsService.ts
@@ -229,6 +229,10 @@ export class MockChatSessionsService implements IChatSessionsService {
 		return undefined;
 	}
 
+	registerSessionResourceAlias(_untitledResource: URI, _realResource: URI): void {
+		// noop
+	}
+
 	registerChatModelChangeListeners(chatService: IChatService, chatSessionType: string, onChange: () => void): IDisposable {
 		// Store the emitter so tests can trigger it
 		this.onChange = onChange;


### PR DESCRIPTION
Implement a mechanism to register aliases for session resources, allowing session-option lookups to redirect to the correct canonical resource. This change enhances the handling of chat sessions by ensuring that the correct resources are used in session management.

I think this is pretty fragile, but it fixes the critical issues that need to be fixed this release.

ref https://github.com/microsoft/vscode/issues/298378