### PR TITLE
fix(git): quick diff and blame break for worktrees inside bare repositories

### DIFF
--- a/extensions/git/src/quickDiffProvider.ts
+++ b/extensions/git/src/quickDiffProvider.ts
@@ -26,8 +26,14 @@ export class GitQuickDiffProvider implements QuickDiffProvider {
 			return undefined;
 		}
 
-		// Ignore path that is inside the .git directory (ex: COMMIT_EDITMSG)
-		if (isDescendant(this.repository.dotGit.commonPath ?? this.repository.dotGit.path, uri.fsPath)) {
+		// Ignore path that is inside the .git directory (ex: COMMIT_EDITMSG).
+		// Special case: when a bare repository is used as the common git directory and
+		// worktrees are stored inside the bare repo directory (e.g. repo.git/work/), the
+		// commonPath is an ancestor of repository.root. Files inside repository.root are
+		// working tree files and must NOT be treated as git metadata.
+		const gitDir = this.repository.dotGit.commonPath ?? this.repository.dotGit.path;
+		if (isDescendant(gitDir, uri.fsPath) &&
+			(!isDescendant(this.repository.root, uri.fsPath) || isDescendant(this.repository.root, gitDir))) {
 			this.logger.trace(`[Repository][provideOriginalResource] Resource is inside .git directory: ${uri.toString()}`);
 			return undefined;
 		}


### PR DESCRIPTION
Fixes #299244

## Problem

When a bare repository is used as the common git directory **and worktrees are stored inside the bare repo directory** (e.g. `repo/worktree-name/`), `GitQuickDiffProvider.provideOriginalResource` returns `undefined` for every source file in those worktrees.

`dotGit.commonPath` equals the bare repo root (e.g. `C:/repo/`), so `isDescendant(commonPath, "C:/repo/worktree-name/src/file.cpp")` evaluates to `true` for all working-tree files. They are incorrectly treated as git metadata.

This silently breaks `TextEditor.diffInformation`, causing gutter decorations, inline blame, status bar blame, and stage-hunk to stop working entirely.

## Fix

Exempt files that are inside `repository.root` (the working tree), **unless** `gitDir` is itself inside `repository.root` - the standard case (`.git/` as a subdirectory of root) where the original skip is correct.

```ts
const gitDir = this.repository.dotGit.commonPath ?? this.repository.dotGit.path;
if (isDescendant(gitDir, uri.fsPath) &&
    (!isDescendant(this.repository.root, uri.fsPath) || isDescendant(this.repository.root, gitDir))) {
    return undefined;
}
```

| Scenario | Before | After |
|---|---|---|
| Standard repo - source file | Skip: No ✓ | Skip: No ✓ |
| Standard repo - `.git/config` | Skip: Yes ✓ | Skip: Yes ✓ |
| Bare repo, worktree inside - source file | Skip: Yes ✗ | Skip: No ✓ |
| Bare repo, worktree inside - repo metadata | Skip: Yes ✓ | Skip: Yes ✓ |
| Normal worktree (outside main repo) | Skip: No ✓ | Skip: No ✓ |

## Reproduction

```bash
git clone --bare <url> repo
git -C repo worktree add worktree-name <branch>
code repo/worktree-name/
```

Open any tracked file → no gutter decorations, no blame.