### PR TITLE
fix chat question height

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -331,6 +331,17 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			return;
 		}
 
+		// Clear stale size constraints first so this step can shrink after
+		// navigating from a taller question.
+		if (scrollableNode.style.height !== '' || scrollableNode.style.maxHeight !== '') {
+			scrollableNode.style.height = '';
+			scrollableNode.style.maxHeight = '';
+		}
+		if (scrollableContent.style.height !== '' || scrollableContent.style.maxHeight !== '') {
+			scrollableContent.style.height = '';
+			scrollableContent.style.maxHeight = '';
+		}
+
 		// Use the flex-resolved container height (constrained by CSS max-height)
 		// instead of window.innerHeight, so the scroll viewport tracks actual chat space.
 		const maxContainerHeight = this._questionContainer.clientHeight;
@@ -345,12 +356,19 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			.reduce((sum, child) => sum + (child as HTMLElement).offsetHeight, 0);
 
 		const availableScrollableHeight = Math.floor(maxContainerHeight - contentVerticalPadding - nonScrollableContentHeight);
-		const constrainedScrollableHeight = Math.max(0, availableScrollableHeight);
+
+		const contentScrollableHeight = scrollableContent.scrollHeight;
+		const constrainedScrollableHeight = Math.max(0, Math.min(availableScrollableHeight, contentScrollableHeight));
 		const constrainedScrollableHeightPx = `${constrainedScrollableHeight}px`;
+
+		// Constrain wrapper + content so no stale flex sizing survives between steps.
+		if (scrollableNode.style.height !== constrainedScrollableHeightPx || scrollableNode.style.maxHeight !== constrainedScrollableHeightPx) {
+			scrollableNode.style.height = constrainedScrollableHeightPx;
+			scrollableNode.style.maxHeight = constrainedScrollableHeightPx;
+		}
 
 		// Constrain the content element (DomScrollableElement._element) so that
 		// scanDomNode sees clientHeight < scrollHeight and enables scrolling.
-		// The wrapper inherits the same constraint via CSS flex.
 		if (scrollableContent.style.height !== constrainedScrollableHeightPx || scrollableContent.style.maxHeight !== constrainedScrollableHeightPx) {
 			scrollableContent.style.height = constrainedScrollableHeightPx;
 			scrollableContent.style.maxHeight = constrainedScrollableHeightPx;
@@ -582,6 +600,14 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		inputScrollableNode.classList.add('chat-question-input-scrollable');
 		this._questionContainer.appendChild(inputScrollableNode);
 
+		// Render footer before first layout so the scrollable area is measured against
+		// its final available height and does not visibly resize twice.
+		if (!isSingleQuestion) {
+			this.renderFooter();
+		} else {
+			this.renderSingleQuestionFooter();
+		}
+
 		let relayoutScheduled = false;
 		const relayoutScheduler = questionRenderStore.add(new MutableDisposable());
 		const scheduleLayoutInputScrollable = () => {
@@ -600,20 +626,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		questionRenderStore.add(inputResizeObserver.observe(inputScrollableNode));
 		questionRenderStore.add(inputResizeObserver.observe(inputContainer));
 		scheduleLayoutInputScrollable();
-		this.layoutInputScrollable(inputScrollable);
 		questionRenderStore.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(this.domNode), () => {
 			inputContainer.scrollTop = 0;
 			inputContainer.scrollLeft = 0;
 			inputScrollable.setScrollPosition({ scrollTop: 0, scrollLeft: 0 });
 			inputScrollable.scanDomNode();
 		}));
-
-		// Render footer for multi-question carousels or single-question carousels.
-		if (!isSingleQuestion) {
-			this.renderFooter();
-		} else {
-			this.renderSingleQuestionFooter();
-		}
 
 		// Update aria-label to reflect the current question
 		this._updateAriaLabel();


### PR DESCRIPTION
fix #299556

Adjusted the question part so each question step sizes to its real content (not max space), clears stale height constraints between steps, and lays out footer before first measurement to eliminate leftover blank space and double-resize jank.

https://github.com/user-attachments/assets/797be696-86b3-4aff-8c09-50621e5b1a6e

