### PR TITLE
steer uses up arrow (same as send default)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQueueActions.ts
@@ -87,7 +87,7 @@ export class ChatSteerWithMessageAction extends Action2 {
 			id: ChatSteerWithMessageAction.ID,
 			title: localize2('chat.steerWithMessage', "Steer with Message"),
 			tooltip: localize('chat.steerWithMessage.tooltip', "Send this message at the next opportunity, signaling the current request to yield"),
-			icon: Codicon.arrowRight,
+			icon: Codicon.arrowUp,
 			f1: false,
 			category: CHAT_CATEGORY,
 			precondition: ContextKeyExpr.and(
@@ -271,7 +271,7 @@ export function registerChatQueueActions(): void {
 		order: 1,
 	});
 	MenuRegistry.appendMenuItem(MenuId.ChatExecuteQueue, {
-		command: { id: ChatSteerWithMessageAction.ID, title: localize2('chat.steerWithMessage', "Steer with Message"), icon: Codicon.arrowRight },
+		command: { id: ChatSteerWithMessageAction.ID, title: localize2('chat.steerWithMessage', "Steer with Message"), icon: Codicon.arrowUp },
 		group: 'navigation',
 		order: 2,
 	});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem.ts
@@ -62,7 +62,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		this._primaryActionAction = this._register(new Action(
 			'chat.queuePickerPrimary',
 			isSteerDefault ? localize('chat.steerWithMessage', "Steer with Message") : localize('chat.queueMessage', "Add to Queue"),
-			ThemeIcon.asClassName(isSteerDefault ? Codicon.arrowRight : Codicon.add),
+			ThemeIcon.asClassName(isSteerDefault ? Codicon.arrowUp : Codicon.add),
 			!!contextKeyService.getContextKeyValue(ChatContextKeys.inputHasText.key),
 			() => this._runDefaultAction()
 		));
@@ -116,7 +116,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 		this._primaryActionAction.label = isSteer
 			? localize('chat.steerWithMessage', "Steer with Message")
 			: localize('chat.queueMessage', "Add to Queue");
-		this._primaryActionAction.class = ThemeIcon.asClassName(isSteer ? Codicon.arrowRight : Codicon.add);
+		this._primaryActionAction.class = ThemeIcon.asClassName(isSteer ? Codicon.arrowUp : Codicon.add);
 	}
 
 	private _runDefaultAction(): void {
@@ -198,7 +198,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			tooltip: '',
 			enabled: true,
 			checked: isSteerDefault,
-			icon: Codicon.arrowRight,
+			icon: Codicon.arrowUp,
 			class: undefined,
 			hover: {
 				content: localize('chat.steerWithMessage.hover', "Send this message at the next opportunity, signaling the current request to yield. The current response will stop and the new message will be sent immediately."),
@@ -213,7 +213,7 @@ export class ChatQueuePickerActionItem extends BaseActionViewItem {
 			label: localize('chat.sendImmediately', "Stop and Send"),
 			tooltip: '',
 			enabled: true,
-			icon: Codicon.arrowUp,
+			icon: Codicon.arrowRight,
 			class: undefined,
 			hover: {
 				content: localize('chat.sendImmediately.hover', "Cancel the current request and send this message immediately."),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Swapped Stop and Send and Steering arrow icons. Steer is the default interaction mid turn, made icon same as default send so there is no difference between states.
<img width="549" height="193" alt="Screenshot 2026-03-05 at 2 58 05 PM" src="https://github.com/user-attachments/assets/4f306813-59cc-4322-8152-357fcd845719" />
