### PR TITLE
Avoid flicker when checkpoint toolbar appears on request

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -530,7 +530,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		}
 
 		const footerToolbar = templateDisposables.add(scopedInstantiationService.createInstance(MenuWorkbenchToolBar, footerToolbarContainer, MenuId.ChatMessageFooter, {
-			eventDebounceDelay: 0,
 			menuOptions: { shouldForwardArgs: true, renderShortTitle: true },
 			toolbarOptions: { shouldInlineSubmenu: submenu => submenu.actions.length <= 1 },
 			actionViewItemProvider: (action: IAction, options: IActionViewItemOptions) => {
@@ -755,6 +754,12 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const isPendingRequest = isRequestVM(element) && !!element.pendingKind;
 
 		templateData.checkpointContainer.classList.toggle('hidden', isResponseVM(element) || isPendingRequest || !(checkpointEnabled));
+
+		// Force toolbars to synchronously re-evaluate after context key changes
+		// to avoid size measurement issues from the debounced menu update.
+		templateData.footerToolbar.refresh();
+		templateData.checkpointToolbar.refresh();
+		templateData.checkpointRestoreToolbar.refresh();
 
 		// Track response template data by request ID for cross-row hover effects
 		if (isResponseVM(element)) {


### PR DESCRIPTION
When scrolling to a request row in the chat list, the checkpoint toolbar (and other `MenuWorkbenchToolBar` instances) would not populate their actions until after the debounced menu change event fired (~50-100ms after context keys were set in `renderElement`). This caused a visible height jump as the toolbar went from empty to populated.

## Changes

### `src/vs/platform/actions/browser/toolbar.ts`
- Added a `refresh()` method to `MenuWorkbenchToolBar` that forces an immediate synchronous re-evaluation of menu actions
- Promoted the local `updateToolbar` closure to a private `_updateToolbar()` method, storing the necessary state (`_menu`, `_menuOptions`, `_toolbarOptions`, `_container`) as class fields

### `src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts`
- After setting context keys during `renderChatTreeItem`, call `refresh()` on all four toolbars (title, footer, checkpoint, checkpoint restore) to force synchronous action evaluation
- Removed the previous `eventDebounceDelay: 0` workaround from the footer toolbar

(Written by Copilot)

cc @jrieken 