### PR TITLE
sessions - disconnect inactive pickers when switching local/cloud target

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -355,7 +355,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._folderPicker.setNewSession(undefined);
 			this._isolationModePicker.setNewSession(undefined);
 			this._branchPicker.setNewSession(undefined);
-			this._repoPicker.setNewSession(target === AgentSessionProviders.Cloud ? session : undefined);
+			this._repoPicker.setNewSession(session);
 		}
 
 		// Set the current model on the session (for local sessions)

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -344,16 +344,18 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 	private _setNewSession(session: INewSession): void {
 		this._newSession.value = session;
 
-		// Wire pickers to the new session
+		// Wire pickers to the new session and disconnect inactive ones
 		const target = this._targetPicker.selectedTarget;
 		if (target === AgentSessionProviders.Background) {
 			this._folderPicker.setNewSession(session);
 			this._isolationModePicker.setNewSession(session);
 			this._branchPicker.setNewSession(session);
-		}
-
-		if (target === AgentSessionProviders.Cloud) {
-			this._repoPicker.setNewSession(session);
+			this._repoPicker.setNewSession(undefined);
+		} else {
+			this._folderPicker.setNewSession(undefined);
+			this._isolationModePicker.setNewSession(undefined);
+			this._branchPicker.setNewSession(undefined);
+			this._repoPicker.setNewSession(target === AgentSessionProviders.Cloud ? session : undefined);
 		}
 
 		// Set the current model on the session (for local sessions)


### PR DESCRIPTION
When switching between Local and Cloud targets in the sessions new chat view, the pickers for the inactive target were not disconnected from the session. This caused:

- Cloud repo picker pushing its repository to a local session when switching to Local
- Local folder/branch/isolation pickers pushing their values to a cloud session when switching to Cloud

Fix: In `_setNewSession`, explicitly clear (`setNewSession(undefined)`) the pickers belonging to the inactive target, ensuring each target type only wires its own pickers to the session.