### PR TITLE
fix: explicitly set volume size for dmg

### DIFF
--- a/build/darwin/dmg-settings.py.template
+++ b/build/darwin/dmg-settings.py.template
@@ -6,8 +6,9 @@ format = 'ULMO'
 badge_icon = {{BADGE_ICON}}
 background = {{BACKGROUND}}
 
-# Volume size (None = auto-calculate)
-size = None
+# Volume size
+size = '1g'
+shrink = False
 
 # Files and symlinks
 files = [{{APP_PATH}}]


### PR DESCRIPTION
Refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=414434&view=logs&j=ba869b8a-0cfb-5aa5-b782-f2da1b413300&t=0b104013-a7af-5462-1778-8a1087c92d8c&s=d26761af-f5e8-5e3e-3ed3-ef1ee2069094

The default volume size auto calculated based app contents is insufficient to replace the icons later due to shrinking, explicitly set the volume size to workaround it.

Backports https://github.com/microsoft/vscode/pull/298918