### PR TITLE
mcp: fix sampling model selection to exclude CLI models

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpSamplingService.ts
@@ -17,7 +17,7 @@ import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } fr
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { ChatAgentLocation, ChatConfiguration } from '../../chat/common/constants.js';
+import { ChatConfiguration } from '../../chat/common/constants.js';
 import { ChatImageMimeType, ChatMessageRole, IChatMessage, IChatMessagePart, ILanguageModelsService } from '../../chat/common/languageModels.js';
 import { McpCommandIds } from './mcpCommandIds.js';
 import { IMcpServerSamplingConfiguration, mcpServerSamplingSection } from './mcpConfiguration.js';
@@ -241,11 +241,8 @@ export class McpSamplingService extends Disposable implements IMcpSamplingServic
 			return config.allowedOutsideChat === undefined ? ModelMatch.UnsureAllowedOutsideChat : ModelMatch.NotAllowed;
 		}
 
-		// 2. Get the configured models, or the default model(s)
-		const foundModelIdsDeep = config.allowedModels?.filter(m => !!this._languageModelsService.lookupLanguageModel(m)) || this._languageModelsService.getLanguageModelIds().filter(m => this._languageModelsService.lookupLanguageModel(m)?.isDefaultForLocation[ChatAgentLocation.Chat]);
-
-		const foundModelIds = foundModelIdsDeep.flat().sort((a, b) => b.length - a.length); // Sort by length to prefer most specific
-
+		// 2. Get the configured models, or the default free model(s)
+		const foundModelIds = config.allowedModels?.filter(m => !!this._languageModelsService.lookupLanguageModel(m)) || this._getDefaultModels();
 		if (!foundModelIds.length) {
 			return ModelMatch.NoMatchingModel;
 		}
@@ -259,6 +256,20 @@ export class McpSamplingService extends Disposable implements IMcpSamplingServic
 		}
 
 		return foundModelIds[0]; // Return the first matching model
+	}
+
+	private _getDefaultModels() {
+		const candidates = this._languageModelsService.getLanguageModelIds().map(m => {
+			const model = this._languageModelsService.lookupLanguageModel(m);
+			return model && !model.multiplierNumeric && !model.targetChatSessionType ? { model, id: m } : undefined;
+		}).filter(isDefined);
+
+		const someDefault = candidates.findIndex(c => Object.values(c.model.isDefaultForLocation).some(Boolean));
+		if (someDefault !== -1) {
+			[candidates[0], candidates[someDefault]] = [candidates[someDefault], candidates[0]];
+		}
+
+		return candidates.map(c => c.id);
 	}
 
 	private _configKey(server: IMcpServer) {


### PR DESCRIPTION
- Changes _findMatchingModel to use a new _getDefaultModels helper instead
  of filtering for models with ChatAgentLocation.Chat default location
- The new _getDefaultModels method filters for free models (no multiplier
  numeric or target chat session type), preventing CLI-only models from
  being selected as defaults by default
- Also removes unused ChatAgentLocation import

Fixes #299336

(Commit message generated by Copilot)