### PR TITLE
chat: deduplicate global auto-approve warning across windows

### DIFF
--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
 import { ThemeIcon } from '../../../base/common/themables.js';
 import { IMarkdownString } from '../../../base/common/htmlContent.js';
@@ -37,6 +38,13 @@ export interface IBaseDialogOptions {
 	 * Allows to enforce use of custom dialog even in native environments.
 	 */
 	readonly custom?: boolean | ICustomDialogOptions;
+
+	/**
+	 * An optional cancellation token that can be used to dismiss the dialog
+	 * programmatically. When cancelled, the dialog resolves as if the cancel
+	 * button was pressed.
+	 */
+	readonly token?: CancellationToken;
 }
 
 export interface IConfirmDialogArgs {

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -41,8 +41,12 @@ export interface IBaseDialogOptions {
 
 	/**
 	 * An optional cancellation token that can be used to dismiss the dialog
-	 * programmatically. When cancelled, the dialog resolves as if the cancel
-	 * button was pressed.
+	 * programmatically for custom dialog implementations.
+	 *
+	 * When cancelled, the custom dialog resolves as if the cancel button was
+	 * pressed. Native dialog handlers cannot currently be dismissed
+	 * programmatically and ignore this option unless a custom dialog is
+	 * explicitly enforced via the {@link custom} option.
 	 */
 	readonly token?: CancellationToken;
 }

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../nls.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IConfirmation, IConfirmationResult, IInputResult, ICheckbox, IInputElement, ICustomDialogOptions, IInput, AbstractDialogHandler, DialogType, IPrompt, IAsyncPromptResult } from '../../../../platform/dialogs/common/dialogs.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -47,7 +48,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 
 		const buttons = this.getPromptButtons(prompt);
 
-		const { button, checkboxChecked } = await this.doShow(prompt.type, prompt.message, buttons, prompt.detail, prompt.cancelButton ? buttons.length - 1 : -1 /* Disabled */, prompt.checkbox, undefined, typeof prompt?.custom === 'object' ? prompt.custom : undefined);
+		const { button, checkboxChecked } = await this.doShow(prompt.type, prompt.message, buttons, prompt.detail, prompt.cancelButton ? buttons.length - 1 : -1 /* Disabled */, prompt.checkbox, undefined, typeof prompt?.custom === 'object' ? prompt.custom : undefined, prompt.token);
 
 		return this.getPromptResult(prompt, button, checkboxChecked);
 	}
@@ -90,7 +91,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		}
 	}
 
-	private async doShow(type: Severity | DialogType | undefined, message: string, buttons?: string[], detail?: string, cancelId?: number, checkbox?: ICheckbox, inputs?: IInputElement[], customOptions?: ICustomDialogOptions): Promise<IDialogResult> {
+	private async doShow(type: Severity | DialogType | undefined, message: string, buttons?: string[], detail?: string, cancelId?: number, checkbox?: ICheckbox, inputs?: IInputElement[], customOptions?: ICustomDialogOptions, token?: CancellationToken): Promise<IDialogResult> {
 		const dialogDisposables = new DisposableStore();
 
 		const renderBody = customOptions ? (parent: HTMLElement) => {
@@ -125,6 +126,10 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 		);
 
 		dialogDisposables.add(dialog);
+
+		if (token) {
+			dialogDisposables.add(token.onCancellationRequested(() => dialogDisposables.dispose()));
+		}
 
 		const result = await dialog.show();
 		dialogDisposables.dispose();

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -58,7 +58,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 
 		const buttons = this.getConfirmationButtons(confirmation);
 
-		const { button, checkboxChecked } = await this.doShow(confirmation.type ?? 'question', confirmation.message, buttons, confirmation.detail, buttons.length - 1, confirmation.checkbox, undefined, typeof confirmation?.custom === 'object' ? confirmation.custom : undefined);
+		const { button, checkboxChecked } = await this.doShow(confirmation.type ?? 'question', confirmation.message, buttons, confirmation.detail, buttons.length - 1, confirmation.checkbox, undefined, typeof confirmation?.custom === 'object' ? confirmation.custom : undefined, confirmation.token);
 
 		return { confirmed: button === 0, checkboxChecked };
 	}
@@ -68,7 +68,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 
 		const buttons = this.getInputButtons(input);
 
-		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs, typeof input.custom === 'object' ? input.custom : undefined);
+		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs, typeof input.custom === 'object' ? input.custom : undefined, input.token);
 
 		return { confirmed: button === 0, checkboxChecked, values };
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -5,7 +5,8 @@
 
 import { timeout } from '../../../../base/common/async.js';
 import { MarkdownString, isMarkdownString } from '../../../../base/common/htmlContent.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import * as nls from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -26,7 +27,10 @@ import { CONFIGURE_INSTRUCTIONS_ACTION_ID } from './promptSyntax/attachInstructi
 import { showConfigureHooksQuickPick } from './promptSyntax/hookActions.js';
 import { CONFIGURE_PROMPTS_ACTION_ID } from './promptSyntax/runPromptAction.js';
 import { CONFIGURE_SKILLS_ACTION_ID } from './promptSyntax/skillActions.js';
-import { globalAutoApproveDescription } from './tools/languageModelToolsService.js';
+import {
+	AutoApproveStorageKeys,
+	globalAutoApproveDescription
+} from './tools/languageModelToolsService.js';
 import { agentSlashCommandToMarkdown, agentToMarkdown } from './widget/chatContentParts/chatMarkdownDecorationsRenderer.js';
 import { Target } from '../common/promptSyntax/service/promptsService.js';
 
@@ -187,23 +191,38 @@ export class ChatSlashCommandsContribution extends Disposable {
 				notificationService.info(nls.localize('autoApprove.alreadyEnabled', "Global auto-approve is already enabled."));
 				return;
 			}
-			const alreadyOptedIn = storageService.getBoolean('chat.tools.global.autoApprove.optIn', StorageScope.APPLICATION, false);
+			const alreadyOptedIn = storageService.getBoolean(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION, false);
 			if (!alreadyOptedIn) {
-				const result = await dialogService.prompt({
-					type: Severity.Warning,
-					message: nls.localize('autoApprove.enable.title', 'Enable global auto approve?'),
-					buttons: [
-						{ label: nls.localize('autoApprove.enable.button', 'Enable'), run: () => true },
-						{ label: nls.localize('autoApprove.cancel.button', 'Cancel'), run: () => false },
-					],
-					custom: {
-						markdownDetails: [{ markdown: new MarkdownString(globalAutoApproveDescription.value, { isTrusted: { enabledCommands: ['workbench.action.openSettings'] } }) }],
+				const store = new DisposableStore();
+				try {
+					const cts = new CancellationTokenSource();
+					store.add(cts);
+					store.add(storageService.onDidChangeValue(StorageScope.APPLICATION, AutoApproveStorageKeys.GlobalAutoApproveOptIn, store)(() => {
+						if (storageService.getBoolean(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION, false)) {
+							cts.cancel();
+						}
+					}));
+
+					const result = await dialogService.prompt({
+						type: Severity.Warning,
+						message: nls.localize('autoApprove.enable.title', 'Enable global auto approve?'),
+						buttons: [
+							{ label: nls.localize('autoApprove.enable.button', 'Enable'), run: () => true },
+							{ label: nls.localize('autoApprove.cancel.button', 'Cancel'), run: () => false },
+						],
+						custom: {
+							markdownDetails: [{ markdown: new MarkdownString(globalAutoApproveDescription.value, { isTrusted: { enabledCommands: ['workbench.action.openSettings'] } }) }],
+						},
+						token: cts.token,
+					});
+
+					if (!cts.token.isCancellationRequested && result.result !== true) {
+						return;
 					}
-				});
-				if (result.result !== true) {
-					return;
+					storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
+				} finally {
+					store.dispose();
 				}
-				storageService.store('chat.tools.global.autoApprove.optIn', true, StorageScope.APPLICATION, StorageTarget.USER);
 			}
 			await configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, true);
 			notificationService.info(nls.localize('autoApprove.enabled', "Global auto-approve enabled — all tool calls will be approved automatically"));

--- a/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/browser/tools/languageModelToolsService.ts
@@ -61,7 +61,7 @@ interface ITrackedCall {
 	store: IDisposable;
 }
 
-const enum AutoApproveStorageKeys {
+export const enum AutoApproveStorageKeys {
 	GlobalAutoApproveOptIn = 'chat.tools.global.autoApprove.optIn'
 }
 
@@ -109,6 +109,9 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 
 	/** Pending tool calls in the streaming phase, keyed by toolCallId */
 	private readonly _pendingToolCalls = new Map<string, ChatToolInvocation>();
+
+	/** Deduplicates _checkGlobalAutoApprove calls within this window */
+	private _pendingGlobalAutoApproveCheck: Promise<boolean> | undefined;
 
 	private readonly _isAgentModeEnabled: IObservable<boolean>;
 
@@ -1092,34 +1095,68 @@ export class LanguageModelToolsService extends Disposable implements ILanguageMo
 			return true;
 		}
 
-		const promptResult = await this._dialogService.prompt({
-			type: Severity.Warning,
-			message: localize('autoApprove2.title', 'Enable global auto approve?'),
-			buttons: [
-				{
-					label: localize('autoApprove2.button.enable', 'Enable'),
-					run: () => true
-				},
-				{
-					label: localize('autoApprove2.button.disable', 'Disable'),
-					run: () => false
-				},
-			],
-			custom: {
-				icon: Codicon.warning,
-				markdownDetails: [{
-					markdown: new MarkdownString(globalAutoApproveDescription.value, { isTrusted: { enabledCommands: ['workbench.action.openSettings'] } }),
-				}],
-			}
-		});
-
-		if (promptResult.result !== true) {
-			await this._configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, false);
-			return false;
+		if (this._pendingGlobalAutoApproveCheck) {
+			return this._pendingGlobalAutoApproveCheck;
 		}
 
-		this._storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
-		return true;
+		this._pendingGlobalAutoApproveCheck = this._doCheckGlobalAutoApprove();
+		try {
+			return await this._pendingGlobalAutoApproveCheck;
+		} finally {
+			this._pendingGlobalAutoApproveCheck = undefined;
+		}
+	}
+
+	private async _doCheckGlobalAutoApprove(): Promise<boolean> {
+		const store = new DisposableStore();
+		try {
+			// Dismiss the dialog automatically if another window stores the
+			// opt-in flag, avoiding duplicate approval prompts.
+			const cts = new CancellationTokenSource();
+			store.add(cts);
+			store.add(this._storageService.onDidChangeValue(StorageScope.APPLICATION, AutoApproveStorageKeys.GlobalAutoApproveOptIn, store)(() => {
+				if (this._storageService.getBoolean(AutoApproveStorageKeys.GlobalAutoApproveOptIn, StorageScope.APPLICATION, false)) {
+					cts.cancel();
+				}
+			}));
+
+			const promptResult = await this._dialogService.prompt({
+				type: Severity.Warning,
+				message: localize('autoApprove2.title', 'Enable global auto approve?'),
+				buttons: [
+					{
+						label: localize('autoApprove2.button.enable', 'Enable'),
+						run: () => true
+					},
+					{
+						label: localize('autoApprove2.button.disable', 'Disable'),
+						run: () => false
+					},
+				],
+				custom: {
+					icon: Codicon.warning,
+					markdownDetails: [{
+						markdown: new MarkdownString(globalAutoApproveDescription.value, { isTrusted: { enabledCommands: ['workbench.action.openSettings'] } }),
+					}],
+				},
+				token: cts.token,
+			});
+
+			// If cancelled by cross-window approval, treat as approved
+			if (cts.token.isCancellationRequested) {
+				return true;
+			}
+
+			if (promptResult.result !== true) {
+				await this._configurationService.updateValue(ChatConfiguration.GlobalAutoApprove, false);
+				return false;
+			}
+
+			this._storageService.store(AutoApproveStorageKeys.GlobalAutoApproveOptIn, true, StorageScope.APPLICATION, StorageTarget.USER);
+			return true;
+		} finally {
+			store.dispose();
+		}
 	}
 
 	private cleanupCallDisposables(requestId: string | undefined, store: DisposableStore): void {


### PR DESCRIPTION
Add CancellationToken support to IDialogService.prompt() and implement cross-window deduplication for the global auto-approve confirmation dialog.

When \chat.tools.global.autoApprove\ is enabled, the opt-in warning previously appeared in every window because each window independently checked the APPLICATION-scoped storage flag and showed the dialog without coordination.

Changes:
- Add <token?: CancellationToken> to IBaseDialogOptions, allowing dialogs to be programmatically dismissed via cancellation
- Update BrowserDialogHandler.doShow() to register token cancellation and dispose the dialog when the token fires
- In LanguageModelToolsService._checkGlobalAutoApprove(), use CancellationTokenSource + storageService.onDidChangeValue listener to detect when another window stores the opt-in flag and cancel the dialog
- Apply the same pattern to the /autoApprove slash command handler
- Within-window deduplication: pending promise cached in _pendingGlobalAutoApproveCheck prevents duplicate dialogs from multiple simultaneous tool invocations

After opt-in is stored by any window, other windows detect the storage change via the token listener and cancel their dialogs. The prompt then resolves as if approved, avoiding duplicate user interaction.

Fixes https://github.com/microsoft/vscode/issues/292150

(Commit message generated by Copilot)