### PR TITLE
Scope EditorTabsVisibleContext to editor parts for correct action resolution

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -34,7 +34,7 @@ import { IBoundarySashes } from '../../../../base/browser/ui/sash/sash.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext } from '../../../common/contextkeys.js';
+import { EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, EditorTabsVisibleContext } from '../../../common/contextkeys.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 
 export interface IEditorPartUIState {
@@ -1039,6 +1039,7 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 	protected handleContextKeys(): void {
 		const multipleEditorGroupsContext = EditorPartMultipleEditorGroupsContext.bindTo(this.scopedContextKeyService);
 		const maximizedEditorGroupContext = EditorPartMaximizedEditorGroupContext.bindTo(this.scopedContextKeyService);
+		const editorTabsVisibleContext = EditorTabsVisibleContext.bindTo(this.scopedContextKeyService);
 
 		const updateContextKeys = () => {
 			const groupCount = this.count;
@@ -1055,11 +1056,17 @@ export class EditorPart extends Part<IEditorPartMemento> implements IEditorPart,
 			}
 		};
 
+		const updateEditorTabsVisibleContext = () => {
+			editorTabsVisibleContext.set(this.partOptions.showTabs === 'multiple');
+		};
+
 		updateContextKeys();
+		updateEditorTabsVisibleContext();
 
 		this._register(this.onDidAddGroup(() => updateContextKeys()));
 		this._register(this.onDidRemoveGroup(() => updateContextKeys()));
 		this._register(this.onDidChangeGroupMaximized(() => updateContextKeys()));
+		this._register(this.onDidChangeEditorPartOptions(() => updateEditorTabsVisibleContext()));
 	}
 
 	private setupDragAndDropSupport(parent: HTMLElement, container: HTMLElement): void {

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -505,6 +505,7 @@ suite('EditorGroupsService', () => {
 		const enforced2 = part.enforcePartOptions({ showTabs: 'single' });
 		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), false);
 		enforced2.dispose();
+		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
 	});
 
 	test('editor basics', async function () {

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -483,6 +483,30 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(part.partOptions.allowDropIntoGroup, true);
 	});
 
+	test('enforced options update EditorTabsVisibleContext', async () => {
+		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
+		const [part] = await createPart(instantiationService);
+
+		const group = part.activeGroup;
+
+		// Default: showTabs is 'multiple', context key should be true
+		assert.strictEqual(part.partOptions.showTabs, 'multiple');
+		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
+
+		// Enforce showTabs to 'none': context key should be false
+		const enforced1 = part.enforcePartOptions({ showTabs: 'none' });
+		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), false);
+
+		// Dispose enforcement: back to 'multiple', context key should be true
+		enforced1.dispose();
+		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
+
+		// Enforce showTabs to 'single': context key should be false
+		const enforced2 = part.enforcePartOptions({ showTabs: 'single' });
+		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), false);
+		enforced2.dispose();
+	});
+
 	test('editor basics', async function () {
 		const [part] = await createPart();
 		const group = part.activeGroup;

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -483,31 +483,6 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(part.partOptions.allowDropIntoGroup, true);
 	});
 
-	test('enforced options update EditorTabsVisibleContext', async () => {
-		const instantiationService = workbenchInstantiationService({ contextKeyService: instantiationService => instantiationService.createInstance(MockScopableContextKeyService) }, disposables);
-		const [part] = await createPart(instantiationService);
-
-		const group = part.activeGroup;
-
-		// Default: showTabs is 'multiple', context key should be true
-		assert.strictEqual(part.partOptions.showTabs, 'multiple');
-		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
-
-		// Enforce showTabs to 'none': context key should be false
-		const enforced1 = part.enforcePartOptions({ showTabs: 'none' });
-		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), false);
-
-		// Dispose enforcement: back to 'multiple', context key should be true
-		enforced1.dispose();
-		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
-
-		// Enforce showTabs to 'single': context key should be false
-		const enforced2 = part.enforcePartOptions({ showTabs: 'single' });
-		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), false);
-		enforced2.dispose();
-		assert.strictEqual(group.scopedContextKeyService.getContextKeyValue('editorTabsVisible'), true);
-	});
-
 	test('editor basics', async function () {
 		const [part] = await createPart();
 		const group = part.activeGroup;


### PR DESCRIPTION
When the modal editor part enforces `showTabs: 'multiple'` (or `'none'`), the `EditorTabsVisibleContext` was only set globally based on the main editor part's options. This caused close/unpin actions gated on `EditorTabsVisibleContext.toNegated()` to incorrectly appear in the modal editor when the user had tabs configured as `'single'` globally.

**Fix:** Bind `EditorTabsVisibleContext` to `EditorPart.scopedContextKeyService` in `handleContextKeys()`, matching the existing pattern for `EditorPartMultipleEditorGroupsContext` and `EditorPartMaximizedEditorGroupContext`. The scoped value overrides the global one within each editor part's DOM subtree, so actions resolve correctly against the enforced options.

**Consumers of this context key** (all in `editor.contribution.ts`):
- Close button (normal/dirty editor) — `when: EditorTabsVisibleContext.toNegated()`
- Unpin button (sticky/dirty+sticky) — `when: EditorTabsVisibleContext.toNegated()`
- "Close to the Right" context menu — `when: EditorTabsVisibleContext`