### PR TITLE
Maximize editor group on double click

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -40,6 +40,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'terminal.integrated.initialHint': false,
 
+		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',
 		'workbench.editor.restoreEditors': false,
 		'workbench.startupEditor': 'none',
 		'workbench.tips.enabled': false,


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a configuration option to maximize the editor group when double-clicking the tab.

