### PR TITLE
Fix SCM history graph merge commit lines using wrong branch color

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistory.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistory.ts
@@ -208,7 +208,7 @@ export function renderSCMHistoryItemGraph(historyItemViewModel: ISCMHistoryItemV
 
 		// Draw -\
 		const d: string[] = [];
-		const path = createPath(outputSwimlanes[parentOutputIndex].color);
+		const path = createPath(circleColor);
 
 		// Draw \
 		d.push(`M ${SWIMLANE_WIDTH * parentOutputIndex} ${SWIMLANE_HEIGHT / 2}`);

--- a/src/vs/workbench/contrib/scm/browser/scmHistory.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistory.ts
@@ -208,7 +208,8 @@ export function renderSCMHistoryItemGraph(historyItemViewModel: ISCMHistoryItemV
 
 		// Draw -\
 		const d: string[] = [];
-		const path = createPath(circleColor);
+		const parentColor = outputSwimlanes[parentOutputIndex].color;
+		const path = createPath(parentColor);
 
 		// Draw \
 		d.push(`M ${SWIMLANE_WIDTH * parentOutputIndex} ${SWIMLANE_HEIGHT / 2}`);


### PR DESCRIPTION
Fixes #298588

## Problem

In the Source Control history graph, when a merge commit has more than one parent, the lines connecting the merge node to its additional parents are drawn using \circleColor\ (the merge commit's own color) instead of the color of the target parent's swimlane.

This makes it impossible to visually trace branch colors through merge commits.

## Root Cause

In `renderSCMHistoryItemGraph` (`scmHistory.ts`), the `// Add remaining parent(s)` loop uses `circleColor` for all paths:

```typescript
const path = createPath(circleColor);
```

## Fix

Use the color from the target parent's output swimlane entry instead:

```typescript
const parentColor = outputSwimlanes[parentOutputIndex].color;
const path = createPath(parentColor);
```

`outputSwimlanes[parentOutputIndex].color` holds the color that was already assigned to that specific parent branch when building the view model, so this single change is sufficient to propagate the correct color for each merged-in line.