### PR TITLE
Fix AsyncIterableProducer.tee() to properly synchronize producers

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -2434,34 +2434,37 @@ export class AsyncIterableProducer<T> implements AsyncIterable<T> {
 		let emitter1: AsyncIterableEmitter<T> | undefined;
 		let emitter2: AsyncIterableEmitter<T> | undefined;
 
-		const defer = new DeferredPromise<void>();
+		const bothReady = new DeferredPromise<void>();
+		const done = new DeferredPromise<void>();
 
-		const start = async () => {
-			if (!emitter1 || !emitter2) {
-				return; // not yet ready
-			}
+		// Start consuming the source iterable once both producers are ready
+		bothReady.p.then(async () => {
 			try {
 				for await (const item of iterable) {
-					emitter1.emitOne(item);
-					emitter2.emitOne(item);
+					emitter1!.emitOne(item);
+					emitter2!.emitOne(item);
 				}
 			} catch (err) {
-				emitter1.reject(err);
-				emitter2.reject(err);
+				emitter1!.reject(err);
+				emitter2!.reject(err);
 			} finally {
-				defer.complete();
+				done.complete();
 			}
-		};
+		});
 
 		const p1 = new AsyncIterableProducer<T>(async (emitter) => {
 			emitter1 = emitter;
-			start();
-			return defer.p;
+			if (emitter1 && emitter2) {
+				bothReady.complete();
+			}
+			return done.p;
 		});
 		const p2 = new AsyncIterableProducer<T>(async (emitter) => {
 			emitter2 = emitter;
-			start();
-			return defer.p;
+			if (emitter1 && emitter2) {
+				bothReady.complete();
+			}
+			return done.p;
 		});
 		return [p1, p2];
 	}

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -2183,7 +2183,6 @@ suite('Async', () => {
 		});
 
 		test('tee - both iterators receive all values', async () => {
-			// TODO: Implementation bug - executors don't await start(), causing producers to finalize early
 			async function* sourceGenerator() {
 				yield 1;
 				yield 2;
@@ -2216,7 +2215,6 @@ suite('Async', () => {
 		});
 
 		test('tee - sequential consumption', async () => {
-			// TODO: Implementation bug - executors don't await start(), causing producers to finalize early
 			const source = new async.AsyncIterableProducer<number>(emitter => {
 				emitter.emitMany([1, 2, 3]);
 			});
@@ -2239,8 +2237,7 @@ suite('Async', () => {
 			assert.deepStrictEqual(result2, [1, 2, 3]);
 		});
 
-		test.skip('tee - empty source', async () => {
-			// TODO: Implementation bug - executors don't await start(), causing producers to finalize early
+		test('tee - empty source', async () => {
 			const source = new async.AsyncIterableProducer<number>(emitter => {
 				// Emit nothing
 			});
@@ -2267,8 +2264,7 @@ suite('Async', () => {
 			assert.deepStrictEqual(result2, []);
 		});
 
-		test.skip('tee - handles errors in source', async () => {
-			// TODO: Implementation bug - executors don't await start(), causing producers to finalize early
+		test('tee - handles errors in source', async () => {
 			const expectedError = new Error('source error');
 			const source = new async.AsyncIterableProducer<number>(async emitter => {
 				emitter.emitOne(1);


### PR DESCRIPTION
Fixes a known implementation issue in `AsyncIterableProducer.tee()` (added in #276037) where `start()` was called without being awaited inside executors, relying on implicit microtask ordering for correctness.

## Problem

The previous implementation used a fire-and-forget `start()` call from each executor, with an early-return guard (`if (!emitter1 || !emitter2) return`). This was fragile — two test cases ('tee - empty source' and 'tee - handles errors in source') were skipped with a TODO noting the bug.

## Solution

Restructure `tee()` to use explicit synchronization:
- A `bothReady` deferred promise that signals when both emitters are available
- A `done` deferred promise that keeps executors alive until source iteration completes
- Source consumption starts via `bothReady.p.then(...)` instead of a fire-and-forget `start()` call

This makes the data flow explicit and eliminates reliance on microtask ordering.

## Test plan
- [x] Unskipped 'tee - empty source' and 'tee - handles errors in source' tests
- [x] Removed TODO comments from all four tee test cases
- [x] Verified all tee tests pass (including stress test with 100 iterations)
- [x] Verified tee-of-tee composition works correctly