### PR TITLE
fix: passing js-flags to utility process

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -342,7 +342,7 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	app.commandLine.appendSwitch('disable-blink-features', blinkFeaturesToDisable);
 
 	// Support JS Flags
-	const jsFlags = getJSFlags(cliArgs);
+	const jsFlags = getJSFlags(cliArgs, argvConfig);
 	if (jsFlags) {
 		app.commandLine.appendSwitch('js-flags', jsFlags);
 	}
@@ -374,6 +374,7 @@ interface IArgvConfig {
 	readonly 'use-inmemory-secretstorage'?: boolean;
 	readonly 'enable-rdp-display-tracking'?: boolean;
 	readonly 'remote-debugging-port'?: string;
+	readonly 'js-flags'?: string;
 }
 
 function readArgvConfigSync(): IArgvConfig {
@@ -537,12 +538,17 @@ function configureCrashReporter(): void {
 	});
 }
 
-function getJSFlags(cliArgs: NativeParsedArgs): string | null {
+function getJSFlags(cliArgs: NativeParsedArgs, argvConfig: IArgvConfig): string | null {
 	const jsFlags: string[] = [];
 
 	// Add any existing JS flags we already got from the command line
 	if (cliArgs['js-flags']) {
 		jsFlags.push(cliArgs['js-flags']);
+	}
+
+	// Add JS flags from runtime arguments (argv.json)
+	if (typeof argvConfig['js-flags'] === 'string' && argvConfig['js-flags']) {
+		jsFlags.push(argvConfig['js-flags']);
 	}
 
 	if (process.platform === 'linux') {

--- a/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
+++ b/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts
@@ -245,8 +245,12 @@ export class UtilityProcess extends Disposable {
 		const serviceName = `${this.configuration.type}-${this.id}`;
 		const modulePath = FileAccess.asFileUri('bootstrap-fork.js').fsPath;
 		const args = this.configuration.args ?? [];
-		const execArgv = this.configuration.execArgv ?? [];
+		const execArgv = [...(this.configuration.execArgv ?? [])];
 		const allowLoadingUnsignedLibraries = this.configuration.allowLoadingUnsignedLibraries;
+		const jsFlags = app.commandLine.getSwitchValue('js-flags');
+		if (jsFlags) {
+			execArgv.push(`--js-flags=${jsFlags}`);
+		}
 		const respondToAuthRequestsFromMainProcess = this.configuration.respondToAuthRequestsFromMainProcess;
 		const stdio = 'pipe';
 		const env = this.createEnv(configuration);

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -455,6 +455,10 @@ import product from '../../platform/product/common/product.js';
 			'remote-debugging-port': {
 				type: 'string',
 				description: localize('argv.remoteDebuggingPort', "Specifies the port to use for remote debugging.")
+			},
+			'js-flags': {
+				type: 'string',
+				description: localize('argv.jsFlags', "Specifies V8 JavaScript engine flags to pass (e.g. \"--max-old-space-size=4096\"). These flags are applied to the main process, renderer and utility processes.")
 			}
 		}
 	};


### PR DESCRIPTION
JS stacks from utility process couldn't be recorded by the methods in https://github.com/microsoft/vscode/wiki/Runtime-debugging due to the flag not being propagated.