### PR TITLE
Refactor dialog CSS styles for improved layout and spacing

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -253,5 +253,5 @@
 }
 
 .monaco-dialog-modal-block .dialog-shadow {
-	border-radius: var(--vscode-cornerRadius-large);
+	border-radius: var(--vscode-cornerRadius-xLarge);
 }

--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -180,10 +180,6 @@
 	align-items: center;
 	padding-right: 1px;
 	overflow: hidden; /* buttons row should never overflow */
-}
-
-.monaco-dialog-box > .dialog-buttons-row {
-	display: flex;
 	white-space: nowrap;
 	padding: 20px 0px 0px;
 }

--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -25,13 +25,13 @@
 	display: flex;
 	flex-direction: column-reverse;
 	width: min-content;
-	min-width: 500px;
+	min-width: 480px;
 	max-width: 90vw;
 	max-height: 90vh;
 	min-height: 75px;
-	padding: 10px;
+	padding: 8px;
 	transform: translate3d(0px, 0px, 0px);
-	border-radius: var(--vscode-cornerRadius-large);
+	border-radius: var(--vscode-cornerRadius-xLarge);
 	box-shadow: var(--vscode-shadow-xl);
 }
 
@@ -41,7 +41,7 @@
 
 /** Dialog: Title Actions Row */
 .monaco-dialog-box .dialog-toolbar-row {
-	height: 22px;
+	height: 20px;
 	padding-bottom: 4px;
 }
 
@@ -55,7 +55,7 @@
 	display: flex;
 	flex-grow: 1;
 	align-items: center;
-	padding: 0 10px;
+	padding: 0 8px 0 12px;
 	min-height: 0; /* allow flex item to shrink below content size */
 	overflow: hidden;
 }
@@ -69,9 +69,9 @@
 }
 
 .monaco-dialog-box .dialog-message-row > .dialog-icon.codicon {
-	flex: 0 0 48px;
-	height: 48px;
-	font-size: 48px;
+	flex: 0 0 24px;
+	height: 24px;
+	font-size: 24px;
 }
 
 .monaco-dialog-box.align-vertical .dialog-message-row > .dialog-icon.codicon {
@@ -108,7 +108,7 @@
 
 .monaco-dialog-box:not(.align-vertical) .dialog-message-row .dialog-message-container,
 .monaco-dialog-box:not(.align-vertical) .dialog-footer-row {
-	padding-left: 24px;
+	padding-left: 12px;
 }
 
 .monaco-dialog-box.align-vertical .dialog-message-row .dialog-message-container,
@@ -124,20 +124,20 @@
 
 /** Dialog: Message */
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message {
-	line-height: 22px;
-	font-size: 18px;
+	font-size: 14px;
+	font-weight: 600;
 	flex: 1; /* let the message always grow */
 	white-space: normal;
 	word-wrap: break-word; /* never overflow long words, but break to next line */
-	min-height: 48px; /* matches icon height */
-	margin-bottom: 8px;
+	min-height: 22px; /* matches icon height */
+	margin-bottom: 4px;
 	display: flex;
 	align-items: center;
 }
 
 /** Dialog: Details */
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
-	line-height: 22px;
+	line-height: 20px;
 	flex: 1; /* let the message always grow */
 }
 
@@ -185,7 +185,7 @@
 .monaco-dialog-box > .dialog-buttons-row {
 	display: flex;
 	white-space: nowrap;
-	padding: 20px 10px 10px;
+	padding: 20px 0px 0px;
 }
 
 /** Dialog: Buttons */
@@ -209,8 +209,8 @@
 .monaco-dialog-box > .dialog-buttons-row > .dialog-buttons > .monaco-button {
 	overflow: hidden;
 	text-overflow: ellipsis;
-	margin: 4px 5px; /* allows button focus outline to be visible */
-	outline-offset: 2px !important;
+	margin: 4px; /* allows button focus outline to be visible */
+	outline-offset: 1px !important;
 }
 
 .monaco-dialog-box.align-vertical > .dialog-buttons-row > .dialog-buttons > .monaco-button {

--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -129,7 +129,7 @@
 	flex: 1; /* let the message always grow */
 	white-space: normal;
 	word-wrap: break-word; /* never overflow long words, but break to next line */
-	min-height: 22px; /* matches icon height */
+	min-height: 22px;
 	margin-bottom: 4px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Enhance the dialog's visual layout by refining CSS styles for better spacing and alignment. Adjustments include modifications to padding, margins, and dimensions to create a more cohesive and user-friendly interface. Test the dialog to ensure the layout appears as intended across different screen sizes.

**Before**
<img width="839" height="453" alt="image" src="https://github.com/user-attachments/assets/2ca388ce-677d-40f5-8c62-3991dde90454" />

**After**
<img width="1156" height="562" alt="image" src="https://github.com/user-attachments/assets/fb0f62b5-4e05-4f8c-925b-8e3b0b7b9963" />


