### PR TITLE
sessions - do not steal focus when auto-opening changes view

### DIFF
--- a/src/vs/sessions/contrib/changesView/browser/toggleChangesView.ts
+++ b/src/vs/sessions/contrib/changesView/browser/toggleChangesView.ts
@@ -110,7 +110,7 @@ export class ToggleChangesViewContribution extends Disposable {
 
 	private syncAuxiliaryBarVisibility(hasChanges: boolean): void {
 		if (hasChanges) {
-			this.viewsService.openView(CHANGES_VIEW_ID, true);
+			this.viewsService.openView(CHANGES_VIEW_ID, false);
 		} else {
 			this.layoutService.setPartHidden(true, Parts.AUXILIARYBAR_PART);
 		}


### PR DESCRIPTION
When the changes view is automatically opened (e.g. after a turn completes with new changes, or when switching sessions), it should not steal focus from the chat. Only the explicit user action (clicking the Changes button) should focus the view.

Fix: pass `false` instead of `true` to `openView` in `syncAuxiliaryBarVisibility`, so the view opens without taking focus. The `OpenChangesViewAction` (user-initiated) still correctly passes `true` to focus.