### PR TITLE
Sessions: Ask for workspace trust when picking a folder in new chat view

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/folderPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/folderPicker.ts
@@ -260,6 +260,20 @@ export class FolderPicker extends Disposable {
 		return items;
 	}
 
+	/**
+	 * Removes a folder from the recently picked list and storage.
+	 */
+	removeFromRecents(folderUri: URI): void {
+		this._recentlyPickedFolders = this._recentlyPickedFolders.filter(f => !isEqual(f, folderUri));
+		this.storageService.store(STORAGE_KEY_RECENT_FOLDERS, JSON.stringify(this._recentlyPickedFolders.map(f => f.toString())), StorageScope.PROFILE, StorageTarget.MACHINE);
+		// If this was the last picked folder, clear it
+		if (this._selectedFolderUri && isEqual(this._selectedFolderUri, folderUri)) {
+			this._selectedFolderUri = undefined;
+			this.storageService.remove(STORAGE_KEY_LAST_FOLDER, StorageScope.PROFILE);
+			this._updateTriggerLabel(this._triggerElement);
+		}
+	}
+
 	private _removeFolder(folderUri: URI): void {
 		this._recentlyPickedFolders = this._recentlyPickedFolders.filter(f => !isEqual(f, folderUri));
 		this.storageService.store(STORAGE_KEY_RECENT_FOLDERS, JSON.stringify(this._recentlyPickedFolders.map(f => f.toString())), StorageScope.PROFILE, StorageTarget.MACHINE);

--- a/src/vs/sessions/contrib/chat/browser/folderPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/folderPicker.ts
@@ -16,6 +16,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { INewSession } from './newSession.js';
 
@@ -66,6 +67,7 @@ export class FolderPicker extends Disposable {
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@ICommandService private readonly commandService: ICommandService,
+		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 
@@ -162,10 +164,10 @@ export class FolderPicker extends Disposable {
 	}
 
 	/**
-	 * Programmatically set the selected folder.
+	 * Programmatically set the selected folder without trust check (e.g. restoring draft state).
 	 */
 	setSelectedFolder(folderUri: URI): void {
-		this._selectFolder(folderUri);
+		this._applyFolderSelection(folderUri);
 	}
 
 	/**
@@ -176,7 +178,16 @@ export class FolderPicker extends Disposable {
 		this._updateTriggerLabel(this._triggerElement);
 	}
 
-	private _selectFolder(folderUri: URI): void {
+	private async _selectFolder(folderUri: URI): Promise<void> {
+		const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({ uri: folderUri });
+		if (!trusted) {
+			return;
+		}
+
+		this._applyFolderSelection(folderUri);
+	}
+
+	private _applyFolderSelection(folderUri: URI): void {
 		this._selectedFolderUri = folderUri;
 		this._addToRecentlyPickedFolders(folderUri);
 		this.storageService.store(STORAGE_KEY_LAST_FOLDER, folderUri.toString(), StorageScope.PROFILE, StorageTarget.MACHINE);

--- a/src/vs/sessions/contrib/chat/browser/folderPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/folderPicker.ts
@@ -16,9 +16,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
-import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
-import { INewSession } from './newSession.js';
 
 const STORAGE_KEY_LAST_FOLDER = 'agentSessions.lastPickedFolder';
 const STORAGE_KEY_RECENT_FOLDERS = 'agentSessions.recentlyPickedFolders';
@@ -44,7 +42,6 @@ export class FolderPicker extends Disposable {
 
 	private _selectedFolderUri: URI | undefined;
 	private _recentlyPickedFolders: URI[] = [];
-	private _newSession: INewSession | undefined;
 
 	private _triggerElement: HTMLElement | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
@@ -53,21 +50,12 @@ export class FolderPicker extends Disposable {
 		return this._selectedFolderUri;
 	}
 
-	/**
-	 * Sets the pending session that this picker writes to.
-	 * When the user selects a folder, it calls `setRepoUri` on the session.
-	 */
-	setNewSession(session: INewSession | undefined): void {
-		this._newSession = session;
-	}
-
 	constructor(
 		@IActionWidgetService private readonly actionWidgetService: IActionWidgetService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@ICommandService private readonly commandService: ICommandService,
-		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 
@@ -164,10 +152,10 @@ export class FolderPicker extends Disposable {
 	}
 
 	/**
-	 * Programmatically set the selected folder without trust check (e.g. restoring draft state).
+	 * Programmatically set the selected folder (e.g. restoring draft state).
 	 */
 	setSelectedFolder(folderUri: URI): void {
-		this._applyFolderSelection(folderUri);
+		this._selectFolder(folderUri);
 	}
 
 	/**
@@ -178,21 +166,11 @@ export class FolderPicker extends Disposable {
 		this._updateTriggerLabel(this._triggerElement);
 	}
 
-	private async _selectFolder(folderUri: URI): Promise<void> {
-		const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({ uri: folderUri });
-		if (!trusted) {
-			return;
-		}
-
-		this._applyFolderSelection(folderUri);
-	}
-
-	private _applyFolderSelection(folderUri: URI): void {
+	private _selectFolder(folderUri: URI): void {
 		this._selectedFolderUri = folderUri;
 		this._addToRecentlyPickedFolders(folderUri);
 		this.storageService.store(STORAGE_KEY_LAST_FOLDER, folderUri.toString(), StorageScope.PROFILE, StorageTarget.MACHINE);
 		this._updateTriggerLabel(this._triggerElement);
-		this._newSession?.setRepoUri(folderUri);
 		this._onDidSelectFolder.fire(folderUri);
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -115,6 +115,11 @@
 	color: var(--vscode-icon-foreground);
 	background: transparent !important;
 	border: none !important;
+	cursor: pointer;
+}
+
+.sessions-chat-send-button .monaco-button.disabled {
+	cursor: default;
 }
 
 .sessions-chat-send-button .monaco-button:not(.disabled):hover {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -1055,6 +1055,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
 		});
 		if (!trusted) {
+			this._folderPicker.removeFromRecents(folderUri);
 			const previousFolderUri = this._newSession.value?.repoUri;
 			if (previousFolderUri) {
 				this._folderPicker.setSelectedFolder(previousFolderUri);

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -185,7 +185,6 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ILogService private readonly logService: ILogService,
 		@IHoverService private readonly hoverService: IHoverService,
-		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@IGitService private readonly gitService: IGitService,
 		@IStorageService private readonly storageService: IStorageService,

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -225,7 +225,14 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._focusEditor();
 		}));
 
-		this._register(this._folderPicker.onDidSelectFolder(() => {
+		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
+			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
+				uri: folderUri,
+				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Copilot will be able to read files, run commands, and make changes in this folder."),
+			});
+			if (trusted) {
+				this._newSession.value?.setRepoUri(folderUri);
+			}
 			this._updateDraftState();
 			this._focusEditor();
 		}));
@@ -352,12 +359,14 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		// Wire pickers to the new session and disconnect inactive ones
 		const target = this._targetPicker.selectedTarget;
 		if (target === AgentSessionProviders.Background) {
-			this._folderPicker.setNewSession(session);
 			this._isolationModePicker.setNewSession(session);
 			this._branchPicker.setNewSession(session);
 			this._repoPicker.setNewSession(undefined);
+			const folderUri = this._folderPicker.selectedFolderUri;
+			if (folderUri) {
+				session.setRepoUri(folderUri);
+			}
 		} else {
-			this._folderPicker.setNewSession(undefined);
 			this._isolationModePicker.setNewSession(undefined);
 			this._branchPicker.setNewSession(undefined);
 			this._repoPicker.setNewSession(session);
@@ -967,20 +976,6 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 				this._openRepoOrFolderPicker(session.target);
 			}
 			return;
-		}
-
-		// For local targets, request workspace trust for the selected folder
-		if (session.target === AgentSessionProviders.Background) {
-			const folderUri = this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
-			if (folderUri) {
-				const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
-					uri: folderUri,
-					message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Copilot will be able to read files, run commands, and make changes in this folder."),
-				});
-				if (!trusted) {
-					return;
-				}
-			}
 		}
 
 		// Check for slash commands first

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -226,9 +226,9 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		}));
 
 		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
-			const session = this._newSession.value;
-			if (session) {
-				await this._requestFolderTrust(folderUri, session);
+			const trusted = await this._requestFolderTrust(folderUri);
+			if (trusted) {
+				this._newSession.value?.setRepoUri(folderUri);
 			}
 			this._updateDraftState();
 			this._focusEditor();
@@ -336,6 +336,15 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 	private async _createNewSession(): Promise<void> {
 		const target = this._targetPicker.selectedTarget;
 		const defaultRepoUri = this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
+
+		// For local targets, request workspace trust before creating the session
+		if (target === AgentSessionProviders.Background && defaultRepoUri) {
+			const trusted = await this._requestFolderTrust(defaultRepoUri);
+			if (!trusted) {
+				return;
+			}
+		}
+
 		const resource = getResourceForNewChatSession({
 			type: target,
 			position: this._options.sessionPosition ?? ChatSessionPosition.Sidebar,
@@ -344,13 +353,13 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 		try {
 			const session = await this.sessionsManagementService.createNewSessionForTarget(target, resource, defaultRepoUri);
-			await this._setNewSession(session);
+			this._setNewSession(session);
 		} catch (e) {
 			this.logService.error('Failed to create new session:', e);
 		}
 	}
 
-	private async _setNewSession(session: INewSession): Promise<void> {
+	private _setNewSession(session: INewSession): void {
 		this._newSession.value = session;
 
 		// Wire pickers to the new session and disconnect inactive ones
@@ -361,7 +370,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._repoPicker.setNewSession(undefined);
 			const folderUri = this._folderPicker.selectedFolderUri;
 			if (folderUri) {
-				await this._requestFolderTrust(folderUri, session);
+				session.setRepoUri(folderUri);
 			}
 		} else {
 			this._isolationModePicker.setNewSession(undefined);
@@ -1041,19 +1050,20 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		}
 	}
 
-	private async _requestFolderTrust(folderUri: URI, session: INewSession): Promise<void> {
-		const previousFolderUri = session.repoUri;
+	private async _requestFolderTrust(folderUri: URI): Promise<boolean> {
 		const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 			uri: folderUri,
 			message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
 		});
-		if (trusted) {
-			session.setRepoUri(folderUri);
-		} else if (previousFolderUri) {
-			this._folderPicker.setSelectedFolder(previousFolderUri);
-		} else {
-			this._folderPicker.clearSelection();
+		if (!trusted) {
+			const previousFolderUri = this._newSession.value?.repoUri;
+			if (previousFolderUri) {
+				this._folderPicker.setSelectedFolder(previousFolderUri);
+			} else {
+				this._folderPicker.clearSelection();
+			}
 		}
+		return !!trusted;
 	}
 
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -228,7 +228,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
 			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 				uri: folderUri,
-				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Copilot will be able to read files, run commands, and make changes in this folder."),
+				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Code in this folder will be able to run commands and make changes."),
 			});
 			if (trusted) {
 				this._newSession.value?.setRepoUri(folderUri);

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -335,7 +335,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 	private async _createNewSession(): Promise<void> {
 		const target = this._targetPicker.selectedTarget;
-		const defaultRepoUri = this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
+		const defaultRepoUri = this._folderPicker.selectedFolderUri;
 
 		// For local targets, request workspace trust before creating the session
 		if (target === AgentSessionProviders.Background && defaultRepoUri) {
@@ -604,7 +604,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		const target = this._targetPicker.selectedTarget;
 
 		if (target === AgentSessionProviders.Background) {
-			return this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
+			return this._folderPicker.selectedFolderUri;
 		}
 
 		// For cloud targets, use the repo picker's selection

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -49,6 +49,7 @@ import { EnhancedModelPickerActionItem } from '../../../../workbench/contrib/cha
 import { IChatInputPickerOptions } from '../../../../workbench/contrib/chat/browser/widget/input/chatInputPickerActionItem.js';
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/views/viewPane.js';
 import { ContextMenuController } from '../../../../editor/contrib/contextmenu/browser/contextmenu.js';
 import { getSimpleEditorOptions } from '../../../../workbench/contrib/codeEditor/browser/simpleEditorOptions.js';
@@ -188,6 +189,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		@ISessionsManagementService private readonly sessionsManagementService: ISessionsManagementService,
 		@IGitService private readonly gitService: IGitService,
 		@IStorageService private readonly storageService: IStorageService,
+		@IWorkspaceTrustRequestService private readonly workspaceTrustRequestService: IWorkspaceTrustRequestService,
 	) {
 		super();
 		this._history = this._register(this.instantiationService.createInstance(ChatHistoryNavigator, ChatAgentLocation.Chat));
@@ -965,6 +967,20 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 				this._openRepoOrFolderPicker(session.target);
 			}
 			return;
+		}
+
+		// For local targets, request workspace trust for the selected folder
+		if (session.target === AgentSessionProviders.Background) {
+			const folderUri = this._folderPicker.selectedFolderUri ?? this.workspaceContextService.getWorkspace().folders[0]?.uri;
+			if (folderUri) {
+				const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
+					uri: folderUri,
+					message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Copilot will be able to read files, run commands, and make changes in this folder."),
+				});
+				if (!trusted) {
+					return;
+				}
+			}
 		}
 
 		// Check for slash commands first

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -335,13 +335,13 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 	private async _createNewSession(): Promise<void> {
 		const target = this._targetPicker.selectedTarget;
-		const defaultRepoUri = this._folderPicker.selectedFolderUri;
+		let defaultRepoUri = this._folderPicker.selectedFolderUri;
 
 		// For local targets, request workspace trust before creating the session
 		if (target === AgentSessionProviders.Background && defaultRepoUri) {
 			const trusted = await this._requestFolderTrust(defaultRepoUri);
 			if (!trusted) {
-				return;
+				defaultRepoUri = undefined;
 			}
 		}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -226,17 +226,9 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		}));
 
 		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
-			const previousFolderUri = this._newSession.value?.repoUri;
-			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
-				uri: folderUri,
-				message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
-			});
-			if (trusted) {
-				this._newSession.value?.setRepoUri(folderUri);
-			} else if (previousFolderUri) {
-				this._folderPicker.setSelectedFolder(previousFolderUri);
-			} else {
-				this._folderPicker.clearSelection();
+			const session = this._newSession.value;
+			if (session) {
+				await this._requestFolderTrust(folderUri, session);
 			}
 			this._updateDraftState();
 			this._focusEditor();
@@ -369,7 +361,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._repoPicker.setNewSession(undefined);
 			const folderUri = this._folderPicker.selectedFolderUri;
 			if (folderUri) {
-				session.setRepoUri(folderUri);
+				this._requestFolderTrust(folderUri, session);
 			}
 		} else {
 			this._isolationModePicker.setNewSession(undefined);
@@ -1046,6 +1038,21 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._folderPicker.showPicker();
 		} else {
 			this._repoPicker.showPicker();
+		}
+	}
+
+	private async _requestFolderTrust(folderUri: URI, session: INewSession): Promise<void> {
+		const previousFolderUri = session.repoUri;
+		const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
+			uri: folderUri,
+			message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
+		});
+		if (trusted) {
+			session.setRepoUri(folderUri);
+		} else if (previousFolderUri) {
+			this._folderPicker.setSelectedFolder(previousFolderUri);
+		} else {
+			this._folderPicker.clearSelection();
 		}
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -226,12 +226,17 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		}));
 
 		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
+			const previousFolderUri = this._newSession.value?.repoUri;
 			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 				uri: folderUri,
 				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? An agent session will be able to read files, run commands, and make changes in this folder."),
 			});
 			if (trusted) {
 				this._newSession.value?.setRepoUri(folderUri);
+			} else if (previousFolderUri) {
+				this._folderPicker.setSelectedFolder(previousFolderUri);
+			} else {
+				this._folderPicker.clearSelection();
 			}
 			this._updateDraftState();
 			this._focusEditor();

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -229,7 +229,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			const previousFolderUri = this._newSession.value?.repoUri;
 			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 				uri: folderUri,
-				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? An agent session will be able to read files, run commands, and make changes in this folder."),
+				message: localize('trustFolderMessage', "An agent session will be able to read files, run commands, and make changes in this folder."),
 			});
 			if (trusted) {
 				this._newSession.value?.setRepoUri(folderUri);

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -228,7 +228,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		this._register(this._folderPicker.onDidSelectFolder(async (folderUri) => {
 			const trusted = await this.workspaceTrustRequestService.requestResourcesTrust({
 				uri: folderUri,
-				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? Code in this folder will be able to run commands and make changes."),
+				message: localize('trustFolderMessage', "Do you trust the authors of the files in this folder? An agent session will be able to read files, run commands, and make changes in this folder."),
 			});
 			if (trusted) {
 				this._newSession.value?.setRepoUri(folderUri);

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -344,13 +344,13 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 
 		try {
 			const session = await this.sessionsManagementService.createNewSessionForTarget(target, resource, defaultRepoUri);
-			this._setNewSession(session);
+			await this._setNewSession(session);
 		} catch (e) {
 			this.logService.error('Failed to create new session:', e);
 		}
 	}
 
-	private _setNewSession(session: INewSession): void {
+	private async _setNewSession(session: INewSession): Promise<void> {
 		this._newSession.value = session;
 
 		// Wire pickers to the new session and disconnect inactive ones
@@ -361,7 +361,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._repoPicker.setNewSession(undefined);
 			const folderUri = this._folderPicker.selectedFolderUri;
 			if (folderUri) {
-				this._requestFolderTrust(folderUri, session);
+				await this._requestFolderTrust(folderUri, session);
 			}
 		} else {
 			this._isolationModePicker.setNewSession(undefined);

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -367,10 +367,6 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._isolationModePicker.setNewSession(session);
 			this._branchPicker.setNewSession(session);
 			this._repoPicker.setNewSession(undefined);
-			const folderUri = this._folderPicker.selectedFolderUri;
-			if (folderUri) {
-				session.setRepoUri(folderUri);
-			}
 		} else {
 			this._isolationModePicker.setNewSession(undefined);
 			this._branchPicker.setNewSession(undefined);

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -19,7 +19,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'breadcrumbs.enabled': false,
 
-		'diffEditor.renderSideBySide': false,
 		'diffEditor.hideUnchangedRegions.enabled': true,
 
 		'extensions.ignoreRecommendations': true,


### PR DESCRIPTION
## Summary

Ask for workspace trust when a folder is picked or during initialization in the Sessions new chat view.

### Changes

**`folderPicker.ts`** — Simplified to a pure picker:
- Removed session management (`setNewSession`, `_newSession`, `setRepoUri`)
- Removed `IWorkspaceTrustRequestService` — trust is now handled by the caller

**`newChatViewPane.ts`** — Orchestrates trust and session wiring:
- Trust is requested **before** creating a new session in `_createNewSession`
- Trust is requested when the user picks a new folder via `onDidSelectFolder`
- If trust is denied, the folder picker resets to the previous value
- Session still gets created without a folder URI if trust is denied (so pickers render correctly)
- Removed `workspaceContextService.getWorkspace().folders[0]` fallback — folder URI comes solely from the picker
- Removed unused `workspaceContextService` injection from `NewChatWidget`

**`chatWidget.css`** — Fixed send button cursor:
- Added `cursor: pointer` for enabled state
- Added `cursor: default` for disabled state

**`configuration.contribution.ts`**:
- Removed `diffEditor.renderSideBySide` from default overrides