### PR TITLE
Auto-approve `tee` and allow `/tmp` writes

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/commandParserUtils.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/commandParserUtils.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Tokenizes a shell command into individual arguments, handling quotes and escape sequences.
+ *
+ * Quotes (single and double) and backslash escapes are preserved in the returned tokens so
+ * that callers can detect whether a path was originally quoted.
+ */
+export function tokenizeCommand(commandText: string): string[] {
+	const tokens: string[] = [];
+	let current = '';
+	let inSingleQuote = false;
+	let inDoubleQuote = false;
+	let escaped = false;
+
+	for (let i = 0; i < commandText.length; i++) {
+		const char = commandText[i];
+
+		if (escaped) {
+			current += char;
+			escaped = false;
+			continue;
+		}
+
+		if (char === '\\' && !inSingleQuote) {
+			escaped = true;
+			current += char;
+			continue;
+		}
+
+		if (char === '\'' && !inDoubleQuote) {
+			inSingleQuote = !inSingleQuote;
+			current += char;
+			continue;
+		}
+
+		if (char === '"' && !inSingleQuote) {
+			inDoubleQuote = !inDoubleQuote;
+			current += char;
+			continue;
+		}
+
+		if (/\s/.test(char) && !inSingleQuote && !inDoubleQuote) {
+			if (current) {
+				tokens.push(current);
+				current = '';
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current) {
+		tokens.push(current);
+	}
+
+	return tokens;
+}
+
+/**
+ * Strips surrounding single or double quotes from a token, if present.
+ */
+export function stripQuotes(token: string): string {
+	if (
+		(token.startsWith('\'') && token.endsWith('\'')) ||
+		(token.startsWith('"') && token.endsWith('"'))
+	) {
+		return token.slice(1, -1);
+	}
+	return token;
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/sedFileWriteParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/sedFileWriteParser.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ICommandFileWriteParser } from './commandFileWriteParser.js';
+import { stripQuotes, tokenizeCommand } from './commandParserUtils.js';
 
 /**
  * Parser for detecting file writes from `sed` commands using in-place editing.
@@ -31,63 +32,8 @@ export class SedFileWriteParser implements ICommandFileWriteParser {
 	}
 
 	extractFileWrites(commandText: string): string[] {
-		const tokens = this._tokenizeCommand(commandText);
+		const tokens = tokenizeCommand(commandText);
 		return this._extractFileTargets(tokens);
-	}
-
-	/**
-	 * Tokenizes a command into individual arguments, handling quotes and escapes.
-	 */
-	private _tokenizeCommand(commandText: string): string[] {
-		const tokens: string[] = [];
-		let current = '';
-		let inSingleQuote = false;
-		let inDoubleQuote = false;
-		let escaped = false;
-
-		for (let i = 0; i < commandText.length; i++) {
-			const char = commandText[i];
-
-			if (escaped) {
-				current += char;
-				escaped = false;
-				continue;
-			}
-
-			if (char === '\\' && !inSingleQuote) {
-				escaped = true;
-				current += char;
-				continue;
-			}
-
-			if (char === '\'' && !inDoubleQuote) {
-				inSingleQuote = !inSingleQuote;
-				current += char;
-				continue;
-			}
-
-			if (char === '"' && !inSingleQuote) {
-				inDoubleQuote = !inDoubleQuote;
-				current += char;
-				continue;
-			}
-
-			if (/\s/.test(char) && !inSingleQuote && !inDoubleQuote) {
-				if (current) {
-					tokens.push(current);
-					current = '';
-				}
-				continue;
-			}
-
-			current += char;
-		}
-
-		if (current) {
-			tokens.push(current);
-		}
-
-		return tokens;
 	}
 
 	/**
@@ -198,12 +144,7 @@ export class SedFileWriteParser implements ICommandFileWriteParser {
 			}
 
 			// Subsequent non-option arguments are files
-			// Strip surrounding quotes from file path
-			let file = token;
-			if ((file.startsWith('\'') && file.endsWith('\'')) || (file.startsWith('"') && file.endsWith('"'))) {
-				file = file.slice(1, -1);
-			}
-			files.push(file);
+			files.push(stripQuotes(token));
 			i++;
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICommandFileWriteParser } from './commandFileWriteParser.js';
+import { stripQuotes, tokenizeCommand } from './commandParserUtils.js';
+
+/**
+ * Parser for detecting file writes from `tee` commands.
+ *
+ * `tee` reads from stdin and writes to stdout and one or more files.
+ *
+ * Handles:
+ * - `tee file.txt` (write to file)
+ * - `tee -a file.txt` (append to file)
+ * - `tee file1.txt file2.txt` (write to multiple files)
+ * - `tee --append file.txt` (long form append)
+ */
+export class TeeFileWriteParser implements ICommandFileWriteParser {
+	readonly commandName = 'tee';
+
+	canHandle(commandText: string): boolean {
+		return /^tee(\s|$)/.test(commandText);
+	}
+
+	extractFileWrites(commandText: string): string[] {
+		const tokens = tokenizeCommand(commandText);
+		return this._extractFileTargets(tokens);
+	}
+
+	/**
+	 * Extracts file targets from tokenized tee command arguments.
+	 * All non-option arguments after `tee` are file targets.
+	 */
+	private _extractFileTargets(tokens: string[]): string[] {
+		if (tokens.length === 0 || tokens[0] !== 'tee') {
+			return [];
+		}
+
+		const files: string[] = [];
+		let i = 1; // Skip 'tee'
+
+		while (i < tokens.length) {
+			const token = tokens[i];
+
+			// Long options
+			if (token.startsWith('--')) {
+				if (token === '--output-error') {
+					// --output-error takes an argument (warn, warn-nopipe, exit, exit-nopipe)
+					i += 2;
+					continue;
+				}
+				if (token.startsWith('--output-error=')) {
+					i++;
+					continue;
+				}
+				// Other long options like --append, --help, --version
+				i++;
+				continue;
+			}
+
+			// Short options
+			if (token.startsWith('-') && token.length > 1) {
+				// Flags like -a, -i, -p, or combined like -ai
+				i++;
+				continue;
+			}
+
+			// Non-option argument: this is a file target
+			files.push(stripQuotes(token));
+			i++;
+		}
+
+		return files;
+	}
+}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
@@ -82,6 +82,12 @@ export class TeeFileWriteParser implements ICommandFileWriteParser {
 				continue;
 			}
 
+			// A lone "-" is stdout, not a file target
+			if (token === '-') {
+				i++;
+				continue;
+			}
+
 			// Non-option argument: this is a file target
 			files.push(stripQuotes(token));
 			i++;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/commandParsers/teeFileWriteParser.ts
@@ -40,9 +40,24 @@ export class TeeFileWriteParser implements ICommandFileWriteParser {
 
 		const files: string[] = [];
 		let i = 1; // Skip 'tee'
+		let endOfOptions = false;
 
 		while (i < tokens.length) {
 			const token = tokens[i];
+
+			// After --, all remaining tokens are file targets
+			if (endOfOptions) {
+				files.push(stripQuotes(token));
+				i++;
+				continue;
+			}
+
+			// End-of-options marker
+			if (token === '--') {
+				endOfOptions = true;
+				i++;
+				continue;
+			}
 
 			// Long options
 			if (token.startsWith('--')) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -125,7 +125,13 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 			return false;
 		}
 		const normalized = posix.normalize(fileUri.path);
-		return normalized.startsWith('/tmp/') || normalized.startsWith('/private/tmp/');
+		if (normalized.startsWith('/tmp/')) {
+			return true;
+		}
+		if (os === OperatingSystem.Macintosh && normalized.startsWith('/private/tmp/')) {
+			return true;
+		}
+		return false;
 	}
 
 	private _getResult(options: ICommandLineAnalyzerOptions, fileWrites: FileWrite[]): ICommandLineAnalyzerResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -128,7 +128,9 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 		if (normalized.startsWith('/tmp/')) {
 			return true;
 		}
-		if (os === OperatingSystem.Macintosh && normalized.startsWith('/private/tmp/')) {
+		// /private/tmp is the real path behind the /tmp symlink on macOS.
+		// This path does not exist on Linux by default
+		if (normalized.startsWith('/private/tmp/')) {
 			return true;
 		}
 		return false;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -151,7 +151,11 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								this._log('File write blocked due to likely containing a variable or sub-command', fileUri.toString());
 								break;
 							}
-
+							// Allow writes to /tmp (and /private/tmp on macOS)
+							if (options.os !== OperatingSystem.Windows && (fileUri.path.startsWith('/tmp/') || fileUri.path.startsWith('/private/tmp/'))) {
+								this._log('File write to tmp directory allowed', fileUri.toString());
+								continue;
+							}
 							const isInsideWorkspace = workspaceFolders.some(folder =>
 								folder.uri.scheme === fileUri.scheme &&
 								(fileUri.path.startsWith(folder.uri.path + '/') || fileUri.path === folder.uri.path)
@@ -163,9 +167,20 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							}
 						}
 					} else {
-						// No workspace folders, allow safe null device paths even without workspace
-						const hasOnlyNullDevices = fileWrites.every(fw => fw === nullDevice);
-						if (!hasOnlyNullDevices) {
+						// No workspace folders, allow safe null device and tmp paths even without workspace
+						const hasOnlySafeTargets = fileWrites.every(fw => {
+							if (fw === nullDevice) {
+								return true;
+							}
+							if (options.os !== OperatingSystem.Windows) {
+								const fileUri = URI.isUri(fw) ? fw : isString(fw) ? URI.file(fw) : undefined;
+								if (fileUri && (fileUri.path.startsWith('/tmp/') || fileUri.path.startsWith('/private/tmp/'))) {
+									return true;
+								}
+							}
+							return false;
+						});
+						if (!hasOnlySafeTargets) {
 							isAutoApproveAllowed = false;
 							this._log('File writes blocked - no workspace folders');
 						}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -116,6 +116,18 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 			: rawFileWrite;
 	}
 
+	/**
+	 * Checks whether a file URI points to a safe temporary directory.
+	 * Normalizes the path first to prevent traversal bypasses like `/tmp/../etc/config`.
+	 */
+	private _isSafeTmpPath(os: OperatingSystem, fileUri: URI): boolean {
+		if (os === OperatingSystem.Windows) {
+			return false;
+		}
+		const normalized = posix.normalize(fileUri.path);
+		return normalized.startsWith('/tmp/') || normalized.startsWith('/private/tmp/');
+	}
+
 	private _getResult(options: ICommandLineAnalyzerOptions, fileWrites: FileWrite[]): ICommandLineAnalyzerResult {
 		let isAutoApproveAllowed = true;
 		if (fileWrites.length > 0) {
@@ -152,7 +164,7 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								break;
 							}
 							// Allow writes to /tmp (and /private/tmp on macOS)
-							if (options.os !== OperatingSystem.Windows && (fileUri.path.startsWith('/tmp/') || fileUri.path.startsWith('/private/tmp/'))) {
+							if (this._isSafeTmpPath(options.os, fileUri)) {
 								this._log('File write to tmp directory allowed', fileUri.toString());
 								continue;
 							}
@@ -172,9 +184,13 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 							if (fw === nullDevice) {
 								return true;
 							}
-							if (options.os !== OperatingSystem.Windows) {
-								const fileUri = URI.isUri(fw) ? fw : isString(fw) ? URI.file(fw) : undefined;
-								if (fileUri && (fileUri.path.startsWith('/tmp/') || fileUri.path.startsWith('/private/tmp/'))) {
+							const fileUri = URI.isUri(fw) ? fw : isString(fw) ? URI.file(fw) : undefined;
+							if (fileUri) {
+								// Block paths likely containing variables or sub-commands
+								if (fileUri.fsPath.match(/[$\(\){}`]/)) {
+									return false;
+								}
+								if (this._isSafeTmpPath(options.os, fileUri)) {
 									return true;
 								}
 							}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/treeSitterCommandParser.ts
@@ -11,6 +11,7 @@ import { Disposable, MutableDisposable, toDisposable } from '../../../../../base
 import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
 import { ICommandFileWriteParser } from './commandParsers/commandFileWriteParser.js';
 import { SedFileWriteParser } from './commandParsers/sedFileWriteParser.js';
+import { TeeFileWriteParser } from './commandParsers/teeFileWriteParser.js';
 
 export const enum TreeSitterCommandParserLanguage {
 	Bash = 'bash',
@@ -22,6 +23,7 @@ export class TreeSitterCommandParser extends Disposable {
 	private readonly _treeCache = this._register(new TreeCache());
 	private readonly _commandFileWriteParsers: ICommandFileWriteParser[] = [
 		new SedFileWriteParser(),
+		new TeeFileWriteParser(),
 	];
 
 	constructor(

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -197,6 +197,12 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 			//   manual approval.
 			grep: true,
 
+			// tee
+			//
+			// Reads stdin and writes to stdout and files. File write safety is handled by
+			// the file write analyzer.
+			tee: true,
+
 			// #endregion
 
 			// #region Safe sub-commands

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -105,7 +105,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('relative path - grandparent directory - block', () => t('echo hello > ../../file.txt', 'outsideWorkspace', false, 1));
 
 			// Absolute paths (parsed as-is)
-			test('absolute path - /tmp - block', () => t('echo hello > /tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('absolute path - /tmp - allow', () => t('echo hello > /tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('absolute path - /private/tmp - allow', () => t('echo hello > /private/tmp/file.txt', 'outsideWorkspace', true, 1));
 			test('absolute path - /etc - block', () => t('echo hello > /etc/config.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - /home - block', () => t('echo hello > /home/user/file.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - root - block', () => t('echo hello > /file.txt', 'outsideWorkspace', false, 1));
@@ -114,6 +115,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			// Special cases
 			test('no workspace folders - block', () => t('echo hello > file.txt', 'outsideWorkspace', false, 1, []));
 			test('no workspace folders - /dev/null allowed', () => t('echo hello > /dev/null', 'outsideWorkspace', true, 1, []));
+			test('no workspace folders - /tmp allowed', () => t('echo hello > /tmp/file.txt', 'outsideWorkspace', true, 1, []));
+			test('no workspace folders - /private/tmp allowed', () => t('echo hello > /private/tmp/file.txt', 'outsideWorkspace', true, 1, []));
 			test('no redirections - allow', () => t('echo hello', 'outsideWorkspace', true, 0));
 			test('variable in filename - block', () => t('echo hello > $HOME/file.txt', 'outsideWorkspace', false, 1));
 			test('command substitution - block', () => t('echo hello > $(pwd)/file.txt', 'outsideWorkspace', false, 1));
@@ -129,7 +132,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 
 		suite('complex scenarios', () => {
 			test('pipeline with redirection inside workspace', () => t('cat file.txt | grep "test" > output.txt', 'outsideWorkspace', true, 1));
-			test('multiple redirections mixed inside/outside', () => t('echo hello > file.txt && echo world > /tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('multiple redirections mixed inside/outside', () => t('echo hello > file.txt && echo world > /tmp/file.txt', 'outsideWorkspace', true, 1));
 			test('here-document', () => t('cat > file.txt << EOF\nhello\nEOF', 'outsideWorkspace', true, 1));
 			test('error output to /dev/null - allow', () => t('cat missing.txt 2> /dev/null', 'outsideWorkspace', true, 1));
 		});
@@ -153,9 +156,9 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('sed -i multiple files inside workspace - allow', () => t('sed -i \'s/foo/bar/\' file1.txt file2.txt', 'outsideWorkspace', true, 1));
 
 			// Outside workspace
-			test('sed -i outside workspace - block', () => t('sed -i \'s/foo/bar/\' /tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('sed -i outside workspace /tmp - allow', () => t('sed -i \'s/foo/bar/\' /tmp/file.txt', 'outsideWorkspace', true, 1));
 			test('sed -i absolute path outside workspace - block', () => t('sed -i \'s/foo/bar/\' /etc/config', 'outsideWorkspace', false, 1));
-			test('sed -i mixed inside/outside - block', () => t('sed -i \'s/foo/bar/\' file.txt /tmp/other.txt', 'outsideWorkspace', false, 1));
+			test('sed -i mixed inside/outside /tmp - allow', () => t('sed -i \'s/foo/bar/\' file.txt /tmp/other.txt', 'outsideWorkspace', true, 1));
 
 			// With blockDetectedFileWrites: all
 			test('sed -i with all setting - block', () => t('sed -i \'s/foo/bar/\' file.txt', 'all', false, 1));
@@ -166,6 +169,14 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			// Without -i flag (should not detect as file write)
 			test('sed without -i - no file write detected', () => t('sed \'s/foo/bar/\' file.txt', 'outsideWorkspace', true, 0));
 			test('sed with pipe - no file write detected', () => t('cat file.txt | sed \'s/foo/bar/\'', 'outsideWorkspace', true, 0));
+		});
+
+		suite('tee', () => {
+			test('tee to /tmp - allow', () => t('echo hello | tee /tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('tee to /private/tmp - allow', () => t('echo hello | tee /private/tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('tee to workspace - allow', () => t('echo hello | tee file.txt', 'outsideWorkspace', true, 1));
+			test('tee to outside workspace - block', () => t('echo hello | tee /etc/file.txt', 'outsideWorkspace', false, 1));
+			test('tee append to /tmp - allow', () => t('echo hello | tee -a /tmp/file.txt', 'outsideWorkspace', true, 1));
 		});
 
 		suite('no cwd provided', () => {
@@ -318,7 +329,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			strictEqual(combinedDisclaimers.includes(expectedContains), true, `Expected disclaimer to contain "${expectedContains}" but got: ${combinedDisclaimers}`);
 		}
 
-		test('blocked disclaimer - absolute path outside workspace', () => checkDisclaimer('echo hello > /tmp/file.txt', 'outsideWorkspace', 'cannot be auto approved'));
+		test('blocked disclaimer - absolute path outside workspace', () => checkDisclaimer('echo hello > /etc/file.txt', 'outsideWorkspace', 'cannot be auto approved'));
 		test('allowed disclaimer - relative path inside workspace', () => checkDisclaimer('echo hello > file.txt', 'outsideWorkspace', 'File write operations detected'));
 		test('blocked disclaimer - all setting blocks everything', () => checkDisclaimer('echo hello > file.txt', 'all', 'cannot be auto approved'));
 	});
@@ -350,7 +361,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 
 		test('relative path in same workspace - allow', () => t(workspace1, 'echo hello > file.txt', true, 1));
 		test('absolute path to other workspace - allow', () => t(workspace1, 'echo hello > /workspace/project2/file.txt', true, 1));
-		test('absolute path outside all workspaces - block', () => t(workspace1, 'echo hello > /tmp/file.txt', false, 1));
+		test('absolute path outside all workspaces - block', () => t(workspace1, 'echo hello > /etc/file.txt', false, 1));
 		test('relative path to parent of workspace - block', () => t(workspace1, 'echo hello > ../file.txt', false, 1));
 	});
 
@@ -379,7 +390,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 		test('file scheme - relative path inside workspace', () => t('file', undefined, 'file.txt', true));
 		test('vscode-remote scheme - relative path inside workspace', () => t('vscode-remote', 'wsl+debian', 'file.txt', true));
 		test('vscode-remote scheme - absolute path inside workspace', () => t('vscode-remote', 'wsl+debian', '/workspace/project/file.txt', true));
-		test('vscode-remote scheme - absolute path outside workspace', () => t('vscode-remote', 'wsl+debian', '/tmp/file.txt', false));
+		test('vscode-remote scheme - absolute path outside workspace', () => t('vscode-remote', 'wsl+debian', '/etc/file.txt', false));
 		test('vscode-remote scheme - absolute path to home directory outside workspace', () => t('vscode-remote', 'wsl+debian', '/home/user/file.txt', false));
 	});
 
@@ -410,13 +421,13 @@ suite('CommandLineFileWriteAnalyzer', () => {
 		// Double-quoted paths
 		test('double-quoted relative path inside workspace - allow', () => t('echo hello > "file.txt"', 'outsideWorkspace', true, 1));
 		test('double-quoted relative path with spaces inside workspace - allow', () => t('echo hello > "file with spaces.txt"', 'outsideWorkspace', true, 1));
-		test('double-quoted absolute path outside workspace - block', () => t('echo hello > "/tmp/file.txt"', 'outsideWorkspace', false, 1));
+		test('double-quoted absolute path outside workspace - block', () => t('echo hello > "/etc/file.txt"', 'outsideWorkspace', false, 1));
 		test('double-quoted absolute path to home - block', () => t('echo hello > "/home/user/foo.txt"', 'outsideWorkspace', false, 1));
 
 		// Single-quoted paths
 		test('single-quoted relative path inside workspace - allow', () => t('echo hello > \'file.txt\'', 'outsideWorkspace', true, 1));
 		test('single-quoted relative path with spaces inside workspace - allow', () => t('echo hello > \'file with spaces.txt\'', 'outsideWorkspace', true, 1));
-		test('single-quoted absolute path outside workspace - block', () => t('echo hello > \'/tmp/file.txt\'', 'outsideWorkspace', false, 1));
+		test('single-quoted absolute path outside workspace - block', () => t('echo hello > \'/etc/file.txt\'', 'outsideWorkspace', false, 1));
 		test('single-quoted absolute path to home - block', () => t('echo hello > \'/home/user/foo.txt\'', 'outsideWorkspace', false, 1));
 
 		// Note: Backticks in bash are command substitution, not quoting, so no tests for backtick-quoted paths

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -183,6 +183,7 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('tee append to /tmp - allow', () => t('echo hello | tee -a /tmp/file.txt', 'outsideWorkspace', true, 1));
 			test('tee /tmp traversal - block', () => t('echo hello | tee /tmp/../etc/config', 'outsideWorkspace', false, 1));
 			test('tee with -- treats dash-args as files', () => t('echo hello | tee -- -file.txt', 'outsideWorkspace', true, 1));
+			test('tee lone - is stdout not a file', () => t('echo hello | tee -', 'outsideWorkspace', true, 0));
 		});
 
 		suite('no cwd provided', () => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -107,6 +107,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			// Absolute paths (parsed as-is)
 			test('absolute path - /tmp - allow', () => t('echo hello > /tmp/file.txt', 'outsideWorkspace', true, 1));
 			test('absolute path - /private/tmp - allow', () => t('echo hello > /private/tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('absolute path - /tmp traversal - block', () => t('echo hello > /tmp/../etc/config', 'outsideWorkspace', false, 1));
+			test('absolute path - /private/tmp traversal - block', () => t('echo hello > /private/tmp/../../../etc/passwd', 'outsideWorkspace', false, 1));
 			test('absolute path - /etc - block', () => t('echo hello > /etc/config.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - /home - block', () => t('echo hello > /home/user/file.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - root - block', () => t('echo hello > /file.txt', 'outsideWorkspace', false, 1));
@@ -117,6 +119,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('no workspace folders - /dev/null allowed', () => t('echo hello > /dev/null', 'outsideWorkspace', true, 1, []));
 			test('no workspace folders - /tmp allowed', () => t('echo hello > /tmp/file.txt', 'outsideWorkspace', true, 1, []));
 			test('no workspace folders - /private/tmp allowed', () => t('echo hello > /private/tmp/file.txt', 'outsideWorkspace', true, 1, []));
+			test('no workspace folders - /tmp traversal - block', () => t('echo hello > /tmp/../etc/config', 'outsideWorkspace', false, 1, []));
+			test('no workspace folders - /tmp with variable - block', () => t('echo hello > /tmp/$FOO/out.txt', 'outsideWorkspace', false, 1, []));
 			test('no redirections - allow', () => t('echo hello', 'outsideWorkspace', true, 0));
 			test('variable in filename - block', () => t('echo hello > $HOME/file.txt', 'outsideWorkspace', false, 1));
 			test('command substitution - block', () => t('echo hello > $(pwd)/file.txt', 'outsideWorkspace', false, 1));
@@ -177,6 +181,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			test('tee to workspace - allow', () => t('echo hello | tee file.txt', 'outsideWorkspace', true, 1));
 			test('tee to outside workspace - block', () => t('echo hello | tee /etc/file.txt', 'outsideWorkspace', false, 1));
 			test('tee append to /tmp - allow', () => t('echo hello | tee -a /tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('tee /tmp traversal - block', () => t('echo hello | tee /tmp/../etc/config', 'outsideWorkspace', false, 1));
+			test('tee with -- treats dash-args as files', () => t('echo hello | tee -- -file.txt', 'outsideWorkspace', true, 1));
 		});
 
 		suite('no cwd provided', () => {
@@ -208,7 +214,8 @@ suite('CommandLineFileWriteAnalyzer', () => {
 
 			// Absolute paths are converted to URIs and checked normally
 			test('absolute path inside workspace - outsideWorkspace setting - allow', () => tNoCwd('echo hello > /workspace/project/file.txt', 'outsideWorkspace', true, 1));
-			test('absolute path outside workspace - outsideWorkspace setting - block', () => tNoCwd('echo hello > /tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('absolute path /tmp - outsideWorkspace setting - allow', () => tNoCwd('echo hello > /tmp/file.txt', 'outsideWorkspace', true, 1));
+			test('absolute path outside workspace - outsideWorkspace setting - block', () => tNoCwd('echo hello > /etc/config.txt', 'outsideWorkspace', false, 1));
 			test('absolute path - all setting - block', () => tNoCwd('echo hello > /tmp/file.txt', 'all', false, 1));
 		});
 	});


### PR DESCRIPTION
I thought this would be a simple first PR, but adding `tee` means the file write analyzer needs to know which files `tee` targets (redirections are already caught by tree-sitter). So it also needed a `TeeFileWriteParser` and shared tokenizer extraction? Happy to make some edits and resubmit if there is a better idea.

This adds `tee` to the auto-approve allowlist, a `TeeFileWriteParser` so the file write analyzer detects `tee`'s file arguments (same pattern as `SedFileWriteParser`) and allows writes to `/tmp` and `/private/tmp` in the analyzer.

On macOS `/tmp` is a symlink to `/private/tmp`. If the shell resolves the symlink before the path reaches the analyzer `startsWith('/tmp/')` misses it. Checking both prefixes covers both cases.

I left out `/var/tmp`. I believe it's more for stuff that survives reboots and #288327 only asks for `/tmp`.

Not sure if `/private/tmp` is in scope for #288327. Let me know if you'd rather drop it and keep only `/tmp`.

#288328 covers most of the same ground but doesn't handle `/private/tmp`. Copilot also didn't touch the no-workspace-folders path to allow `/tmp` there, so I added that too.

Also moves the duplicate `_tokenizeCommand` from `SedFileWriteParser` into a shared `commandParserUtils.ts`.

For pre-existing tests that used `/tmp/file.txt` as the "outside workspace - block" example, I updated the path to `/etc/file.txt` to preserve the original intent rather than flipping them to "allow" like #288328 does

Tests added for `/tmp`, `/private/tmp`, and `tee` with various destinations.

Fixes #288327 
