### PR TITLE
Fix PowerShell highlighting of built-in constant variables

### DIFF
--- a/extensions/powershell/syntaxes/powershell.tmLanguage.json
+++ b/extensions/powershell/syntaxes/powershell.tmLanguage.json
@@ -647,7 +647,7 @@
 				{
 					"captures": {
 						"0": {
-							"name": "support.constant.variable.powershell"
+							"name": "variable.other.constant.powershell"
 						},
 						"1": {
 							"name": "punctuation.definition.variable.powershell"
@@ -825,7 +825,7 @@
 				{
 					"captures": {
 						"0": {
-							"name": "support.constant.variable.powershell"
+							"name": "variable.other.constant.powershell"
 						},
 						"1": {
 							"name": "punctuation.definition.variable.powershell"


### PR DESCRIPTION
Related PowerShell/EditorSyntax PR: <https://github.com/PowerShell/EditorSyntax/pull/223>

## Fix

Use a TextMate scope for PowerShell built-in constant variables that most themes actually have defined in `tokenColors`.

I see that C#, Ruby and Go TextMate files uses `variable.other.constant.<language>`, so I went with that.

* <https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20variable.other.constant.&type=code>

## Context

For a long time, PowerShell highlighting for built-in constant variables has been broken in VSCode.

<img width="652" height="751" alt="image" src="https://github.com/user-attachments/assets/bd71d2de-5171-4e67-9d11-647c490969ee" />

Some related issues:

* 2024-03-16: <https://github.com/PowerShell/vscode-powershell/issues/4944>
* 2024-03-17: <https://github.com/PowerShell/EditorSyntax/issues/218>
* 2025-04-03: <https://github.com/PowerShell/vscode-powershell/issues/5166>

I believe I've tracked it down to the PowerShell TextMate using a TextMate scope most themes do not have a definition for:

<img width="1243" height="976" alt="image" src="https://github.com/user-attachments/assets/8340fdf3-eae9-405b-b542-159d918d0b40" />

The official Dracula theme even has a workaround just for this <https://github.com/dracula/visual-studio-code/blob/main/src/dracula.yml>:

```yml
  - name: Powershell constants mistakenly scoped to `support`, rather than `constant` (edge)
    scope:
    - support.constant
    settings:
      fontStyle: normal
      foreground: *PURPLE
```
