### PR TITLE
Allow hiding chat input toolbar items via right-click context menu

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2179,7 +2179,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.inputActionsToolbar = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, this.options.renderInputToolbarBelowInput ? this.attachmentsContainer : toolbarsContainer, MenuId.ChatInput, {
 			telemetrySource: this.options.menus.telemetrySource,
 			menuOptions: { shouldForwardArgs: true },
-			hiddenItemStrategy: HiddenItemStrategy.NoHide,
+			hiddenItemStrategy: HiddenItemStrategy.Ignore,
 			hoverDelegate,
 			responsiveBehavior: {
 				enabled: true,


### PR DESCRIPTION
Changes `HiddenItemStrategy` from `NoHide` to `Ignore` on the chat input actions toolbar (`MenuId.ChatInput`), enabling the standard `WorkbenchToolBar` right-click hide/show behavior.