### PR TITLE
Use older zip.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4475,9 +4475,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.23",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.23.tgz",
-      "integrity": "sha512-RB+RLnxPJFPrGvQ9rgO+4JOcsob6lD32OcF0QE0yg24oeW9q8KnTTNlugcDaIveEcCbclobJcZP+fLQ++sH0bw==",
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.21.tgz",
+      "integrity": "sha512-fkyzXISE3IMrstDO1AgPkJCx14MYHP/suIGiAovEYEuBjq3mffsuL6aMV7ohOSjW4rXtuACuUfpA3GtITgdtYg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {


### PR DESCRIPTION
This recent update was published in the last 24 hours which breaks our private builds

Opened #299632 to track better long term fix to avoid this