### PR TITLE
[MCP_Sandboxing]: Notifying network domains that need access 

### DIFF
--- a/src/vs/workbench/contrib/mcp/common/mcpSandboxService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpSandboxService.ts
@@ -276,7 +276,7 @@ export class McpSandboxService extends Disposable implements IMcpSandboxService 
 	private async _getSandboxEnvVariables(baseEnv: McpServerTransportStdio['env'], tempDir: URI | undefined, rgPath: string | undefined, remoteAuthority?: string): Promise<McpServerTransportStdio['env']> {
 		let env: McpServerTransportStdio['env'] = { ...baseEnv };
 		if (tempDir) {
-			env = { ...env, TMPDIR: tempDir.path, SRT_DEBUG: 'true' };
+			env = { ...env, TMPDIR: tempDir.path, SRT_DEBUG: 'true', NODE_USE_ENV_PROXY: '1' };
 		}
 		if (rgPath) {
 			env = { ...env, PATH: env['PATH'] ? `${env['PATH']}${await this._getPathDelimiter(remoteAuthority)}${dirname(rgPath)}` : dirname(rgPath) };

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -162,15 +162,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 			};
 		}
 
-		if (/\b(?:EAI_AGAIN|ENOTFOUND)\b/i.test(message)) {
-			return {
-				kind: 'network',
-				message,
-				host: this._extractSandboxHost(message),
-			};
-		}
-
-		if (/(?:\b(?:EACCES|EPERM|ENOENT|fail(?:ed|ure)?)\b|not accessible)/i.test(message)) {
+		if (/(?:\b(?:EACCES|EPERM|ENOENT|EROFS|fail(?:ed|ure)?)\b|not accessible |read only)/i.test(message)) {
 			return {
 				kind: 'filesystem',
 				message,

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -189,16 +189,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 	}
 
 	private _extractSandboxHost(value: string): string | undefined {
-		const deniedMatch = value.match(/No matching config rule, denying:\s+(.+)$/i);
-		const matchTarget = deniedMatch?.[1] ?? value;
-		const trimmed = matchTarget.trim().replace(/^["'`]+|["'`,.;]+$/g, '');
-		if (!trimmed) {
-			return undefined;
-		}
-
-		const withoutProtocol = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
-		const firstToken = withoutProtocol.split(/[\s/]/, 1)[0] ?? '';
-		const host = firstToken.replace(/:\d+$/, '');
-		return host || undefined;
+		const match = value.match(/No matching config rule, denying:\s+(?<host>[^:\s]+):\d+\.?$/i);
+		return match?.groups?.host;
 	}
 }

--- a/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServerConnection.ts
@@ -162,7 +162,7 @@ export class McpServerConnection extends Disposable implements IMcpServerConnect
 			};
 		}
 
-		if (/(?:\b(?:EACCES|EPERM|ENOENT|EROFS|fail(?:ed|ure)?)\b|not accessible |read only)/i.test(message)) {
+		if (/(?:\b(?:EACCES|EPERM|ENOENT|EROFS|fail(?:ed|ure)?)\b|\bnot accessible\b|read only)/i.test(message)) {
 			return {
 				kind: 'filesystem',
 				message,

--- a/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpServerConnection.test.ts
@@ -338,6 +338,42 @@ suite('Workbench - MCP - ServerConnection', () => {
 		await timeout(10);
 	});
 
+	test('should emit a sandbox network block with the denied host', async () => {
+		const sandboxedDefinition: McpServerDefinition = {
+			...serverDefinition,
+			sandboxEnabled: true,
+		};
+
+		const connection = instantiationService.createInstance(
+			McpServerConnection,
+			collection,
+			sandboxedDefinition,
+			delegate,
+			sandboxedDefinition.launch,
+			new NullLogger(),
+			false,
+			store.add(new McpTaskManager()),
+		);
+		store.add(connection);
+
+		const sandboxBlock = Event.toPromise(connection.onPotentialSandboxBlock);
+		const startPromise = connection.start({});
+
+		transport.simulateLog('No matching config rule, denying: api.example.com:443.');
+		transport.setConnectionState({ state: McpConnectionState.Kind.Running });
+
+		assert.deepStrictEqual(await sandboxBlock, {
+			kind: 'network',
+			message: 'No matching config rule, denying: api.example.com:443.',
+			host: 'api.example.com',
+		});
+
+		await startPromise;
+
+		connection.dispose();
+		await timeout(10);
+	});
+
 	test('should correctly handle transitions to and from error state', async () => {
 		// Create server connection
 		const connection = instantiationService.createInstance(


### PR DESCRIPTION
fixes(#297462)

For network domains, currently all the requests are not going through proxy as they are not honoring http_proxy environment variables. This is resulting in error code specific to the calling library. By setting  NODE_USE_ENV_PROXY, all the calls are now passing through proxy and throwing consistent error message if they are not in allowed list.