### PR TITLE
fix stray checkmarks, consistent opacity, and icon not showing up

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
@@ -379,6 +379,29 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 
 		const labelElement = this._collapseButton.labelElement;
 
+		if (!this.isActive) {
+			labelElement.textContent = '';
+			this.titleShimmerSpan = undefined;
+
+			if (this.titleDetailRendered) {
+				this.titleDetailRendered.dispose();
+				this.titleDetailRendered = undefined;
+			}
+			this.titleDetailContainer = undefined;
+
+			const prefixSpan = $('span');
+			prefixSpan.textContent = `${prefix}:`;
+			labelElement.appendChild(prefixSpan);
+
+			const descSpan = $('span.chat-thinking-title-detail-text');
+			descSpan.textContent = ` ${this.description}`;
+			labelElement.appendChild(descSpan);
+
+			this._collapseButton.element.ariaLabel = shimmerText;
+			this._collapseButton.element.ariaExpanded = String(this.isExpanded());
+			return;
+		}
+
 		// Ensure the persistent shimmer span exists
 		if (!this.titleShimmerSpan || !this.titleShimmerSpan.parentElement) {
 			labelElement.textContent = '';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatConfirmationWidget.css
@@ -104,6 +104,7 @@
 
 .chat-confirmation-widget-title small {
 	font-size: 1em;
+	opacity: 0.7;
 
 	&::before {
 		content: ' \2013  ';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -111,45 +111,45 @@
 
 		.chat-thinking-tool-wrapper {
 			.chat-used-context {
-					margin-bottom: 0px;
-					margin-left: 4px;
-					padding-left: 2px;
-				}
+				margin-bottom: 0px;
+				margin-left: 4px;
+				padding-left: 2px;
 
-				.chat-used-context {
-					.monaco-button.monaco-text-button {
-						color: var(--vscode-descriptionForeground);
+				.monaco-button.monaco-text-button {
+					color: var(--vscode-descriptionForeground);
+					display: flex;
+					align-items: center;
 
-						:hover {
-							color: var(--vscode-foreground);
-						}
-
-						.monaco-button:hover .chat-collapsible-hover-chevron {
-							opacity: 1;
-						}
-					}
-				}
-
-				.chat-used-context:not(.chat-used-context-collapsed) {
-					.monaco-button.monaco-text-button {
+					:hover {
 						color: var(--vscode-foreground);
 					}
-				}
 
-				.progress-container,
-				.chat-confirmation-widget-container {
-					margin: 0 0 2px 6px;
+					.monaco-button:hover .chat-collapsible-hover-chevron {
+						opacity: 1;
+					}
 				}
+			}
 
-				/* todo: ideally not !important, but the competing css has 14 specificity */
-				.codicon.codicon-check,
-				.codicon.codicon-loading {
-					display: none !important;
+			.chat-used-context:not(.chat-used-context-collapsed) {
+				.monaco-button.monaco-text-button {
+					color: var(--vscode-foreground);
 				}
+			}
 
-				.chat-collapsible-hover-chevron.codicon {
-					display: inline-flex;
-				}
+			.progress-container,
+			.chat-confirmation-widget-container {
+				margin: 0 0 2px 6px;
+			}
+
+			/* todo: ideally not !important, but the competing css has 14 specificity */
+			.codicon.codicon-check,
+			.codicon.codicon-loading {
+				display: none !important;
+			}
+
+			.chat-collapsible-hover-chevron.codicon {
+				display: inline-flex;
+			}
 
 			.show-checkmarks .chat-confirmation-widget-title > .codicon:first-child:not(.chat-collapsible-hover-chevron) {
 				display: inline-block;
@@ -297,6 +297,11 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
+
+	.monaco-button.monaco-text-button {
+		display: flex;
+		align-items: center;
+	}
 
 	.chat-used-context-list.chat-terminal-thinking-content {
 		border: none;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatThinkingContent.css
@@ -142,7 +142,8 @@
 				}
 
 				/* todo: ideally not !important, but the competing css has 14 specificity */
-				.codicon:not(.chat-thinking-icon){
+				.codicon.codicon-check,
+				.codicon.codicon-loading {
 					display: none !important;
 				}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -110,6 +110,7 @@ import { ChatPendingDragController } from './chatPendingDragAndDrop.js';
 import { HookType } from '../../common/promptSyntax/hookSchema.js';
 import { ChatQuestionCarouselAutoReply } from './chatQuestionCarouselAutoReply.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
+import { AccessibilityWorkbenchSettingId } from '../../../accessibility/browser/accessibilityConfiguration.js';
 
 const $ = dom.$;
 
@@ -912,6 +913,14 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			dom.append(templateData.detail, $('span.confirmation-text', undefined, localize('chatConfirmationAction', 'Selected "{0}"', element.confirmation)));
 			templateData.header?.classList.remove('header-disabled');
 			templateData.header?.classList.add('partially-disabled');
+
+			const updateCheckmarks = () => templateData.detail.classList.toggle('show-checkmarks', !!this.configService.getValue<boolean>(AccessibilityWorkbenchSettingId.ShowChatCheckmarks));
+			updateCheckmarks();
+			templateData.elementDisposables.add(this.configService.onDidChangeConfiguration(e => {
+				if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.ShowChatCheckmarks)) {
+					updateCheckmarks();
+				}
+			}));
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -2726,14 +2726,24 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 
 	.interactive-request .header.partially-disabled .detail-container {
-		margin-left: 4px;
+		margin-left: 0px;
 	}
 
 	.interactive-item-container .header .detail .codicon-check {
 		margin-right: 7px;
 		vertical-align: middle;
 		font-size: 11px;
+		display: none;
 	}
+
+	.interactive-item-container .header.partially-disabled .detail.show-checkmarks {
+		margin-left: 4px;
+
+		.codicon-check {
+			display: inline;
+		}
+	}
+
 
 	.request-hover {
 		position: absolute;


### PR DESCRIPTION
1. on error retries, checkmarks were still being shown
2. applies same opacity styling to subagent and mcp tool calls
3. in a change on thursday, accidentally removed the console button in thinking dropdowns. fix https://github.com/microsoft/vscode/issues/298310
4.  allow ui bug in subagent https://github.com/microsoft/vscode/issues/288109