### PR TITLE
Polish chat input part: picker collapse, padding, and icon sizing

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -60,6 +60,7 @@
 		"list.hoverBackground": "#262728",
 		"list.hoverForeground": "#bfbfbf",
 		"list.dropBackground": "#3994BC1A",
+		"toolbar.hoverBackground": "#262728",
 		"list.focusBackground": "#3994BC26",
 		"list.focusForeground": "#bfbfbf",
 		"list.focusOutline": "#3994BCB3",

--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -50,7 +50,7 @@
 	display: flex;
 	font-size: 11px;
 	padding: 3px;
-	border-radius: 5px;
+	border-radius: var(--vscode-cornerRadius-medium);
 }
 
 .monaco-action-bar .action-item.disabled .action-label:not(.icon) ,

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -119,7 +119,7 @@
 
 .action-widget .monaco-list-row.action {
 	display: flex;
-	gap: 6px;
+	gap: 8px;
 	align-items: center;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -655,9 +655,7 @@ export class ModelPickerWidget extends Disposable {
 			domChildren.push(this._badgeIcon);
 		}
 
-		if (!this._hideChevrons?.get()) {
-			domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
-		}
+		domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(this._domNode, ...domChildren);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -209,9 +209,7 @@ export class ModelPickerActionItem extends ChatInputPickerActionViewItem {
 		}
 
 		domChildren.push(dom.$('span.chat-input-picker-label', undefined, name ?? localize('chat.modelPicker.auto', "Auto")));
-		if (!this.pickerOptions.hideChevrons.get()) {
-			domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
-		}
+		domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...domChildren);
 		this.setAriaLabelAttributes(element);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem.ts
@@ -213,12 +213,9 @@ export class SessionTypePickerActionItem extends ChatInputPickerActionViewItem {
 		const icon = getAgentSessionProviderIcon(currentType ?? AgentSessionProviders.Local);
 
 		const labelElements = [];
-		const collapsed = this.pickerOptions.hideChevrons.get();
 		labelElements.push(...renderLabelWithIcons(`$(${icon.id})`));
-		if (!collapsed) {
-			labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
-			labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
-		}
+		labelElements.push(dom.$('span.chat-input-picker-label', undefined, label));
+		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...labelElements);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1342,7 +1342,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	padding: 2px 5px 2px 6px;
+	padding: 0 4px 0 5px;
 }
 
 .interactive-session .chat-secondary-toolbar:empty {
@@ -1412,8 +1412,9 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .monaco-workbench .interactive-session .chat-secondary-toolbar .chat-input-picker-item .action-label .codicon-chevron-down {
-	font-size: 12px;
-	margin-left: 2px;
+	font-size: 10px;
+	margin-left: 4px;
+	opacity: 0.75;
 }
 
 .interactive-session .chat-input-toolbars :not(.responsive.chat-input-toolbar) .actions-container:first-child {
@@ -1525,25 +1526,32 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-/* When chevrons are hidden but label is still shown (e.g. model picker), use equal padding */
-.interactive-session .chat-input-toolbar .chat-input-picker-item .action-label.hide-chevrons:has(.chat-input-picker-label),
-.interactive-session .chat-input-toolbar .chat-input-picker-item.hide-chevrons .action-label:has(.chat-input-picker-label),
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label.hide-chevrons:has(.chat-input-picker-label) {
-	padding: 3px 7px;
-}
 
 /* Hide the tools button when the toolbar is in collapsed state */
 .interactive-session .chat-input-toolbar:has(.hide-chevrons) .action-item:has(.codicon-settings) {
 	display: none;
 }
 
-.monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
-.monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
-	font-size: 12px;
-	margin-left: 2px;
+/* Add context button icon sizing */
+.interactive-session .chat-input-toolbar .action-item:has(.codicon-add) .action-label {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
-.interactive-session .chat-input-toolbars .monaco-action-bar .actions-container {
+.interactive-session .chat-input-toolbar .action-item:has(.codicon-add) .codicon-add {
+	font-size: 14px;
+}
+
+.monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
+.monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
+	font-size: 10px;
+	margin-left: 4px;
+	opacity: 0.75;
+}
+
+.interactive-session .chat-input-toolbars .monaco-action-bar .actions-container,
+.interactive-session .chat-secondary-toolbar .monaco-action-bar .actions-container {
 	display: flex;
 	gap: 4px;
 }
@@ -1755,7 +1763,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 .interactive-session .interactive-input-part {
 	margin: 0px 12px;
-	padding: 4px 0 6px 0px;
+	padding: 4px 0 4px 0px;
 	display: flex;
 	flex-direction: column;
 	gap: 4px;


### PR DESCRIPTION
## Changes

- **Input part bottom padding**: Reduced from 6px to 4px for tighter spacing
- **Picker collapse behavior**: Model picker, session type picker, and permissions picker no longer hide their labels/chevrons when the input part is narrow. Only the agent mode picker collapses (hides label + chevron)
- **Removed excess padding rule**: Removed the CSS rule that added extra right padding to pickers with labels when chevrons were hidden (no longer needed since chevrons stay visible)
- **Add context icon**: Set the "+" codicon to 14px and centered it within its icon button