### PR TITLE
Copy over .sh scripts in git extension too

### DIFF
--- a/extensions/git/esbuild.mts
+++ b/extensions/git/esbuild.mts
@@ -2,11 +2,26 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { run } from '../esbuild-extension-common.mts';
 
 const srcDir = path.join(import.meta.dirname, 'src');
 const outDir = path.join(import.meta.dirname, 'dist');
+
+async function copyNonTsFiles(outDir: string): Promise<void> {
+	const entries = await fs.readdir(srcDir, { withFileTypes: true, recursive: true });
+	for (const entry of entries) {
+		if (!entry.isFile() || entry.name.endsWith('.ts')) {
+			continue;
+		}
+		const srcPath = path.join(entry.parentPath, entry.name);
+		const relativePath = path.relative(srcDir, srcPath);
+		const destPath = path.join(outDir, relativePath);
+		await fs.mkdir(path.dirname(destPath), { recursive: true });
+		await fs.copyFile(srcPath, destPath);
+	}
+}
 
 run({
 	platform: 'node',
@@ -17,4 +32,4 @@ run({
 	},
 	srcDir,
 	outdir: outDir,
-}, process.argv);
+}, process.argv, copyNonTsFiles);


### PR DESCRIPTION
Fixes #299332 

Restoring previous webpack behavior. In the future let's consider just moving these to the `git/scripts` folder so we don't have to copy them around

Double checked and I think git is the only extension that needs this


