### PR TITLE
Add padding to statusbar items for improved layout

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -49,13 +49,10 @@
 .monaco-workbench .part.statusbar > .right-items {
 	flex-wrap: wrap; /* overflow elements by wrapping */
 	flex-direction: row-reverse; /* let the elements to the left wrap first */
-	padding-right: 2px;
 }
 
 .monaco-workbench .part.statusbar > .left-items {
-	flex-grow: 1; /* left items push right items to the far right end */
-	padding-left: 2px;
-}
+	flex-grow: 1; /* left items push right items to the far right end */}
 
 .monaco-workbench .part.statusbar > .items-container > .statusbar-item {
 	display: inline-block;
@@ -90,6 +87,16 @@
 .monaco-workbench .part.statusbar > .items-container > .statusbar-item.left.first-visible-item,
 .monaco-workbench .part.statusbar > .items-container > .statusbar-item.right.last-visible-item {
 	padding-right: 0;
+	padding-left: 0;
+}
+
+.monaco-workbench .part.statusbar > .items-container > .statusbar-item.left.first-visible-item {
+	padding-right: 0;
+	padding-left: 2px;
+}
+
+.monaco-workbench .part.statusbar > .items-container > .statusbar-item.right.last-visible-item {
+	padding-right: 2px;
 	padding-left: 0;
 }
 

--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -84,12 +84,6 @@
 	border-right: 5px solid transparent;
 }
 
-.monaco-workbench .part.statusbar > .items-container > .statusbar-item.left.first-visible-item,
-.monaco-workbench .part.statusbar > .items-container > .statusbar-item.right.last-visible-item {
-	padding-right: 0;
-	padding-left: 0;
-}
-
 .monaco-workbench .part.statusbar > .items-container > .statusbar-item.left.first-visible-item {
 	padding-right: 0;
 	padding-left: 2px;

--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -49,10 +49,12 @@
 .monaco-workbench .part.statusbar > .right-items {
 	flex-wrap: wrap; /* overflow elements by wrapping */
 	flex-direction: row-reverse; /* let the elements to the left wrap first */
+	padding-right: 2px;
 }
 
 .monaco-workbench .part.statusbar > .left-items {
 	flex-grow: 1; /* left items push right items to the far right end */
+	padding-left: 2px;
 }
 
 .monaco-workbench .part.statusbar > .items-container > .statusbar-item {


### PR DESCRIPTION
Improve the layout of the status bar by adding padding to the left and right items, enhancing visual spacing and overall appearance.

