### PR TITLE
feat(chat): add support for hand-off prompts in chat sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -172,6 +172,10 @@ const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsEx
 						supportsPromptAttachments: {
 							description: localize('chatSessionsExtPoint.supportsPromptAttachments', 'Whether this chat session supports attaching prompts.'),
 							type: 'boolean'
+						},
+						supportsHandOffs: {
+							description: localize('chatSessionsExtPoint.supportsHandOffs', 'Whether this chat session supports hand-off prompts.'),
+							type: 'boolean'
 						}
 					}
 				},

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -183,6 +183,7 @@ const supportsAllAttachments: Required<IChatAgentAttachmentCapabilities> = {
 	supportsSymbolAttachments: true,
 	supportsTerminalAttachments: true,
 	supportsPromptAttachments: true,
+	supportsHandOffs: true,
 };
 
 const DISCLAIMER = localize('chatDisclaimer', "AI responses may be inaccurate");
@@ -1154,8 +1155,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
-		// Skip rendering in coding agent sessions
-		if (this.isLockedToCodingAgent) {
+		// Skip rendering in coding agent sessions unless the agent supports hand-offs
+		if (this.isLockedToCodingAgent && !this._attachmentCapabilities.supportsHandOffs) {
 			this.chatSuggestNextWidget.hide();
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -47,6 +47,7 @@ export interface IChatAgentAttachmentCapabilities {
 	supportsSymbolAttachments?: boolean;
 	supportsTerminalAttachments?: boolean;
 	supportsPromptAttachments?: boolean;
+	supportsHandOffs?: boolean;
 }
 
 export interface IChatAgentData {


### PR DESCRIPTION
## Summary

Adds `supportsHandOffs` capability to `IChatAgentAttachmentCapabilities`, allowing chat session extensions to opt in to showing the suggest-next widget even when locked to a coding agent.

## Changes

- **`chatAgents.ts`**: Added `supportsHandOffs?: boolean` to `IChatAgentAttachmentCapabilities` interface.
- **`chatWidget.ts`**: Added `supportsHandOffs: true` to `supportsAllAttachments` constant, and updated `renderChatSuggestNextWidget` to allow rendering when the agent supports hand-offs (even in coding agent sessions).
- **`chatSessions.contribution.ts`**: Registered `supportsHandOffs` in the chat sessions extension point JSON schema so extensions can declare this capability.