### PR TITLE
sessions: add built-in prompt files with override support

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -100,6 +100,7 @@ const vscodeResourceIncludes = [
 
 	// Sessions
 	'out-build/vs/sessions/contrib/chat/browser/media/*.svg',
+	'out-build/vs/sessions/prompts/*.prompt.md',
 
 	// Extensions
 	'out-build/vs/workbench/contrib/extensions/browser/media/{theme-icon.png,language-icon.svg}',

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -90,8 +90,20 @@ The shared `applyStorageSourceFilter()` helper applies this filter to any `{uri,
 Sessions overrides `PromptsService` via `AgenticPromptsService` (in `promptsService.ts`):
 
 - **Discovery**: `AgenticPromptFilesLocator` scopes workspace folders to the active session's worktree
+- **Built-in prompts**: Discovers bundled `.prompt.md` files from `vs/sessions/prompts/` and surfaces them with `PromptsStorage.builtin` storage type
+- **User override**: Built-in prompts are omitted when a user or workspace prompt with the same name exists
 - **Creation targets**: `getSourceFolders()` override replaces VS Code profile user roots with `~/.copilot/{subfolder}` for CLI compatibility
 - **Hook folders**: Falls back to `.github/hooks` in the active worktree
+
+### Built-in Prompts
+
+Prompt files bundled with the Sessions app live in `src/vs/sessions/prompts/`. They are:
+
+- Discovered at runtime via `FileAccess.asFileUri('vs/sessions/prompts')`
+- Tagged with `PromptsStorage.builtin` storage type
+- Shown in a "Built-in" group in the AI Customization tree view and management editor
+- Filtered out when a user/workspace prompt shares the same clean name (override behavior)
+- Included in storage filters for prompts and CLI-user types
 
 ### Count Consistency
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -80,7 +80,7 @@ interface IAICustomizationGroupItem {
 	readonly type: 'group';
 	readonly id: string;
 	readonly label: string;
-	readonly storage: PromptsStorage;
+	readonly storage: AICustomizationPromptsStorage;
 	readonly promptType: PromptsType;
 	readonly icon: ThemeIcon;
 }
@@ -94,7 +94,7 @@ interface IAICustomizationFileItem {
 	readonly uri: URI;
 	readonly name: string;
 	readonly description?: string;
-	readonly storage: PromptsStorage;
+	readonly storage: AICustomizationPromptsStorage;
 	readonly promptType: PromptsType;
 }
 
@@ -442,7 +442,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 			type: 'group',
 			id: `group-${promptType}-${storageSuffixes[storage]}`,
 			label: storageLabels[storage],
-			storage: storage as PromptsStorage,
+			storage,
 			promptType,
 			icon: storageIcons[storage],
 		};
@@ -452,7 +452,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 	 * Returns files for a specific storage/type combination from cache.
 	 * getStorageGroups must be called first to populate the cache.
 	 */
-	private async getFilesForStorageAndType(storage: PromptsStorage, promptType: PromptsType): Promise<IAICustomizationFileItem[]> {
+	private async getFilesForStorageAndType(storage: AICustomizationPromptsStorage, promptType: PromptsType): Promise<IAICustomizationFileItem[]> {
 		const cached = this.cache.get(promptType);
 
 		// For skills, use the cached skills data

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -29,7 +29,7 @@ import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../..
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon, builtinIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
-import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection, AICustomizationPromptsStorage, BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer, ITreeContextMenuEvent } from '../../../../base/browser/ui/tree/tree.js';
@@ -234,7 +234,7 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
  */
 interface ICachedTypeData {
 	skills?: IAgentSkill[];
-	files?: Map<PromptsStorage, readonly IPromptPath[]>;
+	files?: Map<string, readonly IPromptPath[]>;
 }
 
 /**
@@ -377,7 +377,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);
 			const builtinItems = allItems.filter(item => item.storage === BUILTIN_STORAGE);
 
-			cached.files = new Map<PromptsStorage, readonly IPromptPath[]>([
+			cached.files = new Map<string, readonly IPromptPath[]>([
 				[PromptsStorage.local, workspaceItems],
 				[PromptsStorage.user, userItems],
 				[PromptsStorage.extension, extensionItems],
@@ -413,7 +413,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 	/**
 	 * Creates a group item with consistent structure.
 	 */
-	private createGroupItem(promptType: PromptsType, storage: PromptsStorage, count: number): IAICustomizationGroupItem {
+	private createGroupItem(promptType: PromptsType, storage: AICustomizationPromptsStorage, count: number): IAICustomizationGroupItem {
 		const storageLabels: Record<string, string> = {
 			[PromptsStorage.local]: localize('workspaceWithCount', "Workspace ({0})", count),
 			[PromptsStorage.user]: localize('userWithCount', "User ({0})", count),
@@ -442,7 +442,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 			type: 'group',
 			id: `group-${promptType}-${storageSuffixes[storage]}`,
 			label: storageLabels[storage],
-			storage,
+			storage: storage as PromptsStorage,
 			promptType,
 			icon: storageIcons[storage],
 		};

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -29,7 +29,8 @@ import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../..
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon, builtinIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
-import { AICustomizationManagementSection, AICustomizationPromptsStorage, BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationPromptsStorage, BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer, ITreeContextMenuEvent } from '../../../../base/browser/ui/tree/tree.js';

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -27,9 +27,9 @@ import { IViewPaneOptions, ViewPane } from '../../../../workbench/browser/parts/
 import { IViewDescriptorService } from '../../../../workbench/common/views.js';
 import { IPromptsService, PromptsStorage, IAgentSkill, IPromptPath } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
+import { agentIcon, extensionIcon, instructionsIcon, mcpServerIcon, pluginIcon, promptIcon, skillIcon, userIcon, workspaceIcon, builtinIcon } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
-import { AICustomizationManagementSection } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationManagementSection, BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationManagementEditorInput } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.js';
 import { AICustomizationManagementEditor } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.js';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer, ITreeContextMenuEvent } from '../../../../base/browser/ui/tree/tree.js';
@@ -375,11 +375,13 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 			const workspaceItems = allItems.filter(item => item.storage === PromptsStorage.local);
 			const userItems = allItems.filter(item => item.storage === PromptsStorage.user);
 			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);
+			const builtinItems = allItems.filter(item => item.storage === BUILTIN_STORAGE);
 
 			cached.files = new Map<PromptsStorage, readonly IPromptPath[]>([
 				[PromptsStorage.local, workspaceItems],
 				[PromptsStorage.user, userItems],
 				[PromptsStorage.extension, extensionItems],
+				[BUILTIN_STORAGE, builtinItems],
 			]);
 
 			const itemCount = allItems.length;
@@ -390,6 +392,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 		const workspaceItems = cached.files!.get(PromptsStorage.local) || [];
 		const userItems = cached.files!.get(PromptsStorage.user) || [];
 		const extensionItems = cached.files!.get(PromptsStorage.extension) || [];
+		const builtinItems = cached.files!.get(BUILTIN_STORAGE) || [];
 
 		if (workspaceItems.length > 0) {
 			groups.push(this.createGroupItem(promptType, PromptsStorage.local, workspaceItems.length));
@@ -400,6 +403,9 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 		if (extensionItems.length > 0) {
 			groups.push(this.createGroupItem(promptType, PromptsStorage.extension, extensionItems.length));
 		}
+		if (builtinItems.length > 0) {
+			groups.push(this.createGroupItem(promptType, BUILTIN_STORAGE, builtinItems.length));
+		}
 
 		return groups;
 	}
@@ -408,25 +414,28 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 	 * Creates a group item with consistent structure.
 	 */
 	private createGroupItem(promptType: PromptsType, storage: PromptsStorage, count: number): IAICustomizationGroupItem {
-		const storageLabels: Record<PromptsStorage, string> = {
+		const storageLabels: Record<string, string> = {
 			[PromptsStorage.local]: localize('workspaceWithCount', "Workspace ({0})", count),
 			[PromptsStorage.user]: localize('userWithCount', "User ({0})", count),
 			[PromptsStorage.extension]: localize('extensionsWithCount', "Extensions ({0})", count),
 			[PromptsStorage.plugin]: localize('pluginsWithCount', "Plugins ({0})", count),
+			[BUILTIN_STORAGE]: localize('builtinWithCount', "Built-in ({0})", count),
 		};
 
-		const storageIcons: Record<PromptsStorage, ThemeIcon> = {
+		const storageIcons: Record<string, ThemeIcon> = {
 			[PromptsStorage.local]: workspaceIcon,
 			[PromptsStorage.user]: userIcon,
 			[PromptsStorage.extension]: extensionIcon,
 			[PromptsStorage.plugin]: pluginIcon,
+			[BUILTIN_STORAGE]: builtinIcon,
 		};
 
-		const storageSuffixes: Record<PromptsStorage, string> = {
+		const storageSuffixes: Record<string, string> = {
 			[PromptsStorage.local]: 'workspace',
 			[PromptsStorage.user]: 'user',
 			[PromptsStorage.extension]: 'extensions',
 			[PromptsStorage.plugin]: 'plugins',
+			[BUILTIN_STORAGE]: 'builtin',
 		};
 
 		return {
@@ -602,7 +611,7 @@ export class AICustomizationViewPane extends ViewPane {
 		this.treeDisposables.add(this.tree.onDidOpen(async e => {
 			if (e.element && e.element.type === 'file') {
 				this.editorService.openEditor({
-					resource: e.element.uri
+					resource: e.element.uri,
 				});
 			} else if (e.element && e.element.type === 'link') {
 				const input = AICustomizationManagementEditorInput.getOrCreate();

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -70,7 +70,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 			joinPath(userHome, '.agents'),
 		];
 		this._cliUserFilter = {
-			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE as PromptsStorage],
+			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
 			includedUserFileRoots: this._cliUserRoots,
 		};
 
@@ -122,7 +122,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 	};
 
 	private static readonly _allUserRootsFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE as PromptsStorage],
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
 	};
 
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -9,6 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection, IStorageSourceFilter, applyStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IChatPromptSlashCommand, IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { CustomizationCreatorService } from '../../../../workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.js';
@@ -69,7 +70,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 			joinPath(userHome, '.agents'),
 		];
 		this._cliUserFilter = {
-			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin],
+			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
 			includedUserFileRoots: this._cliUserRoots,
 		};
 
@@ -121,7 +122,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 	};
 
 	private static readonly _allUserRootsFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin],
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
 	};
 
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -70,7 +70,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 			joinPath(userHome, '.agents'),
 		];
 		this._cliUserFilter = {
-			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
+			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE as PromptsStorage],
 			includedUserFileRoots: this._cliUserRoots,
 		};
 
@@ -122,7 +122,7 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 	};
 
 	private static readonly _allUserRootsFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE as PromptsStorage],
 	};
 
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection, IStorageSourceFilter, applyStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { IChatPromptSlashCommand, IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
-import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { CustomizationCreatorService } from '../../../../workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.js';

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -17,7 +17,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform
 import { HOOKS_SOURCE_FOLDER, getCleanPromptName } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptPath, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
-import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { ISearchService } from '../../../../workbench/services/search/common/search.js';

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -8,21 +8,28 @@ import { PromptFilesLocator } from '../../../../workbench/contrib/chat/common/pr
 import { Event } from '../../../../base/common/event.js';
 import { basename, isEqualOrParent, joinPath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { FileAccess } from '../../../../base/common/network.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
-import { HOOKS_SOURCE_FOLDER } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
+import { HOOKS_SOURCE_FOLDER, getCleanPromptName } from '../../../../workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptPath, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { IWorkbenchEnvironmentService } from '../../../../workbench/services/environment/common/environmentService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { ISearchService } from '../../../../workbench/services/search/common/search.js';
 import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 
+/** URI root for built-in prompts bundled with the Sessions app. */
+export const BUILTIN_PROMPTS_URI = FileAccess.asFileUri('vs/sessions/prompts');
+
 export class AgenticPromptsService extends PromptsService {
 	private _copilotRoot: URI | undefined;
+	private _builtinPromptsCache: Map<PromptsType, Promise<readonly IPromptPath[]>> | undefined;
 
 	protected override createPromptFilesLocator(): PromptFilesLocator {
 		return this.instantiationService.createInstance(AgenticPromptFilesLocator);
@@ -34,6 +41,79 @@ export class AgenticPromptsService extends PromptsService {
 			this._copilotRoot = joinPath(pathService.userHome({ preferLocal: true }), '.copilot');
 		}
 		return this._copilotRoot;
+	}
+
+	/**
+	 * Returns built-in prompt files bundled with the Sessions app.
+	 * These are discovered from the `vs/sessions/prompts/` directory.
+	 */
+	private async getBuiltinPromptFiles(type: PromptsType): Promise<readonly IPromptPath[]> {
+		if (type !== PromptsType.prompt) {
+			return [];
+		}
+
+		if (!this._builtinPromptsCache) {
+			this._builtinPromptsCache = new Map();
+		}
+
+		let cached = this._builtinPromptsCache.get(type);
+		if (!cached) {
+			cached = this.discoverBuiltinPrompts(type);
+			this._builtinPromptsCache.set(type, cached);
+		}
+		return cached;
+	}
+
+	private async discoverBuiltinPrompts(type: PromptsType): Promise<readonly IPromptPath[]> {
+		const fileService = this.instantiationService.invokeFunction(accessor => accessor.get(IFileService));
+		const promptsDir = FileAccess.asFileUri('vs/sessions/prompts');
+		try {
+			const stat = await fileService.resolve(promptsDir);
+			if (!stat.children) {
+				return [];
+			}
+			return stat.children
+				.filter(child => !child.isDirectory && child.name.endsWith('.prompt.md'))
+				.map(child => ({
+					uri: child.resource,
+					storage: BUILTIN_STORAGE,
+					type,
+				} as IPromptPath));
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * Override to include built-in prompts and filter out those overridden
+	 * by user or workspace prompts with the same name.
+	 */
+	public override async listPromptFiles(type: PromptsType, token: CancellationToken): Promise<readonly IPromptPath[]> {
+		const baseResults = await super.listPromptFiles(type, token);
+		const builtinPrompts = await this.getBuiltinPromptFiles(type);
+		if (builtinPrompts.length === 0) {
+			return baseResults;
+		}
+
+		// Collect names of user/workspace prompts to detect overrides
+		const overriddenNames = new Set<string>();
+		for (const p of baseResults) {
+			if (p.storage === PromptsStorage.local || p.storage === PromptsStorage.user) {
+				overriddenNames.add(getCleanPromptName(p.uri));
+			}
+		}
+
+		const nonOverridden = builtinPrompts.filter(
+			p => !overriddenNames.has(getCleanPromptName(p.uri))
+		);
+		return [...baseResults, ...nonOverridden];
+	}
+
+	public override async listPromptFilesForStorage(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly IPromptPath[]> {
+		if (storage === BUILTIN_STORAGE) {
+			return this.getBuiltinPromptFiles(type);
+		}
+		return super.listPromptFilesForStorage(type, storage, token);
 	}
 
 	/**

--- a/src/vs/sessions/contrib/chat/common/builtinPromptsStorage.ts
+++ b/src/vs/sessions/contrib/chat/common/builtinPromptsStorage.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+
+/**
+ * Extended storage type for AI Customization that includes built-in prompts
+ * shipped with the application, alongside the core `PromptsStorage` values.
+ */
+export type AICustomizationPromptsStorage = PromptsStorage | 'builtin';
+
+/**
+ * Storage type discriminator for built-in prompts shipped with the application.
+ */
+export const BUILTIN_STORAGE: AICustomizationPromptsStorage = 'builtin';

--- a/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
@@ -10,6 +10,7 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { parseHooksFromFile } from '../../../../workbench/contrib/chat/common/promptSyntax/hookCompatibility.js';
@@ -20,12 +21,14 @@ export interface ISourceCounts {
 	readonly workspace: number;
 	readonly user: number;
 	readonly extension: number;
+	readonly builtin: number;
 }
 
 const storageToCountKey: Partial<Record<PromptsStorage, keyof ISourceCounts>> = {
 	[PromptsStorage.local]: 'workspace',
 	[PromptsStorage.user]: 'user',
 	[PromptsStorage.extension]: 'extension',
+	[BUILTIN_STORAGE]: 'builtin',
 };
 
 export function getSourceCountsTotal(counts: ISourceCounts, filter: IStorageSourceFilter): number {
@@ -129,6 +132,7 @@ export async function getSourceCounts(
 		workspace: filtered.filter(i => i.storage === PromptsStorage.local).length,
 		user: filtered.filter(i => i.storage === PromptsStorage.user).length,
 		extension: filtered.filter(i => i.storage === PromptsStorage.extension).length,
+		builtin: filtered.filter(i => i.storage === BUILTIN_STORAGE).length,
 	};
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
@@ -24,7 +24,7 @@ export interface ISourceCounts {
 	readonly builtin: number;
 }
 
-const storageToCountKey: Partial<Record<PromptsStorage, keyof ISourceCounts>> = {
+const storageToCountKey: Partial<Record<string, keyof ISourceCounts>> = {
 	[PromptsStorage.local]: 'workspace',
 	[PromptsStorage.user]: 'user',
 	[PromptsStorage.extension]: 'extension',

--- a/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
@@ -10,7 +10,7 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
-import { BUILTIN_STORAGE } from '../../../../workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 import { IMcpService } from '../../../../workbench/contrib/mcp/common/mcpTypes.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter, IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { parseHooksFromFile } from '../../../../workbench/contrib/chat/common/promptSyntax/hookCompatibility.js';

--- a/src/vs/sessions/contrib/sessions/test/browser/customizationCounts.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/customizationCounts.test.ts
@@ -126,31 +126,31 @@ suite('customizationCounts', () => {
 
 	suite('getSourceCountsTotal', () => {
 		test('sums only visible sources', () => {
-			const counts = { workspace: 5, user: 3, extension: 2 };
+			const counts = { workspace: 5, user: 3, extension: 2, builtin: 0 };
 			const filter: IStorageSourceFilter = { sources: [PromptsStorage.local, PromptsStorage.user] };
 			assert.strictEqual(getSourceCountsTotal(counts, filter), 8);
 		});
 
 		test('returns 0 for empty sources', () => {
-			const counts = { workspace: 5, user: 3, extension: 2 };
+			const counts = { workspace: 5, user: 3, extension: 2, builtin: 0 };
 			const filter: IStorageSourceFilter = { sources: [] };
 			assert.strictEqual(getSourceCountsTotal(counts, filter), 0);
 		});
 
 		test('sums all sources', () => {
-			const counts = { workspace: 5, user: 3, extension: 2 };
+			const counts = { workspace: 5, user: 3, extension: 2, builtin: 0 };
 			const filter: IStorageSourceFilter = { sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension] };
 			assert.strictEqual(getSourceCountsTotal(counts, filter), 10);
 		});
 
 		test('handles single source', () => {
-			const counts = { workspace: 7, user: 0, extension: 0 };
+			const counts = { workspace: 7, user: 0, extension: 0, builtin: 0 };
 			const filter: IStorageSourceFilter = { sources: [PromptsStorage.local] };
 			assert.strictEqual(getSourceCountsTotal(counts, filter), 7);
 		});
 
 		test('ignores plugin storage in totals (not in ISourceCounts)', () => {
-			const counts = { workspace: 1, user: 1, extension: 1 };
+			const counts = { workspace: 1, user: 1, extension: 1, builtin: 0 };
 			const filter: IStorageSourceFilter = { sources: [PromptsStorage.plugin] };
 			assert.strictEqual(getSourceCountsTotal(counts, filter), 0);
 		});
@@ -334,7 +334,7 @@ suite('customizationCounts', () => {
 				workspaceService,
 			);
 
-			assert.deepStrictEqual(counts, { workspace: 1, user: 1, extension: 1 });
+			assert.deepStrictEqual(counts, { workspace: 1, user: 1, extension: 1, builtin: 0 });
 		});
 
 		test('empty agents returns all zeros', async () => {
@@ -348,7 +348,7 @@ suite('customizationCounts', () => {
 				contextService, workspaceService,
 			);
 
-			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0 });
+			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0, builtin: 0 });
 		});
 	});
 
@@ -386,7 +386,7 @@ suite('customizationCounts', () => {
 				contextService, workspaceService,
 			);
 
-			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0 });
+			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0, builtin: 0 });
 		});
 
 		test('skills filtered by storage source filter', async () => {
@@ -450,7 +450,7 @@ suite('customizationCounts', () => {
 				contextService, workspaceService,
 			);
 
-			assert.deepStrictEqual(counts, { workspace: 1, user: 1, extension: 0 });
+			assert.deepStrictEqual(counts, { workspace: 1, user: 1, extension: 0, builtin: 0 });
 		});
 
 		test('all skills are excluded from prompt counts', async () => {
@@ -469,7 +469,7 @@ suite('customizationCounts', () => {
 				contextService, workspaceService,
 			);
 
-			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0 });
+			assert.deepStrictEqual(counts, { workspace: 0, user: 0, extension: 0, builtin: 0 });
 		});
 	});
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,0 +1,11 @@
+---
+description: Create a pull request for the current session
+---
+<!-- Tip: Create a workspace or user prompt named 'create-pr' to override this built-in prompt -->
+
+Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
+
+1. Review all changes in the current session
+2. Write a clear, concise PR title with a short area prefix (e.g. "sessions: …", "editor: …")
+3. Write a description covering what changed, why, and anything reviewers should know
+4. Create the pull request

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons.ts
@@ -68,6 +68,11 @@ export const extensionIcon = registerIcon('ai-customization-extension', Codicon.
 export const pluginIcon = registerIcon('ai-customization-plugin', Codicon.plug, localize('aiCustomizationPluginIcon', "Icon for plugin-contributed items."));
 
 /**
+ * Icon for built-in storage.
+ */
+export const builtinIcon = registerIcon('ai-customization-builtin', Codicon.starFull, localize('aiCustomizationBuiltinIcon', "Icon for built-in items."));
+
+/**
  * Icon for MCP servers.
  */
 export const mcpServerIcon = registerIcon('ai-customization-mcp-server', Codicon.server, localize('aiCustomizationMcpServerIcon', "Icon for MCP servers."));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -19,8 +19,8 @@ import { WorkbenchList } from '../../../../../platform/list/browser/listService.
 import { IListVirtualDelegate, IListRenderer, IListContextMenuEvent } from '../../../../../base/browser/ui/list/list.js';
 import { IPromptsService, PromptsStorage, IPromptPath } from '../../common/promptSyntax/service/promptsService.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
-import { agentIcon, instructionsIcon, promptIcon, skillIcon, hookIcon, userIcon, workspaceIcon, extensionIcon, pluginIcon } from './aiCustomizationIcons.js';
-import { AICustomizationManagementItemMenuId, AICustomizationManagementSection } from './aiCustomizationManagement.js';
+import { agentIcon, instructionsIcon, promptIcon, skillIcon, hookIcon, userIcon, workspaceIcon, extensionIcon, pluginIcon, builtinIcon } from './aiCustomizationIcons.js';
+import { AICustomizationManagementItemMenuId, AICustomizationManagementSection, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
 import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { Delayer } from '../../../../../base/common/async.js';
@@ -889,6 +889,7 @@ export class AICustomizationListWidget extends Disposable {
 			const userItems = allItems.filter(item => item.storage === PromptsStorage.user);
 			const extensionItems = allItems.filter(item => item.storage === PromptsStorage.extension);
 			const pluginItems = allItems.filter(item => item.storage === PromptsStorage.plugin);
+			const builtinItems = allItems.filter(item => item.storage === BUILTIN_STORAGE);
 
 			const mapToListItem = (item: IPromptPath): IAICustomizationListItem => {
 				const filename = basename(item.uri);
@@ -909,6 +910,7 @@ export class AICustomizationListWidget extends Disposable {
 			items.push(...userItems.map(mapToListItem));
 			items.push(...extensionItems.map(mapToListItem));
 			items.push(...pluginItems.map(mapToListItem));
+			items.push(...builtinItems.map(mapToListItem));
 		}
 
 		// Apply storage source filter (removes items not in visible sources or excluded user roots)
@@ -983,6 +985,7 @@ export class AICustomizationListWidget extends Disposable {
 			{ groupKey: PromptsStorage.user, label: localize('userGroup', "User"), icon: userIcon, description: localize('userGroupDescription', "Customizations stored locally on your machine in a central location. Private to you and available across all projects."), items: [] },
 			{ groupKey: PromptsStorage.extension, label: localize('extensionGroup', "Extensions"), icon: extensionIcon, description: localize('extensionGroupDescription', "Read-only customizations provided by installed extensions."), items: [] },
 			{ groupKey: PromptsStorage.plugin, label: localize('pluginGroup', "Plugins"), icon: pluginIcon, description: localize('pluginGroupDescription', "Read-only customizations provided by installed plugins."), items: [] },
+			{ groupKey: BUILTIN_STORAGE, label: localize('builtinGroup', "Built-in"), icon: builtinIcon, description: localize('builtinGroupDescription', "Built-in customizations shipped with the application."), items: [] },
 			{ groupKey: 'agents', label: localize('agentsGroup', "Agents"), icon: agentIcon, description: localize('agentsGroupDescription', "Hooks defined in agent files."), items: [] },
 		].filter(g => visibleSources.has(g.groupKey as PromptsStorage) || g.groupKey === 'agents');
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -5,11 +5,20 @@
 
 import { RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
+import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { localize } from '../../../../../nls.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 
 // Re-export for convenience — consumers import from this file
 export { AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
+
+/**
+ * Storage type for built-in prompts shipped with the application.
+ * Defined as a cast to avoid adding a new enum value to the core
+ * PromptsStorage enum — only the AI Customization UI needs to know
+ * about this storage type.
+ */
+export const BUILTIN_STORAGE = 'builtin' as PromptsStorage;
 
 /**
  * Editor pane ID for the AI Customizations Management Editor.

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -13,12 +13,15 @@ import { MenuId } from '../../../../../platform/actions/common/actions.js';
 export { AICustomizationManagementSection } from '../../common/aiCustomizationWorkspaceService.js';
 
 /**
- * Storage type for built-in prompts shipped with the application.
- * Defined as a cast to avoid adding a new enum value to the core
- * PromptsStorage enum — only the AI Customization UI needs to know
- * about this storage type.
+ * Extended storage type for AI Customization that includes built-in prompts
+ * shipped with the application, alongside the core `PromptsStorage` values.
  */
-export const BUILTIN_STORAGE = 'builtin' as PromptsStorage;
+export type AICustomizationPromptsStorage = PromptsStorage | 'builtin';
+
+/**
+ * Storage type discriminator for built-in prompts shipped with the application.
+ */
+export const BUILTIN_STORAGE: AICustomizationPromptsStorage = 'builtin';
 
 /**
  * Editor pane ID for the AI Customizations Management Editor.

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -39,6 +39,7 @@ import {
 	AI_CUSTOMIZATION_MANAGEMENT_SIDEBAR_WIDTH_KEY,
 	AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY,
 	AICustomizationManagementSection,
+	BUILTIN_STORAGE,
 	CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_EDITOR,
 	CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_SECTION,
 	SIDEBAR_DEFAULT_WIDTH,
@@ -452,7 +453,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		// Handle item selection
 		this.editorDisposables.add(this.listWidget.onDidSelectItem(item => {
 			const isWorkspaceFile = item.storage === PromptsStorage.local;
-			const isReadOnly = item.storage === PromptsStorage.extension || item.storage === PromptsStorage.plugin;
+			const isReadOnly = item.storage === PromptsStorage.extension || item.storage === PromptsStorage.plugin || item.storage === BUILTIN_STORAGE;
 			this.showEmbeddedEditor(item.uri, item.name, isWorkspaceFile, isReadOnly);
 		}));
 

--- a/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/aiCustomizationWorkspaceService.ts
@@ -35,9 +35,9 @@ export type AICustomizationManagementSection = typeof AICustomizationManagementS
  */
 export interface IStorageSourceFilter {
 	/**
-	 * Which storage groups to display (e.g. workspace, user, extension).
+	 * Which storage groups to display (e.g. workspace, user, extension, builtin).
 	 */
-	readonly sources: readonly PromptsStorage[];
+	readonly sources: readonly string[];
 
 	/**
 	 * If set, only user files under these roots are shown (allowlist).
@@ -51,7 +51,7 @@ export interface IStorageSourceFilter {
  * Removes items whose storage is not in the filter's source list,
  * and for user-storage items, removes those not under an allowed root.
  */
-export function applyStorageSourceFilter<T extends { readonly uri: URI; readonly storage: PromptsStorage }>(items: readonly T[], filter: IStorageSourceFilter): readonly T[] {
+export function applyStorageSourceFilter<T extends { readonly uri: URI; readonly storage: string }>(items: readonly T[], filter: IStorageSourceFilter): readonly T[] {
 	const sourceSet = new Set(filter.sources);
 	return items.filter(item => {
 		if (!sourceSet.has(item.storage)) {


### PR DESCRIPTION
Ship bundled .prompt.md files with the Sessions app that appear as slash commands out of the box. Built-in prompts show under a 'Built-in' group in AI Customizations and are automatically hidden when a user or workspace prompt with the same name exists.

- Add PromptsStorage.builtin enum value and IBuiltinPromptPath interface
- AgenticPromptsService discovers prompts from vs/sessions/prompts/ at runtime and injects them into the prompt listing pipeline
- Override logic: user/workspace prompts with matching names take precedence over built-in ones
- Built-in prompts open as read-only in the management editor
- Add /create-pr as the first built-in prompt
- Update tree view, management editor, counts, and storage filters

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
