### PR TITLE
editor: add experimental fold header detection for sticky scroll

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3136,6 +3136,14 @@ export interface IEditorStickyScrollOptions {
 	 * Define whether to scroll sticky scroll with editor horizontal scrollbae
 	 */
 	scrollWithEditor?: boolean;
+	/**
+	 * Use heuristics to find a more meaningful scope header by walking back from
+	 * the raw fold-start line. Handles Allman-style braces, trailing return types
+	 * (`-> T`) on their own line, and multi-line signatures. Best-effort;
+	 * primarily designed for C++ and Rust. Has no effect on languages that do not
+	 * use brace-delimited blocks.
+	 */
+	foldHeaderDetection?: boolean;
 }
 
 /**
@@ -3146,7 +3154,7 @@ export type EditorStickyScrollOptions = Readonly<Required<IEditorStickyScrollOpt
 class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEditorStickyScrollOptions, EditorStickyScrollOptions> {
 
 	constructor() {
-		const defaults: EditorStickyScrollOptions = { enabled: true, maxLineCount: 5, defaultModel: 'outlineModel', scrollWithEditor: true };
+		const defaults: EditorStickyScrollOptions = { enabled: true, maxLineCount: 5, defaultModel: 'outlineModel', scrollWithEditor: true, foldHeaderDetection: false };
 		super(
 			EditorOption.stickyScroll, 'stickyScroll', defaults,
 			{
@@ -3173,6 +3181,12 @@ class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEd
 					default: defaults.scrollWithEditor,
 					description: nls.localize('editor.stickyScroll.scrollWithEditor', "Enable scrolling of Sticky Scroll with the editor's horizontal scrollbar.")
 				},
+				'editor.stickyScroll.foldHeaderDetection': {
+					type: 'boolean',
+					default: defaults.foldHeaderDetection,
+					tags: ['experimental'],
+					description: nls.localize('editor.stickyScroll.foldHeaderDetection', "Walk back from the raw fold-start line to find a more meaningful scope header. Handles Allman-style braces, trailing return types on their own line, and multi-line function signatures. Best-effort heuristic; primarily designed for C++ and Rust.")
+				},
 			}
 		);
 	}
@@ -3186,7 +3200,8 @@ class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEd
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			maxLineCount: EditorIntOption.clampedInt(input.maxLineCount, this.defaultValue.maxLineCount, 1, 20),
 			defaultModel: stringSet<'outlineModel' | 'foldingProviderModel' | 'indentationModel'>(input.defaultModel, this.defaultValue.defaultModel, ['outlineModel', 'foldingProviderModel', 'indentationModel']),
-			scrollWithEditor: boolean(input.scrollWithEditor, this.defaultValue.scrollWithEditor)
+			scrollWithEditor: boolean(input.scrollWithEditor, this.defaultValue.scrollWithEditor),
+			foldHeaderDetection: boolean(input.foldHeaderDetection, this.defaultValue.foldHeaderDetection)
 		};
 	}
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
@@ -16,6 +16,7 @@ import { ILanguageConfigurationService } from '../../../common/languages/languag
 import { FoldingRegions } from '../../folding/browser/foldingRanges.js';
 import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { StickyElement, StickyModel, StickyRange } from './stickyScrollElement.js';
+import { ITextModel } from '../../../common/model.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { EditorOption } from '../../../common/config/editorOptions.js';
@@ -320,8 +321,8 @@ abstract class StickyModelFromCandidateFoldingProvider extends StickyModelCandid
 	}
 
 	protected createStickyModel(token: CancellationToken, model: FoldingRegions): StickyModel {
-		const foldingElement = this._fromFoldingRegions(model);
 		const textModel = this._editor.getModel();
+		const foldingElement = this._fromFoldingRegions(model, textModel);
 		return new StickyModel(textModel.uri, textModel.getVersionId(), foldingElement, undefined);
 	}
 
@@ -329,40 +330,94 @@ abstract class StickyModelFromCandidateFoldingProvider extends StickyModelCandid
 		return model !== null;
 	}
 
-
-	private _fromFoldingRegions(foldingRegions: FoldingRegions): StickyElement {
-		const length = foldingRegions.length;
+	private _fromFoldingRegions(foldingRegions: FoldingRegions, textModel: ITextModel): StickyElement {
+		const foldHeaderDetection = this._editor.getOption(EditorOption.stickyScroll).foldHeaderDetection;
 		const orderedStickyElements: StickyElement[] = [];
+		const root = new StickyElement(undefined, [], undefined);
 
-		// The root sticky outline element
-		const stickyOutlineElement = new StickyElement(
-			undefined,
-			[],
-			undefined
-		);
-
-		for (let i = 0; i < length; i++) {
-			// Finding the parent index of the current range
+		for (let i = 0; i < foldingRegions.length; i++) {
 			const parentIndex = foldingRegions.getParentIndex(i);
+			const parentNode = parentIndex !== -1 ? orderedStickyElements[parentIndex] : root;
+			const parentStart = parentIndex !== -1 ? foldingRegions.getStartLineNumber(parentIndex) : 1;
+			const foldStart = foldingRegions.getStartLineNumber(i);
 
-			let parentNode;
-			if (parentIndex !== -1) {
-				// Access the reference of the parent node
-				parentNode = orderedStickyElements[parentIndex];
-			} else {
-				// In that case the parent node is the root node
-				parentNode = stickyOutlineElement;
-			}
+			const headerLine = foldHeaderDetection
+				? this._findFoldHeaderLine(textModel, foldStart, parentStart)
+				: foldStart;
 
 			const child = new StickyElement(
-				new StickyRange(foldingRegions.getStartLineNumber(i), foldingRegions.getEndLineNumber(i) + 1),
+				new StickyRange(headerLine, foldingRegions.getEndLineNumber(i) + 1),
 				[],
 				parentNode
 			);
 			parentNode.children.push(child);
 			orderedStickyElements.push(child);
 		}
-		return stickyOutlineElement;
+		return root;
+	}
+
+	/**
+	 * Maximum number of lines to scan upward when searching for the opening
+	 * bracket of a multi-line signature. Kept small to avoid crossing into
+	 * unrelated scopes in pathological files.
+	 */
+	private static readonly _SIGNATURE_SCAN_LIMIT = 15;
+
+	/**
+	 * Given the raw fold-start line, walks upward to find the line that best
+	 * represents the scope header (e.g. the function-name line rather than a
+	 * lone Allman `{`), then delegates to {@link _findSignatureOpeningLine} to
+	 * handle multi-line signatures.
+	 */
+	private _findFoldHeaderLine(textModel: ITextModel, foldStart: number, parentStart: number): number {
+		// Walk past a lone Allman `{` and any blank lines above it.
+		let line = foldStart;
+		while (line > 1 && textModel.getLineContent(line).trim() === '{') { line--; }
+		while (line > 1 && textModel.getLineContent(line).trim() === '') { line--; }
+
+		// If the walk overshot into a lone `}` (e.g. an orphaned `{` block with
+		// no signature above it), give up and show the raw fold-start line.
+		if (textModel.getLineContent(line).trim() === '}') { return foldStart; }
+
+		// Walk past trailing-return-type continuation lines (`-> ReturnType`).
+		// This is a best-effort heuristic for languages like C++ and Rust where
+		// a trailing return type may appear on its own line between `)` and `{`.
+		while (line > 1 && textModel.getLineContent(line).trim().startsWith('->')) { line--; }
+		while (line > 1 && textModel.getLineContent(line).trim() === '') { line--; }
+
+		const lowerBound = Math.max(parentStart, line - StickyModelFromCandidateFoldingProvider._SIGNATURE_SCAN_LIMIT);
+		return this._findSignatureOpeningLine(textModel, line, lowerBound);
+	}
+
+	/**
+	 * Scans right-to-left from `startLine` down to `lowerBound` looking for
+	 * the line that contains the **outermost** unmatched `(` or `[` — i.e. the
+	 * line where a multi-line signature opens. Returns `startLine` unchanged
+	 * when no multi-line signature is detected (single-line declaration or
+	 * no-paren scope).
+	 *
+	 * **Limitation:** The scanner operates on raw character content and is not
+	 * aware of string literals or comments. A `(` inside a comment or string
+	 * above `startLine` could be misidentified as a signature opener. The
+	 * {@link _SIGNATURE_SCAN_LIMIT} bound and the depth-zero early-break on the
+	 * first scanned line keep the practical exposure small.
+	 */
+	private _findSignatureOpeningLine(textModel: ITextModel, startLine: number, lowerBound: number): number {
+		let depth = 0;
+		for (let line = startLine; line >= lowerBound; line--) {
+			const content = textModel.getLineContent(line);
+			for (let col = content.length - 1; col >= 0; col--) {
+				const ch = content[col];
+				if (ch === ')' || ch === ']') { depth++; }
+				else if (ch === '(' || ch === '[') {
+					if (--depth === 0) { return line; }
+				}
+			}
+			// No unmatched `)` on the first scanned line means there is no
+			// multi-line signature to walk back through.
+			if (line === startLine && depth === 0) { break; }
+		}
+		return startLine;
 	}
 }
 

--- a/src/vs/editor/contrib/stickyScroll/test/browser/stickyScroll.test.ts
+++ b/src/vs/editor/contrib/stickyScroll/test/browser/stickyScroll.test.ts
@@ -359,4 +359,180 @@ suite('Sticky Scroll Tests', () => {
 			});
 		});
 	});
+
+	// Folding-based header detection
+
+	// Uses the suite-level `serviceCollection` defined at the top of this suite.
+	async function withIndentProvider(
+		lines: string[],
+		callback: (provider: StickyLineCandidateProvider) => void | Promise<void>
+	): Promise<void> {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const model = createTextModel(lines.join('\n'));
+			await withAsyncTestCodeEditor(model, {
+				stickyScroll: { enabled: true, maxLineCount: 10, defaultModel: 'indentationModel', foldHeaderDetection: true },
+				envConfig: { outerHeight: 500 },
+				serviceCollection,
+			}, async (editor, _viewModel, instantiationService) => {
+				const provider = new StickyLineCandidateProvider(
+					editor,
+					instantiationService.get(ILanguageFeaturesService),
+					instantiationService.get(ILanguageConfigurationService),
+				);
+				await provider.update();
+				await callback(provider);
+				provider.dispose();
+				model.dispose();
+			});
+		});
+	}
+
+	function stickyAt(provider: StickyLineCandidateProvider, line: number): number[] {
+		return provider
+			.getCandidateStickyLinesIntersecting({ startLineNumber: line, endLineNumber: line })
+			.map(c => c.startLineNumber);
+	}
+
+	test('folding: Allman brace, single-line signature shows the header line', () =>
+		withIndentProvider([
+			'void foo(int x)',   // 1
+			'{',                 // 2
+			'    code();',       // 3
+			'}',                 // 4
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 3), [1]);
+		})
+	);
+
+	test('folding: Allman brace, multi-line signature shows the opening ( line', () =>
+		withIndentProvider([
+			'void foo(',         // 1
+			'    int x,',        // 2
+			'    int y)',        // 3
+			'{',                 // 4
+			'    code();',       // 5
+			'}',                 // 6
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 5), [1]);
+		})
+	);
+
+	test('folding: K&R style, fold start is already the scope header line', () =>
+		withIndentProvider([
+			'function foo() {',  // 1
+			'    code();',       // 2
+			'}',                 // 3
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 2), [1]);
+		})
+	);
+
+	test('folding: no-parens scope (namespace) shows the keyword line', () =>
+		withIndentProvider([
+			'namespace Foo',     // 1
+			'{',                 // 2
+			'    int x = 1;',   // 3
+			'}',                 // 4
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 3), [1]);
+		})
+	);
+
+	test('folding: trailing return type on own line, shows the opening ( line', () =>
+		withIndentProvider([
+			'auto foo(',         // 1
+			'    int x)',        // 2
+			'    -> int',        // 3
+			'{',                 // 4
+			'    code();',       // 5
+			'}',                 // 6
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 5), [1]);
+		})
+	);
+
+	test('folding: trailing return type after ) const, does not show -> line (regression)', () =>
+		withIndentProvider([
+			'auto foo(int x) const',  // 1
+			'    -> int',             // 2
+			'{',                      // 3
+			'    code();',            // 4
+			'}',                      // 5
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 4), [1]);
+		})
+	);
+
+	test('folding: multi-line if condition shows the if( line', () =>
+		withIndentProvider([
+			'if (condition1',       // 1
+			'    && condition2)',   // 2
+			'{',                    // 3
+			'    code();',          // 4
+			'}',                    // 5
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 4), [1]);
+		})
+	);
+
+	test('folding: nested Allman scopes show correct headers at both levels', () =>
+		withIndentProvider([
+			'class Outer',      // 1
+			'{',                // 2
+			'    void foo()',   // 3
+			'    {',            // 4
+			'        code();',  // 5
+			'    }',            // 6
+			'}',                // 7
+		], provider => {
+			assert.deepStrictEqual(stickyAt(provider, 5), [1, 3]);
+		})
+	);
+
+	test('folding: walk-back safety — does not show } when overshoot occurs', () =>
+		withIndentProvider([
+			'void foo() {',  // 1
+			'    prior();',  // 2
+			'}',             // 3
+			'',              // 4
+			'{',             // 5
+			'    code();',   // 6
+			'}',             // 7
+		], provider => {
+			assert.ok(!stickyAt(provider, 6).includes(3), 'should not show } on line 3 as a scope header');
+		})
+	);
+
+	test('folding (syntax provider): Allman brace walks back to signature line', () => {
+		return runWithFakedTimers({ useFakeTimers: true }, async () => {
+			const model = createTextModel([
+				'void foo(int x)',  // 1
+				'{',               // 2
+				'    code();',     // 3
+				'}',               // 4
+				'',                // 5 — trailing line so StickyRange(1,5) is valid
+			].join('\n'));
+			await withAsyncTestCodeEditor(model, {
+				stickyScroll: { enabled: true, maxLineCount: 10, defaultModel: 'foldingProviderModel', foldHeaderDetection: true },
+				envConfig: { outerHeight: 500 },
+				serviceCollection,
+			}, async (editor, _viewModel, instantiationService) => {
+				const languageService = instantiationService.get(ILanguageFeaturesService);
+				// Register a mock syntax folding provider: lines 2–4 form one fold.
+				disposables.add(languageService.foldingRangeProvider.register('*', {
+					provideFoldingRanges: (_model, _context, _token) => [{ start: 2, end: 4 }]
+				}));
+				const provider = new StickyLineCandidateProvider(
+					editor, languageService, instantiationService.get(ILanguageConfigurationService)
+				);
+				await provider.update();
+				const sticky = provider
+					.getCandidateStickyLinesIntersecting({ startLineNumber: 3, endLineNumber: 3 })
+					.map(c => c.startLineNumber);
+				assert.deepStrictEqual(sticky, [1]);
+				provider.dispose();
+				model.dispose();
+			});
+		});
+	});
 });

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4473,6 +4473,14 @@ declare namespace monaco.editor {
 		 * Define whether to scroll sticky scroll with editor horizontal scrollbae
 		 */
 		scrollWithEditor?: boolean;
+		/**
+		 * Use heuristics to find a more meaningful scope header by walking back from
+		 * the raw fold-start line. Handles Allman-style braces, trailing return types
+		 * (`-> T`) on their own line, and multi-line signatures. Best-effort;
+		 * primarily designed for C++ and Rust. Has no effect on languages that do not
+		 * use brace-delimited blocks.
+		 */
+		foldHeaderDetection?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #238568

Introduces `editor.stickyScroll.foldHeaderDetection` - an opt-in experimental boolean (default `false`) that makes folding-based sticky scroll providers walk back from the raw fold-start line to find a more meaningful scope header.

**What it does when enabled:**

- Walks past lone Allman-style `{` lines and any blank lines above them
- Walks past trailing return-type lines (`-> ReturnType`) that appear between `)` and `{` in C++/Rust
- Performs a right-to-left bracket scan (up to 15 lines back) to resolve multi-line signatures to their opening `(` line

**Result:** instead of the sticky strip showing stacked `{` characters, it shows the actual declaration — `void foo(int x, int y)` or the `if (` that opened a multi-line condition.

**What it does not change:**
- K&R style (`void foo() {`) - fold start is already the header line, no walk-back occurs
- Python, JSON, etc. - no standalone `{` lines, no walk-back triggered
- Default behaviour - flag is `false`, zero impact on existing users

## Scope

| File | Change |
|---|---|
| `src/vs/editor/common/config/editorOptions.ts` | New `foldHeaderDetection` field, default, schema entry with `tags: ['experimental']`, validate |
| `src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts` | Guard heuristic behind flag in `_fromFoldingRegions`; extracted helpers `_findFoldHeaderLine` and `_findSignatureOpeningLine` with full JSDoc |
| `src/vs/editor/contrib/stickyScroll/test/browser/stickyScroll.test.ts` | 9 indentation-model tests + 1 syntax-provider smoke test covering Allman braces, multi-line signatures, trailing return types, nested scopes, and walk-back safety |
| `src/vs/monaco.d.ts` | Public API surface updated to include new interface field |

## Test plan

- [x] Open a C++ file with Allman-style braces - with flag `false` (default), sticky scroll unchanged
- [x] Set `"editor.stickyScroll.foldHeaderDetection": true` - sticky strip walks back to function signature lines
- [x] Search `stickyScroll` in Settings UI - new entry appears tagged **(Experimental)**