### PR TITLE
Remove background blurs and update theme colors for quick input and breadcrumb components

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -227,7 +227,7 @@
 		"quickInputList.focusBackground": "#3994BC26",
 		"quickInputList.focusForeground": "#bfbfbf",
 		"quickInputList.focusIconForeground": "#bfbfbf",
-		"quickInputList.hoverBackground": "#515253",
+		"quickInputList.hoverBackground": "#262728",
 		"terminal.selectionBackground": "#3994BC33",
 		"terminal.background": "#191A1B",
 		"terminal.border": "#2A2B2CFF",

--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -208,7 +208,7 @@
 		"breadcrumb.background": "#FFFFFF",
 		"breadcrumb.focusForeground": "#202020",
 		"breadcrumb.activeSelectionForeground": "#202020",
-		"breadcrumbPicker.background": "#F0F0F3",
+		"breadcrumbPicker.background": "#FAFAFD",
 		"notificationCenter.border": "#F0F1F2FF",
 		"notificationCenterHeader.foreground": "#202020",
 		"notificationCenterHeader.background": "#FAFAFD",

--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -229,7 +229,7 @@
 		"extensionButton.prominentHoverBackground": "#0064CC",
 		"pickerGroup.border": "#EEEEF1",
 		"pickerGroup.foreground": "#202020",
-		"quickInput.background": "#F0F0F3",
+		"quickInput.background": "#FAFAFD",
 		"quickInput.foreground": "#202020",
 		"quickInputList.focusBackground": "#0069CC1A",
 		"quickInputList.focusForeground": "#202020",

--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -256,7 +256,7 @@
 		"gauge.errorForeground": "#ad0707",
 		"gauge.errorBackground": "#ad070740",
 		"statusBarItem.prominentHoverForeground": "#FFFFFF",
-		"quickInputTitle.background": "#F0F0F3",
+		"quickInputTitle.background": "#FAFAFD",
 		"chat.requestBubbleBackground": "#EEF4FB",
 		"chat.requestBubbleHoverBackground": "#E6EDFA",
 		"chat.thinkingShimmer": "#999999",

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -5,7 +5,6 @@
 
 :root {
 	--radius-sm: 4px;
-	--radius-md: 6px;
 	--radius-lg: 8px;
 
 	--shadow-sm: 0 0 4px rgba(0, 0, 0, 0.08);
@@ -19,16 +18,10 @@
 	/* Panel depth shadows cast onto the editor surface */
 	--shadow-depth-x: 5px 0 10px -4px rgba(0, 0, 0, 0.05);
 	--shadow-depth-y: 0 5px 10px -4px rgba(0, 0, 0, 0.04);
-
-	--backdrop-blur-md: blur(20px) saturate(180%);
-	--backdrop-blur-lg: blur(40px) saturate(180%);
 }
 
 /* Dark theme: add brightness reduction for contrast-safe luminosity blending over bright backgrounds */
 .monaco-workbench.vs-dark {
-	--backdrop-blur-md: blur(20px) saturate(180%) brightness(0.55);
-	--backdrop-blur-lg: blur(40px) saturate(180%) brightness(0.55);
-
 	--shadow-depth-x: 5px 0 12px -4px rgba(0, 0, 0, 0.14);
 	--shadow-depth-y: 0 5px 12px -4px rgba(0, 0, 0, 0.10);
 }
@@ -125,17 +118,6 @@
 /* Quick Input (Command Palette) */
 .monaco-workbench .quick-input-widget {
 	box-shadow: var(--shadow-xl) !important;
-	background-color: color-mix(in srgb, var(--vscode-quickInput-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-lg);
-	-webkit-backdrop-filter: var(--backdrop-blur-lg);
-}
-
-/* Remove backdrop-filter when quick chat is active, because it creates a new
-   containing block that shifts position:fixed suggest widgets to the right. */
-.monaco-workbench .quick-input-widget:has(.interactive-session) {
-	backdrop-filter: none;
-	-webkit-backdrop-filter: none;
-	background-color: var(--vscode-quickInput-background) !important;
 }
 
 .monaco-workbench.vs-dark .quick-input-widget {
@@ -158,10 +140,6 @@
 
 .monaco-workbench .quick-input-widget .quick-input-list .monaco-list-rows {
 	background: transparent !important;
-}
-
-.monaco-workbench.vs .quick-input-widget .quick-input-list .monaco-list-row:hover:not(.selected):not(.focused) {
-	background-color: color-mix(in srgb, var(--vscode-list-hoverBackground) 95%, black) !important;
 }
 
 .monaco-workbench .quick-input-list .quick-input-list-entry .quick-input-list-separator {
@@ -222,8 +200,6 @@
 	overflow: visible;
 }
 
-/* .monaco-workbench .notifications-list-container,
-.monaco-workbench > .notifications-center > .notifications-center-header, */
 .monaco-workbench .notifications-list-container .monaco-list-rows {
 	background: transparent !important;
 }
@@ -233,10 +209,6 @@
 .monaco-workbench .context-view .monaco-menu {
 	box-shadow: var(--shadow-lg);
 	border: none;
-	border-radius: var(--radius-lg);
-	background: color-mix(in srgb, var(--vscode-menu-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench .monaco-select-box-dropdown-container {
@@ -245,15 +217,6 @@
 
 .monaco-workbench .monaco-menu-container > .monaco-scrollable-element {
 	box-shadow: var(--shadow-lg) !important;
-	background: color-mix(in srgb, var(--vscode-menu-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-}
-
-.monaco-workbench .action-widget {
-	background: color-mix(in srgb, var(--vscode-menu-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench .action-widget .action-widget-action-bar {
@@ -263,9 +226,6 @@
 /* Suggest Widget */
 .monaco-workbench .monaco-editor .suggest-widget {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-	background: color-mix(in srgb, var(--vscode-editorSuggestWidget-background) 60%, transparent) !important;
 }
 
 .monaco-workbench.vs-dark .monaco-editor .suggest-widget {
@@ -276,35 +236,21 @@
 /* Find Widget */
 .monaco-workbench .monaco-editor .find-widget {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench .inline-chat-gutter-menu {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 /* Dialog */
 .monaco-workbench .monaco-dialog-box {
 	border: 1px solid var(--vscode-dialog-border);
 	box-shadow: var(--shadow-xl);
-	backdrop-filter: var(--backdrop-blur-lg);
-	-webkit-backdrop-filter: var(--backdrop-blur-lg);
-	background: color-mix(in srgb, var(--vscode-editor-background) 60%, transparent) !important;
 }
 
 /* Peek View */
 .monaco-workbench .monaco-editor .peekview-widget {
 	box-shadow: var(--shadow-hover);
-	background: color-mix(in srgb, var(--vscode-peekViewEditor-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-}
-
-.monaco-workbench.vs-dark .monaco-editor .peekview-widget {
-	background: color-mix(in srgb, var(--vscode-peekViewEditor-background) 60%, transparent) !important;
 }
 
 .monaco-workbench .monaco-editor .peekview-widget .head,
@@ -313,33 +259,22 @@
 }
 
 .monaco-editor .monaco-hover {
-	background-color: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 60%, transparent) !important;
 	box-shadow: var(--shadow-sm-strong);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench .monaco-hover.workbench-hover,
 .monaco-hover.workbench-hover {
-	background-color: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 60%, transparent) !important;
-	backdrop-filter: var(--backdrop-blur-lg) !important;
-	-webkit-backdrop-filter: var(--backdrop-blur-lg) !important;
 	box-shadow: var(--shadow-sm-strong);
 }
 
 .monaco-workbench .defineKeybindingWidget {
 	border: 1px solid var(--vscode-editorWidget-border);
 	box-shadow: var(--shadow-lg) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-	background-color: color-mix(in srgb, var(--vscode-editorHoverWidget-background) 60%, transparent) !important;
 }
 
 .monaco-workbench .chat-editor-overlay-widget,
 .monaco-workbench .chat-diff-change-content-widget {
 	box-shadow: var(--shadow-md);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench.vs-dark .chat-editor-overlay-widget,
@@ -381,15 +316,6 @@
 }
 
 /* Breadcrumbs */
-.monaco-workbench .breadcrumbs-picker-widget {
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-	background: color-mix(in srgb, var(--vscode-breadcrumbPicker-background) 60%, transparent) !important;
-}
-
-.monaco-workbench.vs-dark .breadcrumbs-picker-widget {
-	background: color-mix(in srgb, var(--vscode-breadcrumbPicker-background) 60%, transparent) !important;
-}
 
 .monaco-workbench.vs .breadcrumbs-control {
 	border-bottom: 1px solid var(--vscode-editorWidget-border);
@@ -441,20 +367,15 @@
 /* SCM */
 .monaco-workbench .scm-view .scm-provider {
 	box-shadow: var(--shadow-sm);
-	border-radius: var(--radius-md);
 }
 
 /* Debug Toolbar */
 .monaco-workbench .debug-toolbar {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-lg) !important;
-	-webkit-backdrop-filter: var(--backdrop-blur-lg) !important;
 }
 
 .monaco-workbench .debug-hover-widget {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 	color: var(--vscode-editor-foreground) !important;
 }
 
@@ -470,13 +391,6 @@
 /* Parameter Hints */
 .monaco-workbench .monaco-editor .parameter-hints-widget {
 	box-shadow: var(--shadow-lg);
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-}
-
-.monaco-workbench.vs-dark .monaco-editor .parameter-hints-widget,
-.monaco-workbench.vs .monaco-editor .parameter-hints-widget {
-	background: color-mix(in srgb, var(--vscode-editorWidget-background) 60%, transparent) !important;
 }
 
 /* Minimap */
@@ -534,8 +448,6 @@
 }
 
 .monaco-editor .rename-box.preview {
-	backdrop-filter: var(--backdrop-blur-lg) !important;
-	-webkit-backdrop-filter: var(--backdrop-blur-lg) !important;
 	box-shadow: var(--shadow-hover) !important;
 	border: 1px solid var(--vscode-editorWidget-border);
 }
@@ -548,8 +460,6 @@
 
 .notebookOverlay .monaco-list-row .cell-title-toolbar {
 	background-color: var(--vscode-editorWidget-background) !important;
-	backdrop-filter: var(--backdrop-blur-md);
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
 	box-shadow: var(--shadow-sm);
 }
 
@@ -562,9 +472,6 @@
 /* Command Center */
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center {
 	box-shadow: inset var(--shadow-sm) !important;
-	background: color-mix(in srgb, var(--vscode-commandCenter-background) 60%, transparent) !important;
-	-webkit-backdrop-filter: var(--backdrop-blur-md);
-	backdrop-filter: var(--backdrop-blur-md);
 }
 
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center:hover {
@@ -597,182 +504,4 @@
 .monaco-workbench .quick-input-list .monaco-icon-label .label-description {
 	opacity: 1;
 	color: var(--vscode-descriptionForeground);
-}
-
-/* ============================================================================================
- * Reduced Transparency - disable backdrop-filter blur and color-mix transparency effects
- * for improved rendering performance. Controlled by workbench.reduceTransparency setting.
- * ============================================================================================ */
-
-/* Reset blur variables to none */
-.monaco-workbench.monaco-reduce-transparency {
-	--backdrop-blur-sm: none;
-	--backdrop-blur-md: none;
-	--backdrop-blur-lg: none;
-}
-
-/* Quick Input (Command Palette) */
-.monaco-workbench.monaco-reduce-transparency .quick-input-widget {
-	background-color: var(--vscode-quickInput-background) !important;
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Notifications */
-.monaco-workbench.monaco-reduce-transparency .notification-toast-container {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-notifications-background) !important;
-}
-
-.monaco-workbench.monaco-reduce-transparency .notifications-list-container {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-notifications-background) !important;
-}
-
-.monaco-workbench.monaco-reduce-transparency .notification-list-item,
-.monaco-workbench.monaco-reduce-transparency .notifications-center-header {
-	background: var(--vscode-notifications-background) !important;
-}
-
-.monaco-workbench.monaco-reduce-transparency .notifications-center {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-notifications-background) !important;
-}
-
-/* Context Menu / Action Widget */
-.monaco-workbench.monaco-reduce-transparency .action-widget {
-	background: var(--vscode-menu-background) !important;
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Suggest Widget */
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .suggest-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-editorSuggestWidget-background) !important;
-}
-
-/* Find Widget */
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .find-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-.monaco-workbench.monaco-reduce-transparency .inline-chat-gutter-menu {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Dialog */
-.monaco-workbench.monaco-reduce-transparency .monaco-dialog-box {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-editor-background) !important;
-}
-
-/* Peek View */
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .peekview-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-peekViewEditor-background) !important;
-}
-
-/* Hover */
-.monaco-reduce-transparency .monaco-hover {
-	background-color: var(--vscode-editorHoverWidget-background) !important;
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-.monaco-reduce-transparency .monaco-hover.workbench-hover,
-.monaco-reduce-transparency .workbench-hover {
-	background-color: var(--vscode-editorHoverWidget-background) !important;
-	-webkit-backdrop-filter: none !important;
-	backdrop-filter: none !important;
-}
-
-/* Keybinding Widget */
-.monaco-workbench.monaco-reduce-transparency .defineKeybindingWidget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-editorHoverWidget-background) !important;
-}
-
-/* Chat Editor Overlay */
-.monaco-workbench.monaco-reduce-transparency .chat-editor-overlay-widget,
-.monaco-workbench.monaco-reduce-transparency .chat-diff-change-content-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Debug Toolbar */
-.monaco-workbench.monaco-reduce-transparency .debug-toolbar {
-	-webkit-backdrop-filter: none !important;
-	backdrop-filter: none !important;
-}
-
-.monaco-workbench.monaco-reduce-transparency .debug-hover-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Parameter Hints */
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .parameter-hints-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-editorWidget-background) !important;
-}
-
-/* Sticky Scroll */
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .sticky-widget {
-	-webkit-backdrop-filter: none !important;
-	backdrop-filter: none !important;
-	background: var(--vscode-editor-background) !important;
-}
-
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .sticky-widget .sticky-widget-line-numbers,
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .sticky-widget .sticky-widget-lines,
-.monaco-workbench.monaco-reduce-transparency .monaco-editor .sticky-widget .sticky-line-content {
-	-webkit-backdrop-filter: none !important;
-	backdrop-filter: none !important;
-	background: var(--vscode-editor-background) !important;
-}
-
-/* Rename Box */
-.monaco-reduce-transparency .monaco-editor .rename-box.preview {
-	-webkit-backdrop-filter: none !important;
-	backdrop-filter: none !important;
-}
-
-/* Notebook */
-.monaco-workbench.monaco-reduce-transparency .notebookOverlay .monaco-list-row .cell-title-toolbar {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-/* Command Center */
-.monaco-workbench.monaco-reduce-transparency .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center {
-	background: var(--vscode-commandCenter-background) !important;
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-}
-
-.monaco-workbench.monaco-reduce-transparency .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center:hover {
-	background: var(--vscode-commandCenter-activeBackground) !important;
-}
-
-/* Breadcrumbs */
-.monaco-workbench.monaco-reduce-transparency .breadcrumbs-picker-widget {
-	-webkit-backdrop-filter: none;
-	backdrop-filter: none;
-	background: var(--vscode-breadcrumbPicker-background) !important;
-}
-
-/* Quick Input filter input */
-.monaco-workbench.monaco-reduce-transparency .quick-input-widget .quick-input-filter .monaco-inputbox {
-	background: var(--vscode-input-background) !important;
 }

--- a/extensions/theme-2026/themes/styles.css
+++ b/extensions/theme-2026/themes/styles.css
@@ -229,7 +229,6 @@
 }
 
 .monaco-workbench.vs-dark .monaco-editor .suggest-widget {
-	background: color-mix(in srgb, var(--vscode-editorSuggestWidget-background) 60%, transparent) !important;
 	border: 1px solid var(--vscode-editorWidget-border);
 }
 
@@ -472,10 +471,6 @@
 /* Command Center */
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center {
 	box-shadow: inset var(--shadow-sm) !important;
-}
-
-.monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center .action-item.command-center-center:hover {
-	background: color-mix(in srgb, var(--vscode-commandCenter-activeBackground) 60%, transparent) !important;
 }
 
 .monaco-workbench .part.titlebar .command-center .agent-status-pill {


### PR DESCRIPTION
Removing blurred backgrounds from 2026 themes.

Enhance the visual consistency of the application by updating hover and background colors in the quick input and breadcrumb components for both dark and light themes.

