### PR TITLE
Fix SCM graph merge destination line color (#291486)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistory.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistory.ts
@@ -208,7 +208,7 @@ export function renderSCMHistoryItemGraph(historyItemViewModel: ISCMHistoryItemV
 
 		// Draw -\
 		const d: string[] = [];
-		const path = createPath(outputSwimlanes[parentOutputIndex].color);
+		const path = createPath(circleColor);
 
 		// Draw \
 		d.push(`M ${SWIMLANE_WIDTH * parentOutputIndex} ${SWIMLANE_HEIGHT / 2}`);


### PR DESCRIPTION
Fixes #291486

When a merge commit is rendered in the Source Control graph, the line connecting the merge commit to the secondary parent(s) was colored with the source branch color instead of the destination branch color.

The fix changes the `createPath()` call in the "Add remaining parent(s)" loop to use `circleColor` (the destination branch color) instead of `outputSwimlanes[parentOutputIndex].color` (the source branch color).

This ensures that all lines that arrive at a merge commit node use the color of the destination branch, which is the expected behavior.