### PR TITLE
mcp: replace repeated variable placeholders in config values

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -205,6 +205,10 @@ export abstract class AbstractCommonMcpManagementService extends Disposable impl
 		return variables;
 	}
 
+	private replaceInputVariableReference(value: string, variableId: string): string {
+		return value.split(`{${variableId}}`).join(`\${input:${variableId}}`);
+	}
+
 	private processKeyValueInputs(keyValueInputs: ReadonlyArray<IMcpServerKeyValueInput>): { inputs: Record<string, string>; variables: IMcpServerVariable[]; notices: string[] } {
 		const notices: string[] = [];
 		const inputs: Record<string, string> = {};
@@ -217,7 +221,7 @@ export abstract class AbstractCommonMcpManagementService extends Disposable impl
 			// If explicit variables exist, use them regardless of value
 			if (inputVariables.length) {
 				for (const variable of inputVariables) {
-					value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
+					value = this.replaceInputVariableReference(value, variable.id);
 				}
 				variables.push(...inputVariables);
 			} else if (!value && (input.description || input.choices || input.default !== undefined)) {
@@ -250,7 +254,7 @@ export abstract class AbstractCommonMcpManagementService extends Disposable impl
 				let value = arg.value;
 				if (value) {
 					for (const variable of argVariables) {
-						value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
+						value = this.replaceInputVariableReference(value, variable.id);
 					}
 					args.push(value);
 					if (argVariables.length) {
@@ -279,7 +283,7 @@ export abstract class AbstractCommonMcpManagementService extends Disposable impl
 				if (arg.value) {
 					let value = arg.value;
 					for (const variable of argVariables) {
-						value = value.replace(`{${variable.id}}`, `\${input:${variable.id}}`);
+						value = this.replaceInputVariableReference(value, variable.id);
 					}
 					args.push(value);
 					if (argVariables.length) {

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -756,6 +756,74 @@ suite('McpManagementService - getMcpServerConfigurationFromManifest', () => {
 			assert.strictEqual(dbNameInput?.description, 'Database name');
 		});
 
+		test('repeated variable placeholders in environment values should all be replaced', () => {
+			const manifest: IGalleryMcpServerConfiguration = {
+				packages: [{
+					registryType: RegistryType.NODE,
+					identifier: 'test-server',
+					transport: { type: TransportType.STDIO },
+					version: '1.0.0',
+					environmentVariables: [{
+						name: 'AUTH_CHAIN',
+						value: 'Bearer {api_token}:{api_token}',
+						variables: {
+							api_token: {
+								description: 'API token',
+								isSecret: true,
+								isRequired: true
+							}
+						}
+					}]
+				}]
+			};
+
+			const result = service.getMcpServerConfigurationFromManifest(manifest, RegistryType.NODE);
+
+			if (result.mcpServerConfiguration.config.type === McpServerType.LOCAL) {
+				assert.deepStrictEqual(result.mcpServerConfiguration.config.env, {
+					'AUTH_CHAIN': 'Bearer ${input:api_token}:${input:api_token}'
+				});
+			}
+			assert.strictEqual(result.mcpServerConfiguration.inputs?.length, 1);
+			assert.strictEqual(result.mcpServerConfiguration.inputs?.[0].id, 'api_token');
+		});
+
+		test('repeated variable placeholders in argument values should all be replaced', () => {
+			const manifest: IGalleryMcpServerConfiguration = {
+				packages: [{
+					registryType: RegistryType.NODE,
+					identifier: 'test-server',
+					transport: { type: TransportType.STDIO },
+					version: '1.0.0',
+					packageArguments: [{
+						type: 'named',
+						name: '--header',
+						value: 'Authorization=Bearer {api_token}:{api_token}',
+						isRepeated: false,
+						variables: {
+							api_token: {
+								description: 'API token',
+								isSecret: true,
+								isRequired: true
+							}
+						}
+					}]
+				}]
+			};
+
+			const result = service.getMcpServerConfigurationFromManifest(manifest, RegistryType.NODE);
+
+			if (result.mcpServerConfiguration.config.type === McpServerType.LOCAL) {
+				assert.deepStrictEqual(result.mcpServerConfiguration.config.args, [
+					'test-server@1.0.0',
+					'--header',
+					'Authorization=Bearer ${input:api_token}:${input:api_token}'
+				]);
+			}
+			assert.strictEqual(result.mcpServerConfiguration.inputs?.length, 1);
+			assert.strictEqual(result.mcpServerConfiguration.inputs?.[0].id, 'api_token');
+		});
+
 		test('variable with choices creates pick input', () => {
 			const manifest: IGalleryMcpServerConfiguration = {
 				packages: [{


### PR DESCRIPTION
## Summary
Fixes placeholder interpolation for MCP manifest values when the same variable appears multiple times in a single string.

Previously, interpolation used single-replacement behavior, so only the first `{variable}` occurrence was converted to `${input:variable}`. This left subsequent occurrences unresolved.

## Changes
- Add `replaceInputVariableReference(value, variableId)` helper in `mcpManagementService.ts`.
- Use the helper in all variable interpolation paths:
  - key/value inputs (env + remote headers)
  - positional arguments
  - named arguments
- Add regression tests for repeated placeholders in:
  - environment values
  - argument values

## Example
`Bearer {api_token}:{api_token}` now becomes:
`Bearer ${input:api_token}:${input:api_token}`

## Validation
- `npm run transpile-client` ✅
- `scripts/test.bat --grep "McpManagementService - getMcpServerConfigurationFromManifest"` ✅ (37 passing)

