### PR TITLE
[Terminal Sandbox]Wrapping the command in single quotes and escaping it to prevent any shell injection issues.

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -105,8 +105,8 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		}
 		// Use ELECTRON_RUN_AS_NODE=1 to make Electron executable behave as Node.js
 		// TMPDIR must be set as environment variable before the command
-		// Use -c to pass the command string directly (like sh -c), avoiding argument parsing issues
-		const wrappedCommand = `PATH="$PATH:${dirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" "${this._execPath}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c "${command}"`;
+		// Quote shell arguments so the wrapped command cannot break out of the outer shell.
+		const wrappedCommand = `PATH="$PATH:${dirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" "${this._execPath}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c ${this._quoteShellArgument(command)}`;
 		if (this._remoteEnvDetails) {
 			return `${wrappedCommand}`;
 		}
@@ -129,6 +129,11 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		}
 		return this._sandboxConfigPath;
 	}
+
+	private _quoteShellArgument(value: string): string {
+		return `'${value.replace(/'/g, `'\\''`)}'`;
+	}
+
 
 	private async _resolveSrtPath(): Promise<void> {
 		if (this._srtPathResolved) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -134,7 +134,6 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		return `'${value.replace(/'/g, `'\\''`)}'`;
 	}
 
-
 	private async _resolveSrtPath(): Promise<void> {
 		if (this._srtPathResolved) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -266,4 +266,68 @@ suite('TerminalSandboxService - allowTrustedDomains', () => {
 			'Wrapped command should include PATH modification with ripgrep'
 		);
 	});
+
+	test('should pass wrapped command as a single quoted argument', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const command = '";echo SANDBOX_ESCAPE_REPRO; # $(uname) `id`';
+		const wrappedCommand = sandboxService.wrapCommand(command);
+
+		ok(
+			wrappedCommand.includes(`-c '";echo SANDBOX_ESCAPE_REPRO; # $(uname) \`id\`'`),
+			'Wrapped command should shell-quote the command argument using single quotes'
+		);
+		ok(
+			!wrappedCommand.includes(`-c "${command}"`),
+			'Wrapped command should not embed the command in double quotes'
+		);
+	});
+
+	test('should keep variable and command substitution payloads literal', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const command = 'echo $HOME $(curl eth0.me) `id`';
+		const wrappedCommand = sandboxService.wrapCommand(command);
+
+		ok(
+			wrappedCommand.includes(`-c 'echo $HOME $(curl eth0.me) \`id\`'`),
+			'Wrapped command should keep variable and command substitutions inside the quoted argument'
+		);
+		ok(
+			!wrappedCommand.includes(`-c ${command}`),
+			'Wrapped command should not pass substitution payloads to -c without quoting'
+		);
+	});
+
+	test('should escape single-quote breakout payloads in wrapped command argument', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const command = `';curl eth0.me; #'`;
+		const wrappedCommand = sandboxService.wrapCommand(command);
+
+		ok(
+			wrappedCommand.includes(`-c '`),
+			'Wrapped command should continue to use a single-quoted -c argument'
+		);
+		ok(
+			wrappedCommand.includes('curl eth0.me'),
+			'Wrapped command should preserve the payload text literally'
+		);
+		ok(
+			!wrappedCommand.includes(`-c '${command}'`),
+			'Wrapped command should not embed attacker-controlled single quotes without escaping'
+		);
+		strictEqual((wrappedCommand.match(/\\''/g) ?? []).length, 2, 'Single quote breakout payload should escape each embedded single quote');
+	});
+
+	test('should escape embedded single quotes in wrapped command argument', async () => {
+		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
+		await sandboxService.getSandboxConfigPath();
+
+		const wrappedCommand = sandboxService.wrapCommand(`echo 'hello'`);
+		strictEqual((wrappedCommand.match(/\\''/g) ?? []).length, 2, 'Single quote escapes should be inserted for each embedded single quote');
+	});
 });


### PR DESCRIPTION
fixes(#298729)