### PR TITLE
update selection background colors in 2026 dark and light themes for better visibility

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -110,7 +110,7 @@
 		"editorLineNumber.foreground": "#858889",
 		"editorLineNumber.activeForeground": "#BBBEBF",
 		"editorCursor.foreground": "#BBBEBF",
-		"editor.selectionBackground": "#27678280",
+		"editor.selectionBackground": "#276782dd",
 		"editor.inactiveSelectionBackground": "#27678260",
 		"editor.selectionHighlightBackground": "#27678260",
 		"editor.wordHighlightBackground": "#27678250",

--- a/extensions/theme-2026/themes/2026-light.json
+++ b/extensions/theme-2026/themes/2026-light.json
@@ -116,7 +116,7 @@
 		"editorLineNumber.foreground": "#606060",
 		"editorLineNumber.activeForeground": "#202020",
 		"editorCursor.foreground": "#202020",
-		"editor.selectionBackground": "#0069CC1A",
+		"editor.selectionBackground": "#0069CC40",
 		"editor.inactiveSelectionBackground": "#0069CC1A",
 		"editor.selectionHighlightBackground": "#0069CC15",
 		"editor.wordHighlightBackground": "#0069CC26",


### PR DESCRIPTION
This pull request makes minor adjustments to the selection background color opacity in both the dark and light 2026 theme JSON files to improve editor selection visibility.

- Theme color adjustments:
  * Increased the opacity of `editor.selectionBackground` in `2026-dark.json` for better contrast when selecting text.
  * Increased the opacity of `editor.selectionBackground` in `2026-light.json` for improved selection visibility.