### PR TITLE
Fix typos: informations to information, seperate to separate, excpet to except

### DIFF
--- a/src/vs/editor/browser/config/fontMeasurements.ts
+++ b/src/vs/editor/browser/config/fontMeasurements.ts
@@ -107,7 +107,7 @@ export class FontMeasurementsImpl extends Disposable {
 	}
 
 	/**
-	 * Restore previously serialized font informations.
+	 * Restore previously serialized font information.
 	 */
 	public restoreFontInfo(targetWindow: Window, savedFontInfos: ISerializedFontInfo[]): void {
 		// Take all the saved font info and insert them in the cache without the trusted flag.

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3116,7 +3116,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1686,11 +1686,11 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			if (items.some((source) => {
 				if (source.isRoot) {
-					return false; // Root folders are handled seperately
+					return false; // Root folders are handled separately
 				}
 
 				if (this.uriIdentityService.extUri.isEqual(source.resource, target.resource)) {
-					return true; // Can not move anything onto itself excpet for root folders
+					return true; // Can not move anything onto itself except for root folders
 				}
 
 				if (!isCopy && this.uriIdentityService.extUri.isEqual(dirname(source.resource), target.resource)) {


### PR DESCRIPTION
Fix typos in code comments:
- fontMeasurements.ts: 'informations' to 'information'
- explorerViewer.ts: 'seperately' to 'separately' and 'excpet' to 'except'
- extHostTypes.ts: 'seperate' to 'separate'