### PR TITLE
fix: clarify scope in Extensions view disable button label and tooltip

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1734,7 +1734,7 @@ export class DisableForWorkspaceAction extends ExtensionAction {
 export class DisableGloballyAction extends ExtensionAction {
 
 	static readonly ID = 'extensions.disableGlobally';
-	static readonly LABEL = localize('disableGloballyAction', "Disable");
+	static readonly LABEL = localize('disableGloballyAction', "Disable (Always)");
 
 	constructor(
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
@@ -1742,7 +1742,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		@IExtensionService private readonly extensionService: IExtensionService,
 	) {
 		super(DisableGloballyAction.ID, DisableGloballyAction.LABEL, ExtensionAction.LABEL_ACTION_CLASS);
-		this.tooltip = localize('disableGloballyActionToolTip', "Disable this extension");
+		this.tooltip = localize('disableGloballyActionToolTip', "Disable this extension for all workspaces");
 		this.update();
 		this._register(this.extensionService.onDidChangeExtensions(() => this.update()));
 	}


### PR DESCRIPTION
DisableGloballyAction previously showed Disable with no scope context. Changed to Disable (Always) with tooltip Disable this extension for all workspaces, making the dropdown symmetrical with Disable (Workspace). Fixes #244138