### PR TITLE
Add background color to resizable hover widget

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -11,6 +11,7 @@
 	border: 1px solid var(--vscode-editorHoverWidget-border);
 	border-radius: var(--vscode-cornerRadius-large);
 	box-sizing: content-box;
+	background-color: var(--vscode-editorHoverWidget-background);
 }
 
 .monaco-editor .monaco-resizable-hover > .monaco-hover {


### PR DESCRIPTION
Introduce a background color for the resizable hover widget in the hover.css file to enhance visibility and user experience. Test the changes by hovering over the widget to observe the new background color.

Fixes an issue where the rounded corners have transparent areas: 
<img width="674" height="170" alt="image" src="https://github.com/user-attachments/assets/80c276ea-c085-442b-a801-c898ea5061f2" />


