### PR TITLE
Use settings icon instead of tools icon in chat input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatToolActions.ts
@@ -121,7 +121,7 @@ export class ConfigureToolsAction extends Action2 {
 		super({
 			id: ConfigureToolsAction.ID,
 			title: localize('label', "Configure Tools..."),
-			icon: Codicon.tools,
+			icon: Codicon.settings,
 			f1: false,
 			category: CHAT_CATEGORY,
 			precondition: ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1447,7 +1447,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 /* Hide the tools button when the toolbar is in collapsed state */
-.interactive-session .chat-input-toolbar:has(.hide-chevrons) .action-item:has(.codicon-tools) {
+.interactive-session .chat-input-toolbar:has(.hide-chevrons) .action-item:has(.codicon-settings) {
 	display: none;
 }
 


### PR DESCRIPTION
Use the `settings` codicon instead of `tools` for the Configure Tools button in the chat input toolbar.