### PR TITLE
dialogs: prevent custom dialogs from overflowing screen vertically

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -27,6 +27,7 @@
 	width: min-content;
 	min-width: 500px;
 	max-width: 90vw;
+	max-height: 90vh;
 	min-height: 75px;
 	padding: 10px;
 	transform: translate3d(0px, 0px, 0px);
@@ -55,10 +56,16 @@
 	flex-grow: 1;
 	align-items: center;
 	padding: 0 10px;
+	min-height: 0; /* allow flex item to shrink below content size */
+	overflow: hidden;
 }
 
 .monaco-dialog-box.align-vertical .dialog-message-row {
 	flex-direction: column;
+}
+
+.monaco-dialog-box.align-vertical .dialog-message-row .dialog-message-container {
+	min-height: 0; /* allow flex item to shrink below content size in column layout */
 }
 
 .monaco-dialog-box .dialog-message-row > .dialog-icon.codicon {
@@ -77,12 +84,17 @@
 	align-self: baseline;
 }
 
+.monaco-dialog-box:not(.align-vertical) .dialog-message-row .dialog-message-container {
+	align-self: stretch; /* fill row height so overflow-y scrolling works */
+}
+
 /** Dialog: Message/Footer Container */
 .monaco-dialog-box .dialog-message-row .dialog-message-container,
 .monaco-dialog-box .dialog-footer-row {
 	display: flex;
 	flex-direction: column;
-	overflow: hidden;
+	overflow-y: auto;
+	overflow-x: hidden;
 	text-overflow: ellipsis;
 	user-select: text;
 	-webkit-user-select: text;


### PR DESCRIPTION
Adds max-height: 90vh to the dialog box to prevent it from exceeding the
viewport height, matching the existing max-width: 90vw constraint.

The message content area now scrolls when it exceeds available space:
- Added align-self: stretch to .dialog-message-container in horizontal
  layout so it fills the row height and triggers overflow-y scrolling
- Added min-height: 0 to .dialog-message-container in vertical layout
  to allow flex shrinking and overflow-y scrolling
- Changed .dialog-message-container overflow from 'hidden' to 'overflow-y:
  auto; overflow-x: hidden' to enable vertical scrolling

Buttons, toolbar, and footer remain visible. Only message content scrolls.

Fixes https://github.com/microsoft/vscode/issues/296538

(Commit message generated by Copilot)