### PR TITLE
sessions - allow all workbench commands when `useModal` is `all`

### DIFF
--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -26,7 +26,6 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { EditorPartModalContext, EditorPartModalMaximizedContext, EditorPartModalNavigationContext } from '../../../common/contextkeys.js';
 import { EditorResourceAccessor, SideBySideEditor, Verbosity } from '../../../common/editor.js';
 import { ResourceLabel } from '../../labels.js';
-import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
 import { mainWindow } from '../../../../base/browser/window.js';
@@ -65,7 +64,7 @@ export class ModalEditorPart {
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IHostService private readonly hostService: IHostService,
-		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
 	) {
 	}
 
@@ -89,8 +88,9 @@ export class ModalEditorPart {
 		disposables.add(addDisposableListener(modalElement, EventType.KEY_DOWN, e => {
 			const event = new StandardKeyboardEvent(e);
 
-			// Prevent unsupported commands (not in sessions windows)
-			if (!this.environmentService.isSessionsWindow) {
+			// Prevent unsupported commands unless all editors open in modal
+			const useModal = this.configurationService.getValue<string>('workbench.editor.useModal');
+			if (useModal !== 'all') {
 				const resolved = this.keybindingService.softDispatch(event, this.layoutService.mainContainer);
 				if (resolved.kind === ResultKind.KbFound && resolved.commandId) {
 					if (

--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -85,12 +85,18 @@ export class ModalEditorPart {
 			}
 		}));
 
+		let useModalMode = this.configurationService.getValue<string>('workbench.editor.useModal');
+		disposables.add(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('workbench.editor.useModal')) {
+				useModalMode = this.configurationService.getValue<string>('workbench.editor.useModal');
+			}
+		}));
+
 		disposables.add(addDisposableListener(modalElement, EventType.KEY_DOWN, e => {
 			const event = new StandardKeyboardEvent(e);
 
 			// Prevent unsupported commands unless all editors open in modal
-			const useModal = this.configurationService.getValue<string>('workbench.editor.useModal');
-			if (useModal !== 'all') {
+			if (useModalMode !== 'all') {
 				const resolved = this.keybindingService.softDispatch(event, this.layoutService.mainContainer);
 				if (resolved.kind === ResultKind.KbFound && resolved.commandId) {
 					if (


### PR DESCRIPTION
When `workbench.editor.useModal` is set to `all`, all workbench commands are now allowed in the modal editor overlay. Previously, the command allowlist was only bypassed for the agent sessions window (`isSessionsWindow`). Since `useModal: all` means the user intends to use modal for everything, restricting workbench commands doesn't make sense in that mode.\n\nThis also covers the agent sessions window case since it sets `useModal` to `'all'` via its configuration defaults.

Fixes #299379