### PR TITLE
Clean up model picker input styles

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -600,6 +600,10 @@ export class ModelPickerWidget extends Disposable {
 		const activeElement = dom.getActiveElement();
 		if (dom.isHTMLInputElement(activeElement) && activeElement.classList.contains('action-list-filter-input')) {
 			activeElement.classList.add('chat-model-picker-filter-input');
+			const filterContainer = activeElement.closest('.action-list-filter');
+			if (dom.isHTMLElement(filterContainer)) {
+				filterContainer.classList.add('chat-model-picker-filter-container');
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -600,10 +600,6 @@ export class ModelPickerWidget extends Disposable {
 		const activeElement = dom.getActiveElement();
 		if (dom.isHTMLInputElement(activeElement) && activeElement.classList.contains('action-list-filter-input')) {
 			activeElement.classList.add('chat-model-picker-filter-input');
-			const filterContainer = activeElement.closest('.action-list-filter');
-			if (dom.isHTMLElement(filterContainer)) {
-				filterContainer.classList.add('chat-model-picker-filter-container');
-			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1441,6 +1441,11 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	outline: none;
 	box-shadow: none;
 	border-color: transparent;
+	background-color: transparent;
+}
+
+.action-widget .action-list-filter.chat-model-picker-filter-container {
+	margin-bottom: 4px;
 }
 
 .interactive-session .chat-input-toolbars .codicon-debug-stop {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1444,7 +1444,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: transparent;
 }
 
-.action-widget .action-list-filter.chat-model-picker-filter-container {
+.action-widget .action-list-filter:has(.chat-model-picker-filter-input) {
 	margin-bottom: 4px;
 }
 


### PR DESCRIPTION
Cleans up leftover model picker input styles after the focus outline removal:

- Remove background color from the filter input (was left behind when focus outlines were removed)
- Add spacing below the filter separator to match the gap between the last model item and the "Other models" separator section