### PR TITLE
Fix MCP tool validation warning for schemas without properties

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -904,6 +904,13 @@ export class McpServer extends Disposable implements IMcpServer {
 			tool.name = tool.name.replace(toolInvalidCharRe, '_');
 		}
 
+		// Per MCP spec, properties is optional. But JSON Schema Draft 7 requires
+		// it for object types. Normalize the schema to include an empty properties
+		// object if not present. https://github.com/microsoft/vscode/issues/251723
+		if (tool.inputSchema && !tool.inputSchema.properties) {
+			tool.inputSchema = { ...tool.inputSchema, properties: {} };
+		}
+
 		type JsonDiagnostic = { message: string; range: { line: number; character: number }[] };
 
 		let diagnostics: JsonDiagnostic[] = [];


### PR DESCRIPTION
Per the MCP spec, the \properties\ field in tool inputSchema is optional, with \	ype\ being the only required field. However, JSON Schema Draft 7 validation requires \properties\ for object types, causing spurious warnings like 'Tool foo failed validation: schema must have a properties object'.

Fix by normalizing the inputSchema to include an empty \properties\ object when not present.

Fixes #251723