### PR TITLE
Fix Ctrl+W keybinding to close session

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -325,10 +325,27 @@ KeybindingsRegistry.registerKeybindingRule({
 	primary: KeyMod.CtrlCmd | KeyCode.KeyN,
 });
 
+const CLOSE_SESSION_COMMAND_ID = 'agentSession.close';
+registerAction2(class RefreshAgentSessionsViewerAction extends Action2 {
+	constructor() {
+		super({
+			id: CLOSE_SESSION_COMMAND_ID,
+			title: localize2('closeSession', "Close Session"),
+			f1: true,
+			precondition: ContextKeyExpr.and(IsNewChatSessionContext.negate(), EditorsVisibleContext.negate()),
+			category: SessionsCategories.Sessions,
+		});
+	}
+	override async run(accessor: ServicesAccessor) {
+		const sessionsService = accessor.get(ISessionsManagementService);
+		await sessionsService.openNewSessionView();
+	}
+});
+
 // Register Cmd+W / Ctrl+W to open new session when the current session is non-empty,
 // mirroring how Cmd+W closes the active editor in the normal workbench.
 KeybindingsRegistry.registerKeybindingRule({
-	id: ACTION_ID_NEW_CHAT,
+	id: CLOSE_SESSION_COMMAND_ID,
 	weight: KeybindingWeight.WorkbenchContrib + 1,
 	when: ContextKeyExpr.and(IsNewChatSessionContext.negate(), EditorsVisibleContext.negate()),
 	primary: KeyMod.CtrlCmd | KeyCode.KeyW,

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -342,7 +342,7 @@ registerAction2(class CloseSessionAction extends Action2 {
 	}
 });
 
-// Register Cmd+W / Ctrl+W to open new session when the current session is non-empty,
+// Register Cmd+W / Ctrl+W to close the current session and navigate to the new-session view,
 // mirroring how Cmd+W closes the active editor in the normal workbench.
 KeybindingsRegistry.registerKeybindingRule({
 	id: CLOSE_SESSION_COMMAND_ID,

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -326,7 +326,7 @@ KeybindingsRegistry.registerKeybindingRule({
 });
 
 const CLOSE_SESSION_COMMAND_ID = 'agentSession.close';
-registerAction2(class RefreshAgentSessionsViewerAction extends Action2 {
+registerAction2(class CloseSessionAction extends Action2 {
 	constructor() {
 		super({
 			id: CLOSE_SESSION_COMMAND_ID,


### PR DESCRIPTION
```Copilot Generated Description:``` Update the Ctrl+W keybinding to close the current session instead of opening a new one.

