### PR TITLE
Refactor workspace trust editor styles for improved layout

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
+++ b/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .workspace-trust-editor {
-	max-width: 1000px;
-	padding-top: 11px;
-	margin: auto;
-	height: calc(100% - 11px);
+	padding-top: 12px;
+	margin: 0;
+	height: calc(100% - 12px);
 }
 
 .workspace-trust-editor:focus {
@@ -15,10 +14,14 @@
 }
 
 .workspace-trust-editor > .workspace-trust-header {
-	padding: 14px;
+	padding: 16px 24px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+}
+
+.workspace-trust-editor > .workspace-trust-header:focus:not(:focus-visible) {
+	outline: none;
 }
 
 .workspace-trust-editor .workspace-trust-header .workspace-trust-title {
@@ -35,7 +38,7 @@
 }
 
 .workspace-trust-editor .workspace-trust-header .workspace-trust-title .workspace-trust-title-icon {
-	color: var(--workspace-trust-selected-color) !important;
+	color: var(--workspace-trust-selected-color);
 }
 
 .workspace-trust-editor .workspace-trust-header .workspace-trust-description {
@@ -43,7 +46,8 @@
 	user-select: text;
 	max-width: 600px;
 	text-align: center;
-	padding: 14px 0;
+	padding: 8px 0;
+	line-height: 20px;
 }
 
 .workspace-trust-editor .workspace-trust-section-title {
@@ -64,59 +68,67 @@
 
 /** Features List */
 .workspace-trust-editor .workspace-trust-features {
-	padding: 14px;
+	padding: 24px;
 	cursor: default;
 	user-select: text;
 	display: flex;
 	flex-direction: row;
-	flex-flow: wrap;
-	justify-content: space-evenly;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 16px;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations {
-	min-height: 315px;
 	border: 1px solid var(--workspace-trust-unselected-color);
-	margin: 4px 4px;
+	border-radius: var(--vscode-cornerRadius-medium);
 	display: flex;
 	flex-direction: column;
-	padding: 10px 40px;
+	padding: 8px 36px;
 }
 
 .workspace-trust-editor.trusted .workspace-trust-features .workspace-trust-limitations.trusted,
 .workspace-trust-editor.untrusted .workspace-trust-features .workspace-trust-limitations.untrusted {
-	border-width: 2px;
-	border-color: var(--workspace-trust-selected-color) !important;
-	padding: 9px 39px;
-	outline-offset: 2px;
+	outline: 2px solid var(--workspace-trust-selected-color);
+	outline-offset: -2px;
+}
+
+.workspace-trust-editor .workspace-trust-features .workspace-trust-limitations:focus:not(:focus-visible) {
+	outline: none;
+}
+
+.workspace-trust-editor .workspace-trust-features .workspace-trust-limitations:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations ul {
 	list-style: none;
 	padding-inline-start: 0px;
+	margin: 16px 0;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations li {
 	display: flex;
-	padding-bottom: 10px;
+	padding-bottom: 4px;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations .list-item-icon {
-	padding-right: 5px;
 	line-height: 24px;
+	padding: 0 6px 0 0;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations.trusted .list-item-icon {
-	color: var(--workspace-trust-check-color) !important;
-	font-size: 18px;
+	color: var(--workspace-trust-check-color);
+	font-size: 16px;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations.untrusted .list-item-icon {
-	color: var(--workspace-trust-x-color) !important;
-	font-size: 20px;
+	color: var(--workspace-trust-x-color);
+	font-size: 16px;
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-limitations .list-item-text {
-	font-size: 16px;
+	font-size: 14px;
 	line-height: 24px;
 }
 
@@ -130,7 +142,7 @@
 	font-size: 16px;
 	font-weight: 600;
 	line-height: 24px;
-	padding: 10px 0px;
+	padding: 16px 0px;
 	display: flex;
 }
 
@@ -143,12 +155,13 @@
 .workspace-trust-editor.trusted .workspace-trust-features .workspace-trust-limitations.trusted .workspace-trust-limitations-header .workspace-trust-limitations-title .workspace-trust-title-icon,
 .workspace-trust-editor.untrusted .workspace-trust-features .workspace-trust-limitations.untrusted .workspace-trust-limitations-header .workspace-trust-limitations-title .workspace-trust-title-icon {
 	display: unset;
-	color: var(--workspace-trust-selected-color) !important;
+	color: var(--workspace-trust-selected-color);
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-untrusted-description {
 	font-style: italic;
-	padding-bottom: 10px;
+	color: var(--vscode-descriptionForeground);
+	padding-bottom: 8px;
 }
 
 /** Buttons Container */
@@ -170,7 +183,7 @@
 }
 
 .workspace-trust-editor .workspace-trust-settings .trusted-uris-button-bar {
-	margin-top: 5px;
+	margin-top: 8px;
 }
 
 .workspace-trust-editor .workspace-trust-settings .trusted-uris-button-bar .monaco-button {
@@ -183,7 +196,7 @@
 .workspace-trust-editor .workspace-trust-features .workspace-trust-buttons-row .workspace-trust-buttons > .monaco-button,
 .workspace-trust-editor .workspace-trust-features .workspace-trust-buttons-row .workspace-trust-buttons > .monaco-button-dropdown,
 .workspace-trust-editor .workspace-trust-settings .trusted-uris-button-bar .monaco-button {
-	margin: 4px 5px; /* allows button focus outline to be visible */
+	margin: 8px 4px; /* allows button focus outline to be visible */
 }
 
 .workspace-trust-editor .workspace-trust-features .workspace-trust-buttons-row .workspace-trust-buttons .monaco-button-dropdown .monaco-dropdown-button {
@@ -192,7 +205,7 @@
 
 .workspace-trust-limitations {
 	width: 50%;
-	max-width: 350px;
+	max-width: 400px;
 	min-width: 250px;
 	flex: 1;
 }
@@ -208,7 +221,7 @@
 }
 
 .workspace-trust-intro-dialog .workspace-trust-dialog-image-row.badge-row img {
-	max-height: 40px;
+	max-height: 36px;
 	padding-right: 10px;
 }
 
@@ -218,7 +231,9 @@
 }
 
 .workspace-trust-editor .workspace-trust-settings {
-	padding: 20px 14px;
+	padding: 24px 36px;
+	border-top: 1px solid var(--vscode-editorWidget-border);
+	margin-top: 8px;
 }
 
 .workspace-trust-editor .workspace-trust-settings .workspace-trusted-folders-title {
@@ -227,6 +242,10 @@
 
 .workspace-trust-editor .empty > .trusted-uris-table {
 	display: none;
+}
+
+.workspace-trust-editor .trusted-uris-table {
+	margin-top: 16px;
 }
 
 .workspace-trust-editor .monaco-table-tr .monaco-table-td .path {
@@ -291,4 +310,29 @@
 .workspace-trust-editor .workspace-trust-settings .monaco-table .monaco-list-row.focused .monaco-table-tr .monaco-table-td .actions .monaco-action-bar,
 .workspace-trust-editor .workspace-trust-settings .monaco-list-row:hover .monaco-table-tr .monaco-table-td .actions .monaco-action-bar {
 	display: flex;
+}
+
+/** Responsive: single-column layout for narrow widths */
+@container (max-width: 600px) {
+	.workspace-trust-editor .workspace-trust-features {
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.workspace-trust-limitations {
+		width: 100%;
+		max-width: 400px;
+	}
+}
+
+@media (max-width: 600px) {
+	.workspace-trust-editor .workspace-trust-features {
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.workspace-trust-limitations {
+		width: 100%;
+		max-width: 400px;
+	}
 }

--- a/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
+++ b/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .workspace-trust-editor {
+	max-width: 1600px;
 	padding-top: 12px;
 	margin: 0;
 	height: calc(100% - 12px);


### PR DESCRIPTION
Enhance the layout and responsiveness of the workspace trust editor by adjusting styles and max-width settings. This improves the overall user experience and visual consistency.

<img width="1552" height="1131" alt="image" src="https://github.com/user-attachments/assets/4a5cc4ac-0d99-46ff-b5f1-6fc43e9ba23e" />

<img width="981" height="1131" alt="image" src="https://github.com/user-attachments/assets/bb621399-d5f0-4821-8607-3896625cb9af" />


