### PR TITLE
Fix potential listener leak in document semantic tokens

### DIFF
--- a/src/vs/editor/contrib/semanticTokens/browser/documentSemanticTokens.ts
+++ b/src/vs/editor/contrib/semanticTokens/browser/documentSemanticTokens.ts
@@ -128,6 +128,7 @@ class ModelSemanticColoring extends Disposable {
 	private readonly _fetchDocumentSemanticTokens: RunOnceScheduler;
 	private _currentDocumentResponse: SemanticTokensResponse | null;
 	private _currentDocumentRequestCancellationTokenSource: CancellationTokenSource | null;
+	private _relevantProviders = new Set<DocumentSemanticTokensProvider>();
 	private _providersChangedDuringRequest: boolean;
 
 	constructor(
@@ -147,6 +148,7 @@ class ModelSemanticColoring extends Disposable {
 		this._currentDocumentResponse = null;
 		this._currentDocumentRequestCancellationTokenSource = null;
 		this._providersChangedDuringRequest = false;
+		this._updateRelevantProviders();
 
 		this._register(this._model.onDidChangeContent(() => {
 			if (!this._fetchDocumentSemanticTokens.isScheduled()) {
@@ -169,6 +171,7 @@ class ModelSemanticColoring extends Disposable {
 				this._currentDocumentRequestCancellationTokenSource = null;
 			}
 			this._setDocumentSemanticTokens(null, null, null, []);
+			this._updateRelevantProviders();
 			this._fetchDocumentSemanticTokens.schedule(0);
 		}));
 
@@ -182,11 +185,12 @@ class ModelSemanticColoring extends Disposable {
 	}
 
 	public handleRegistryChange(): void {
+		this._updateRelevantProviders();
 		this._fetchDocumentSemanticTokens.schedule(this._debounceInformation.get(this._model));
 	}
 
 	public handleProviderDidChange(provider: DocumentSemanticTokensProvider): void {
-		if (!this._provider.all(this._model).includes(provider)) {
+		if (!this._relevantProviders.has(provider)) {
 			return;
 		}
 		if (this._currentDocumentRequestCancellationTokenSource) {
@@ -195,6 +199,10 @@ class ModelSemanticColoring extends Disposable {
 			return;
 		}
 		this._fetchDocumentSemanticTokens.schedule(0);
+	}
+
+	private _updateRelevantProviders(): void {
+		this._relevantProviders = new Set(this._provider.all(this._model));
 	}
 
 	public override dispose(): void {

--- a/src/vs/editor/contrib/semanticTokens/browser/documentSemanticTokens.ts
+++ b/src/vs/editor/contrib/semanticTokens/browser/documentSemanticTokens.ts
@@ -6,7 +6,7 @@
 import { RunOnceScheduler } from '../../../../base/common/async.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import * as errors from '../../../../base/common/errors.js';
-import { Disposable, IDisposable, dispose } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -27,6 +27,7 @@ import { SEMANTIC_HIGHLIGHTING_SETTING_ID, isSemanticColoringEnabled } from '../
 export class DocumentSemanticTokensFeature extends Disposable {
 
 	private readonly _watchers = new ResourceMap<ModelSemanticColoring>();
+	private readonly _providerChangeListeners = this._register(new DisposableStore());
 
 	constructor(
 		@ISemanticTokensStylingService semanticTokensStylingService: ISemanticTokensStylingService,
@@ -37,6 +38,8 @@ export class DocumentSemanticTokensFeature extends Disposable {
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 	) {
 		super();
+
+		const provider = languageFeaturesService.documentSemanticTokensProvider;
 
 		const register = (model: ITextModel) => {
 			this._watchers.get(model.uri)?.dispose();
@@ -60,6 +63,20 @@ export class DocumentSemanticTokensFeature extends Disposable {
 				}
 			}
 		};
+
+		const bindProviderChangeListeners = () => {
+			this._providerChangeListeners.clear();
+			for (const p of provider.allNoModel()) {
+				if (typeof p.onDidChange === 'function') {
+					this._providerChangeListeners.add(p.onDidChange(() => {
+						for (const watcher of this._watchers.values()) {
+							watcher.handleProviderDidChange(p);
+						}
+					}));
+				}
+			}
+		};
+
 		modelService.getModels().forEach(model => {
 			if (isSemanticColoringEnabled(model, themeService, configurationService)) {
 				register(model);
@@ -82,6 +99,13 @@ export class DocumentSemanticTokensFeature extends Disposable {
 			}
 		}));
 		this._register(themeService.onDidColorThemeChange(handleSettingOrThemeChange));
+		bindProviderChangeListeners();
+		this._register(provider.onDidChange(() => {
+			bindProviderChangeListeners();
+			for (const watcher of this._watchers.values()) {
+				watcher.handleRegistryChange();
+			}
+		}));
 	}
 
 	override dispose(): void {
@@ -104,7 +128,6 @@ class ModelSemanticColoring extends Disposable {
 	private readonly _fetchDocumentSemanticTokens: RunOnceScheduler;
 	private _currentDocumentResponse: SemanticTokensResponse | null;
 	private _currentDocumentRequestCancellationTokenSource: CancellationTokenSource | null;
-	private _documentProvidersChangeListeners: IDisposable[];
 	private _providersChangedDuringRequest: boolean;
 
 	constructor(
@@ -123,7 +146,6 @@ class ModelSemanticColoring extends Disposable {
 		this._fetchDocumentSemanticTokens = this._register(new RunOnceScheduler(() => this._fetchDocumentSemanticTokensNow(), ModelSemanticColoring.REQUEST_MIN_DELAY));
 		this._currentDocumentResponse = null;
 		this._currentDocumentRequestCancellationTokenSource = null;
-		this._documentProvidersChangeListeners = [];
 		this._providersChangedDuringRequest = false;
 
 		this._register(this._model.onDidChangeContent(() => {
@@ -150,34 +172,28 @@ class ModelSemanticColoring extends Disposable {
 			this._fetchDocumentSemanticTokens.schedule(0);
 		}));
 
-		const bindDocumentChangeListeners = () => {
-			dispose(this._documentProvidersChangeListeners);
-			this._documentProvidersChangeListeners = [];
-			for (const provider of this._provider.all(model)) {
-				if (typeof provider.onDidChange === 'function') {
-					this._documentProvidersChangeListeners.push(provider.onDidChange(() => {
-						if (this._currentDocumentRequestCancellationTokenSource) {
-							// there is already a request running,
-							this._providersChangedDuringRequest = true;
-							return;
-						}
-						this._fetchDocumentSemanticTokens.schedule(0);
-					}));
-				}
-			}
-		};
-		bindDocumentChangeListeners();
-		this._register(this._provider.onDidChange(() => {
-			bindDocumentChangeListeners();
-			this._fetchDocumentSemanticTokens.schedule(this._debounceInformation.get(this._model));
-		}));
-
 		this._register(themeService.onDidColorThemeChange(_ => {
 			// clear out existing tokens
 			this._setDocumentSemanticTokens(null, null, null, []);
 			this._fetchDocumentSemanticTokens.schedule(this._debounceInformation.get(this._model));
 		}));
 
+		this._fetchDocumentSemanticTokens.schedule(0);
+	}
+
+	public handleRegistryChange(): void {
+		this._fetchDocumentSemanticTokens.schedule(this._debounceInformation.get(this._model));
+	}
+
+	public handleProviderDidChange(provider: DocumentSemanticTokensProvider): void {
+		if (!this._provider.all(this._model).includes(provider)) {
+			return;
+		}
+		if (this._currentDocumentRequestCancellationTokenSource) {
+			// there is already a request running,
+			this._providersChangedDuringRequest = true;
+			return;
+		}
 		this._fetchDocumentSemanticTokens.schedule(0);
 	}
 
@@ -190,8 +206,6 @@ class ModelSemanticColoring extends Disposable {
 			this._currentDocumentRequestCancellationTokenSource.cancel();
 			this._currentDocumentRequestCancellationTokenSource = null;
 		}
-		dispose(this._documentProvidersChangeListeners);
-		this._documentProvidersChangeListeners = [];
 		this._setDocumentSemanticTokens(null, null, null, []);
 		this._isDisposed = true;
 


### PR DESCRIPTION
Closes #226407

Hoist provider onDidChange and registry onDidChange subscriptions from each ModelSemanticColoring instance into the singleton DocumentSemanticTokensFeature.

Previously, every ModelSemanticColoring subscribed individually to both the global LanguageFeatureRegistry.onDidChange and each provider's onDidChange event, resulting in O(N*M) listeners (N models × M providers). In scenarios like chat editing where many models are created rapidly, these listeners accumulated and triggered leak detection.

Now the singleton subscribes once to the registry change and once per provider (via allNoModel()), then fans out notifications to watchers. Each watcher checks provider relevance via _provider.all(model).includes() before acting on the event.

Also replaces manual IDisposable[] management with a DisposableStore for proper lifecycle tracking.
