### PR TITLE
Hiding and showing of terminals

### DIFF
--- a/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
+++ b/src/vs/sessions/contrib/terminal/browser/sessionsTerminalContribution.ts
@@ -44,9 +44,10 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 
 	static readonly ID = 'workbench.contrib.sessionsTerminal';
 
-	/** Maps worktree/repository fsPath (lower-cased) to the terminal instance id. */
-	private readonly _pathToInstanceId = new Map<string, number>();
-	private _lastTargetFsPath: string | undefined;
+	/** Maps worktree/repository fsPath (lower-cased) to terminal instance ids. */
+	private readonly _pathToInstanceIds = new Map<string, Set<number>>();
+	private _activeKey: string | undefined;
+	private _isCreatingTerminal = false;
 
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
@@ -75,11 +76,22 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 
 		// Clean up mapping when terminals are disposed
 		this._register(this._terminalService.onDidDisposeInstance(instance => {
-			for (const [path, id] of this._pathToInstanceId) {
-				if (id === instance.instanceId) {
-					this._pathToInstanceId.delete(path);
-					break;
+			for (const [path, ids] of this._pathToInstanceIds) {
+				if (ids.delete(instance.instanceId) && ids.size === 0) {
+					this._pathToInstanceIds.delete(path);
 				}
+			}
+		}));
+
+		// When terminals are restored on startup, ensure visibility matches active session
+		this._register(this._terminalService.onDidCreateInstance(instance => {
+			if (this._isCreatingTerminal || this._activeKey === undefined) {
+				return;
+			}
+			// If this instance is not tracked by us, hide it
+			const activeIds = this._pathToInstanceIds.get(this._activeKey);
+			if (!activeIds?.has(instance.instanceId)) {
+				this._terminalService.moveToBackground(instance);
 			}
 		}));
 	}
@@ -91,16 +103,23 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 	 */
 	async ensureTerminal(cwd: URI, focus: boolean): Promise<void> {
 		const key = cwd.fsPath.toLowerCase();
-		const existingId = this._pathToInstanceId.get(key);
+		const ids = this._pathToInstanceIds.get(key);
+		const existingId = ids ? ids.values().next().value : undefined;
 		const existing = existingId !== undefined ? this._terminalService.getInstanceFromId(existingId) : undefined;
 
 		if (existing) {
+			await this._terminalService.showBackgroundTerminal(existing);
 			this._terminalService.setActiveInstance(existing);
 		} else {
-			const instance = await this._terminalService.createTerminal({ config: { cwd } });
-			this._pathToInstanceId.set(key, instance.instanceId);
-			this._terminalService.setActiveInstance(instance);
-			this._logService.trace(`[SessionsTerminal] Created terminal ${instance.instanceId} for ${cwd.fsPath}`);
+			this._isCreatingTerminal = true;
+			try {
+				const instance = await this._terminalService.createTerminal({ config: { cwd } });
+				this._addInstanceToPath(key, instance.instanceId);
+				this._terminalService.setActiveInstance(instance);
+				this._logService.trace(`[SessionsTerminal] Created terminal ${instance.instanceId} for ${cwd.fsPath}`);
+			} finally {
+				this._isCreatingTerminal = false;
+			}
 		}
 
 		if (focus) {
@@ -116,25 +135,68 @@ export class SessionsTerminalContribution extends Disposable implements IWorkben
 		const sessionCwd = getSessionCwd(session);
 
 		const targetPath = sessionCwd ?? await this._pathService.userHome();
-		const targetFsPath = targetPath.fsPath;
-		if (this._lastTargetFsPath?.toLowerCase() === targetFsPath.toLowerCase()) {
+		const targetKey = targetPath.fsPath.toLowerCase();
+		if (this._activeKey === targetKey) {
 			return;
 		}
-		this._lastTargetFsPath = targetFsPath;
+		this._activeKey = targetKey;
 
 		await this.ensureTerminal(targetPath, false);
+
+		// If the active key changed while we were awaiting, a newer call has
+		// taken over — skip the visibility update to avoid flicker.
+		if (this._activeKey !== targetKey) {
+			return;
+		}
+		this._updateTerminalVisibility(targetKey);
+	}
+
+	private _addInstanceToPath(key: string, instanceId: number): void {
+		let ids = this._pathToInstanceIds.get(key);
+		if (!ids) {
+			ids = new Set();
+			this._pathToInstanceIds.set(key, ids);
+		}
+		ids.add(instanceId);
+	}
+
+	/**
+	 * Hides all foreground terminals that do not belong to the given active key
+	 * and shows all background terminals that do belong to it.
+	 */
+	private _updateTerminalVisibility(activeKey: string): void {
+		const activeIds = this._pathToInstanceIds.get(activeKey);
+
+		// Hide foreground terminals not belonging to the active session
+		for (const instance of [...this._terminalService.foregroundInstances]) {
+			if (!activeIds?.has(instance.instanceId)) {
+				this._terminalService.moveToBackground(instance);
+			}
+		}
+
+		// Show background terminals belonging to the active session
+		if (activeIds) {
+			for (const id of activeIds) {
+				const instance = this._terminalService.getInstanceFromId(id);
+				if (instance && !this._terminalService.foregroundInstances.includes(instance)) {
+					this._terminalService.showBackgroundTerminal(instance, true);
+				}
+			}
+		}
 	}
 
 	private _closeTerminalsForPath(fsPath: string): void {
 		const key = fsPath.toLowerCase();
-		const instanceId = this._pathToInstanceId.get(key);
-		if (instanceId !== undefined) {
-			const instance = this._terminalService.getInstanceFromId(instanceId);
-			if (instance) {
-				this._terminalService.safeDisposeTerminal(instance);
-				this._logService.trace(`[SessionsTerminal] Closed archived terminal ${instanceId}`);
+		const ids = this._pathToInstanceIds.get(key);
+		if (ids) {
+			for (const instanceId of ids) {
+				const instance = this._terminalService.getInstanceFromId(instanceId);
+				if (instance) {
+					this._terminalService.safeDisposeTerminal(instance);
+					this._logService.trace(`[SessionsTerminal] Closed archived terminal ${instanceId}`);
+				}
 			}
-			this._pathToInstanceId.delete(key);
+			this._pathToInstanceIds.delete(key);
 		}
 	}
 }

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -59,12 +59,16 @@ suite('SessionsTerminalContribution', () => {
 	let onDidChangeSessionArchivedState: Emitter<IAgentSession>;
 	let onDidDisposeInstance: Emitter<ITerminalInstance>;
 
+	let onDidCreateInstance: Emitter<ITerminalInstance>;
 	let createdTerminals: { cwd: URI }[];
 	let activeInstanceSet: number[];
 	let focusCalls: number;
 	let disposedInstances: ITerminalInstance[];
 	let nextInstanceId: number;
 	let terminalInstances: Map<number, ITerminalInstance>;
+	let backgroundedInstances: Set<number>;
+	let moveToBackgroundCalls: number[];
+	let showBackgroundCalls: number[];
 
 	setup(() => {
 		createdTerminals = [];
@@ -73,12 +77,16 @@ suite('SessionsTerminalContribution', () => {
 		disposedInstances = [];
 		nextInstanceId = 1;
 		terminalInstances = new Map();
+		backgroundedInstances = new Set();
+		moveToBackgroundCalls = [];
+		showBackgroundCalls = [];
 
 		const instantiationService = store.add(new TestInstantiationService());
 
 		activeSessionObs = observableValue('activeSession', undefined);
 		onDidChangeSessionArchivedState = store.add(new Emitter<IAgentSession>());
 		onDidDisposeInstance = store.add(new Emitter<ITerminalInstance>());
+		onDidCreateInstance = store.add(new Emitter<ITerminalInstance>());
 
 		instantiationService.stub(ILogService, new NullLogService());
 
@@ -88,11 +96,16 @@ suite('SessionsTerminalContribution', () => {
 
 		instantiationService.stub(ITerminalService, new class extends mock<ITerminalService>() {
 			override onDidDisposeInstance = onDidDisposeInstance.event;
+			override onDidCreateInstance = onDidCreateInstance.event;
+			override get foregroundInstances(): readonly ITerminalInstance[] {
+				return [...terminalInstances.values()].filter(i => !backgroundedInstances.has(i.instanceId));
+			}
 			override async createTerminal(opts?: any): Promise<ITerminalInstance> {
 				const id = nextInstanceId++;
 				const instance = { instanceId: id } as ITerminalInstance;
 				createdTerminals.push({ cwd: opts?.config?.cwd });
 				terminalInstances.set(id, instance);
+				onDidCreateInstance.fire(instance);
 				return instance;
 			}
 			override getInstanceFromId(id: number): ITerminalInstance | undefined {
@@ -107,6 +120,15 @@ suite('SessionsTerminalContribution', () => {
 			override async safeDisposeTerminal(instance: ITerminalInstance): Promise<void> {
 				disposedInstances.push(instance);
 				terminalInstances.delete(instance.instanceId);
+				backgroundedInstances.delete(instance.instanceId);
+			}
+			override moveToBackground(instance: ITerminalInstance): void {
+				backgroundedInstances.add(instance.instanceId);
+				moveToBackgroundCalls.push(instance.instanceId);
+			}
+			override async showBackgroundTerminal(instance: ITerminalInstance): Promise<void> {
+				backgroundedInstances.delete(instance.instanceId);
+				showBackgroundCalls.push(instance.instanceId);
 			}
 		});
 
@@ -345,6 +367,105 @@ suite('SessionsTerminalContribution', () => {
 		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
 		await tick();
 		assert.strictEqual(createdTerminals.length, 2, 'should reuse the terminal for cwd1');
+	});
+
+	// --- Terminal visibility management ---
+
+	test('hides terminals from previous session when switching to a new session', async () => {
+		const cwd1 = URI.file('/cwd1');
+		const cwd2 = URI.file('/cwd2');
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+		const firstTerminalId = createdTerminals.length;
+		assert.strictEqual(firstTerminalId, 1);
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// The first terminal (id=1) should have been moved to background
+		assert.ok(moveToBackgroundCalls.includes(1), 'terminal for cwd1 should be backgrounded');
+		assert.ok(backgroundedInstances.has(1), 'terminal for cwd1 should remain backgrounded');
+	});
+
+	test('shows previously hidden terminals when switching back to their session', async () => {
+		const cwd1 = URI.file('/cwd1');
+		const cwd2 = URI.file('/cwd2');
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// Switch back to cwd1
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// Terminal for cwd1 (id=1) should be shown again
+		assert.ok(showBackgroundCalls.includes(1), 'terminal for cwd1 should be shown');
+		assert.ok(!backgroundedInstances.has(1), 'terminal for cwd1 should be foreground');
+		// Terminal for cwd2 (id=2) should now be backgrounded
+		assert.ok(backgroundedInstances.has(2), 'terminal for cwd2 should be backgrounded');
+	});
+
+	test('only terminals of the active session are visible after multiple switches', async () => {
+		const cwd1 = URI.file('/cwd1');
+		const cwd2 = URI.file('/cwd2');
+		const cwd3 = URI.file('/cwd3');
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd2, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		activeSessionObs.set(makeAgentSession({ worktree: cwd3, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// Only terminal for cwd3 (id=3) should be foreground
+		assert.ok(backgroundedInstances.has(1), 'terminal for cwd1 should be backgrounded');
+		assert.ok(backgroundedInstances.has(2), 'terminal for cwd2 should be backgrounded');
+		assert.ok(!backgroundedInstances.has(3), 'terminal for cwd3 should be foreground');
+	});
+
+	test('hides restored terminals that do not belong to the active session', async () => {
+		// Set an active session first
+		const cwd1 = URI.file('/cwd1');
+		activeSessionObs.set(makeAgentSession({ worktree: cwd1, providerType: AgentSessionProviders.Background }), undefined);
+		await tick();
+
+		// Simulate a terminal being restored (e.g. on startup) that is not tracked
+		const restoredInstance = { instanceId: nextInstanceId++ } as ITerminalInstance;
+		terminalInstances.set(restoredInstance.instanceId, restoredInstance);
+		onDidCreateInstance.fire(restoredInstance);
+
+		// The restored terminal should be moved to background
+		assert.ok(moveToBackgroundCalls.includes(restoredInstance.instanceId), 'restored terminal should be backgrounded');
+	});
+
+	test('does not hide restored terminals before any session is active', async () => {
+		// Simulate a terminal being restored before any session is active
+		const restoredInstance = { instanceId: nextInstanceId++ } as ITerminalInstance;
+		terminalInstances.set(restoredInstance.instanceId, restoredInstance);
+		onDidCreateInstance.fire(restoredInstance);
+
+		assert.strictEqual(moveToBackgroundCalls.length, 0, 'should not background before any session is active');
+	});
+
+	test('ensureTerminal shows a backgrounded terminal instead of creating a new one', async () => {
+		const cwd = URI.file('/test-cwd');
+		await contribution.ensureTerminal(cwd, false);
+		const instanceId = activeInstanceSet[0];
+
+		// Manually background it
+		backgroundedInstances.add(instanceId);
+
+		// ensureTerminal should show it, not create a new one
+		await contribution.ensureTerminal(cwd, false);
+
+		assert.strictEqual(createdTerminals.length, 1, 'should not create a new terminal');
+		assert.ok(showBackgroundCalls.includes(instanceId), 'should show the backgrounded terminal');
 	});
 });
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -520,6 +520,12 @@ export interface ITerminalService extends ITerminalInstanceHost {
 	 * @param forceSaveState Used when the window is shutting down and we need to reveal and save hideFromUser terminals
 	 */
 	showBackgroundTerminal(instance: ITerminalInstance, suppressSetActive?: boolean): Promise<void>;
+	/**
+	 * Moves a visible terminal instance to the background. The terminal process
+	 * remains alive but the instance is removed from its group/editor and tracked
+	 * internally so it can later be shown again via {@link showBackgroundTerminal}.
+	 */
+	moveToBackground(instance: ITerminalInstance): void;
 	revealActiveTerminal(preserveFocus?: boolean): Promise<void>;
 	moveToEditor(source: ITerminalInstance, group?: GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE | AUX_WINDOW_GROUP_TYPE): void;
 	moveIntoNewEditor(source: ITerminalInstance): void;

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1233,6 +1233,45 @@ export class TerminalService extends Disposable implements ITerminalService {
 		}
 	}
 
+	moveToBackground(instance: ITerminalInstance): void {
+		// Already backgrounded
+		if (this._backgroundedTerminalInstances.some(bg => bg.instance === instance)) {
+			return;
+		}
+
+		// Remove from its current location (panel group or editor)
+		if (instance.target === TerminalLocation.Editor) {
+			this._terminalEditorService.detachInstance(instance);
+		} else {
+			const group = this._terminalGroupService.getGroupForInstance(instance);
+			if (!group) {
+				return;
+			}
+			group.removeInstance(instance);
+		}
+
+		instance.detachFromElement();
+
+		// Track in background
+		this._backgroundedTerminalInstances.push({ instance, terminalLocationOptions: instance.target === TerminalLocation.Editor ? { viewColumn: ACTIVE_GROUP } : undefined });
+		this._backgroundedTerminalDisposables.set(instance.instanceId, [
+			instance.onDisposed(instance => {
+				const idx = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
+				if (idx !== -1) {
+					this._backgroundedTerminalInstances.splice(idx, 1);
+				}
+				const disposables = this._backgroundedTerminalDisposables.get(instance.instanceId);
+				if (disposables) {
+					dispose(disposables);
+				}
+				this._backgroundedTerminalDisposables.delete(instance.instanceId);
+				this._onDidDisposeInstance.fire(instance);
+			})
+		]);
+
+		this._onDidChangeInstances.fire();
+	}
+
 	public async showBackgroundTerminal(instance: ITerminalInstance, suppressSetActive?: boolean): Promise<void> {
 		const index = this._backgroundedTerminalInstances.findIndex(bg => bg.instance === instance);
 		if (index === -1) {


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce functionality to move terminal instances to the background, allowing them to remain alive while being hidden from the user interface. This includes updates to manage visibility based on active sessions and ensures that only relevant terminals are displayed.

FYI @meganrogge regarding `moveToBackground` which I added to `TerminalService`