### PR TITLE
Fix wrong current index in find widget if matches > 1000

### DIFF
--- a/src/vs/editor/contrib/find/browser/findDecorations.ts
+++ b/src/vs/editor/contrib/find/browser/findDecorations.ts
@@ -103,7 +103,7 @@ export class FindDecorations implements IDisposable {
 		const candidates = this._editor.getModel().getDecorationsInRange(desiredRange);
 		for (const candidate of candidates) {
 			const candidateOpts = candidate.options;
-			if (candidateOpts === FindDecorations._FIND_MATCH_DECORATION || candidateOpts === FindDecorations._CURRENT_FIND_MATCH_DECORATION) {
+			if (candidateOpts === FindDecorations._FIND_MATCH_DECORATION || candidateOpts === FindDecorations._FIND_MATCH_NO_OVERVIEW_DECORATION || candidateOpts === FindDecorations._CURRENT_FIND_MATCH_DECORATION) {
 				return this._getDecorationIndex(candidate.id);
 			}
 		}

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -2383,4 +2383,26 @@ suite('FindModel', () => {
 
 	});
 
+	test('issue #288515: Wrong current index in find widget if matches > 1000', () => {
+		// Create 1001 lines of 'hello'
+		const textArr = Array(1001).fill('hello');
+		withTestCodeEditor(textArr, {}, (_editor) => {
+			const editor = _editor as IActiveCodeEditor;
+
+			// Place cursor at line 900, selecting 'hello'
+			editor.setSelection(new Selection(900, 1, 900, 6));
+
+			const findState = disposables.add(new FindReplaceState());
+			findState.change({ searchString: 'hello' }, false);
+			const findModel = disposables.add(new FindModelBoundToEditorModel(editor, findState));
+
+			assert.strictEqual(findState.matchesCount, 1001);
+			// With cursor selecting 'hello' at line 900, matchesPosition should be 900
+			assert.strictEqual(findState.matchesPosition, 900);
+
+			findModel.dispose();
+			findState.dispose();
+		});
+	});
+
 });

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -2399,9 +2399,6 @@ suite('FindModel', () => {
 			assert.strictEqual(findState.matchesCount, 1001);
 			// With cursor selecting 'hello' at line 900, matchesPosition should be 900
 			assert.strictEqual(findState.matchesPosition, 900);
-
-			findModel.dispose();
-			findState.dispose();
 		});
 	});
 

--- a/src/vs/editor/contrib/find/test/browser/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findModel.test.ts
@@ -2394,7 +2394,7 @@ suite('FindModel', () => {
 
 			const findState = disposables.add(new FindReplaceState());
 			findState.change({ searchString: 'hello' }, false);
-			const findModel = disposables.add(new FindModelBoundToEditorModel(editor, findState));
+			disposables.add(new FindModelBoundToEditorModel(editor, findState));
 
 			assert.strictEqual(findState.matchesCount, 1001);
 			// With cursor selecting 'hello' at line 900, matchesPosition should be 900


### PR DESCRIPTION
Fixes #288515

When there are more than 1000 matches, decorations use _FIND_MATCH_NO_OVERVIEW_DECORATION instead of _FIND_MATCH_DECORATION. getCurrentMatchesPosition did not check for this decoration type, causing it to return 0 and fall through to a fallback with an off-by-one error.
