### PR TITLE
docs: fix duplicated wording in proposed API comment

### DIFF
--- a/src/vscode-dts/vscode.proposed.languageModelToolSupportsModel.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModelToolSupportsModel.d.ts
@@ -42,7 +42,7 @@ declare module 'vscode' {
 		 * Registers a language model tool along with its definition. Unlike {@link lm.registerTool},
 		 * this does not require the tool to be present first in the extension's `package.json` contributions.
 		 *
-		 * Multiple tools may be registered with the the same name using the API. In any given context,
+		 * Multiple tools may be registered with the same name using the API. In any given context,
 		 * the most specific tool (based on the {@link LanguageModelToolDefinition.models}) will be used.
 		 *
 		 * @param definition The definition of the tool to register.


### PR DESCRIPTION
## Summary
- fix duplicated wording in `src/vscode-dts/vscode.proposed.languageModelToolSupportsModel.d.ts`
- changed `with the the same name` -> `with the same name`

## Related issue
- N/A (trivial comment typo fix)

## How to test
- N/A (single-file comment text change only; no behavior/API changes)

## Guideline alignment
- reference: https://github.com/microsoft/vscode/blob/main/CONTRIBUTING.md
- minimal change scoped to one file
