### PR TITLE
Round custom line heights

### DIFF
--- a/src/vs/editor/common/viewLayout/lineHeights.ts
+++ b/src/vs/editor/common/viewLayout/lineHeights.ts
@@ -37,9 +37,9 @@ export class CustomLine {
 		this.decorationId = decorationId;
 		this.index = index;
 		this.lineNumber = lineNumber;
-		this.specialHeight = specialHeight;
+		this.specialHeight = Math.round(specialHeight);
 		this.prefixSum = prefixSum;
-		this.maximumSpecialHeight = specialHeight;
+		this.maximumSpecialHeight = Math.round(specialHeight);
 		this.deleted = false;
 	}
 }


### PR DESCRIPTION
In most calculations within VSCode when dealing with line heights, integer values are used. However, custom line heights via decorations introduce floats. These floats end up in the CSS used to render lines. As a result, this causes a wobble effect when scrolling.

This change fixes it, by rounding custom line height values.

Fixes #296539