### PR TITLE
chat: wrap markdown tables with horizontal scrollbar

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -10,6 +10,7 @@ import { status } from '../../../../../../base/browser/ui/aria/aria.js';
 import { HoverStyle } from '../../../../../../base/browser/ui/hover/hover.js';
 import { HoverPosition } from '../../../../../../base/browser/ui/hover/hoverWidget.js';
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { wrapTablesWithScrollable } from './chatMarkdownTableScrolling.js';
 import { coalesce } from '../../../../../../base/common/arrays.js';
 import { findLast } from '../../../../../../base/common/arraysFind.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
@@ -373,6 +374,8 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 				layoutParticipants.value.add(() => { scrollable.scanDomNode(); });
 				scrollable.scanDomNode();
 			}
+
+			wrapTablesWithScrollable(this.domNode, orderedDisposablesList, layoutParticipants);
 
 			orderedDisposablesList.reverse().forEach(d => store.add(d));
 		};

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownContentPart.ts
@@ -375,7 +375,7 @@ export class ChatMarkdownContentPart extends Disposable implements IChatContentP
 				scrollable.scanDomNode();
 			}
 
-			wrapTablesWithScrollable(this.domNode, orderedDisposablesList, layoutParticipants);
+			orderedDisposablesList.push(wrapTablesWithScrollable(this.domNode, layoutParticipants));
 
 			orderedDisposablesList.reverse().forEach(d => store.add(d));
 		};

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownTableScrolling.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownTableScrolling.ts
@@ -6,7 +6,8 @@
 import * as dom from '../../../../../../base/browser/dom.js';
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { Lazy } from '../../../../../../base/common/lazy.js';
-import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+
 import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
 
 /**
@@ -21,7 +22,8 @@ import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js
  * like "001" from being squeezed to one character wide. Single-character columns
  * are left unchanged. This is layout-free: only `textContent` lengths are read.
  */
-export function wrapTablesWithScrollable(domNode: HTMLElement, orderedDisposablesList: IDisposable[], layoutParticipants: Lazy<Set<() => void>>): void {
+export function wrapTablesWithScrollable(domNode: HTMLElement, layoutParticipants: Lazy<Set<() => void>>): DisposableStore {
+	const store = new DisposableStore();
 	// eslint-disable-next-line no-restricted-syntax
 	for (const table of domNode.querySelectorAll('table')) {
 		if (!dom.isHTMLElement(table)) {
@@ -38,11 +40,10 @@ export function wrapTablesWithScrollable(domNode: HTMLElement, orderedDisposable
 		const nextSibling = table.nextSibling;
 		const tableContainer = document.createElement('div');
 		tableContainer.appendChild(table); // moves table out of DOM
-		const scrollable = new DomScrollableElement(tableContainer, { // moves tableContainer into scrollNode
+		const scrollable = store.add(new DomScrollableElement(tableContainer, { // moves tableContainer into scrollNode
 			vertical: ScrollbarVisibility.Hidden,
 			horizontal: ScrollbarVisibility.Auto,
-		});
-		orderedDisposablesList.push(scrollable);
+		}));
 		const scrollNode = scrollable.getDomNode();
 		scrollNode.classList.add('rendered-markdown-table-scroll-wrapper');
 		parent?.insertBefore(scrollNode, nextSibling);
@@ -50,6 +51,7 @@ export function wrapTablesWithScrollable(domNode: HTMLElement, orderedDisposable
 		layoutParticipants.value.add(() => { scrollable.scanDomNode(); });
 		scrollable.scanDomNode();
 	}
+	return store;
 }
 
 /** Maximum `min-width` (in `ch`) applied to any table column, regardless of its content length. */
@@ -66,11 +68,14 @@ function applyTableColumnMinWidths(table: HTMLTableElement): void {
 			}
 		}
 	}
-	for (const row of rows) {
-		for (let c = 0; c < row.cells.length; c++) {
+	// Apply min-width only to the first row's cells so each column width
+	// constraint is set once rather than touching every cell in the table.
+	const firstRow = rows[0];
+	if (firstRow) {
+		for (let c = 0; c < firstRow.cells.length; c++) {
 			const minCh = colMaxChars[c];
 			if (minCh !== undefined && minCh > 1) {
-				row.cells[c].style.minWidth = Math.min(minCh, TABLE_COLUMN_MIN_WIDTH_CAP_CH) + 'ch';
+				firstRow.cells[c].style.minWidth = Math.min(minCh, TABLE_COLUMN_MIN_WIDTH_CAP_CH) + 'ch';
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownTableScrolling.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMarkdownTableScrolling.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../../../base/browser/dom.js';
+import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
+import { Lazy } from '../../../../../../base/common/lazy.js';
+import { IDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ScrollbarVisibility } from '../../../../../../base/common/scrollable.js';
+
+/**
+ * Finds all tables in `domNode` and wraps each in a {@link DomScrollableElement}
+ * so they scroll horizontally with the custom VS Code scrollbar instead of the
+ * native one. Each wrapped table is pushed onto `orderedDisposablesList` and a
+ * `scanDomNode` callback is registered on `layoutParticipants` so the scrollbar
+ * re-measures whenever the container is resized.
+ *
+ * Each column's `min-width` is also set to the maximum character count across
+ * all cells in that column (in `ch` units), preventing short-content columns
+ * like "001" from being squeezed to one character wide. Single-character columns
+ * are left unchanged. This is layout-free: only `textContent` lengths are read.
+ */
+export function wrapTablesWithScrollable(domNode: HTMLElement, orderedDisposablesList: IDisposable[], layoutParticipants: Lazy<Set<() => void>>): void {
+	// eslint-disable-next-line no-restricted-syntax
+	for (const table of domNode.querySelectorAll('table')) {
+		if (!dom.isHTMLElement(table)) {
+			continue;
+		}
+
+		applyTableColumnMinWidths(table);
+
+		// Wrap the table in a div so DomScrollableElement can compare the div's
+		// constrained clientWidth against the table's natural scrollWidth.
+		// Passing the table directly doesn't work because a table always expands
+		// to its content width, so clientWidth == scrollWidth and no scrollbar appears.
+		const parent = table.parentElement;
+		const nextSibling = table.nextSibling;
+		const tableContainer = document.createElement('div');
+		tableContainer.appendChild(table); // moves table out of DOM
+		const scrollable = new DomScrollableElement(tableContainer, { // moves tableContainer into scrollNode
+			vertical: ScrollbarVisibility.Hidden,
+			horizontal: ScrollbarVisibility.Auto,
+		});
+		orderedDisposablesList.push(scrollable);
+		const scrollNode = scrollable.getDomNode();
+		scrollNode.classList.add('rendered-markdown-table-scroll-wrapper');
+		parent?.insertBefore(scrollNode, nextSibling);
+
+		layoutParticipants.value.add(() => { scrollable.scanDomNode(); });
+		scrollable.scanDomNode();
+	}
+}
+
+/** Maximum `min-width` (in `ch`) applied to any table column, regardless of its content length. */
+const TABLE_COLUMN_MIN_WIDTH_CAP_CH = 3;
+
+function applyTableColumnMinWidths(table: HTMLTableElement): void {
+	const rows = table.rows;
+	const colMaxChars: number[] = [];
+	for (const row of rows) {
+		for (let c = 0; c < row.cells.length; c++) {
+			const len = row.cells[c].textContent?.length ?? 0;
+			if (len > (colMaxChars[c] ?? 0)) {
+				colMaxChars[c] = len;
+			}
+		}
+	}
+	for (const row of rows) {
+		for (let c = 0; c < row.cells.length; c++) {
+			const minCh = colMaxChars[c];
+			if (minCh !== undefined && minCh > 1) {
+				row.cells[c].style.minWidth = Math.min(minCh, TABLE_COLUMN_MIN_WIDTH_CAP_CH) + 'ch';
+			}
+		}
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -313,10 +313,13 @@
 	font-weight: 600;
 }
 
-.interactive-item-container .value .rendered-markdown table {
+.interactive-item-container .value .rendered-markdown .rendered-markdown-table-scroll-wrapper {
 	width: 100%;
-	text-align: left;
 	margin-bottom: 16px;
+}
+
+.interactive-item-container .value .rendered-markdown table {
+	text-align: left;
 	border-radius: var(--vscode-cornerRadius-medium);
 	overflow: hidden;
 	border-collapse: separate;
@@ -330,6 +333,11 @@
 	border-top: none;
 	border-left: none;
 	padding: 4px 6px;
+}
+
+.interactive-item-container .value .rendered-markdown table th {
+	white-space: normal;
+	overflow-wrap: break-word;
 }
 
 .interactive-item-container .value .rendered-markdown table td:last-child,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownTableScrolling.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownTableScrolling.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import { Lazy } from '../../../../../../base/common/lazy.js';
-import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { wrapTablesWithScrollable } from '../../../browser/widget/chatContentParts/chatMarkdownTableScrolling.js';
 
@@ -35,15 +34,10 @@ function buildContainer(tables: string[][][]): HTMLDivElement {
 suite('wrapTablesWithScrollable', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
-	function wrap(container: HTMLDivElement): { disposables: DisposableStore; layoutParticipants: Set<() => void> } {
-		const disposables = store.add(new DisposableStore());
-		const orderedDisposablesList: { dispose(): void }[] = [];
+	function wrap(container: HTMLDivElement): { layoutParticipants: Set<() => void> } {
 		const layoutParticipants = new Set<() => void>();
-		wrapTablesWithScrollable(container, orderedDisposablesList, new Lazy(() => layoutParticipants));
-		for (const d of orderedDisposablesList) {
-			disposables.add(d);
-		}
-		return { disposables, layoutParticipants };
+		store.add(wrapTablesWithScrollable(container, new Lazy(() => layoutParticipants)));
+		return { layoutParticipants };
 	}
 
 	test('replaces each table with a scroll wrapper in the DOM', () => {
@@ -91,15 +85,16 @@ suite('wrapTablesWithScrollable', () => {
 		wrap(container);
 
 		const table = container.querySelector('table')!;
-		const allMinWidths = Array.from(table.rows).map(row =>
-			Array.from(row.cells).map(cell => cell.style.minWidth)
-		);
+		// min-width is set only on the first row; other rows are untouched
 		// col 0 max = 3 chars -> 3ch; col 1 max = 11 chars -> capped at 3ch
-		assert.deepStrictEqual(allMinWidths, [
-			['3ch', '3ch'],
-			['3ch', '3ch'],
-			['3ch', '3ch'],
-		]);
+		assert.deepStrictEqual(
+			Array.from(table.rows[0].cells).map(cell => cell.style.minWidth),
+			['3ch', '3ch']
+		);
+		assert.deepStrictEqual(
+			Array.from(table.rows[1].cells).map(cell => cell.style.minWidth),
+			['', '']
+		);
 	});
 
 	test('uses actual char count when below the 3ch cap', () => {
@@ -117,8 +112,7 @@ suite('wrapTablesWithScrollable', () => {
 		wrap(container);
 
 		const table = container.querySelector('table')!;
-		const col0Widths = Array.from(table.rows).map(row => row.cells[0].style.minWidth);
-		assert.ok(col0Widths.every(w => w === ''), 'single-char column should have no min-width');
+		assert.strictEqual(table.rows[0].cells[0].style.minWidth, '', 'single-char column should have no min-width');
 	});
 
 	test('handles multiple tables independently', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownTableScrolling.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatMarkdownTableScrolling.test.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Lazy } from '../../../../../../base/common/lazy.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { wrapTablesWithScrollable } from '../../../browser/widget/chatContentParts/chatMarkdownTableScrolling.js';
+
+/** Builds an HTMLElement containing one or more tables from markdown-style 2-D arrays. */
+function buildContainer(tables: string[][][]): HTMLDivElement {
+	const container = document.createElement('div');
+	for (const rows of tables) {
+		const table = document.createElement('table');
+		rows.forEach((rowData, rowIndex) => {
+			const section = rowIndex === 0
+				? table.createTHead()
+				: (table.tBodies[0] ?? table.createTBody());
+			const tr = section.insertRow();
+			for (const text of rowData) {
+				const cell = rowIndex === 0 ? document.createElement('th') : tr.insertCell();
+				cell.textContent = text;
+				if (rowIndex === 0) {
+					tr.appendChild(cell);
+				}
+			}
+		});
+		container.appendChild(table);
+	}
+	return container;
+}
+
+suite('wrapTablesWithScrollable', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	function wrap(container: HTMLDivElement): { disposables: DisposableStore; layoutParticipants: Set<() => void> } {
+		const disposables = store.add(new DisposableStore());
+		const orderedDisposablesList: { dispose(): void }[] = [];
+		const layoutParticipants = new Set<() => void>();
+		wrapTablesWithScrollable(container, orderedDisposablesList, new Lazy(() => layoutParticipants));
+		for (const d of orderedDisposablesList) {
+			disposables.add(d);
+		}
+		return { disposables, layoutParticipants };
+	}
+
+	test('replaces each table with a scroll wrapper in the DOM', () => {
+		const container = buildContainer([[
+			['ID', 'Name'],
+			['001', 'Alice'],
+		]]);
+		// Before: direct child is <table>
+		assert.strictEqual(container.children[0].tagName, 'TABLE');
+
+		wrap(container);
+
+		// After: direct child is the monaco-scrollable-element wrapper
+		const wrapper = container.children[0];
+		assert.ok(wrapper.classList.contains('rendered-markdown-table-scroll-wrapper'),
+			'outer node should have the scroll wrapper class');
+	});
+
+	test('table is preserved inside the scroll wrapper', () => {
+		const container = buildContainer([[['A', 'BB'], ['C', 'DD']]]);
+		wrap(container);
+
+		// The table must still be in the document, nested inside the wrapper
+		const table = container.querySelector('table');
+		assert.ok(table, 'table should still exist in DOM');
+		assert.ok(container.contains(table), 'table should be inside container');
+		assert.ok(!container.children[0].isSameNode(table), 'table should not be a direct child anymore');
+	});
+
+	test('registers a layout participant for each table', () => {
+		const container = buildContainer([
+			[['H1', 'H2'], ['a', 'bb']],
+			[['X', 'YY'], ['c', 'dd']],
+		]);
+		const { layoutParticipants } = wrap(container);
+		assert.strictEqual(layoutParticipants.size, 2, 'one layout participant registered per table');
+	});
+
+	test('sets column min-width capped at 3ch', () => {
+		const container = buildContainer([[
+			['ID', 'Name'],
+			['001', 'Alice'],
+			['002', 'Longer Name'],
+		]]);
+		wrap(container);
+
+		const table = container.querySelector('table')!;
+		const allMinWidths = Array.from(table.rows).map(row =>
+			Array.from(row.cells).map(cell => cell.style.minWidth)
+		);
+		// col 0 max = 3 chars -> 3ch; col 1 max = 11 chars -> capped at 3ch
+		assert.deepStrictEqual(allMinWidths, [
+			['3ch', '3ch'],
+			['3ch', '3ch'],
+			['3ch', '3ch'],
+		]);
+	});
+
+	test('uses actual char count when below the 3ch cap', () => {
+		const container = buildContainer([[['AB', 'C'], ['DE', 'F']]]);
+		wrap(container);
+
+		const table = container.querySelector('table')!;
+		// col 0 max=2 -> 2ch; col 1 max=1 -> no min-width
+		assert.strictEqual(table.rows[0].cells[0].style.minWidth, '2ch');
+		assert.strictEqual(table.rows[0].cells[1].style.minWidth, '');
+	});
+
+	test('does not set min-width on single-character columns', () => {
+		const container = buildContainer([[['X', 'hello'], ['Y', 'world']]]);
+		wrap(container);
+
+		const table = container.querySelector('table')!;
+		const col0Widths = Array.from(table.rows).map(row => row.cells[0].style.minWidth);
+		assert.ok(col0Widths.every(w => w === ''), 'single-char column should have no min-width');
+	});
+
+	test('handles multiple tables independently', () => {
+		const container = buildContainer([
+			[['AB', 'C'], ['DE', 'F']],
+			[['X', 'YYY'], ['Z', 'WWW']],
+		]);
+		wrap(container);
+
+		const tables = container.querySelectorAll('table');
+		assert.strictEqual(tables.length, 2);
+
+		// Table 1: col 0 max=2, col 1 max=1 -> only col 0 gets min-width
+		assert.strictEqual(tables[0].rows[0].cells[0].style.minWidth, '2ch');
+		assert.strictEqual(tables[0].rows[0].cells[1].style.minWidth, '');
+
+		// Table 2: col 0 max=1, col 1 max=3 -> only col 1 gets min-width
+		assert.strictEqual(tables[1].rows[0].cells[0].style.minWidth, '');
+		assert.strictEqual(tables[1].rows[0].cells[1].style.minWidth, '3ch');
+	});
+
+	test('no-ops on a container with no tables', () => {
+		const container = document.createElement('div');
+		container.innerHTML = '<p>hello</p>';
+		const { layoutParticipants } = wrap(container);
+		assert.strictEqual(layoutParticipants.size, 0);
+		assert.strictEqual(container.querySelector('table'), null);
+	});
+});


### PR DESCRIPTION
Fixes #265062

## Summary

Markdown tables in the chat panel can have many columns with wide content. Previously the table would overflow its container with no way to scroll, and short cell values like `001` would be aggressively squished to a single character wide.

### Changes

**Horizontal scrolling**
- Each rendered `<table>` is now wrapped in a `DomScrollableElement` so it scrolls horizontally using the VS Code custom scrollbar.
- The table is placed inside an intermediate `<div>` first — passing a `<table>` directly to `DomScrollableElement` doesn't work because a table always expands to its content width, so `clientWidth === scrollWidth` and the scrollbar never appears.
- A `scanDomNode` callback is registered as a layout participant so the scrollbar re-measures on resize.

**Column min-widths**
- Per-column `min-width` is set (in `ch` units) based on the maximum `textContent.length` of any cell in that column, capped at `3ch`. This prevents columns like `001` from being squeezed to one character wide while keeping the layout flexible for wide content.
- Single-character columns are left alone (no `min-width` applied).
- This is layout-free — only `textContent` lengths are read, causing no forced reflows.

**Header wrapping**
- Table `<th>` cells now use `white-space: normal` + `overflow-wrap: break-word` instead of `white-space: nowrap`, so headers wrap at word boundaries rather than overflowing.

**Refactoring**
- The wrapping logic is extracted into a new `chatMarkdownTableScrolling.ts` module.
- Unit tests added in `chatMarkdownTableScrolling.test.ts` covering DOM structure, scroll wrapper class, layout participants, min-width capping, and multiple-table handling.

(Written by Copilot)