### PR TITLE
Make disabledForeground color darker in 2026 Dark theme

### DIFF
--- a/extensions/theme-2026/themes/2026-dark.json
+++ b/extensions/theme-2026/themes/2026-dark.json
@@ -5,7 +5,7 @@
 	"type": "dark",
 	"colors": {
 		"foreground": "#bfbfbf",
-		"disabledForeground": "#666666",
+		"disabledForeground": "#555555",
 		"errorForeground": "#f48771",
 		"descriptionForeground": "#8C8C8C",
 		"icon.foreground": "#8C8C8C",


### PR DESCRIPTION
Updated the `disabledForeground` color in the 2026 Dark theme for improved visibility. Test by applying the theme and verifying the color change in the UI.

Addresses: https://github.com/microsoft/vscode/issues/299066

