### PR TITLE
chat: add marketplace trust prompt for agent plugin installation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
@@ -20,10 +22,15 @@ export class PluginInstallService implements IPluginInstallService {
 		@IPluginMarketplaceService private readonly _pluginMarketplaceService: IPluginMarketplaceService,
 		@IFileService private readonly _fileService: IFileService,
 		@INotificationService private readonly _notificationService: INotificationService,
+		@IDialogService private readonly _dialogService: IDialogService,
 		@ILogService private readonly _logService: ILogService,
 	) { }
 
 	async installPlugin(plugin: IMarketplacePlugin): Promise<void> {
+		if (!await this._ensureMarketplaceTrusted(plugin)) {
+			return;
+		}
+
 		const kind = plugin.sourceDescriptor.kind;
 
 		if (kind === PluginSourceKind.RelativePath) {
@@ -59,6 +66,31 @@ export class PluginInstallService implements IPluginInstallService {
 			return this._pluginRepositoryService.getPluginInstallUri(plugin);
 		}
 		return this._pluginRepositoryService.getPluginSourceInstallUri(plugin.sourceDescriptor);
+	}
+
+	// --- Trust gate -------------------------------------------------------------
+
+	private async _ensureMarketplaceTrusted(plugin: IMarketplacePlugin): Promise<boolean> {
+		if (this._pluginMarketplaceService.isMarketplaceTrusted(plugin.marketplaceReference)) {
+			return true;
+		}
+
+		const { confirmed } = await this._dialogService.confirm({
+			type: 'question',
+			message: localize('trustMarketplace', "Trust Plugins from '{0}'?", plugin.marketplaceReference.displayLabel),
+			detail: localize('trustMarketplaceDetail', "Plugins can run code on your machine. Only install plugins from sources you trust.\n\nSource: {0}", plugin.marketplaceReference.rawValue),
+			primaryButton: localize({ key: 'trustAndInstall', comment: ['&& denotes a mnemonic'] }, "&&Trust"),
+			custom: {
+				icon: Codicon.shield,
+			},
+		});
+
+		if (!confirmed) {
+			return false;
+		}
+
+		this._pluginMarketplaceService.trustMarketplace(plugin.marketplaceReference);
+		return true;
 	}
 
 	// --- Relative-path source (existing git-based flow) -----------------------

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -154,6 +154,10 @@ export interface IPluginMarketplaceService {
 	addInstalledPlugin(pluginUri: URI, plugin: IMarketplacePlugin): void;
 	removeInstalledPlugin(pluginUri: URI): void;
 	setInstalledPluginEnabled(pluginUri: URI, enabled: boolean): void;
+	/** Returns whether the given marketplace has been explicitly trusted by the user. */
+	isMarketplaceTrusted(ref: IMarketplaceReference): boolean;
+	/** Records that the user trusts the given marketplace, persisted permanently. */
+	trustMarketplace(ref: IMarketplaceReference): void;
 }
 
 /**
@@ -209,10 +213,21 @@ const installedPluginsMemento = observableMemento<readonly IStoredInstalledPlugi
 	},
 });
 
+const trustedMarketplacesMemento = observableMemento<readonly string[]>({
+	defaultValue: [],
+	key: 'chat.plugins.trustedMarketplaces.v1',
+	toStorage: value => JSON.stringify(value),
+	fromStorage: value => {
+		const parsed = JSON.parse(value);
+		return Array.isArray(parsed) ? parsed : [];
+	},
+});
+
 export class PluginMarketplaceService extends Disposable implements IPluginMarketplaceService {
 	declare readonly _serviceBrand: undefined;
 	private readonly _gitHubMarketplaceCache = new Lazy<Map<string, IGitHubMarketplaceCacheEntry>>(() => this._loadPersistedGitHubMarketplaceCache());
 	private readonly _installedPluginsStore: ObservableMemento<readonly IStoredInstalledPlugin[]>;
+	private readonly _trustedMarketplacesStore: ObservableMemento<readonly string[]>;
 
 	readonly onDidChangeMarketplaces: Event<void>;
 
@@ -230,6 +245,10 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		this._installedPluginsStore = this._register(
 			installedPluginsMemento(StorageScope.APPLICATION, StorageTarget.MACHINE, _storageService)
+		);
+
+		this._trustedMarketplacesStore = this._register(
+			trustedMarketplacesMemento(StorageScope.APPLICATION, StorageTarget.MACHINE, _storageService)
 		);
 
 		this.installedPlugins = this._installedPluginsStore.map(s =>
@@ -454,6 +473,17 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			current.map(e => isEqual(e.pluginUri, pluginUri) ? { ...e, enabled } : e),
 			undefined,
 		);
+	}
+
+	isMarketplaceTrusted(ref: IMarketplaceReference): boolean {
+		return this._trustedMarketplacesStore.get().includes(ref.canonicalId);
+	}
+
+	trustMarketplace(ref: IMarketplaceReference): void {
+		const current = this._trustedMarketplacesStore.get();
+		if (!current.includes(ref.canonicalId)) {
+			this._trustedMarketplacesStore.set([...current, ref.canonicalId], undefined);
+		}
 	}
 
 	private async _fetchFromClonedRepo(reference: IMarketplaceReference, token: CancellationToken): Promise<IMarketplacePlugin[]> {

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -62,6 +62,10 @@ suite('PluginInstallService', () => {
 		terminalCompletes: boolean;
 		pullRepositoryCalls: { marketplace: IMarketplaceReference; options?: IPullRepositoryOptions }[];
 		updatePluginSourceCalls: { plugin: IMarketplacePlugin; options?: IPullRepositoryOptions }[];
+		/** Whether the marketplace is already trusted */
+		marketplaceTrusted: boolean;
+		/** Canonical IDs that were trusted via trustMarketplace() */
+		trustedMarketplaces: string[];
 	}
 
 	function createDefaults(): MockState {
@@ -78,6 +82,8 @@ suite('PluginInstallService', () => {
 			terminalCompletes: true,
 			pullRepositoryCalls: [],
 			updatePluginSourceCalls: [],
+			marketplaceTrusted: true,
+			trustedMarketplaces: [],
 		};
 	}
 
@@ -237,6 +243,10 @@ suite('PluginInstallService', () => {
 			addInstalledPlugin: (uri: URI, plugin: IMarketplacePlugin) => {
 				state.addedPlugins.push({ uri: uri.toString(), plugin });
 			},
+			isMarketplaceTrusted: () => state.marketplaceTrusted,
+			trustMarketplace: (ref: IMarketplaceReference) => {
+				state.trustedMarketplaces.push(ref.canonicalId);
+			},
 		} as unknown as IPluginMarketplaceService);
 
 		const service = instantiationService.createInstance(PluginInstallService);
@@ -347,6 +357,8 @@ suite('PluginInstallService', () => {
 			instantiationService.stub(IProgressService, { withProgress: async (_o: unknown, cb: () => Promise<unknown>) => cb() } as unknown as IProgressService);
 			instantiationService.stub(ILogService, new NullLogService());
 			instantiationService.stub(IPluginMarketplaceService, { addInstalledPlugin: () => { } } as unknown as IPluginMarketplaceService);
+			instantiationService.stub(IPluginMarketplaceService, 'isMarketplaceTrusted', () => true);
+			instantiationService.stub(IPluginMarketplaceService, 'trustMarketplace', () => { });
 			const svc = instantiationService.createInstance(PluginInstallService);
 
 			const plugin = createPlugin({
@@ -669,6 +681,70 @@ suite('PluginInstallService', () => {
 
 			assert.strictEqual(state.terminalCommands.length, 1);
 			assert.ok(state.terminalCommands[0].includes('pip'));
+		});
+	});
+
+	// =========================================================================
+	// installPlugin — marketplace trust
+	// =========================================================================
+
+	suite('installPlugin — marketplace trust', () => {
+
+		test('skips trust prompt when marketplace is already trusted', async () => {
+			const { service, state } = createService({ marketplaceTrusted: true });
+			const plugin = createPlugin({
+				source: 'plugins/myPlugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/myPlugin' },
+			});
+
+			await service.installPlugin(plugin);
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.trustedMarketplaces.length, 0, 'should not re-trust');
+		});
+
+		test('shows trust prompt and installs when user confirms', async () => {
+			const { service, state } = createService({ marketplaceTrusted: false, dialogConfirmResult: true });
+			const plugin = createPlugin({
+				source: 'plugins/myPlugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/myPlugin' },
+			});
+
+			await service.installPlugin(plugin);
+
+			assert.strictEqual(state.trustedMarketplaces.length, 1);
+			assert.strictEqual(state.addedPlugins.length, 1);
+		});
+
+		test('does not install when user declines trust', async () => {
+			const { service, state } = createService({ marketplaceTrusted: false, dialogConfirmResult: false });
+			const plugin = createPlugin({
+				source: 'plugins/myPlugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/myPlugin' },
+			});
+
+			await service.installPlugin(plugin);
+
+			assert.strictEqual(state.trustedMarketplaces.length, 0);
+			assert.strictEqual(state.addedPlugins.length, 0);
+		});
+
+		test('trust prompt applies to all source kinds', async () => {
+			const { service, state } = createService({ marketplaceTrusted: false, dialogConfirmResult: false });
+
+			const kinds: IPluginSourceDescriptor[] = [
+				{ kind: PluginSourceKind.RelativePath, path: 'p' },
+				{ kind: PluginSourceKind.GitHub, repo: 'owner/repo' },
+				{ kind: PluginSourceKind.GitUrl, url: 'https://example.com/repo.git' },
+				{ kind: PluginSourceKind.Npm, package: 'my-pkg' },
+				{ kind: PluginSourceKind.Pip, package: 'my-pkg' },
+			];
+
+			for (const sourceDescriptor of kinds) {
+				await service.installPlugin(createPlugin({ sourceDescriptor }));
+			}
+
+			assert.strictEqual(state.addedPlugins.length, 0, 'no plugins should be installed when trust is declined');
 		});
 	});
 });


### PR DESCRIPTION
Adds trust confirmation dialog for agent plugin installations. Trust is scoped per-marketplace and persisted via observableMemento storage. Applies to all source kinds.