### PR TITLE
Fix a regression where the final assistant answer could stay inside the thinking container, leaving only “Working” visible.

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -1229,10 +1229,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	private renderChatContentDiff(partsToRender: ReadonlyArray<IChatRendererContent | null>, contentForThisTurn: ReadonlyArray<IChatRendererContent>, element: IChatResponseViewModel, elementIndex: number, templateData: IChatListItemTemplate): void {
 		const renderedParts = templateData.renderedParts ?? [];
 		templateData.renderedParts = renderedParts;
-		const lastMarkdownIndex = partsToRender.findLastIndex(part => part?.kind === 'markdownContent');
 		partsToRender.forEach((partToRender, contentIndex) => {
 			const alreadyRenderedPart = templateData.renderedParts?.[contentIndex];
-			const isFinalAnswerPart = partToRender?.kind === 'markdownContent' && contentIndex === lastMarkdownIndex && element.isComplete;
+			const isFinalAnswerPart = this.isFinalAnswerMarkdownPart(contentForThisTurn, contentIndex, element);
 
 			if (!partToRender) {
 				// null=no change
@@ -1308,7 +1307,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				try {
 					if (alreadyRenderedPart?.domNode) {
 						if (newPart.domNode) {
-							alreadyRenderedPart.domNode.replaceWith(newPart.domNode);
+							if (isFinalAnswerPart && this.isRenderedPartInsideThinking(alreadyRenderedPart)) {
+								alreadyRenderedPart.domNode.remove();
+								templateData.value.appendChild(newPart.domNode);
+							} else {
+								alreadyRenderedPart.domNode.replaceWith(newPart.domNode);
+							}
 						} else {
 							alreadyRenderedPart.domNode.remove();
 						}
@@ -1450,12 +1454,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private diff(renderedParts: ReadonlyArray<IChatContentPart>, contentToRender: ReadonlyArray<IChatRendererContent>, element: ChatTreeItem): ReadonlyArray<IChatRendererContent | null> {
 		const diff: (IChatRendererContent | null)[] = [];
-		const elementIsComplete = isResponseVM(element) && element.isComplete;
-		const lastMarkdownContentIndex = contentToRender.findLastIndex(part => part.kind === 'markdownContent');
 		for (let i = 0; i < contentToRender.length; i++) {
 			const content = contentToRender[i];
 			const renderedPart = renderedParts[i];
-			const isFinalAnswerPart = content.kind === 'markdownContent' && i === lastMarkdownContentIndex && elementIsComplete;
+			const isFinalAnswerPart = this.isFinalAnswerMarkdownPart(contentToRender, i, element);
 
 			if (isFinalAnswerPart && this.isRenderedPartInsideThinking(renderedPart)) {
 				diff.push(content);
@@ -1471,6 +1473,26 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		return diff;
+	}
+
+	private isFinalAnswerMarkdownPart(content: ReadonlyArray<IChatRendererContent>, index: number, element: ChatTreeItem): boolean {
+		if (!isResponseVM(element) || !element.isComplete) {
+			return false;
+		}
+
+		const part = content[index];
+		if (!part || part.kind !== 'markdownContent') {
+			return false;
+		}
+
+		const lastPinnedPartIndex = content.findLastIndex(c =>
+			c.kind === 'thinking'
+			|| c.kind === 'toolInvocation'
+			|| c.kind === 'toolInvocationSerialized'
+			|| c.kind === 'textEditGroup'
+			|| c.kind === 'hook');
+
+		return index > lastPinnedPartIndex;
 	}
 
 	private isRenderedPartInsideThinking(renderedPart: IChatContentPart | undefined): boolean {
@@ -2381,9 +2403,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private renderMarkdown(markdown: IChatMarkdownContent, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext): IChatContentPart {
 		const element = context.element;
-		const isFinalRenderPass = isResponseVM(element) && element.isComplete && !element.renderData;
-		const lastPinnedPartIndex = isFinalRenderPass ? context.content.findLastIndex(c => c.kind === 'thinking' || c.kind === 'toolInvocation' || c.kind === 'toolInvocationSerialized') : -1;
-		const isFinalAnswerPart = isFinalRenderPass && context.contentIndex > lastPinnedPartIndex;
+		const isFinalAnswerPart = this.isFinalAnswerMarkdownPart(context.content, context.contentIndex, element);
 		if (!this.hasCodeblockUri(markdown) || isFinalAnswerPart) {
 			this.finalizeCurrentThinkingPart(context, templateData);
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatListRenderer.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { mainWindow } from '../../../../../../base/browser/window.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IChatResponseViewModel, IChatRendererContent } from '../../../common/model/chatViewModel.js';
+import { IChatContentPart } from '../../../browser/widget/chatContentParts/chatContentParts.js';
+import { ChatListItemRenderer, IChatListItemTemplate } from '../../../browser/widget/chatListRenderer.js';
+import { IChatMarkdownContent } from '../../../common/chatService/chatService.js';
+
+type ChatListItemRendererPrivateMethods = {
+	isFinalAnswerMarkdownPart(content: ReadonlyArray<IChatRendererContent>, index: number, element: unknown): boolean;
+	diff(renderedParts: ReadonlyArray<IChatContentPart>, contentToRender: ReadonlyArray<IChatRendererContent>, element: unknown): ReadonlyArray<IChatRendererContent | null>;
+	renderChatContentDiff(partsToRender: ReadonlyArray<IChatRendererContent | null>, contentForThisTurn: ReadonlyArray<IChatRendererContent>, element: IChatResponseViewModel, elementIndex: number, templateData: IChatListItemTemplate): void;
+};
+
+suite('ChatListItemRenderer', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const createResponseElement = (isComplete: boolean): IChatResponseViewModel => {
+		const responseLike: Pick<IChatResponseViewModel, 'isComplete' | 'setVote'> = {
+			isComplete,
+			setVote: () => undefined
+		};
+
+		return responseLike as IChatResponseViewModel;
+	};
+
+	const createMarkdown = (value: string): IChatMarkdownContent => ({
+		kind: 'markdownContent',
+		content: new MarkdownString(value)
+	});
+
+	test('isFinalAnswerMarkdownPart: treats markdown after pinned content as final answer', () => {
+		const renderer = Object.create(ChatListItemRenderer.prototype) as ChatListItemRendererPrivateMethods;
+		const response = createResponseElement(true);
+
+		const content: IChatRendererContent[] = [
+			{ kind: 'references', references: [] },
+			{ kind: 'textEditGroup', edits: [], done: true, uri: URI.parse('file:///test.ts') },
+			createMarkdown('final answer')
+		];
+
+		assert.strictEqual(renderer.isFinalAnswerMarkdownPart(content, 2, response), true);
+	});
+
+	test('diff: rerenders final markdown when previous node is inside thinking container', () => {
+		const renderer = Object.create(ChatListItemRenderer.prototype) as ChatListItemRendererPrivateMethods;
+		const response = createResponseElement(true);
+		const finalMarkdown = createMarkdown('final answer');
+
+		const thinkingBox = mainWindow.document.createElement('div');
+		thinkingBox.className = 'chat-thinking-box';
+		const oldMarkdownDomNode = mainWindow.document.createElement('div');
+		thinkingBox.appendChild(oldMarkdownDomNode);
+
+		const renderedPart: IChatContentPart = {
+			domNode: oldMarkdownDomNode,
+			dispose: () => { },
+			hasSameContent: () => true
+		};
+
+		const diff = renderer.diff([renderedPart], [finalMarkdown], response);
+		assert.strictEqual(diff[0], finalMarkdown);
+	});
+
+	test('renderChatContentDiff: moves final markdown from thinking container to root value container', () => {
+		const renderer = Object.create(ChatListItemRenderer.prototype) as ChatListItemRendererPrivateMethods & Record<string, unknown>;
+		const value = mainWindow.document.createElement('div');
+		const rowContainer = mainWindow.document.createElement('div');
+		const thinkingBox = mainWindow.document.createElement('div');
+		thinkingBox.className = 'chat-thinking-box';
+		const oldMarkdownDomNode = mainWindow.document.createElement('div');
+		thinkingBox.appendChild(oldMarkdownDomNode);
+		value.appendChild(thinkingBox);
+
+		let disposed = false;
+		const alreadyRenderedPart: IChatContentPart = {
+			domNode: oldMarkdownDomNode,
+			dispose: () => { disposed = true; },
+			hasSameContent: () => false
+		};
+
+		const newMarkdownDomNode = mainWindow.document.createElement('div');
+		newMarkdownDomNode.className = 'final-answer-node';
+		const newPart: IChatContentPart = {
+			domNode: newMarkdownDomNode,
+			dispose: () => { },
+			hasSameContent: () => false
+		};
+
+		renderer['_editorPool'] = {};
+		renderer['_diffEditorPool'] = {};
+		renderer['codeBlockModelCollection'] = {};
+		renderer['_currentLayoutWidth'] = { get: () => 500 };
+		renderer['_onDidChangeVisibility'] = { event: Event.None };
+		renderer['logService'] = { error: () => { } };
+		renderer['shouldPinPart'] = () => false;
+		renderer['getLastThinkingPart'] = () => undefined;
+		renderer['renderChatContentPart'] = () => newPart;
+		renderer['isFinalAnswerMarkdownPart'] = () => true;
+		renderer['isRenderedPartInsideThinking'] = (renderedPart: IChatContentPart | undefined) => {
+			if (!renderedPart?.domNode) {
+				return false;
+			}
+			return !!renderedPart.domNode.closest('.chat-thinking-box');
+		};
+
+		const templateData = {
+			renderedParts: [alreadyRenderedPart],
+			rowContainer,
+			value,
+			renderedPartsMounted: true
+		} as unknown as IChatListItemTemplate;
+
+		const response = createResponseElement(true);
+		const finalMarkdown = createMarkdown('final answer');
+
+		renderer.renderChatContentDiff([finalMarkdown], [finalMarkdown], response, 0, templateData);
+
+		assert.strictEqual(disposed, true);
+		assert.strictEqual(thinkingBox.contains(newMarkdownDomNode), false);
+		assert.strictEqual(value.contains(newMarkdownDomNode), true);
+		assert.strictEqual(oldMarkdownDomNode.isConnected, false);
+	});
+});


### PR DESCRIPTION
This PR fixes a regression where the final assistant answer could stay inside the thinking container, leaving only “Working” visible. Fix #297392

I used GPT-5.3-Codex to help draft and validate this change.

The “final answer” check was implemented in multiple places with slightly different rules.  
Because of that, some render paths treated the last markdown as still pinned to thinking.

Added regression tests:
1. Final-answer classification after pinned parts.
2. `diff` forces rerender when prior markdown is inside thinking.
3. `renderChatContentDiff` moves final markdown out of thinking into the root container.
