### PR TITLE
refactor: centralize path normalization in CommandLineFileWriteAnalyzer

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineFileWriteAnalyzer.ts
@@ -8,12 +8,11 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { win32, posix } from '../../../../../../../base/common/path.js';
 import { localize } from '../../../../../../../nls.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
-import { IWorkspaceContextService } from '../../../../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceContextService, type IWorkspaceFolder } from '../../../../../../../platform/workspace/common/workspace.js';
 import { TerminalChatAgentToolsSettingId } from '../../../common/terminalChatAgentToolsConfiguration.js';
 import { TreeSitterCommandParserLanguage, type TreeSitterCommandParser } from '../../treeSitterCommandParser.js';
 import type { ICommandLineAnalyzer, ICommandLineAnalyzerOptions, ICommandLineAnalyzerResult } from './commandLineAnalyzer.js';
 import { OperatingSystem } from '../../../../../../../base/common/platform.js';
-import { isString } from '../../../../../../../base/common/types.js';
 import { ILabelService } from '../../../../../../../platform/label/common/label.js';
 
 const nullDevice = Symbol('null device');
@@ -67,24 +66,17 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 						return e;
 					}
 
-					// Surrounding quotes where it's difficult to determine whether this is absolute
-					// or relative
-					if (/^['"].*['"]$/.test(e)) {
-						// Strip surrounding quotes to get a more reasonable view of the path. Note
-						// that this may not get the real file in the case of inner quotes, but the
-						// important thing here is the resolving whether it's absolute or not.
-						e = this._stripSurroundingQuotes(e);
-					}
+					const normalizedPath = this._normalizePathForParsing(e, options.os);
 
 					// Absolute
-					const isAbsolute = options.os === OperatingSystem.Windows ? win32.isAbsolute(e) : posix.isAbsolute(e);
+					const isAbsolute = this._isAbsolutePath(normalizedPath, options.os);
 					if (isAbsolute) {
 						// Ensure cwd's scheme and authority is retained
-						return cwd.with({ path: e });
+						return cwd.with({ path: normalizedPath });
 					}
 
 					// Relative
-					return URI.joinPath(cwd, e);
+					return URI.joinPath(cwd, normalizedPath);
 				});
 			} else {
 				this._log('Cwd could not be detected');
@@ -135,15 +127,12 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								continue;
 							}
 
-							if (isString(fileWrite)) {
-								const isAbsolute = options.os === OperatingSystem.Windows ? win32.isAbsolute(fileWrite) : posix.isAbsolute(fileWrite);
-								if (!isAbsolute) {
-									isAutoApproveAllowed = false;
-									this._log('File write blocked due to unknown terminal cwd', fileWrite);
-									break;
-								}
+							const fileUri = this._toFileWriteUri(fileWrite, options);
+							if (!fileUri) {
+								isAutoApproveAllowed = false;
+								this._log('File write blocked due to unknown terminal cwd', fileWrite);
+								break;
 							}
-							const fileUri = URI.isUri(fileWrite) ? fileWrite : URI.file(fileWrite);
 							// TODO: Handle command substitutions/complex destinations properly https://github.com/microsoft/vscode/issues/274167
 							// TODO: Handle environment variables properly https://github.com/microsoft/vscode/issues/274166
 							if (fileUri.fsPath.match(/[$\(\){}`]/)) {
@@ -152,10 +141,7 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 								break;
 							}
 
-							const isInsideWorkspace = workspaceFolders.some(folder =>
-								folder.uri.scheme === fileUri.scheme &&
-								(fileUri.path.startsWith(folder.uri.path + '/') || fileUri.path === folder.uri.path)
-							);
+							const isInsideWorkspace = this._isWithinWorkspace(fileUri, workspaceFolders, options.os);
 							if (!isInsideWorkspace) {
 								isAutoApproveAllowed = false;
 								this._log('File write blocked outside workspace', fileUri.toString());
@@ -192,5 +178,49 @@ export class CommandLineFileWriteAnalyzer extends Disposable implements ICommand
 			isAutoApproveAllowed,
 			disclaimers,
 		};
+	}
+
+	private _isWithinWorkspace(fileUri: URI, workspaceFolders: readonly IWorkspaceFolder[], os: OperatingSystem): boolean {
+		const normalizedFilePath = this._normalizePathForComparison(fileUri.path, os);
+		return workspaceFolders.some(folder => {
+			const folderAuthority = folder.uri.authority ?? '';
+			const fileAuthority = fileUri.authority ?? '';
+			if (folder.uri.scheme !== fileUri.scheme || folderAuthority !== fileAuthority) {
+				return false;
+			}
+			const normalizedFolderPath = this._normalizePathForComparison(folder.uri.path, os);
+			const folderPrefix = normalizedFolderPath.endsWith('/') ? normalizedFolderPath : `${normalizedFolderPath}/`;
+			return normalizedFilePath === normalizedFolderPath || normalizedFilePath.startsWith(folderPrefix);
+		});
+	}
+
+	private _toFileWriteUri(fileWrite: URI | string, options: ICommandLineAnalyzerOptions): URI | undefined {
+		if (URI.isUri(fileWrite)) {
+			return fileWrite;
+		}
+
+		const normalizedPath = this._normalizePathForParsing(fileWrite, options.os);
+		if (!this._isAbsolutePath(normalizedPath, options.os)) {
+			return undefined;
+		}
+
+		return URI.file(normalizedPath);
+	}
+
+	private _isAbsolutePath(path: string, os: OperatingSystem): boolean {
+		return os === OperatingSystem.Windows ? win32.isAbsolute(path) : posix.isAbsolute(path);
+	}
+
+	private _normalizePathForComparison(path: string, os: OperatingSystem): string {
+		const normalizedPath = this._normalizePathForParsing(path, os);
+		return os === OperatingSystem.Windows ? normalizedPath.toLowerCase() : normalizedPath;
+	}
+
+	private _normalizePathForParsing(path: string, os: OperatingSystem): string {
+		const strippedPath = this._stripSurroundingQuotes(path);
+		if (os === OperatingSystem.Windows) {
+			return strippedPath.replace(/\\/g, '/');
+		}
+		return strippedPath;
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineAnalyzer/commandLineFileWriteAnalyzer.test.ts
@@ -198,6 +198,10 @@ suite('CommandLineFileWriteAnalyzer', () => {
 			// Absolute paths are converted to URIs and checked normally
 			test('absolute path inside workspace - outsideWorkspace setting - allow', () => tNoCwd('echo hello > /workspace/project/file.txt', 'outsideWorkspace', true, 1));
 			test('absolute path outside workspace - outsideWorkspace setting - block', () => tNoCwd('echo hello > /tmp/file.txt', 'outsideWorkspace', false, 1));
+			test('quoted absolute path inside workspace - outsideWorkspace setting - allow', () => tNoCwd('echo hello > "/workspace/project/file.txt"', 'outsideWorkspace', true, 1));
+			test('quoted absolute path outside workspace - outsideWorkspace setting - block', () => tNoCwd('echo hello > "/tmp/file.txt"', 'outsideWorkspace', false, 1));
+			test('single-quoted absolute path inside workspace - outsideWorkspace setting - allow', () => tNoCwd('echo hello > \'/workspace/project/file.txt\'', 'outsideWorkspace', true, 1));
+			test('single-quoted absolute path outside workspace - outsideWorkspace setting - block', () => tNoCwd('echo hello > \'/tmp/file.txt\'', 'outsideWorkspace', false, 1));
 			test('absolute path - all setting - block', () => tNoCwd('echo hello > /tmp/file.txt', 'all', false, 1));
 		});
 	});
@@ -456,5 +460,36 @@ suite('CommandLineFileWriteAnalyzer', () => {
 		test('unquoted absolute path outside remote workspace - block', () => t('echo hello > /home/user/other/file.txt', false, 1));
 		test('relative path in remote workspace - allow', () => t('echo hello > file.txt', true, 1));
 		test('relative path with subdirectory in remote workspace - allow', () => t('echo hello > subdir/file.txt', true, 1));
+	});
+
+	suite('windows path normalization (cross-platform)', () => {
+		const cwd = URI.file('C:/workspace/project');
+
+		async function t(commandLine: string, expectedAutoApprove: boolean, expectedDisclaimers: number = 0) {
+			configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.BlockDetectedFileWrites, 'outsideWorkspace');
+
+			const workspace = new Workspace('test', [toWorkspaceFolder(cwd)]);
+			workspaceContextService.setWorkspace(workspace);
+
+			const options: ICommandLineAnalyzerOptions = {
+				commandLine,
+				cwd,
+				shell: 'pwsh',
+				os: OperatingSystem.Windows,
+				treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+				terminalToolSessionId: 'test',
+				chatSessionResource: undefined,
+			};
+
+			const result = await analyzer.analyze(options);
+			strictEqual(result.isAutoApproveAllowed, expectedAutoApprove, `Expected auto approve to be ${expectedAutoApprove} for: ${commandLine}`);
+			strictEqual((result.disclaimers || []).length, expectedDisclaimers, `Expected ${expectedDisclaimers} disclaimers for: ${commandLine}`);
+		}
+
+		test('absolute path with backslashes inside workspace - allow', () => t('Write-Host "hello" > C:\\workspace\\project\\file.txt', true, 1));
+		test('absolute path with forward slashes inside workspace - allow', () => t('Write-Host "hello" > C:/workspace/project/file.txt', true, 1));
+		test('absolute path with backslashes outside workspace - block', () => t('Write-Host "hello" > C:\\workspace\\outside\\file.txt', false, 1));
+		test('quoted absolute path with backslashes inside workspace - allow', () => t('Write-Host "hello" > "C:\\workspace\\project\\file.txt"', true, 1));
+		test('absolute path with different casing inside workspace - allow', () => t('Write-Host "hello" > c:\\WORKSPACE\\PROJECT\\file.txt', true, 1));
 	});
 });


### PR DESCRIPTION
## Summary

Refactors `CommandLineFileWriteAnalyzer` to centralize path normalization logic into private helper methods, eliminating code duplication between the cwd and no-cwd branches and fixing a Windows case-sensitivity bug.

## Changes

### `commandLineFileWriteAnalyzer.ts`

Extracted the following private helpers:

| Helper | Purpose |
|--------|---------|
| `_normalizePathForParsing(path, os)` | Strips surrounding single/double quotes and normalizes Windows backslashes to forward slashes |
| `_normalizePathForComparison(path, os)` | Calls `_normalizePathForParsing` then lowercases on Windows for case-insensitive comparisons |
| `_isAbsolutePath(path, os)` | Delegates to `win32.isAbsolute` or `posix.isAbsolute` based on OS |
| `_isWithinWorkspace(fileUri, folders, os)` | Replaces the inline `workspaceFolders.some(...)` call with proper scheme+authority+path matching, using case-insensitive path comparison on Windows |
| `_toFileWriteUri(fileWrite, options)` | Consolidates the no-cwd branch's "is absolute string? → `URI.file()`" logic, returning `undefined` for relative paths so the caller can block them |

**Bug fix:** the old `_isWithinWorkspace` inline check compared raw URI paths without normalizing casing, meaning `C:\WORKSPACE\PROJECT\file.txt` would incorrectly be blocked as "outside workspace" on Windows. The new helper lowercases both sides before prefix-matching on Windows.

### `commandLineFileWriteAnalyzer.test.ts`

Added two new test suites:

- **`windows path normalization (cross-platform)`** — verifies that paths using backslashes, forward slashes, mixed casing, quoted backslash paths, and outside-workspace paths all resolve correctly when `os: OperatingSystem.Windows`.
- **Single-quoted path tests in `no cwd provided` · `outsideWorkspace`** — closes a gap where `'/workspace/project/file.txt'` (single-quoted) was not covered.

## Test results

```
64 passing (941ms)
```

All 64 existing + new tests pass. No TypeScript compile errors introduced in changed files.

## Checklist

- [x] No new TypeScript errors in changed files
- [x] All existing tests continue to pass
- [x] New tests added for all new/changed behaviour
- [x] No unnecessary refactoring beyond the scope of the fix
