### PR TITLE
sessions - hide "Open as Editor" and "Open to the Side" in agent sessions window

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,28 +1,4 @@
 {
-	"servers": {
-		"vscode-automation-mcp": {
-			"type": "stdio",
-			"command": "npm",
-			"args": [
-				"run",
-				"start-stdio"
-			],
-			"cwd": "${workspaceFolder}/test/mcp"
-		},
-		"component-explorer": {
-			"type": "stdio",
-			"command": "npx",
-			"cwd": "${workspaceFolder}",
-			"args": [
-				"component-explorer",
-				"mcp",
-				"-c",
-				"./test/componentFixtures/component-explorer.json",
-				"--no-daemon-autostart",
-				"--no-daemon-hint",
-				"Start the daemon by running the 'Launch Component Explorer' VS Code task (use the run_task tool). When you start the task, try up to 4 times to give the daemon enough time to start."
-			]
-		}
-	},
-	"inputs": []
+	"inputs": [],
+	"servers": {}
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,4 +1,28 @@
 {
-	"inputs": [],
-	"servers": {}
+	"servers": {
+		"vscode-automation-mcp": {
+			"type": "stdio",
+			"command": "npm",
+			"args": [
+				"run",
+				"start-stdio"
+			],
+			"cwd": "${workspaceFolder}/test/mcp"
+		},
+		"component-explorer": {
+			"type": "stdio",
+			"command": "npx",
+			"cwd": "${workspaceFolder}",
+			"args": [
+				"component-explorer",
+				"mcp",
+				"-c",
+				"./test/componentFixtures/component-explorer.json",
+				"--no-daemon-autostart",
+				"--no-daemon-hint",
+				"Start the daemon by running the 'Launch Component Explorer' VS Code task (use the run_task tool). When you start the task, try up to 4 times to give the daemon enough time to start."
+			]
+		}
+	},
+	"inputs": []
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -708,7 +708,7 @@ export class OpenAgentSessionInEditorGroupAction extends BaseOpenAgentSessionAct
 					primary: KeyMod.WinCtrl | KeyCode.Enter
 				},
 				weight: KeybindingWeight.WorkbenchContrib + 1,
-				when: ChatContextKeys.agentSessionsViewerFocused,
+				when: ContextKeyExpr.and(ChatContextKeys.agentSessionsViewerFocused, IsSessionsWindowContext.negate()),
 			},
 			menu: {
 				id: MenuId.AgentSessionsContext,
@@ -742,7 +742,7 @@ export class OpenAgentSessionInNewEditorGroupAction extends BaseOpenAgentSession
 					primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Enter
 				},
 				weight: KeybindingWeight.WorkbenchContrib + 1,
-				when: ChatContextKeys.agentSessionsViewerFocused,
+				when: ContextKeyExpr.and(ChatContextKeys.agentSessionsViewerFocused, IsSessionsWindowContext.negate()),
 			},
 			menu: {
 				id: MenuId.AgentSessionsContext,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -28,7 +28,7 @@ import { ChatViewPane } from '../widgetHosts/viewPane/chatViewPane.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { AgentSessionsPicker } from './agentSessionsPicker.js';
-import { ActiveEditorContext } from '../../../../common/contextkeys.js';
+import { ActiveEditorContext, IsSessionsWindowContext } from '../../../../common/contextkeys.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
@@ -712,6 +712,7 @@ export class OpenAgentSessionInEditorGroupAction extends BaseOpenAgentSessionAct
 			},
 			menu: {
 				id: MenuId.AgentSessionsContext,
+				when: IsSessionsWindowContext.negate(),
 				order: 1,
 				group: 'navigation'
 			}
@@ -745,6 +746,7 @@ export class OpenAgentSessionInNewEditorGroupAction extends BaseOpenAgentSession
 			},
 			menu: {
 				id: MenuId.AgentSessionsContext,
+				when: IsSessionsWindowContext.negate(),
 				order: 2,
 				group: 'navigation'
 			}


### PR DESCRIPTION
Hide the "Open as Editor" and "Open to the Side" context menu actions in the Agent Sessions window, as they don't function correctly there.

Adds `when: IsSessionsWindowContext.negate()` to the menu registrations for both `OpenAgentSessionInEditorGroupAction` and `OpenAgentSessionInNewEditorGroupAction`.