### PR TITLE
Sessions: Show repo name with worktree basename in workspace folder label

### DIFF
--- a/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
+++ b/src/vs/sessions/contrib/workspace/browser/workspaceFolderManagement.ts
@@ -68,7 +68,7 @@ export class WorkspaceFolderManagementContribution extends Disposable implements
 		if (session.worktree) {
 			return {
 				uri: session.worktree,
-				name: session.repository ? `${this.uriIdentityService.extUri.basename(session.repository)} (worktree)` : undefined
+				name: session.repository ? `${this.uriIdentityService.extUri.basename(session.repository)} (${this.uriIdentityService.extUri.basename(session.worktree)})` : this.uriIdentityService.extUri.basename(session.worktree)
 			};
 		}
 


### PR DESCRIPTION
When adding a folder to workspace for a worktree in the Sessions window, show the repository name with the worktree basename in brackets (e.g. `vscode (copilot-evil-koi)`) instead of just showing `worktree` in brackets.