### PR TITLE
chat: register file system provider via workbench contribution

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -37,7 +37,7 @@ import '../common/widget/chatColors.js';
 import { IChatEditingService } from '../common/editing/chatEditingService.js';
 import { IChatLayoutService } from '../common/widget/chatLayoutService.js';
 import { ChatModeService, IChatMode, IChatModeService } from '../common/chatModes.js';
-import { ChatResponseResourceFileSystemProvider, IChatResponseResourceFileSystemProvider } from '../common/widget/chatResponseResourceFileSystemProvider.js';
+import { ChatResponseResourceFileSystemProvider, ChatResponseResourceWorkbenchContribution, IChatResponseResourceFileSystemProvider } from '../common/widget/chatResponseResourceFileSystemProvider.js';
 import { IChatService } from '../common/chatService/chatService.js';
 import { ChatService } from '../common/chatService/chatServiceImpl.js';
 import { IChatSessionsService } from '../common/chatSessionsService.js';
@@ -1747,9 +1747,9 @@ registerWorkbenchContribution2(SimpleBrowserOverlay.ID, SimpleBrowserOverlay, Wo
 registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEditorContextKeys, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatTransferContribution.ID, ChatTransferContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatContextContributions.ID, ChatContextContributions, WorkbenchPhase.AfterRestored);
-registerSingleton(IChatResponseResourceFileSystemProvider, ChatResponseResourceFileSystemProvider, InstantiationType.Eager);
 registerWorkbenchContribution2(PromptUrlHandler.ID, PromptUrlHandler, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatEditingNotebookFileSystemProviderContrib.ID, ChatEditingNotebookFileSystemProviderContrib, WorkbenchPhase.BlockStartup);
+registerWorkbenchContribution2(ChatResponseResourceWorkbenchContribution.ID, ChatResponseResourceWorkbenchContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(UserToolSetsContributions.ID, UserToolSetsContributions, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(PromptLanguageFeaturesProvider.ID, PromptLanguageFeaturesProvider, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(ChatWindowNotifier.ID, ChatWindowNotifier, WorkbenchPhase.AfterRestored);
@@ -1785,6 +1785,7 @@ registerEditorFeature(ChatPasteProvidersFeature);
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(ConfiguredAgentPluginDiscovery));
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(MarketplaceAgentPluginDiscovery));
 
+registerSingleton(IChatResponseResourceFileSystemProvider, ChatResponseResourceFileSystemProvider, InstantiationType.Delayed);
 registerSingleton(IChatTransferService, ChatTransferService, InstantiationType.Delayed);
 registerSingleton(IChatService, ChatService, InstantiationType.Delayed);
 registerSingleton(IChatWidgetService, ChatWidgetService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/common/widget/chatResponseResourceFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/chatResponseResourceFileSystemProvider.ts
@@ -11,14 +11,15 @@ import { newWriteableStream, ReadableStreamEvents } from '../../../../../base/co
 import { URI } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
-import { createFileSystemProviderError, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileService, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileReadStreamCapability, IFileSystemProviderWithFileReadWriteCapability, IStat } from '../../../../../platform/files/common/files.js';
+import { createFileSystemProviderError, FileSystemProviderCapabilities, FileSystemProviderErrorCode, FileType, IFileService, IFileSystemProvider, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileReadStreamCapability, IFileSystemProviderWithFileReadWriteCapability, IStat } from '../../../../../platform/files/common/files.js';
+import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { ChatResponseResource } from '../model/chatModel.js';
 import { IChatService, IChatToolInvocation, IChatToolInvocationSerialized } from '../chatService/chatService.js';
 import { isToolResultInputOutputDetails } from '../tools/languageModelToolsService.js';
 
 export const IChatResponseResourceFileSystemProvider = createDecorator<IChatResponseResourceFileSystemProvider>('chatResponseResourceFileSystemProvider');
 
-export interface IChatResponseResourceFileSystemProvider {
+export interface IChatResponseResourceFileSystemProvider extends IFileSystemProvider {
 	readonly _serviceBrand: undefined;
 
 	/**
@@ -59,7 +60,6 @@ export class ChatResponseResourceFileSystemProvider extends Disposable implement
 		@IFileService private readonly _fileService: IFileService
 	) {
 		super();
-		this._register(this._fileService.registerProvider(ChatResponseResource.scheme, this));
 		this._register(this.chatService.onDidDisposeSession(e => {
 			for (const sessionResource of e.sessionResource) {
 				const uris = this._sessionAssociations.get(sessionResource);
@@ -185,5 +185,18 @@ export class ChatResponseResourceFileSystemProvider extends Disposable implement
 		}
 
 		return part.isText ? new TextEncoder().encode(part.value) : decodeBase64(part.value).buffer;
+	}
+}
+
+export class ChatResponseResourceWorkbenchContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'chatResponseResourceWorkbenchContribution';
+
+	constructor(
+		@IChatResponseResourceFileSystemProvider chatResponseResourceFsProvider: IChatResponseResourceFileSystemProvider,
+		@IFileService fileService: IFileService,
+	) {
+		super();
+		this._register(fileService.registerProvider(ChatResponseResource.scheme, chatResponseResourceFsProvider));
 	}
 }


### PR DESCRIPTION
- Moves the registerProvider call from ChatResponseResourceFileSystemProvider constructor
  to a new ChatResponseResourceWorkbenchContribution class that gets instantiated by
  the workbench. This ensures the vscode-chat-response-resource:// file system provider
  is registered even though the service has no other dependencies that would trigger
  eager instantiation.
- Changes the singleton registration from Eager to Delayed since the workbench
  contribution now depends on it, triggering instantiation.
- Fixes file system provider not being found errors (ENOPRO) when MCPs or extensions
  try to access chat response resources.

Refs #299504

(Commit message generated by Copilot)