### PR TITLE
Include remote debug extension host env in remote terminal shell env

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
@@ -159,7 +159,7 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 			 * If the extension host was spawned via a launch configuration,
 			 * include the environment provided by that launch configuration.
 			 */
-			...this._environmentService.debugExtensionHost.env, ...resolverResult.options?.extensionHostEnv
+			...(this._environmentService.debugExtensionHost.env ?? {}), ...resolverResult.options?.extensionHostEnv
 		};
 
 		const workspace = this._workspaceContextService.getWorkspace();

--- a/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
@@ -8,6 +8,7 @@ import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IChannel } from '../../../../../base/parts/ipc/common/ipc.js';
 import { IWorkbenchConfigurationService } from '../../../../services/configuration/common/configuration.js';
 import { IRemoteAuthorityResolverService } from '../../../../../platform/remote/common/remoteAuthorityResolver.js';
+import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { serializeEnvironmentDescriptionMap, serializeEnvironmentVariableCollection } from '../../../../../platform/terminal/common/environmentVariableShared.js';
 import { IConfigurationResolverService } from '../../../../services/configurationResolver/common/configurationResolver.js';
@@ -111,6 +112,7 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@ILabelService private readonly _labelService: ILabelService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 	) { }
 
 	restartPtyHost(): Promise<void> {
@@ -152,7 +154,13 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 		}
 
 		const resolverResult = await this._remoteAuthorityResolverService.resolveAuthority(this._remoteAuthority);
-		const resolverEnv = resolverResult.options && resolverResult.options.extensionHostEnv;
+		const resolverEnv = {
+			/**
+			 * If the extension host was spawned via a launch configuration,
+			 * include the environment provided by that launch configuration.
+			 */
+			...this._environmentService.debugExtensionHost.env, ...resolverResult.options?.extensionHostEnv
+		};
 
 		const workspace = this._workspaceContextService.getWorkspace();
 		const workspaceFolders = workspace.folders;

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -323,7 +323,11 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 						extensionHostDebugEnvironment.params.port = parseInt(value);
 						break;
 					case 'extensionEnvironment':
-						extensionHostDebugEnvironment.params.env = JSON.parse(value);
+						try {
+							extensionHostDebugEnvironment.params.env = JSON.parse(value);
+						} catch (error) {
+							onUnexpectedError(error);
+						}
 						break;
 					case 'enableProposedApi':
 						extensionHostDebugEnvironment.extensionEnabledProposedApi = [];

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -322,6 +322,9 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 					case 'inspect-extensions':
 						extensionHostDebugEnvironment.params.port = parseInt(value);
 						break;
+					case 'extensionEnvironment':
+						extensionHostDebugEnvironment.params.env = JSON.parse(value);
+						break;
 					case 'enableProposedApi':
 						extensionHostDebugEnvironment.extensionEnabledProposedApi = [];
 						break;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This fixes #241078.

The environment specified in a `launch.json` `env` or `envFile` property is passed to the extension host and ultimately into `environmentService.debugExtensionHost.env`.

In the case of the browser service there was a missing parsing of the `extensionEnvironment` parameter in the payload.

Then `createProcess` includes this environment into the call arguments to inject it into spawned terminals.