### PR TITLE
sessions: mcp protocol negotiation, gateway output channel, and customization ui improvements

### DIFF
--- a/src/vs/platform/mcp/node/mcpGatewayService.ts
+++ b/src/vs/platform/mcp/node/mcpGatewayService.ts
@@ -9,7 +9,7 @@ import { JsonRpcMessage, JsonRpcProtocol } from '../../../base/common/jsonRpcPro
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { generateUuid } from '../../../base/common/uuid.js';
-import { ILogService } from '../../log/common/log.js';
+import { ILogger, ILoggerService } from '../../log/common/log.js';
 import { IMcpGatewayInfo, IMcpGatewayService, IMcpGatewayToolInvoker } from '../common/mcpGateway.js';
 import { isInitializeMessage, McpGatewaySession } from './mcpGatewaySession.js';
 
@@ -28,11 +28,14 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 	/** Maps gatewayId to clientId for tracking ownership */
 	private readonly _gatewayToClient = new Map<string, unknown>();
 	private _serverStartPromise: Promise<void> | undefined;
+	private readonly _logger: ILogger;
 
 	constructor(
-		@ILogService private readonly _logService: ILogService,
+		@ILoggerService loggerService: ILoggerService,
 	) {
 		super();
+		this._logger = this._register(loggerService.createLogger('mcpGateway', { name: 'MCP Gateway', logLevel: 'always' }));
+		this._logger.info('[McpGatewayService] Initialized');
 	}
 
 	async createGateway(clientId: unknown, toolInvoker?: IMcpGatewayToolInvoker): Promise<IMcpGatewayInfo> {
@@ -51,15 +54,15 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 			throw new Error('[McpGatewayService] Tool invoker is required to create gateway');
 		}
 
-		const gateway = new McpGatewayRoute(gatewayId, this._logService, toolInvoker);
+		const gateway = new McpGatewayRoute(gatewayId, this._logger, toolInvoker);
 		this._gateways.set(gatewayId, gateway);
 
 		// Track client ownership if clientId provided (for cleanup on disconnect)
 		if (clientId) {
 			this._gatewayToClient.set(gatewayId, clientId);
-			this._logService.info(`[McpGatewayService] Created gateway at http://127.0.0.1:${this._port}/gateway/${gatewayId} for client ${clientId}`);
+			this._logger.info(`[McpGatewayService] Created gateway at http://127.0.0.1:${this._port}/gateway/${gatewayId} for client ${clientId}`);
 		} else {
-			this._logService.warn(`[McpGatewayService] Created gateway without client tracking at http://127.0.0.1:${this._port}/gateway/${gatewayId}`);
+			this._logger.warn(`[McpGatewayService] Created gateway without client tracking at http://127.0.0.1:${this._port}/gateway/${gatewayId}`);
 		}
 
 		const address = URI.parse(`http://127.0.0.1:${this._port}/gateway/${gatewayId}`);
@@ -73,14 +76,14 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 	async disposeGateway(gatewayId: string): Promise<void> {
 		const gateway = this._gateways.get(gatewayId);
 		if (!gateway) {
-			this._logService.warn(`[McpGatewayService] Attempted to dispose unknown gateway: ${gatewayId}`);
+			this._logger.warn(`[McpGatewayService] Attempted to dispose unknown gateway: ${gatewayId}`);
 			return;
 		}
 
 		gateway.dispose();
 		this._gateways.delete(gatewayId);
 		this._gatewayToClient.delete(gatewayId);
-		this._logService.info(`[McpGatewayService] Disposed gateway: ${gatewayId}`);
+		this._logger.info(`[McpGatewayService] Disposed gateway: ${gatewayId}`);
 
 		// If no more gateways, shut down the server
 		if (this._gateways.size === 0) {
@@ -98,7 +101,7 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 		}
 
 		if (gatewaysToDispose.length > 0) {
-			this._logService.info(`[McpGatewayService] Disposing ${gatewaysToDispose.length} gateway(s) for disconnected client ${clientId}`);
+			this._logger.info(`[McpGatewayService] Disposing ${gatewaysToDispose.length} gateway(s) for disconnected client ${clientId}`);
 
 			for (const gatewayId of gatewaysToDispose) {
 				this._gateways.get(gatewayId)?.dispose();
@@ -156,19 +159,19 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 			}
 
 			clearTimeout(portTimeout);
-			this._logService.info(`[McpGatewayService] Server started on port ${this._port}`);
+			this._logger.info(`[McpGatewayService] Server started on port ${this._port}`);
 			deferredPromise.complete();
 		});
 
 		this._server.on('error', (err: NodeJS.ErrnoException) => {
 			if (err.code === 'EADDRINUSE') {
-				this._logService.warn('[McpGatewayService] Port in use, retrying with random port...');
+				this._logger.warn('[McpGatewayService] Port in use, retrying with random port...');
 				// Try with a random port
 				this._server!.listen(0, '127.0.0.1');
 				return;
 			}
 			clearTimeout(portTimeout);
-			this._logService.error(`[McpGatewayService] Server error: ${err}`);
+			this._logger.error(`[McpGatewayService] Server error: ${err}`);
 			deferredPromise.error(err);
 		});
 
@@ -183,13 +186,13 @@ export class McpGatewayService extends Disposable implements IMcpGatewayService 
 			return;
 		}
 
-		this._logService.info('[McpGatewayService] Stopping server (no more gateways)');
+		this._logger.info('[McpGatewayService] Stopping server (no more gateways)');
 
 		this._server.close(err => {
 			if (err) {
-				this._logService.error(`[McpGatewayService] Error closing server: ${err}`);
+				this._logger.error(`[McpGatewayService] Error closing server: ${err}`);
 			} else {
-				this._logService.info('[McpGatewayService] Server stopped');
+				this._logger.info('[McpGatewayService] Server stopped');
 			}
 		});
 
@@ -237,7 +240,7 @@ class McpGatewayRoute extends Disposable {
 
 	constructor(
 		public readonly gatewayId: string,
-		private readonly _logService: ILogService,
+		private readonly _logger: ILogger,
 		private readonly _toolInvoker: IMcpGatewayToolInvoker,
 	) {
 		super();
@@ -344,7 +347,7 @@ class McpGatewayRoute extends Disposable {
 			res.writeHead(200, headers);
 			res.end(JSON.stringify(Array.isArray(message) ? responses : responses[0]));
 		} catch (error) {
-			this._logService.error('[McpGatewayService] Failed handling gateway request', error);
+			this._logger.error('[McpGatewayService] Failed handling gateway request', error);
 			this._respondHttpError(res, 500, 'Internal server error');
 		}
 	}
@@ -366,7 +369,7 @@ class McpGatewayRoute extends Disposable {
 		}
 
 		const sessionId = generateUuid();
-		const session = new McpGatewaySession(sessionId, this._logService, () => {
+		const session = new McpGatewaySession(sessionId, this._logger, () => {
 			this._sessions.delete(sessionId);
 		}, this._toolInvoker);
 		this._sessions.set(sessionId, session);

--- a/src/vs/platform/mcp/node/mcpGatewaySession.ts
+++ b/src/vs/platform/mcp/node/mcpGatewaySession.ts
@@ -10,11 +10,18 @@ import {
 } from '../../../base/common/jsonRpcProtocol.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { hasKey } from '../../../base/common/types.js';
-import { ILogService } from '../../log/common/log.js';
+import { ILogger } from '../../log/common/log.js';
 import { IMcpGatewayToolInvoker } from '../common/mcpGateway.js';
 import { MCP } from '../common/modelContextProtocol.js';
 
 const MCP_LATEST_PROTOCOL_VERSION = '2025-11-25';
+const MCP_SUPPORTED_PROTOCOL_VERSIONS = [
+	'2025-11-25',
+	'2025-06-18',
+	'2025-03-26',
+	'2024-11-05',
+	'2024-10-07',
+];
 const MCP_INVALID_REQUEST = -32600;
 const MCP_METHOD_NOT_FOUND = -32601;
 const MCP_INVALID_PARAMS = -32602;
@@ -79,7 +86,7 @@ export class McpGatewaySession extends Disposable {
 
 	constructor(
 		public readonly id: string,
-		private readonly _logService: ILogService,
+		private readonly _logService: ILogger,
 		private readonly _onDidDispose: () => void,
 		private readonly _toolInvoker: IMcpGatewayToolInvoker,
 	) {
@@ -192,7 +199,7 @@ export class McpGatewaySession extends Disposable {
 
 	private async _handleRequest(request: IJsonRpcRequest): Promise<unknown> {
 		if (request.method === 'initialize') {
-			return this._handleInitialize();
+			return this._handleInitialize(request);
 		}
 
 		if (!this._isInitialized) {
@@ -225,9 +232,21 @@ export class McpGatewaySession extends Disposable {
 		}
 	}
 
-	private _handleInitialize(): MCP.InitializeResult {
+	private _handleInitialize(request: IJsonRpcRequest): MCP.InitializeResult {
+		const params = typeof request.params === 'object' && request.params ? request.params as Record<string, unknown> : undefined;
+		const clientVersion = typeof params?.protocolVersion === 'string' ? params.protocolVersion : undefined;
+		const clientInfo = params?.clientInfo as { name?: string; version?: string } | undefined;
+		const negotiatedVersion = clientVersion && MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(clientVersion)
+			? clientVersion
+			: MCP_LATEST_PROTOCOL_VERSION;
+
+		this._logService.info(`[McpGateway] Initialize: client=${clientInfo?.name ?? 'unknown'}/${clientInfo?.version ?? '?'}, clientProtocol=${clientVersion ?? '(none)'}, negotiated=${negotiatedVersion}`);
+		if (clientVersion && clientVersion !== negotiatedVersion) {
+			this._logService.warn(`[McpGateway] Client requested unsupported protocol version '${clientVersion}', falling back to '${negotiatedVersion}'`);
+		}
+
 		return {
-			protocolVersion: MCP_LATEST_PROTOCOL_VERSION,
+			protocolVersion: negotiatedVersion,
 			capabilities: {
 				tools: {
 					listChanged: true,

--- a/src/vs/platform/mcp/test/node/mcpGatewaySession.test.ts
+++ b/src/vs/platform/mcp/test/node/mcpGatewaySession.test.ts
@@ -112,6 +112,145 @@ suite('McpGatewaySession', () => {
 		onDidChangeResources.dispose();
 	});
 
+	test('negotiates to older protocol version when client requests it', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-negotiate-1', new NullLogService(), () => { }, invoker);
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2025-03-26',
+				capabilities: {},
+				clientInfo: { name: 'test-client', version: '1.0.0' },
+			},
+		});
+
+		assert.strictEqual(responses.length, 1);
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		assert.strictEqual((response.result as { protocolVersion: string }).protocolVersion, '2025-03-26');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('negotiates to each supported protocol version', async () => {
+		const supportedVersions = ['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
+		for (const version of supportedVersions) {
+			const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+			const session = new McpGatewaySession(`session-ver-${version}`, new NullLogService(), () => { }, invoker);
+
+			const responses = await session.handleIncoming({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'initialize',
+				params: { protocolVersion: version, capabilities: {} },
+			});
+
+			const response = responses[0] as IJsonRpcSuccessResponse;
+			assert.strictEqual(
+				(response.result as { protocolVersion: string }).protocolVersion,
+				version,
+				`Expected server to negotiate to ${version}`
+			);
+			session.dispose();
+			onDidChangeTools.dispose();
+			onDidChangeResources.dispose();
+		}
+	});
+
+	test('falls back to latest version for unsupported client version', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-negotiate-2', new NullLogService(), () => { }, invoker);
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: '2099-01-01',
+				capabilities: {},
+				clientInfo: { name: 'test-client', version: '1.0.0' },
+			},
+		});
+
+		assert.strictEqual(responses.length, 1);
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		assert.strictEqual((response.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('falls back to latest version when no params provided', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-negotiate-3', new NullLogService(), () => { }, invoker);
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+		});
+
+		assert.strictEqual(responses.length, 1);
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		assert.strictEqual((response.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('falls back to latest version when protocolVersion is not a string', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-negotiate-4', new NullLogService(), () => { }, invoker);
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: {
+				protocolVersion: 42,
+				capabilities: {},
+			},
+		});
+
+		assert.strictEqual(responses.length, 1);
+		const response = responses[0] as IJsonRpcSuccessResponse;
+		assert.strictEqual((response.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
+	test('initialize response includes server info and capabilities', async () => {
+		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
+		const session = new McpGatewaySession('session-init-caps', new NullLogService(), () => { }, invoker);
+
+		const responses = await session.handleIncoming({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'initialize',
+			params: { protocolVersion: '2025-03-26', capabilities: {} },
+		});
+
+		const result = (responses[0] as IJsonRpcSuccessResponse).result as MCP.InitializeResult;
+		assert.deepStrictEqual(result, {
+			protocolVersion: '2025-03-26',
+			capabilities: {
+				tools: { listChanged: true },
+				resources: { listChanged: true },
+			},
+			serverInfo: {
+				name: 'VS Code MCP Gateway',
+				version: '1.0.0',
+			},
+		});
+		session.dispose();
+		onDidChangeTools.dispose();
+		onDidChangeResources.dispose();
+	});
+
 	test('rejects non-initialize requests before initialized notification', async () => {
 		const { invoker, onDidChangeTools, onDidChangeResources } = createInvoker();
 		const session = new McpGatewaySession('session-2', new NullLogService(), () => { }, invoker);

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -24,10 +24,11 @@ import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyn
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
-import { agentIcon, instructionsIcon, promptIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
+import { agentIcon, instructionsIcon, mcpServerIcon, promptIcon, skillIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IEditorService, MODAL_GROUP } from '../../../../workbench/services/editor/common/editorService.js';
+import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 
 const $ = DOM.$;
 
@@ -67,6 +68,7 @@ export class AICustomizationOverviewView extends ViewPane {
 		@IPromptsService private readonly promptsService: IPromptsService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
+		@IMcpService private readonly mcpService: IMcpService,
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -76,6 +78,7 @@ export class AICustomizationOverviewView extends ViewPane {
 			{ id: AICustomizationManagementSection.Skills, label: localize('skills', "Skills"), icon: skillIcon, count: 0 },
 			{ id: AICustomizationManagementSection.Instructions, label: localize('instructions', "Instructions"), icon: instructionsIcon, count: 0 },
 			{ id: AICustomizationManagementSection.Prompts, label: localize('prompts', "Prompts"), icon: promptIcon, count: 0 },
+			{ id: AICustomizationManagementSection.McpServers, label: localize('mcpServers', "MCP Servers"), icon: mcpServerIcon, count: 0 },
 		);
 
 		// Listen to changes
@@ -172,6 +175,12 @@ export class AICustomizationOverviewView extends ViewPane {
 				sectionData.count = count;
 			}
 		}));
+
+		// Update MCP server count from the MCP service
+		const mcpSection = this.sections.find(s => s.id === AICustomizationManagementSection.McpServers);
+		if (mcpSection) {
+			mcpSection.count = this.mcpService.servers.get().length;
+		}
 
 		this.updateCountElements();
 	}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -176,10 +176,14 @@ export class AICustomizationOverviewView extends ViewPane {
 			}
 		}));
 
-		// Update MCP server count from the MCP service
+		// Update MCP server count reactively
 		const mcpSection = this.sections.find(s => s.id === AICustomizationManagementSection.McpServers);
 		if (mcpSection) {
-			mcpSection.count = this.mcpService.servers.get().length;
+			this._register(autorun(reader => {
+				const servers = this.mcpService.servers.read(reader);
+				mcpSection.count = servers.length;
+				this.updateCountElements();
+			}));
 		}
 
 		this.updateCountElements();

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -27,12 +27,15 @@ import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { agentIcon, extensionIcon, instructionsIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
+import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
+import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
+import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer, ITreeContextMenuEvent } from '../../../../base/browser/ui/tree/tree.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';
 import { IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
-import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IEditorService, MODAL_GROUP } from '../../../../workbench/services/editor/common/editorService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
@@ -95,7 +98,18 @@ interface IAICustomizationFileItem {
 	readonly promptType: PromptsType;
 }
 
-type AICustomizationTreeItem = IAICustomizationTypeItem | IAICustomizationGroupItem | IAICustomizationFileItem;
+/**
+ * Represents a link item that navigates to the management editor.
+ */
+interface IAICustomizationLinkItem {
+	readonly type: 'link';
+	readonly id: string;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly section: AICustomizationManagementSection;
+}
+
+type AICustomizationTreeItem = IAICustomizationTypeItem | IAICustomizationGroupItem | IAICustomizationFileItem | IAICustomizationLinkItem;
 
 //#endregion
 
@@ -109,6 +123,7 @@ class AICustomizationTreeDelegate implements IListVirtualDelegate<AICustomizatio
 	getTemplateId(element: AICustomizationTreeItem): string {
 		switch (element.type) {
 			case 'category':
+			case 'link':
 				return 'category';
 			case 'group':
 				return 'group';
@@ -135,7 +150,7 @@ interface IFileTemplateData {
 	readonly name: HTMLElement;
 }
 
-class AICustomizationCategoryRenderer implements ITreeRenderer<IAICustomizationTypeItem, FuzzyScore, ICategoryTemplateData> {
+class AICustomizationCategoryRenderer implements ITreeRenderer<IAICustomizationTypeItem | IAICustomizationLinkItem, FuzzyScore, ICategoryTemplateData> {
 	readonly templateId = 'category';
 
 	renderTemplate(container: HTMLElement): ICategoryTemplateData {
@@ -145,7 +160,7 @@ class AICustomizationCategoryRenderer implements ITreeRenderer<IAICustomizationT
 		return { container: element, icon, label };
 	}
 
-	renderElement(node: ITreeNode<IAICustomizationTypeItem, FuzzyScore>, _index: number, templateData: ICategoryTemplateData): void {
+	renderElement(node: ITreeNode<IAICustomizationTypeItem | IAICustomizationLinkItem, FuzzyScore>, _index: number, templateData: ICategoryTemplateData): void {
 		templateData.icon.className = 'icon';
 		templateData.icon.classList.add(...ThemeIcon.asClassNameArray(node.element.icon));
 		templateData.label.textContent = node.element.label;
@@ -248,6 +263,9 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 		if (element === ROOT_ELEMENT) {
 			return true;
 		}
+		if (element.type === 'link') {
+			return false;
+		}
 		return element.type === 'category' || element.type === 'group';
 	}
 
@@ -272,7 +290,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 		}
 	}
 
-	private getTypeCategories(): IAICustomizationTypeItem[] {
+	private getTypeCategories(): (IAICustomizationTypeItem | IAICustomizationLinkItem)[] {
 		return [
 			{
 				type: 'category',
@@ -301,6 +319,13 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 				label: localize('prompts', "Prompts"),
 				promptType: PromptsType.prompt,
 				icon: promptIcon,
+			},
+			{
+				type: 'link',
+				id: 'link-mcp-servers',
+				label: localize('mcpServers', "MCP Servers"),
+				icon: mcpServerIcon,
+				section: AICustomizationManagementSection.McpServers,
 			},
 		];
 	}
@@ -549,7 +574,7 @@ export class AICustomizationViewPane extends ViewPane {
 				},
 				accessibilityProvider: {
 					getAriaLabel: (element: AICustomizationTreeItem) => {
-						if (element.type === 'category') {
+						if (element.type === 'category' || element.type === 'link') {
 							return element.label;
 						}
 						if (element.type === 'group') {
@@ -573,12 +598,18 @@ export class AICustomizationViewPane extends ViewPane {
 			}
 		));
 
-		// Handle double-click to open file
-		this.treeDisposables.add(this.tree.onDidOpen(e => {
+		// Handle double-click to open file or navigate to section
+		this.treeDisposables.add(this.tree.onDidOpen(async e => {
 			if (e.element && e.element.type === 'file') {
 				this.editorService.openEditor({
 					resource: e.element.uri
 				});
+			} else if (e.element && e.element.type === 'link') {
+				const input = AICustomizationManagementEditorInput.getOrCreate();
+				const editor = await this.editorService.openEditor(input, { pinned: true }, MODAL_GROUP);
+				if (editor instanceof AICustomizationManagementEditor) {
+					editor.selectSectionById(e.element.section);
+				}
 			}
 		}));
 

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -96,8 +96,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 		AICustomizationManagementSection.Instructions,
 		AICustomizationManagementSection.Prompts,
 		AICustomizationManagementSection.Hooks,
-		// TODO: Re-enable MCP Servers once CLI MCP configuration is unified with VS Code
-		// AICustomizationManagementSection.McpServers,
+		AICustomizationManagementSection.McpServers,
 	];
 
 	private static readonly _hooksFilter: IStorageSourceFilter = {

--- a/src/vs/sessions/contrib/chat/browser/customizationsDebugLog.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationsDebugLog.contribution.ts
@@ -53,13 +53,19 @@ class CustomizationsDebugLogContribution extends Disposable implements IWorkbenc
 	}
 
 	private _pendingSnapshot: Promise<void> | undefined;
+	private _snapshotDirty = false;
 
 	private _logSnapshot(): void {
 		if (this._pendingSnapshot) {
+			this._snapshotDirty = true;
 			return;
 		}
 		this._pendingSnapshot = this._doLogSnapshot().finally(() => {
 			this._pendingSnapshot = undefined;
+			if (this._snapshotDirty) {
+				this._snapshotDirty = false;
+				this._logSnapshot();
+			}
 		});
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/customizationsDebugLog.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationsDebugLog.contribution.ts
@@ -1,0 +1,173 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
+import { ILogger, ILoggerService } from '../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { IPromptsService, PromptsStorage, IPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
+
+const PROMPT_SECTIONS: { section: AICustomizationManagementSection; type: PromptsType }[] = [
+	{ section: AICustomizationManagementSection.Agents, type: PromptsType.agent },
+	{ section: AICustomizationManagementSection.Skills, type: PromptsType.skill },
+	{ section: AICustomizationManagementSection.Instructions, type: PromptsType.instructions },
+	{ section: AICustomizationManagementSection.Prompts, type: PromptsType.prompt },
+	{ section: AICustomizationManagementSection.Hooks, type: PromptsType.hook },
+];
+
+class CustomizationsDebugLogContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.customizationsDebugLog';
+
+	private readonly _logger: ILogger;
+
+	constructor(
+		@ILoggerService loggerService: ILoggerService,
+		@IPromptsService private readonly _promptsService: IPromptsService,
+		@IAICustomizationWorkspaceService private readonly _workspaceService: IAICustomizationWorkspaceService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IMcpService private readonly _mcpService: IMcpService,
+	) {
+		super();
+		this._logger = this._register(loggerService.createLogger('customizationsDebug', { name: 'Customizations Debug' }));
+
+		this._register(this._promptsService.onDidChangeCustomAgents(() => this._logSnapshot()));
+		this._register(this._promptsService.onDidChangeSlashCommands(() => this._logSnapshot()));
+		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => this._logSnapshot()));
+		this._register(autorun(reader => {
+			this._workspaceService.activeProjectRoot.read(reader);
+			this._logSnapshot();
+		}));
+		this._register(autorun(reader => {
+			this._mcpService.servers.read(reader);
+			this._logSnapshot();
+		}));
+	}
+
+	private _pendingSnapshot: Promise<void> | undefined;
+
+	private _logSnapshot(): void {
+		if (this._pendingSnapshot) {
+			return;
+		}
+		this._pendingSnapshot = this._doLogSnapshot().finally(() => {
+			this._pendingSnapshot = undefined;
+		});
+	}
+
+	private async _doLogSnapshot(): Promise<void> {
+		const root = this._workspaceService.getActiveProjectRoot()?.fsPath ?? '(none)';
+
+		this._logger.info('');
+		this._logger.info('=== Customizations Snapshot ===');
+		this._logger.info(`  Root: ${root}`);
+		this._logger.info(`  Sections: ${this._workspaceService.managementSections.join(', ')}`);
+		this._logger.info('');
+
+		// Header
+		this._logger.info(`  ${'Section'.padEnd(16)} ${'Local'.padStart(6)} ${'User'.padStart(6)} ${'Ext'.padStart(6)} ${'Total'.padStart(7)}`);
+		this._logger.info(`  ${'--------'.padEnd(16)} ${'-----'.padStart(6)} ${'----'.padStart(6)} ${'---'.padStart(6)} ${'-----'.padStart(7)}`);
+
+		for (const { section, type } of PROMPT_SECTIONS) {
+			const filter = this._workspaceService.getStorageSourceFilter(type);
+			await this._logSectionRow(section, type, filter);
+		}
+
+		this._logger.info('');
+
+		// Details per section
+		for (const { section, type } of PROMPT_SECTIONS) {
+			const filter = this._workspaceService.getStorageSourceFilter(type);
+			await this._logSectionDetails(section, type, filter);
+		}
+
+		// MCP Servers
+		this._logMcpServers();
+	}
+
+	private _logMcpServers(): void {
+		const servers = this._mcpService.servers.get();
+		this._logger.info(`  -- MCP Servers (${servers.length}) --`);
+		if (servers.length === 0) {
+			this._logger.info('     (none registered)');
+		}
+		for (const server of servers) {
+			const state = server.connectionState.get();
+			const stateStr = state?.state ?? 'unknown';
+			this._logger.info(`     ${server.definition.label} [${stateStr}] id=${server.definition.id}`);
+		}
+		this._logger.info('');
+	}
+
+	private async _logSectionRow(section: AICustomizationManagementSection, type: PromptsType, filter: IStorageSourceFilter): Promise<void> {
+		try {
+			const [localFiles, userFiles, extensionFiles] = await Promise.all([
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.local, CancellationToken.None),
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.user, CancellationToken.None),
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.extension, CancellationToken.None),
+			]);
+			const all: IPromptPath[] = [...localFiles, ...userFiles, ...extensionFiles];
+			const filtered = applyStorageSourceFilter(all, filter);
+			const local = filtered.filter(f => f.storage === PromptsStorage.local).length;
+			const user = filtered.filter(f => f.storage === PromptsStorage.user).length;
+			const ext = filtered.filter(f => f.storage === PromptsStorage.extension).length;
+
+			this._logger.info(`  ${section.padEnd(16)} ${String(local).padStart(6)} ${String(user).padStart(6)} ${String(ext).padStart(6)} ${String(filtered.length).padStart(7)}`);
+		} catch {
+			this._logger.info(`  ${section.padEnd(16)}  (error)`);
+		}
+	}
+
+	private async _logSectionDetails(section: AICustomizationManagementSection, type: PromptsType, filter: IStorageSourceFilter): Promise<void> {
+		try {
+			// Source folders - where we look for files
+			const sourceFolders = await this._promptsService.getSourceFolders(type);
+			if (sourceFolders.length > 0) {
+				this._logger.info(`  -- ${section} --`);
+				this._logger.info(`     Search paths:`);
+				for (const sf of sourceFolders) {
+					this._logger.info(`       [${sf.storage}] ${sf.uri.fsPath}`);
+				}
+			}
+
+			const [localFiles, userFiles, extensionFiles] = await Promise.all([
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.local, CancellationToken.None),
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.user, CancellationToken.None),
+				this._promptsService.listPromptFilesForStorage(type, PromptsStorage.extension, CancellationToken.None),
+			]);
+			const all: IPromptPath[] = [...localFiles, ...userFiles, ...extensionFiles];
+			const filtered = applyStorageSourceFilter(all, filter);
+
+			if (filtered.length > 0) {
+				if (sourceFolders.length === 0) {
+					this._logger.info(`  -- ${section} --`);
+				}
+				this._logger.info(`     Filter: sources=[${filter.sources.join(', ')}]${filter.includedUserFileRoots ? `, roots=[${filter.includedUserFileRoots.map(r => r.fsPath).join(', ')}]` : ''}`);
+				this._logger.info(`     Found ${filtered.length} item(s):`);
+				for (const f of filtered) {
+					this._logger.info(`       [${f.storage}] ${f.uri.fsPath}`);
+				}
+			}
+
+			if (sourceFolders.length > 0 || filtered.length > 0) {
+				this._logger.info('');
+			}
+		} catch {
+			// already logged in row
+		}
+	}
+}
+
+registerWorkbenchContribution2(
+	CustomizationsDebugLogContribution.ID,
+	CustomizationsDebugLogContribution,
+	WorkbenchPhase.AfterRestored,
+);

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -9,6 +9,7 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultConfigurations([{
 	overrides: {
+		'chat.experimentalSessionsWindowOverride': true,
 		'chat.agent.maxRequests': 1000,
 		'chat.customizationsMenu.userStoragePath': '~/.copilot',
 		'chat.viewSessions.enabled': false,

--- a/src/vs/sessions/contrib/logs/browser/logs.contribution.ts
+++ b/src/vs/sessions/contrib/logs/browser/logs.contribution.ts
@@ -18,7 +18,6 @@ import { IViewContainersRegistry, IViewsRegistry, ViewContainerLocation, Extensi
 import { OutputViewPane } from '../../../../workbench/contrib/output/browser/outputView.js';
 import { OUTPUT_VIEW_ID } from '../../../../workbench/services/output/common/output.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
-import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 
 const SESSIONS_LOGS_CONTAINER_ID = 'workbench.sessions.panel.logsContainer';
 
@@ -32,9 +31,8 @@ class RegisterLogsViewContainerContribution implements IWorkbenchContribution {
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IEnvironmentService environmentService: IEnvironmentService,
 	) {
-		CONTEXT_SESSIONS_SHOW_LOGS.bindTo(contextKeyService).set(!environmentService.isBuilt);
+		CONTEXT_SESSIONS_SHOW_LOGS.bindTo(contextKeyService).set(true);
 		const viewContainerRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
 		const viewsRegistry = Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry);
 

--- a/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
@@ -7,10 +7,13 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { isEqualOrParent } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { parseHooksFromFile } from '../../../../workbench/contrib/chat/common/promptSyntax/hookCompatibility.js';
+import { parse as parseJSONC } from '../../../../base/common/jsonc.js';
 
 export interface ISourceCounts {
 	readonly workspace: number;
@@ -45,6 +48,7 @@ export async function getSourceCounts(
 	filter: IStorageSourceFilter,
 	workspaceContextService: IWorkspaceContextService,
 	workspaceService: IAICustomizationWorkspaceService,
+	fileService?: IFileService,
 ): Promise<ISourceCounts> {
 	const items: { storage: PromptsStorage; uri: URI }[] = [];
 
@@ -87,6 +91,28 @@ export async function getSourceCounts(
 				storage: isWorkspaceFile ? PromptsStorage.local : PromptsStorage.user,
 				uri: file.uri,
 			});
+		}
+	} else if (promptType === PromptsType.hook && fileService) {
+		// Must match loadItems: parse individual hooks from each file
+		const hookFiles = await promptsService.listPromptFiles(PromptsType.hook, CancellationToken.None);
+		const activeRoot = workspaceService.getActiveProjectRoot();
+		for (const hookFile of hookFiles) {
+			try {
+				const content = await fileService.readFile(hookFile.uri);
+				const json = parseJSONC(content.value.toString());
+				const { hooks } = parseHooksFromFile(hookFile.uri, json, activeRoot, '');
+				if (hooks.size > 0) {
+					for (const [, entry] of hooks) {
+						for (let i = 0; i < entry.hooks.length; i++) {
+							items.push({ storage: hookFile.storage, uri: hookFile.uri });
+						}
+					}
+				} else {
+					items.push({ storage: hookFile.storage, uri: hookFile.uri });
+				}
+			} catch {
+				items.push({ storage: hookFile.storage, uri: hookFile.uri });
+			}
 		}
 	} else {
 		// hooks and anything else: uses listPromptFiles

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -15,21 +15,22 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
-import { IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { Menus } from '../../../browser/menus.js';
-import { agentIcon, instructionsIcon, promptIcon, skillIcon, hookIcon, workspaceIcon, userIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
+import { agentIcon, instructionsIcon, mcpServerIcon, promptIcon, skillIcon, hookIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { ActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { IAction } from '../../../../base/common/actions.js';
 import { $, append } from '../../../../base/browser/dom.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { ISessionsManagementService } from './sessionsManagementService.js';
 import { Button } from '../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { getSourceCounts, getSourceCountsTotal, ISourceCounts } from './customizationCounts.js';
+import { getSourceCounts, getSourceCountsTotal } from './customizationCounts.js';
 import { IEditorService, MODAL_GROUP } from '../../../../workbench/services/editor/common/editorService.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 
@@ -39,7 +40,7 @@ interface ICustomizationItemConfig {
 	readonly icon: ThemeIcon;
 	readonly section: AICustomizationManagementSection;
 	readonly promptType?: PromptsType;
-	readonly getCount?: (languageModelsService: ILanguageModelsService, mcpService: IMcpService) => Promise<number>;
+	readonly isMcp?: boolean;
 }
 
 const CUSTOMIZATION_ITEMS: ICustomizationItemConfig[] = [
@@ -78,7 +79,13 @@ const CUSTOMIZATION_ITEMS: ICustomizationItemConfig[] = [
 		section: AICustomizationManagementSection.Hooks,
 		promptType: PromptsType.hook,
 	},
-	// TODO: Re-enable MCP Servers once CLI MCP configuration is unified with VS Code
+	{
+		id: 'sessions.customization.mcpServers',
+		label: localize('mcpServers', "MCP Servers"),
+		icon: mcpServerIcon,
+		section: AICustomizationManagementSection.McpServers,
+		isMcp: true,
+	},
 ];
 
 /**
@@ -101,6 +108,7 @@ class CustomizationLinkViewItem extends ActionViewItem {
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@ISessionsManagementService private readonly _activeSessionService: ISessionsManagementService,
 		@IAICustomizationWorkspaceService private readonly _workspaceService: IAICustomizationWorkspaceService,
+		@IFileService private readonly _fileService: IFileService,
 	) {
 		super(undefined, action, { ...options, icon: false, label: false });
 		this._viewItemDisposables = this._register(new DisposableStore());
@@ -166,50 +174,19 @@ class CustomizationLinkViewItem extends ActionViewItem {
 		if (this._config.promptType) {
 			const type = this._config.promptType;
 			const filter = this._workspaceService.getStorageSourceFilter(type);
-			const counts = await getSourceCounts(this._promptsService, type, filter, this._workspaceContextService, this._workspaceService);
+			const counts = await getSourceCounts(this._promptsService, type, filter, this._workspaceContextService, this._workspaceService, this._fileService);
 			if (requestId !== this._updateCountsRequestId) {
 				return;
 			}
-			this._renderSourceCounts(this._countContainer, counts);
-		} else if (this._config.getCount) {
-			const count = await this._config.getCount(this._languageModelsService, this._mcpService);
-			if (requestId !== this._updateCountsRequestId) {
-				return;
-			}
-			this._renderSimpleCount(this._countContainer, count);
+			const total = getSourceCountsTotal(counts, filter);
+			this._renderTotalCount(this._countContainer, total);
+		} else if (this._config.isMcp) {
+			const total = this._mcpService.servers.get().length;
+			this._renderTotalCount(this._countContainer, total);
 		}
 	}
 
-	private _renderSourceCounts(container: HTMLElement, counts: ISourceCounts): void {
-		container.textContent = '';
-		const type = this._config.promptType;
-		const filter = type ? this._workspaceService.getStorageSourceFilter(type) : this._workspaceService.getStorageSourceFilter(PromptsType.prompt);
-		const total = getSourceCountsTotal(counts, filter);
-		container.classList.toggle('hidden', total === 0);
-		if (total === 0) {
-			return;
-		}
-
-		const visibleSourcesSet = new Set(filter.sources);
-		const sources: { storage: PromptsStorage; count: number; icon: ThemeIcon; title: string }[] = [
-			{ storage: PromptsStorage.local, count: counts.workspace, icon: workspaceIcon, title: localize('workspaceCount', "{0} from workspace", counts.workspace) },
-			{ storage: PromptsStorage.user, count: counts.user, icon: userIcon, title: localize('userCount', "{0} from user", counts.user) },
-		];
-
-		for (const source of sources) {
-			if (source.count === 0 || !visibleSourcesSet.has(source.storage)) {
-				continue;
-			}
-			const badge = append(container, $('span.source-count-badge'));
-			badge.title = source.title;
-			const icon = append(badge, $('span.source-count-icon'));
-			icon.classList.add(...ThemeIcon.asClassNameArray(source.icon));
-			const num = append(badge, $('span.source-count-num'));
-			num.textContent = `${source.count}`;
-		}
-	}
-
-	private _renderSimpleCount(container: HTMLElement, count: number): void {
+	private _renderTotalCount(container: HTMLElement, count: number): void {
 		container.textContent = '';
 		container.classList.toggle('hidden', count === 0);
 		if (count > 0) {

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -203,6 +203,7 @@ import './browser/layoutActions.js';
 import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';
 import './contrib/chat/browser/chat.contribution.js';
+import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changesView/browser/changesView.contribution.js';

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
@@ -66,3 +66,8 @@ export const extensionIcon = registerIcon('ai-customization-extension', Codicon.
  * Icon for plugin storage.
  */
 export const pluginIcon = registerIcon('ai-customization-plugin', Codicon.plug, localize('aiCustomizationPluginIcon', "Icon for plugin-contributed items."));
+
+/**
+ * Icon for MCP servers.
+ */
+export const mcpServerIcon = registerIcon('ai-customization-mcp-server', Codicon.server, localize('aiCustomizationMcpServerIcon', "Icon for MCP servers."));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -37,7 +37,6 @@ import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
 import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-import { ISCMService } from '../../../scm/common/scm.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
@@ -51,7 +50,7 @@ import { OS } from '../../../../../base/common/platform.js';
 const $ = DOM.$;
 
 const ITEM_HEIGHT = 44;
-const GROUP_HEADER_HEIGHT = 32;
+const GROUP_HEADER_HEIGHT = 36;
 const GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
 
 /**
@@ -65,7 +64,6 @@ export interface IAICustomizationListItem {
 	readonly description?: string;
 	readonly storage: PromptsStorage;
 	readonly promptType: PromptsType;
-	gitStatus?: 'uncommitted' | 'committed';
 	nameMatches?: IMatch[];
 	descriptionMatches?: IMatch[];
 }
@@ -116,8 +114,6 @@ interface IAICustomizationItemTemplateData {
 	readonly actionsContainer: HTMLElement;
 	readonly nameLabel: HighlightedLabel;
 	readonly description: HighlightedLabel;
-	readonly storageBadge: HTMLElement;
-	readonly gitStatusBadge: HTMLElement;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
 }
@@ -213,14 +209,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		container.classList.add('ai-customization-list-item');
 
 		const leftSection = DOM.append(container, $('.item-left'));
-		// Storage badge on left (shows workspace/user/extension)
-		const storageBadge = DOM.append(leftSection, $('.storage-badge'));
 		const textContainer = DOM.append(leftSection, $('.item-text'));
 		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(textContainer, $('.item-name'))));
 		const description = disposables.add(new HighlightedLabel(DOM.append(textContainer, $('.item-description'))));
-
-		// Git status badge (always visible, outside item-right hover container)
-		const gitStatusBadge = DOM.append(container, $('.git-status-badge'));
 
 		// Right section for actions (hover-visible)
 		const actionsContainer = DOM.append(container, $('.item-right'));
@@ -230,8 +221,6 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			actionsContainer,
 			nameLabel,
 			description,
-			storageBadge,
-			gitStatusBadge,
 			disposables,
 			elementDisposables,
 		};
@@ -266,45 +255,6 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		} else {
 			templateData.description.set('', undefined);
 			templateData.description.element.style.display = 'none';
-		}
-
-		// Storage badge
-		let storageBadgeIcon: ThemeIcon;
-		let storageBadgeLabel: string;
-		switch (element.storage) {
-			case PromptsStorage.local:
-				storageBadgeIcon = workspaceIcon;
-				storageBadgeLabel = localize('workspace', "Workspace");
-				break;
-			case PromptsStorage.user:
-				storageBadgeIcon = userIcon;
-				storageBadgeLabel = localize('user', "User");
-				break;
-			case PromptsStorage.extension:
-				storageBadgeIcon = extensionIcon;
-				storageBadgeLabel = localize('extension', "Extension");
-				break;
-			case PromptsStorage.plugin:
-				storageBadgeIcon = pluginIcon;
-				storageBadgeLabel = localize('plugin', "Plugin");
-				break;
-		}
-
-		templateData.storageBadge.className = 'storage-badge';
-		templateData.storageBadge.classList.add(...ThemeIcon.asClassNameArray(storageBadgeIcon));
-		templateData.storageBadge.title = storageBadgeLabel;
-
-		// Git status badge
-		const gitBadge = templateData.gitStatusBadge;
-		gitBadge.className = 'git-status-badge';
-		if (element.gitStatus === 'committed') {
-			gitBadge.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
-			gitBadge.classList.add('committed');
-			gitBadge.textContent = '';
-			gitBadge.title = localize('committedStatus', "Committed");
-			gitBadge.style.display = '';
-		} else {
-			gitBadge.style.display = 'none';
 		}
 	}
 
@@ -389,7 +339,6 @@ export class AICustomizationListWidget extends Disposable {
 		@ILabelService private readonly labelService: ILabelService,
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IClipboardService private readonly clipboardService: IClipboardService,
-		@ISCMService private readonly scmService: ISCMService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@IFileService private readonly fileService: IFileService,
 		@IPathService private readonly pathService: IPathService,
@@ -404,18 +353,6 @@ export class AICustomizationListWidget extends Disposable {
 			this.updateAddButton();
 			this.refresh();
 		}));
-
-		// Re-filter when SCM repositories change (updates git status badges after commits)
-		const trackRepoChanges = (repo: { provider: { onDidChangeResources: Event<void> } }) => {
-			this._register(repo.provider.onDidChangeResources(() => {
-				this.updateGitStatus(this.allItems);
-				this.filterItems();
-			}));
-		};
-		for (const repo of [...this.scmService.repositories]) {
-			trackRepoChanges(repo);
-		}
-		this._register(this.scmService.onDidAddRepository(repo => trackRepoChanges(repo)));
 
 	}
 
@@ -948,34 +885,9 @@ export class AICustomizationListWidget extends Disposable {
 		// Sort items by name
 		items.sort((a, b) => a.name.localeCompare(b.name));
 
-		// Set git status for workspace (local) items
-		this.updateGitStatus(items);
-
 		this.allItems = items;
 		this.filterItems();
 		this._onDidChangeItemCount.fire(items.length);
-	}
-
-	/**
-	 * Updates git status on local workspace items by checking SCM resource groups.
-	 * Files found in resource groups have uncommitted changes; others are committed.
-	 */
-	private updateGitStatus(items: IAICustomizationListItem[]): void {
-		// Build a set of URIs that have uncommitted changes in SCM
-		const uncommittedUris = new Set<string>();
-		for (const repo of [...this.scmService.repositories]) {
-			for (const group of repo.provider.groups) {
-				for (const resource of group.resources) {
-					uncommittedUris.add(resource.sourceUri.toString());
-				}
-			}
-		}
-
-		for (const item of items) {
-			if (item.storage === PromptsStorage.local) {
-				item.gitStatus = uncommittedUris.has(item.uri.toString()) ? 'uncommitted' : 'committed';
-			}
-		}
 	}
 
 	/**
@@ -1201,14 +1113,25 @@ export class AICustomizationListWidget extends Disposable {
 	 * Layouts the widget.
 	 */
 	layout(height: number, width: number): void {
-		const sectionFooterHeight = this.sectionHeader.offsetHeight || 100;
+		const sectionFooterHeight = this.sectionHeader.offsetHeight || 0;
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight || 40;
-		const margins = 12; // search margin (6+6), not included in offsetHeight
-		const listHeight = height - sectionFooterHeight - searchBarHeight - margins;
+		const listHeight = height - sectionFooterHeight - searchBarHeight;
 
 		this.searchInput.layout();
 		this.listContainer.style.height = `${Math.max(0, listHeight)}px`;
 		this.list.layout(Math.max(0, listHeight), width);
+
+		// Re-layout once after footer renders if we used a zero fallback
+		if (sectionFooterHeight === 0) {
+			requestAnimationFrame(() => {
+				const actualFooterHeight = this.sectionHeader.offsetHeight;
+				if (actualFooterHeight > 0) {
+					const correctedHeight = height - actualFooterHeight - searchBarHeight;
+					this.listContainer.style.height = `${Math.max(0, correctedHeight)}px`;
+					this.list.layout(Math.max(0, correctedHeight), width);
+				}
+			});
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1123,7 +1123,10 @@ export class AICustomizationListWidget extends Disposable {
 
 		// Re-layout once after footer renders if we used a zero fallback
 		if (sectionFooterHeight === 0) {
-			requestAnimationFrame(() => {
+			DOM.getWindow(this.listContainer).requestAnimationFrame(() => {
+				if (this._store.isDisposed) {
+					return;
+				}
 				const actualFooterHeight = this.sectionHeader.offsetHeight;
 				if (actualFooterHeight > 0) {
 					const correctedHeight = height - actualFooterHeight - searchBarHeight;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -6,7 +6,6 @@
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
@@ -289,26 +288,6 @@ class AICustomizationManagementActionsContribution extends Disposable implements
 			}
 		}));
 
-		// Toggle Debug Panel in AI Customizations Editor
-		this._register(registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: AICustomizationManagementCommands.ToggleDebug,
-					title: localize2('toggleDebugPanel', "Customizations Debug"),
-					category: Categories.Developer,
-					f1: true,
-				});
-			}
-
-			async run(accessor: ServicesAccessor): Promise<void> {
-				const editorService = accessor.get(IEditorService);
-				const pane = editorService.activeEditorPane;
-				if (pane instanceof AICustomizationManagementEditor) {
-					const report = await (pane as AICustomizationManagementEditor).generateDebugReport();
-					await editorService.openEditor({ resource: undefined, contents: report, options: { pinned: false } });
-				}
-			}
-		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -26,7 +26,6 @@ export const AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID = 'workbench.input.aiCu
  */
 export const AICustomizationManagementCommands = {
 	OpenEditor: 'aiCustomization.openManagementEditor',
-	ToggleDebug: 'aiCustomization.toggleDebugPanel',
 	CreateNewAgent: 'aiCustomization.createNewAgent',
 	CreateNewSkill: 'aiCustomization.createNewSkill',
 	CreateNewInstructions: 'aiCustomization.createNewInstructions',

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -28,13 +28,14 @@ import { Delayer } from '../../../../../base/common/async.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { getContextMenuActions } from '../../../../contrib/mcp/browser/mcpServerActions.js';
 import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
-import { workspaceIcon, userIcon } from './aiCustomizationIcons.js';
+import { workspaceIcon, userIcon, extensionIcon } from './aiCustomizationIcons.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 
 const $ = DOM.$;
 
-const MCP_ITEM_HEIGHT = 60;
-const MCP_GROUP_HEADER_HEIGHT = 32;
+const MCP_ITEM_HEIGHT = 36;
+const MCP_GROUP_HEADER_HEIGHT = 36;
 const MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
 
 /**
@@ -43,7 +44,7 @@ const MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
 interface IMcpGroupHeaderEntry {
 	readonly type: 'group-header';
 	readonly id: string;
-	readonly scope: LocalMcpServerScope;
+	readonly scope: LocalMcpServerScope | 'builtin';
 	readonly label: string;
 	readonly icon: ThemeIcon;
 	readonly count: number;
@@ -60,7 +61,17 @@ interface IMcpServerItemEntry {
 	readonly server: IWorkbenchMcpServer;
 }
 
-type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry;
+/**
+ * Represents a built-in MCP server provided by an extension.
+ */
+interface IMcpBuiltinItemEntry {
+	readonly type: 'builtin-item';
+	readonly id: string;
+	readonly label: string;
+	readonly description: string;
+}
+
+type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpBuiltinItemEntry;
 
 /**
  * Delegate for the MCP server list.
@@ -76,6 +87,9 @@ class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
 	getTemplateId(element: IMcpListEntry): string {
 		if (element.type === 'group-header') {
 			return 'mcpGroupHeader';
+		}
+		if (element.type === 'builtin-item') {
+			return 'mcpServerItem';
 		}
 		const server = element.server;
 		return server.gallery && !server.local ? 'mcpGalleryItem' : 'mcpServerItem';
@@ -151,7 +165,6 @@ class McpGroupHeaderRenderer implements IListRenderer<IMcpGroupHeaderEntry, IMcp
 
 interface IMcpServerItemTemplateData {
 	readonly container: HTMLElement;
-	readonly icon: HTMLElement;
 	readonly name: HTMLElement;
 	readonly description: HTMLElement;
 	readonly status: HTMLElement;
@@ -161,18 +174,16 @@ interface IMcpServerItemTemplateData {
 /**
  * Renderer for local MCP server list items.
  */
-class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpServerItemTemplateData> {
+class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpBuiltinItemEntry, IMcpServerItemTemplateData> {
 	readonly templateId = 'mcpServerItem';
 
 	constructor(
 		@IMcpService private readonly mcpService: IMcpService,
+		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 	) { }
 
 	renderTemplate(container: HTMLElement): IMcpServerItemTemplateData {
 		container.classList.add('mcp-server-item');
-
-		const icon = DOM.append(container, $('.mcp-server-icon'));
-		icon.classList.add(...ThemeIcon.asClassNameArray(Codicon.server));
 
 		const details = DOM.append(container, $('.mcp-server-details'));
 		const name = DOM.append(details, $('.mcp-server-name'));
@@ -180,14 +191,31 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpSe
 
 		const status = DOM.append(container, $('.mcp-server-status'));
 
-		return { container, icon, name, description, status, disposables: new DisposableStore() };
+		return { container, name, description, status, disposables: new DisposableStore() };
 	}
 
-	renderElement(element: IMcpServerItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
+	renderElement(element: IMcpServerItemEntry | IMcpBuiltinItemEntry, index: number, templateData: IMcpServerItemTemplateData): void {
 		templateData.disposables.clear();
 
+		if (element.type === 'builtin-item') {
+			templateData.name.textContent = element.label;
+			if (element.description) {
+				templateData.description.textContent = element.description;
+				templateData.description.style.display = '';
+			} else {
+				templateData.description.style.display = 'none';
+			}
+			templateData.status.style.display = 'none';
+			return;
+		}
+
 		templateData.name.textContent = element.server.label;
-		templateData.description.textContent = element.server.description || '';
+		if (element.server.description) {
+			templateData.description.textContent = element.server.description;
+			templateData.description.style.display = '';
+		} else {
+			templateData.description.style.display = 'none';
+		}
 
 		// Find the server from IMcpService to get connection state
 		const server = this.mcpService.servers.get().find(s => s.definition.id === element.server.id);
@@ -200,6 +228,13 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpSe
 	private updateStatus(statusElement: HTMLElement, state: McpConnectionState.Kind | undefined): void {
 		statusElement.className = 'mcp-server-status';
 
+		if (this.workspaceService.isSessionsWindow) {
+			// In sessions window, CLI manages MCP servers — hide status
+			statusElement.style.display = 'none';
+			return;
+		}
+
+		statusElement.style.display = '';
 		switch (state) {
 			case McpConnectionState.Kind.Running:
 				statusElement.textContent = localize('running', "Running");
@@ -228,7 +263,6 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpSe
 
 interface IMcpGalleryItemTemplateData {
 	readonly container: HTMLElement;
-	readonly icon: HTMLElement;
 	readonly name: HTMLElement;
 	readonly publisher: HTMLElement;
 	readonly description: HTMLElement;
@@ -250,9 +284,6 @@ class McpGalleryItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpG
 	renderTemplate(container: HTMLElement): IMcpGalleryItemTemplateData {
 		container.classList.add('mcp-server-item', 'mcp-gallery-item');
 
-		const icon = DOM.append(container, $('.mcp-server-icon'));
-		icon.classList.add(...ThemeIcon.asClassNameArray(Codicon.server));
-
 		const details = DOM.append(container, $('.mcp-server-details'));
 		const nameRow = DOM.append(details, $('.mcp-gallery-name-row'));
 		const name = DOM.append(nameRow, $('.mcp-server-name'));
@@ -266,7 +297,7 @@ class McpGalleryItemRenderer implements IListRenderer<IMcpServerItemEntry, IMcpG
 		const templateDisposables = new DisposableStore();
 		templateDisposables.add(installButton);
 
-		return { container, icon, name, publisher, description, installButton, elementDisposables: new DisposableStore(), templateDisposables };
+		return { container, name, publisher, description, installButton, elementDisposables: new DisposableStore(), templateDisposables };
 	}
 
 	renderElement(element: IMcpServerItemEntry, _index: number, templateData: IMcpGalleryItemTemplateData): void {
@@ -346,7 +377,7 @@ export class McpListWidget extends Disposable {
 	private galleryServers: IWorkbenchMcpServer[] = [];
 	private searchQuery: string = '';
 	private browseMode: boolean = false;
-	private readonly collapsedGroups = new Set<LocalMcpServerScope>();
+	private readonly collapsedGroups = new Set<string>();
 	private galleryCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
 	private readonly delayedGallerySearch = new Delayer<void>(400);
@@ -477,6 +508,9 @@ export class McpListWidget extends Disposable {
 						if (element.type === 'group-header') {
 							return localize('mcpGroupAriaLabel', "{0}, {1} items, {2}", element.label, element.count, element.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
+						if (element.type === 'builtin-item') {
+							return element.label;
+						}
 						return element.server.label;
 					},
 					getWidgetAriaLabel() {
@@ -486,7 +520,13 @@ export class McpListWidget extends Disposable {
 				openOnSingleClick: true,
 				identityProvider: {
 					getId(element: IMcpListEntry) {
-						return element.type === 'group-header' ? element.id : element.server.id;
+						if (element.type === 'group-header') {
+							return element.id;
+						}
+						if (element.type === 'builtin-item') {
+							return element.id;
+						}
+						return element.server.id;
 					}
 				}
 			}
@@ -496,9 +536,10 @@ export class McpListWidget extends Disposable {
 			if (e.element) {
 				if (e.element.type === 'group-header') {
 					this.toggleGroup(e.element);
-				} else {
+				} else if (e.element.type === 'server-item') {
 					this._onDidSelectServer.fire(e.element.server);
 				}
+				// builtin-item: no action on click (read-only)
 			}
 		}));
 
@@ -619,8 +660,14 @@ export class McpListWidget extends Disposable {
 			this.filteredServers = [...this.mcpWorkbenchService.local];
 		}
 
+		// Find extension-provided servers not in the local list (e.g. GitHub MCP)
+		const localIds = new Set(this.filteredServers.map(s => s.id));
+		const builtinServers = this.mcpService.servers.get()
+			.filter(s => !localIds.has(s.definition.id))
+			.filter(s => !query || s.definition.label.toLowerCase().includes(query));
+
 		// Show empty state only when there are no servers at all (not when filtered to empty)
-		if (this.filteredServers.length === 0) {
+		if (this.filteredServers.length === 0 && builtinServers.length === 0) {
 			this.emptyContainer.style.display = 'flex';
 			this.listContainer.style.display = 'none';
 
@@ -681,6 +728,32 @@ export class McpListWidget extends Disposable {
 			isFirst = false;
 		}
 
+		// Add built-in / extension-provided servers
+		if (builtinServers.length > 0) {
+			const collapsed = this.collapsedGroups.has('builtin');
+			entries.push({
+				type: 'group-header',
+				id: 'mcp-group-builtin',
+				scope: 'builtin',
+				label: localize('builtInGroup', "Built-in"),
+				icon: extensionIcon,
+				count: builtinServers.length,
+				isFirst,
+				description: localize('builtInGroupDescription', "MCP servers built into VS Code. These are available automatically."),
+				collapsed,
+			});
+			if (!collapsed) {
+				for (const server of builtinServers) {
+					entries.push({
+						type: 'builtin-item',
+						id: `builtin-${server.definition.id}`,
+						label: server.definition.label,
+						description: '',
+					});
+				}
+			}
+		}
+
 		this.displayEntries = entries;
 		this.list.splice(0, this.list.length, this.displayEntries);
 	}
@@ -701,14 +774,25 @@ export class McpListWidget extends Disposable {
 	 * Layouts the widget.
 	 */
 	layout(height: number, width: number): void {
-		const sectionFooterHeight = this.sectionHeader.offsetHeight || 100;
+		const sectionFooterHeight = this.sectionHeader.offsetHeight || 0;
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight || 40;
 		const backLinkHeight = this.browseMode ? (this.backLink.offsetHeight || 28) : 0;
-		const margins = 12;
-		const listHeight = height - sectionFooterHeight - searchBarHeight - backLinkHeight - margins;
+		const listHeight = height - sectionFooterHeight - searchBarHeight - backLinkHeight;
 
 		this.listContainer.style.height = `${Math.max(0, listHeight)}px`;
 		this.list.layout(Math.max(0, listHeight), width);
+
+		// Re-layout once after footer renders if we used a zero fallback
+		if (sectionFooterHeight === 0) {
+			requestAnimationFrame(() => {
+				const actualFooterHeight = this.sectionHeader.offsetHeight;
+				if (actualFooterHeight > 0) {
+					const correctedHeight = height - actualFooterHeight - searchBarHeight - backLinkHeight;
+					this.listContainer.style.height = `${Math.max(0, correctedHeight)}px`;
+					this.list.layout(Math.max(0, correctedHeight), width);
+				}
+			});
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -198,6 +198,7 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 		templateData.disposables.clear();
 
 		if (element.type === 'builtin-item') {
+			templateData.container.classList.add('builtin');
 			templateData.name.textContent = element.label;
 			if (element.description) {
 				templateData.description.textContent = element.description;
@@ -209,6 +210,7 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 			return;
 		}
 
+		templateData.container.classList.remove('builtin');
 		templateData.name.textContent = element.server.label;
 		if (element.server.description) {
 			templateData.description.textContent = element.server.description;
@@ -784,7 +786,10 @@ export class McpListWidget extends Disposable {
 
 		// Re-layout once after footer renders if we used a zero fallback
 		if (sectionFooterHeight === 0) {
-			requestAnimationFrame(() => {
+			DOM.getWindow(this.listContainer).requestAnimationFrame(() => {
+				if (this._store.isDisposed) {
+					return;
+				}
 				const actualFooterHeight = this.sectionHeader.offsetHeight;
 				if (actualFooterHeight > 0) {
 					const correctedHeight = height - actualFooterHeight - searchBarHeight - backLinkHeight;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -702,6 +702,11 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
+.mcp-server-item.builtin {
+	cursor: default;
+	opacity: 0.85;
+}
+
 .mcp-server-item .mcp-server-icon {
 	flex-shrink: 0;
 	width: 24px;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -195,7 +195,8 @@
 
 .ai-customization-list-widget .list-container {
 	flex: 1;
-	overflow: hidden;
+	min-height: 0;
+	overflow: auto;
 }
 
 .ai-customization-list-widget .list-empty-message {
@@ -251,11 +252,9 @@
 	border-radius: 4px;
 }
 
-/* Separator line above non-first group headers */
+/* Spacing above non-first group headers */
 .ai-customization-group-header.has-previous-group {
-	border-top: 1px solid var(--vscode-sideBarSectionHeader-border, var(--vscode-panel-border));
 	margin-top: 4px;
-	padding-top: 12px;
 }
 
 .ai-customization-group-header:hover {
@@ -648,7 +647,8 @@
 
 .mcp-list-widget .mcp-list-container {
 	flex: 1;
-	overflow: hidden;
+	min-height: 0;
+	overflow: auto;
 }
 
 /* MCP Empty State */
@@ -690,11 +690,12 @@
 .mcp-server-item {
 	display: flex;
 	align-items: center;
-	padding: 8px 12px;
+	padding: 6px 8px 6px 24px;
 	cursor: pointer;
 	border-radius: 4px;
 	margin: 2px 0;
-	gap: 12px;
+	min-height: 32px;
+	gap: 10px;
 }
 
 .mcp-server-item:hover {
@@ -721,10 +722,10 @@
 
 .mcp-server-item .mcp-server-name {
 	font-size: 13px;
-	font-weight: 500;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	line-height: 18px;
 }
 
 .mcp-server-item .mcp-server-description {
@@ -733,6 +734,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	line-height: 14px;
 }
 
 .mcp-server-item .mcp-server-status {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -182,6 +182,12 @@ configurationRegistry.registerConfiguration({
 	title: nls.localize('interactiveSessionConfigurationTitle', "Chat"),
 	type: 'object',
 	properties: {
+		'chat.experimentalSessionsWindowOverride': {
+			type: 'boolean',
+			description: nls.localize('chat.experimentalSessionsWindowOverride', "When true, enables sessions-window-specific behavior for extensions."),
+			default: false,
+			tags: ['experimental'],
+		},
 		'chat.fontSize': {
 			type: 'number',
 			description: nls.localize('chat.fontSize', "Controls the font size in pixels in chat messages."),


### PR DESCRIPTION
MCP Gateway Protocol Negotiation:
- Gateway now negotiates protocol version with clients instead of
  hardcoding '2025-11-25', fixing compatibility with older SDK versions
- Adds MCP_SUPPORTED_PROTOCOL_VERSIONS covering all known MCP spec versions
- Responds with client's requested version if supported, falls back to latest
- Logs client info and negotiated version for diagnostics
- 7 new unit tests covering all negotiation scenarios

MCP Gateway Output Channel:
- Dedicated 'MCP Gateway' output channel via ILoggerService (logLevel: always)
- Gateway service and sessions now use ILogger instead of ILogService
- All gateway lifecycle events visible in Output panel

Sessions Window MCP Integration:
- Re-enable MCP Servers section in sessions management editor
- Add MCP Servers to sessions sidebar toolbar with total count
- Add MCP Servers link item in sessions tree view (navigates to editor)
- Add MCP Servers to sessions overview view with count from IMcpService
- Add chat.experimentalSessionsWindowOverride setting for sessions-specific
  extension behavior (overridden to true in sessions defaults)

MCP List Widget Polish:
- Add 'Built-in' group showing extension-provided servers (e.g. GitHub MCP)
- Remove per-item server icons, aligning with other customization sections
- Hide running/stopped status indicators in sessions window
- Match item height (36px), padding, and font styling to other sections
- Hide empty description lines to tighten layout

Customizations UI Cleanup:
- Remove git status badges and SCM service dependency from list widget
- Remove per-item storage badge icons (workspace/user/extension)
- Remove 'Developer: Customizations Debug' command (replaced by output channel)
- Simplify sidebar counts to single total number (no category icon badges)
- Remove group separator borders, use spacing only
- Fix list container overflow (hidden -> auto) and add min-height: 0 for scroll
- Fix layout() fallback from 100px to 0px with requestAnimationFrame re-measure

Customizations Debug Output Channel:
- New sessions-only 'Customizations Debug' output channel
- Streams snapshot on every change: summary table + search paths + file details
- Includes MCP server listing with connection states

Hooks Count Fix:
- Toolbar hook counts now match management editor (per-hook, not per-file)
- Uses IFileService to parse hook JSON files and count individual hooks

The MCP gateway now negotiates the protocol version with connecting
clients instead of hardcoding 2025-11-25. This fixes compatibility
with clients using older @modelcontextprotocol/sdk versions that
do not support the latest protocol version.