### PR TITLE
Fix chat terminal flicker during streaming

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
+++ b/src/vs/workbench/contrib/terminal/browser/chatTerminalCommandMirror.ts
@@ -308,12 +308,10 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 			// if we blindly append.
 			const canAppend = !!this._lastVT && vt.text.length >= this._lastVT.length && this._vtBoundaryMatches(vt.text, this._lastVT.length);
 			if (!canAppend) {
-				// Reset the terminal if we had previous content (can't append, need full rewrite)
-				if (this._lastVT) {
-					detached.xterm.reset();
-				}
-				if (vt.text) {
-					detached.xterm.write(vt.text, resolve);
+				// Use \x1bc (RIS) + new content in one write to avoid a blank frame
+				const payload = this._lastVT ? `\x1bc${vt.text}` : vt.text;
+				if (payload) {
+					detached.xterm.write(payload, resolve);
 				} else {
 					resolve();
 				}
@@ -542,12 +540,10 @@ export class DetachedTerminalCommandMirror extends Disposable implements IDetach
 		const canAppend = !!this._lastVT && startLine >= previousCursor && vt.text.length >= this._lastVT.length && this._vtBoundaryMatches(vt.text, this._lastVT.length);
 		await new Promise<void>(resolve => {
 			if (!canAppend) {
-				// Reset the terminal if we had previous content (can't append, need full rewrite)
-				if (this._lastVT) {
-					detachedRaw.reset();
-				}
-				if (vt.text) {
-					detachedRaw.write(vt.text, resolve);
+				// Use \x1bc (RIS) + new content in one write to avoid a blank frame
+				const payload = this._lastVT ? `\x1bc${vt.text}` : vt.text;
+				if (payload) {
+					detachedRaw.write(payload, resolve);
 				} else {
 					resolve();
 				}

--- a/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/chatTerminalCommandMirror.test.ts
@@ -261,10 +261,8 @@ suite('Workbench - ChatTerminalCommandMirror', () => {
 			// Boundary should NOT match because the prefix diverged
 			strictEqual(boundaryMatches, false, 'Boundary check should detect divergence');
 
-			// When boundary doesn't match, the fix does a full reset + rewrite
-			// instead of corrupting the output by blind slicing
-			mirror.raw.reset();
-			await write(mirror, vt2);
+			// Use \x1bc (RIS) + new content in one write to avoid a blank frame
+			await write(mirror, `\x1bc${vt2}`);
 
 			// Final content should be the complete new VT, not corrupted
 			strictEqual(getBufferText(mirror), 'DifferentPrefixLine3');


### PR DESCRIPTION
The embedded terminal in chat flickers to blank during command execution. I used `npm run test-node` to reproduce/test. I think the issue is in `chatTerminalCommandMirror.ts` when it can't append incrementally it calls `xterm.reset()` then `xterm.write(text)` as two separate calls and xterm renders a blank frame in between.

I changed it to do `write('\x1bc' + text)` instead which puts the reset and the new content in the same write call so xterm handles it all before painting. `\x1bc` is the same thing as `reset()` according to the xterm.js docs (`Perform a full reset (RIS, aka '\x1bc')`). I saw `terminalProcessManager.ts` already does this for seamless relaunch so it seemed like a valid approach.

Tested on Windows and seems to not flicker now.

Tries to fix #293128 and #293579

