### PR TITLE
Fix background color handling in terminal editor

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -63,7 +63,7 @@
 }
 
 .monaco-workbench .terminal-editor .terminal-wrapper {
-	background-color: var(--vscode-terminal-background, var(--vscode-editorPane-background));
+	background-color: var(--vscode-editor-background);
 }
 .monaco-workbench .terminal-editor .terminal-wrapper,
 .monaco-workbench .pane-body.integrated-terminal .terminal-wrapper {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2812,12 +2812,12 @@ export class TerminalInstanceColorProvider implements IXtermColorProvider {
 	}
 
 	getBackgroundColor(theme: IColorTheme) {
+		if (this._target.object === TerminalLocation.Editor) {
+			return theme.getColor(editorBackground);
+		}
 		const terminalBackground = theme.getColor(TERMINAL_BACKGROUND_COLOR);
 		if (terminalBackground) {
 			return terminalBackground;
-		}
-		if (this._target.object === TerminalLocation.Editor) {
-			return theme.getColor(editorBackground);
 		}
 		const location = this._viewDescriptorService.getViewLocationById(TERMINAL_VIEW_ID)!;
 		if (location === ViewContainerLocation.Panel) {


### PR DESCRIPTION
Update the background color handling in the terminal editor to use the editor's background color instead of the terminal's background color. This change improves visual consistency within the editor environment.

