### PR TITLE
Fix variable updating after set response

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -246,7 +246,8 @@ function handleSetResponse(expression: ExpressionContainer, response: DebugProto
 		expression.reference = response.body.variablesReference;
 		expression.namedVariables = response.body.namedVariables;
 		expression.indexedVariables = response.body.indexedVariables;
-		// todo @weinand: the set responses contain most properties, but not memory references. Should they?
+		expression.memoryReference = response.body.memoryReference;
+		expression.valueLocationReference = response.body.valueLocationReference;
 	}
 }
 


### PR DESCRIPTION
To be honest good DAP implementation should send `Invalidated` event after `setVariable` request, so all variables will be refetched and properties will be updated. But I guess it would be better to always update these fields in VS Code. 
