### PR TITLE
fix(terminal): resolved numpad keys reporting 'Unidentified' in TUI apps (Chromium 142 regression)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -36,6 +36,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { ResultKind } from '../../../../platform/keybinding/common/keybindingResolver.js';
+import { IKeyboardLayoutService } from '../../../../platform/keyboardLayout/common/keyboardLayout.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -394,6 +395,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
+		@IKeyboardLayoutService private readonly _keyboardLayoutService: IKeyboardLayoutService,
 	) {
 		super();
 
@@ -1114,6 +1116,17 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			// Disable all input if the terminal is exiting
 			if (this._isExiting) {
 				return false;
+			}
+
+			// Workaround for Chromium 142+ regression where numpad keys report
+			// key: "Unidentified" (chromium issue 405793116). Fix the key property
+			// so xterm.js (especially the Kitty keyboard protocol handler) can
+			// correctly identify numpad keys and generate proper escape sequences.
+			if (event.key === 'Unidentified' && event.code.startsWith('Numpad')) {
+				const fixedKey = this._resolveNumpadKey(event);
+				if (fixedKey) {
+					Object.defineProperty(event, 'key', { value: fixedKey });
+				}
 			}
 
 			const standardKeyboardEvent = new StandardKeyboardEvent(event);
@@ -2031,6 +2044,56 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 		this._onDidChangeShellType.fire(shellType);
 
+	}
+
+	/**
+	 * Maps a numpad KeyboardEvent.code to the correct key value.
+	 * Workaround for Chromium 142+ regression (chromium issue 405793116)
+	 * where numpad keys report key: "Unidentified".
+	 */
+	private _resolveNumpadKey(event: KeyboardEvent): string | undefined {
+		const suffix = event.code.slice(6); // Remove 'Numpad' prefix
+		const numLockOn = event.getModifierState('NumLock');
+
+		// Operator keys produce the same key regardless of NumLock state
+		switch (suffix) {
+			case 'Add': return '+';
+			case 'Subtract': return '-';
+			case 'Multiply': return '*';
+			case 'Divide': return '/';
+			case 'Enter': return 'Enter';
+			case 'Equal': return '=';
+		}
+
+		if (numLockOn) {
+			// NumLock ON: digit keys produce numbers
+			if (suffix >= '0' && suffix <= '9') {
+				return suffix;
+			}
+			if (suffix === 'Decimal') {
+				// Locale-aware: German layouts produce ',' instead of '.'
+				const mapping = this._keyboardLayoutService.getRawKeyboardMapping();
+				const decimalEntry = mapping?.['NumpadDecimal'] as { value?: string } | undefined;
+				return decimalEntry?.value || '.';
+			}
+		} else {
+			// NumLock OFF: digit keys produce navigation keys
+			switch (suffix) {
+				case '0': return 'Insert';
+				case '1': return 'End';
+				case '2': return 'ArrowDown';
+				case '3': return 'PageDown';
+				case '4': return 'ArrowLeft';
+				case '5': return 'Clear';
+				case '6': return 'ArrowRight';
+				case '7': return 'Home';
+				case '8': return 'ArrowUp';
+				case '9': return 'PageUp';
+				case 'Decimal': return 'Delete';
+			}
+		}
+
+		return undefined;
 	}
 
 	private _setAriaLabel(xterm: XTermTerminal | undefined, terminalId: number, title: string | undefined): void {


### PR DESCRIPTION
Fixes #299374

## Summary

Numpad keys (0–9, Enter, Decimal, and operators) are completely ignored by
terminal TUI applications that activate the Kitty keyboard protocol (CSI u /
enhanced keyboard mode) — such as OpenCode, bubbletea-based, and opentui-based
apps — when running inside VS Code 1.110.0's integrated terminal.

The regression was introduced by Electron 39 / Chromium 142 (chromium issue
405793116), which causes numpad `KeyboardEvent` objects to report
`key: "Unidentified"` instead of the correct key value (e.g. `"5"`, `"Enter"`,
`"+"`).

## Root Cause

**Two-path keyboard handling in xterm.js:**

| Scenario | Path | Why numpad worked before |
|---|---|---|
| Normal shell (no enhanced mode) | `keydown` → no match → `keypress`/`input` event fallback sends text | Browser's native fallback still delivers the character |
| Kitty protocol active (TUI app) | `keydown` → xterm.js must produce a CSI u escape sequence | xterm.js reads `ev.key` for identity — gets `"Unidentified"` → drops the event |

When a TUI app activates the Kitty keyboard protocol, xterm.js's
`KittyKeyboard.evaluate()` must produce structured escape sequences (e.g.
`\x1b[57404u` for Numpad5). When `ev.key === "Unidentified"` the key cannot be
identified, `result.key` is left undefined, and the TUI app receives nothing.
The `keypress` fallback path that saves normal shell input is NOT used in Kitty
mode, so strokes are silently dropped.

The `event.code` property (`"Numpad0"–"Numpad9"`, `"NumpadAdd"`,
`"NumpadEnter"`, etc.) is **not** affected by the Chromium regression and
reliably identifies numpad keys.

## Fix

In `terminalInstance.ts`, inside the `attachCustomKeyEventHandler` callback
that runs **before** xterm.js evaluates any event, detect the broken pattern
and restore the correct `key` value:

```typescript
// Workaround for Chromium 142+ regression where numpad keys report
// key: "Unidentified" (chromium issue 405793116)
if (event.key === 'Unidentified' && event.code.startsWith('Numpad')) {
    const fixedKey = this._resolveNumpadKey(event);
    if (fixedKey) {
        Object.defineProperty(event, 'key', { value: fixedKey });
    }
}
```

`_resolveNumpadKey` maps `event.code` → correct `key` string, respecting
NumLock state via `event.getModifierState('NumLock')`:

- **NumLock ON:** `Numpad0`–`Numpad9` → `"0"`–`"9"`, `NumpadDecimal` → `"."`
- **NumLock OFF:** `Numpad0`–`Numpad9` → navigation keys (`Insert`, `End`,
  `ArrowDown`, …), `NumpadDecimal` → `"Delete"`
- **Operators (any NumLock state):** `NumpadAdd` → `"+"`, `NumpadSubtract` →
  `"-"`, `NumpadMultiply` → `"*"`, `NumpadDivide` → `"/"`,
  `NumpadEnter` → `"Enter"`, `NumpadEqual` → `"="`

Patching the property at this layer ensures that **all** downstream consumers
— xterm.js legacy keyboard handler, KittyKeyboard, Win32InputMode, and VS
Code's own keybinding soft-dispatch — see the correct key identity.

## Testing

- Typecheck: `npx tsc --noEmit -p src/tsconfig.json` ✅ (no errors)
- Hygiene: pre-commit hook passed ✅
- Manual: numpad keys in Kitty-protocol TUI apps (OpenCode, bubbletea apps)
  correctly produce input in VS Code integrated terminal

## Affected File

`src/vs/workbench/contrib/terminal/browser/terminalInstance.ts`
+58 lines (11-line inline patch + 47-line private method)
