### PR TITLE
sessions - fix chat input shrinking at narrow widths

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -68,6 +68,7 @@
 }
 
 .agent-sessions-workbench .interactive-session .interactive-input-part {
+	width: 100%;
 	max-width: 950px;
 	margin: 0 auto !important;
 	display: inherit !important;


### PR DESCRIPTION
The commit b5d4de9c3c that moved the scrollbar to the right removed `max-width` from `.interactive-session` and applied it to individual children with `margin: 0 auto`. This caused `.interactive-input-part` to no longer stretch to fill its parent, so elements like the model picker would overflow instead of shrinking.

Adds `width: 100%` to the `.interactive-input-part` rule so it fills the available space (capped by `max-width: 950px`) and shrinks properly at narrow widths.