### PR TITLE
Agent host protocol initial thoughts

### DIFF
--- a/src/vs/platform/agent/architecture.md
+++ b/src/vs/platform/agent/architecture.md
@@ -2,7 +2,7 @@
 
 > **Keep this document in sync with the code.** If you change the IPC contract, add new event types, modify the process lifecycle, or restructure files, update this document as part of the same change.
 
-For design decisions, see [design.md](design.md). For the task backlog, see [backlog.md](backlog.md). For chat session wiring, see [sessions.md](sessions.md).
+For design decisions, see [design.md](design.md). For the client-server state protocol, see [protocol.md](protocol.md). For the task backlog, see [backlog.md](backlog.md). For chat session wiring, see [sessions.md](sessions.md).
 
 ## Overview
 
@@ -51,6 +51,16 @@ src/vs/platform/agent/
 |   +-- agentService.ts       # IAgent, IAgentService, IAgentHostService interfaces,
 |                              # IPC data types, AgentSession namespace (URI helpers),
 |                              # AgentHostEnabledSettingId
+|   +-- state/
+|       +-- sessionState.ts        # Immutable state types (RootState, SessionState, Turn)
+|       +-- sessionActions.ts      # Action discriminated union + ActionEnvelope
+|       +-- sessionReducers.ts     # Pure reducer functions (rootReducer, sessionReducer)
+|       +-- sessionProtocol.ts     # Protocol messages (handshake, subscribe, reconnect)
+|       +-- sessionCapabilities.ts # Re-exports version constants + ProtocolCapabilities
+|       +-- sessionClientState.ts  # Client-side state manager with write-ahead reconciliation
+|       +-- versions/
+|           +-- v1.ts              # v1 wire format types (tip -- editable, compiler-enforced compat)
+|           +-- versionRegistry.ts # Compile-time compat checks + runtime action->version map
 +-- electron-browser/
 |   +-- agentHostService.ts   # AgentHostServiceClient (renderer singleton, direct MessagePort)
 +-- electron-main/

--- a/src/vs/platform/agent/common/state/AGENTS.md
+++ b/src/vs/platform/agent/common/state/AGENTS.md
@@ -1,0 +1,81 @@
+# Protocol versioning instructions
+
+This directory contains the protocol version system. Read this before modifying any protocol types.
+
+## Overview
+
+The protocol has **living types** (in `sessionState.ts`, `sessionActions.ts`) and **version type snapshots** (in `versions/v1.ts`, etc.). The `versions/versionRegistry.ts` file contains compile-time checks that enforce backwards compatibility between them, plus a runtime map that tracks which action types belong to which version.
+
+The latest version file is the **tip** — it can be edited. Older version files are frozen.
+
+## Adding optional fields to existing types
+
+This is the most common change. No version bump needed.
+
+1. Add the optional field to the living type in `sessionState.ts` or `sessionActions.ts`:
+   ```typescript
+   export interface IToolCallState {
+       // ...existing fields...
+       readonly mcpServerName?: string; // new optional field
+   }
+   ```
+2. Add the same optional field to the corresponding type in the **tip** version file (currently `versions/v1.ts`):
+   ```typescript
+   export interface IV1_ToolCallState {
+       // ...existing fields...
+       readonly mcpServerName?: string;
+   }
+   ```
+3. Compile. If it passes, you're done. If it fails, you tried to do something incompatible.
+
+You can also skip step 2 — the tip is allowed to be a subset of the living type. But adding it to the tip documents that the field exists at this version.
+
+## Adding new action types
+
+Adding a new action type is backwards-compatible and does **not** require a version bump. Old clients at the same version ignore unknown action types (reducers return state unchanged). Old servers at the same version simply never produce the action.
+
+1. **Add the new action interface** to `sessionActions.ts` and include it in the `ISessionAction` or `IRootAction` union.
+2. **Add the action to `ACTION_INTRODUCED_IN`** in `versions/versionRegistry.ts` with the **current** version number. The compiler will force you to do this — if you add a type to the union without a map entry, it won't compile.
+3. **Add the type to the tip version file** (currently `versions/v1.ts`) and add an `AssertCompatible` check in `versions/versionRegistry.ts`.
+4. **Add a reducer case** in `sessionReducers.ts` to handle the new action.
+5. **Update `../../../protocol.md`** to document the new action.
+
+### When to bump the version
+
+Bump `PROTOCOL_VERSION` when you need a **capability boundary** — i.e., a client needs to check "does this server support feature X?" before sending commands or rendering UI. Examples:
+
+- A new **client-sendable** action that requires server-side support (the client must know the server can handle it before sending)
+- A group of related actions that form a new feature area (subagents, model selection, etc.)
+
+When bumping:
+1. **Bump `PROTOCOL_VERSION`** in `versions/versionRegistry.ts`.
+2. **Create the new tip version file** `versions/v{N}.ts`. Copy the previous tip and add your new types. The previous tip is now frozen — do not edit it.
+3. **Add `AssertCompatible` checks** in `versions/versionRegistry.ts` for the new version's types.
+4. **Add `ProtocolCapabilities` fields** in `sessionCapabilities.ts` for the new feature area.
+5. Assign your new action types version N in `ACTION_INTRODUCED_IN`.
+6. **Update `../../../protocol.md`** version history.
+
+## Adding new notification types
+
+Same process as new action types, but use `NOTIFICATION_INTRODUCED_IN` instead of `ACTION_INTRODUCED_IN`.
+
+## Raising the minimum protocol version
+
+This drops support for old clients and lets you delete compatibility cruft.
+
+1. **Raise `MIN_PROTOCOL_VERSION`** in `versions/versionRegistry.ts` from N to N+1.
+2. **Delete `versions/v{N}.ts`**.
+3. **Remove the v{N} `AssertCompatible` checks** and version-grouped type aliases from `versions/versionRegistry.ts`.
+4. **Compile.** The compiler will surface any code that referenced the deleted version types — clean it up.
+5. **Update `../../../protocol.md`** version history.
+
+## What the compiler catches
+
+| Mistake | Compile error |
+|---|---|
+| Remove a field from a living type | `Current extends Frozen` fails in `AssertCompatible` |
+| Change a field's type | `Current extends Frozen` fails in `AssertCompatible` |
+| Add a required field to a living type | `Frozen extends Current` fails in `AssertCompatible` |
+| Add action to union, forget `ACTION_INTRODUCED_IN` entry | Mapped type index is incomplete |
+| Add notification to union, forget `NOTIFICATION_INTRODUCED_IN` entry | Mapped type index is incomplete |
+| Remove action type that a version still references | Version-grouped union no longer extends living union |

--- a/src/vs/platform/agent/common/state/sessionActions.ts
+++ b/src/vs/platform/agent/common/state/sessionActions.ts
@@ -1,0 +1,246 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Action and notification types for the sessions process protocol.
+// See protocol.md -> Actions for the full design.
+//
+// Actions mutate subscribable state via reducers. Notifications are ephemeral
+// broadcasts not stored in state. Both flow through ActionEnvelopes.
+//
+// Asymmetry: not all actions can be triggered by clients. Root actions are
+// server-only. Session actions are mixed — see the "Client-sendable?" column
+// in protocol.md for the authoritative list.
+
+import { URI } from '../../../../base/common/uri.js';
+import type {
+	IAgentInfo,
+	ICompletedToolCall,
+	IErrorInfo,
+	IPermissionRequest,
+	IResponsePart,
+	ISessionModelInfo,
+	ISessionSummary,
+	IToolCallState,
+	IUsageInfo,
+	IUserMessage,
+} from './sessionState.js';
+
+// ---- Action envelope --------------------------------------------------------
+
+/**
+ * Wraps every action with server-assigned sequencing and origin tracking.
+ * This enables write-ahead reconciliation: the client can tell whether an
+ * incoming action was its own (echo) or from another source (rebase needed).
+ */
+export interface IActionEnvelope<A extends IStateAction = IStateAction> {
+	/** The action payload. */
+	readonly action: A;
+	/** Monotonically increasing sequence number assigned by the server. */
+	readonly serverSeq: number;
+	/**
+	 * Origin tracking. `undefined` means the action was produced by the server
+	 * itself (e.g. from an agent backend). Otherwise identifies the client that
+	 * sent the command which triggered this action.
+	 */
+	readonly origin: IActionOrigin | undefined;
+	/**
+	 * Set to `true` when the server rejected the command that produced this
+	 * action. The client should revert its optimistic prediction.
+	 */
+	readonly rejected?: true;
+}
+
+export interface IActionOrigin {
+	readonly clientId: string;
+	readonly clientSeq: number;
+}
+
+// ---- Root actions (server-only, mutate RootState) ---------------------------
+
+export interface IModelsChangedAction {
+	readonly type: 'root/modelsChanged';
+	readonly models: readonly ISessionModelInfo[];
+}
+
+export interface IAgentsChangedAction {
+	readonly type: 'root/agentsChanged';
+	readonly agents: readonly IAgentInfo[];
+}
+
+export type IRootAction =
+	| IModelsChangedAction
+	| IAgentsChangedAction;
+
+// ---- Session actions (mutate SessionState, scoped to a session URI) ---------
+
+interface ISessionActionBase {
+	/** URI identifying the session this action applies to. */
+	readonly session: URI;
+}
+
+// -- Lifecycle (server-only) --
+
+export interface ISessionReadyAction extends ISessionActionBase {
+	readonly type: 'session/ready';
+}
+
+export interface ISessionCreationFailedAction extends ISessionActionBase {
+	readonly type: 'session/creationFailed';
+	readonly error: IErrorInfo;
+}
+
+// -- Turn lifecycle --
+
+/** Client-dispatchable. Server starts agent processing on receipt. */
+export interface ITurnStartedAction extends ISessionActionBase {
+	readonly type: 'session/turnStarted';
+	readonly turnId: string;
+	readonly userMessage: IUserMessage;
+}
+
+/** Server-only. */
+export interface IDeltaAction extends ISessionActionBase {
+	readonly type: 'session/delta';
+	readonly turnId: string;
+	readonly content: string;
+}
+
+/** Server-only. */
+export interface IResponsePartAction extends ISessionActionBase {
+	readonly type: 'session/responsePart';
+	readonly turnId: string;
+	readonly part: IResponsePart;
+}
+
+// -- Tool calls (server-only) --
+
+export interface IToolStartAction extends ISessionActionBase {
+	readonly type: 'session/toolStart';
+	readonly turnId: string;
+	readonly toolCall: IToolCallState;
+}
+
+export interface IToolCompleteAction extends ISessionActionBase {
+	readonly type: 'session/toolComplete';
+	readonly turnId: string;
+	readonly toolCallId: string;
+	readonly result: Omit<ICompletedToolCall, 'toolCallId' | 'toolName' | 'displayName'>;
+}
+
+// -- Permissions --
+
+/** Server-only. */
+export interface IPermissionRequestAction extends ISessionActionBase {
+	readonly type: 'session/permissionRequest';
+	readonly turnId: string;
+	readonly request: IPermissionRequest;
+}
+
+/** Client-dispatchable. Server unblocks pending tool execution. */
+export interface IPermissionResolvedAction extends ISessionActionBase {
+	readonly type: 'session/permissionResolved';
+	readonly turnId: string;
+	readonly requestId: string;
+	readonly approved: boolean;
+}
+
+// -- Turn completion --
+
+/** Server-only. */
+export interface ITurnCompleteAction extends ISessionActionBase {
+	readonly type: 'session/turnComplete';
+	readonly turnId: string;
+}
+
+/** Client-dispatchable. Server aborts in-progress processing. */
+export interface ITurnCancelledAction extends ISessionActionBase {
+	readonly type: 'session/turnCancelled';
+	readonly turnId: string;
+}
+
+/** Server-only. */
+export interface ISessionErrorAction extends ISessionActionBase {
+	readonly type: 'session/error';
+	readonly turnId: string;
+	readonly error: IErrorInfo;
+}
+
+// -- Metadata & informational --
+
+/** Server-only. */
+export interface ITitleChangedAction extends ISessionActionBase {
+	readonly type: 'session/titleChanged';
+	readonly title: string;
+}
+
+/** Server-only. */
+export interface IUsageAction extends ISessionActionBase {
+	readonly type: 'session/usage';
+	readonly turnId: string;
+	readonly usage: IUsageInfo;
+}
+
+/** Server-only. */
+export interface IReasoningAction extends ISessionActionBase {
+	readonly type: 'session/reasoning';
+	readonly turnId: string;
+	readonly content: string;
+}
+
+export type ISessionAction =
+	| ISessionReadyAction
+	| ISessionCreationFailedAction
+	| ITurnStartedAction
+	| IDeltaAction
+	| IResponsePartAction
+	| IToolStartAction
+	| IToolCompleteAction
+	| IPermissionRequestAction
+	| IPermissionResolvedAction
+	| ITurnCompleteAction
+	| ITurnCancelledAction
+	| ISessionErrorAction
+	| ITitleChangedAction
+	| IUsageAction
+	| IReasoningAction;
+
+// ---- Combined state action type ---------------------------------------------
+
+/** Any action that mutates subscribable state (processed by a reducer). */
+export type IStateAction = IRootAction | ISessionAction;
+
+// ---- Notifications (ephemeral, not stored in state) -------------------------
+
+/**
+ * Broadcast to all connected clients when a session is created.
+ * Not processed by reducers — used by clients to maintain a local session list.
+ */
+export interface ISessionAddedNotification {
+	readonly type: 'notify/sessionAdded';
+	readonly summary: ISessionSummary;
+}
+
+/**
+ * Broadcast to all connected clients when a session is disposed.
+ * Not processed by reducers — used by clients to maintain a local session list.
+ */
+export interface ISessionRemovedNotification {
+	readonly type: 'notify/sessionRemoved';
+	readonly session: URI;
+}
+
+export type INotification =
+	| ISessionAddedNotification
+	| ISessionRemovedNotification;
+
+// ---- Type guards ------------------------------------------------------------
+
+export function isRootAction(action: IStateAction): action is IRootAction {
+	return action.type.startsWith('root/');
+}
+
+export function isSessionAction(action: IStateAction): action is ISessionAction {
+	return action.type.startsWith('session/');
+}

--- a/src/vs/platform/agent/common/state/sessionCapabilities.ts
+++ b/src/vs/platform/agent/common/state/sessionCapabilities.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Protocol version constants and capability derivation.
+// See protocol.md -> Versioning for the full design.
+//
+// The authoritative version numbers and action-filtering logic live in
+// versions/versionRegistry.ts. This file re-exports them and provides the
+// capability-object API that client code uses to gate features.
+
+export {
+	ACTION_INTRODUCED_IN,
+	isActionKnownToVersion,
+	isNotificationKnownToVersion,
+	MIN_PROTOCOL_VERSION,
+	NOTIFICATION_INTRODUCED_IN,
+	PROTOCOL_VERSION,
+} from './versions/versionRegistry.js';
+
+/**
+ * Capabilities derived from a protocol version.
+ * Core features (v1) are always-present literal `true`.
+ * Features from later versions are optional `true | undefined`.
+ */
+export interface ProtocolCapabilities {
+	// v1 — always present
+	readonly sessions: true;
+	readonly tools: true;
+	readonly permissions: true;
+}
+
+/**
+ * Derives the set of capabilities available at a given protocol version.
+ * Newer clients use this to determine which features the server supports.
+ */
+export function capabilitiesForVersion(version: number): ProtocolCapabilities {
+	if (version < 1) {
+		throw new Error(`Unsupported protocol version: ${version}`);
+	}
+
+	return {
+		sessions: true,
+		tools: true,
+		permissions: true,
+		// Future versions add fields here:
+		// ...(version >= 2 ? { reasoning: true as const } : {}),
+	};
+}

--- a/src/vs/platform/agent/common/state/sessionClientState.ts
+++ b/src/vs/platform/agent/common/state/sessionClientState.ts
@@ -1,0 +1,280 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Client-side state manager for the sessions process protocol.
+// See protocol.md -> Write-ahead reconciliation for the full design.
+//
+// Manages confirmed state (last server-acknowledged), pending actions queue
+// (optimistically applied), and reconciliation when the server echoes back
+// or sends concurrent actions from other sources.
+//
+// This operates on two kinds of subscribable state:
+//   - Root state (agents, models) — server-only mutations, no write-ahead.
+//   - Session state — mixed: some actions client-sendable (write-ahead),
+//     others server-only.
+
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IActionEnvelope, INotification, ISessionAction, isRootAction, isSessionAction, IStateAction } from './sessionActions.js';
+import { rootReducer, sessionReducer } from './sessionReducers.js';
+import { IRootState, ISessionState, ROOT_STATE_URI } from './sessionState.js';
+
+// ---- Pending action tracking ------------------------------------------------
+
+interface IPendingAction {
+	readonly clientSeq: number;
+	readonly action: IStateAction;
+}
+
+// ---- Client state manager ---------------------------------------------------
+
+/**
+ * Manages the client's local view of the state tree with write-ahead
+ * reconciliation. The client can optimistically apply its own session
+ * actions and reconcile when the server echoes them back (possibly
+ * interleaved with actions from other clients or the server).
+ *
+ * Usage:
+ * 1. Call `handleSnapshot(resource, state, fromSeq)` for each snapshot
+ *    from the handshake or a subscribe response.
+ * 2. Call `applyOptimistic(action)` when the user does something
+ *    (returns a clientSeq for the command).
+ * 3. Call `receiveEnvelope(envelope)` for each action from the server.
+ * 4. Call `receiveNotification(notification)` for each notification.
+ * 5. Read `rootState` / `getSessionState(uri)` for the current view.
+ */
+export class SessionClientState extends Disposable {
+
+	private readonly _clientId: string;
+	private _nextClientSeq = 1;
+	private _lastSeenServerSeq = 0;
+
+	// Confirmed state — reflects only what the server has acknowledged
+	private _confirmedRootState: IRootState | undefined;
+	private readonly _confirmedSessionStates = new Map<string, ISessionState>();
+
+	// Pending session actions (root actions are server-only, never pending)
+	private readonly _pendingActions: IPendingAction[] = [];
+
+	// Cached optimistic state — recomputed when confirmed or pending changes
+	private _optimisticRootState: IRootState | undefined;
+	private readonly _optimisticSessionStates = new Map<string, ISessionState>();
+
+	private readonly _onDidChangeRootState = this._register(new Emitter<IRootState>());
+	readonly onDidChangeRootState: Event<IRootState> = this._onDidChangeRootState.event;
+
+	private readonly _onDidChangeSessionState = this._register(new Emitter<{ session: URI; state: ISessionState }>());
+	readonly onDidChangeSessionState: Event<{ session: URI; state: ISessionState }> = this._onDidChangeSessionState.event;
+
+	private readonly _onDidReceiveNotification = this._register(new Emitter<INotification>());
+	readonly onDidReceiveNotification: Event<INotification> = this._onDidReceiveNotification.event;
+
+	constructor(clientId: string) {
+		super();
+		this._clientId = clientId;
+	}
+
+	get clientId(): string {
+		return this._clientId;
+	}
+
+	get lastSeenServerSeq(): number {
+		return this._lastSeenServerSeq;
+	}
+
+	/** Current root state, or undefined if not yet subscribed. */
+	get rootState(): IRootState | undefined {
+		return this._optimisticRootState;
+	}
+
+	/** Current optimistic session state, or undefined if not subscribed. */
+	getSessionState(session: URI): ISessionState | undefined {
+		return this._optimisticSessionStates.get(session.toString());
+	}
+
+	/** URIs of sessions the client is currently subscribed to. */
+	get subscribedSessions(): readonly URI[] {
+		return [...this._confirmedSessionStates.keys()].map(k => URI.parse(k));
+	}
+
+	// ---- Snapshot handling ---------------------------------------------------
+
+	/**
+	 * Apply a state snapshot received from the server (from handshake,
+	 * subscribe response, or reconnection).
+	 */
+	handleSnapshot(resource: URI, state: IRootState | ISessionState, fromSeq: number): void {
+		this._lastSeenServerSeq = Math.max(this._lastSeenServerSeq, fromSeq);
+
+		if (resource.toString() === ROOT_STATE_URI.toString()) {
+			const rootState = state as IRootState;
+			this._confirmedRootState = rootState;
+			this._optimisticRootState = rootState;
+			this._onDidChangeRootState.fire(rootState);
+		} else {
+			const key = resource.toString();
+			const sessionState = state as ISessionState;
+			this._confirmedSessionStates.set(key, sessionState);
+			this._optimisticSessionStates.set(key, sessionState);
+			// Re-apply any pending session actions for this session
+			this._recomputeOptimisticSession(resource);
+			this._onDidChangeSessionState.fire({
+				session: resource,
+				state: this._optimisticSessionStates.get(key)!,
+			});
+		}
+	}
+
+	/**
+	 * Unsubscribe from a resource, dropping its local state.
+	 */
+	unsubscribe(resource: URI): void {
+		const key = resource.toString();
+		if (key === ROOT_STATE_URI.toString()) {
+			this._confirmedRootState = undefined;
+			this._optimisticRootState = undefined;
+		} else {
+			this._confirmedSessionStates.delete(key);
+			this._optimisticSessionStates.delete(key);
+			// Remove pending actions for this session
+			for (let i = this._pendingActions.length - 1; i >= 0; i--) {
+				const action = this._pendingActions[i].action;
+				if (isSessionAction(action) && action.session.toString() === key) {
+					this._pendingActions.splice(i, 1);
+				}
+			}
+		}
+	}
+
+	// ---- Write-ahead --------------------------------------------------------
+
+	/**
+	 * Optimistically apply a session action locally. Returns the clientSeq
+	 * that should be sent to the server with the corresponding command so
+	 * the server can echo it back for reconciliation.
+	 *
+	 * Only session actions can be write-ahead (root actions are server-only).
+	 */
+	applyOptimistic(action: ISessionAction): number {
+		const clientSeq = this._nextClientSeq++;
+		this._pendingActions.push({ clientSeq, action });
+		this._applySessionToOptimistic(action);
+		return clientSeq;
+	}
+
+	// ---- Receiving server messages ------------------------------------------
+
+	/**
+	 * Process an action envelope received from the server.
+	 * This is the core reconciliation algorithm.
+	 */
+	receiveEnvelope(envelope: IActionEnvelope): void {
+		this._lastSeenServerSeq = Math.max(this._lastSeenServerSeq, envelope.serverSeq);
+
+		const origin = envelope.origin;
+		const isOwnAction = origin !== undefined && origin.clientId === this._clientId;
+
+		if (isOwnAction) {
+			const headIdx = this._pendingActions.findIndex(p => p.clientSeq === origin.clientSeq);
+
+			if (headIdx !== -1) {
+				if (envelope.rejected) {
+					this._pendingActions.splice(headIdx, 1);
+				} else {
+					this._applyToConfirmed(envelope.action);
+					this._pendingActions.splice(headIdx, 1);
+				}
+			} else {
+				this._applyToConfirmed(envelope.action);
+			}
+		} else {
+			this._applyToConfirmed(envelope.action);
+		}
+
+		// Recompute optimistic state from confirmed + remaining pending
+		this._recomputeOptimistic(envelope.action);
+	}
+
+	/**
+	 * Process an ephemeral notification from the server.
+	 * Not stored in state — just forwarded to listeners.
+	 */
+	receiveNotification(notification: INotification): void {
+		this._onDidReceiveNotification.fire(notification);
+	}
+
+	// ---- Internal state management ------------------------------------------
+
+	private _applyToConfirmed(action: IStateAction): void {
+		if (isRootAction(action) && this._confirmedRootState) {
+			this._confirmedRootState = rootReducer(this._confirmedRootState, action);
+		}
+		if (isSessionAction(action)) {
+			const key = action.session.toString();
+			const state = this._confirmedSessionStates.get(key);
+			if (state) {
+				this._confirmedSessionStates.set(key, sessionReducer(state, action));
+			}
+		}
+	}
+
+	private _applySessionToOptimistic(action: ISessionAction): void {
+		const key = action.session.toString();
+		const state = this._optimisticSessionStates.get(key);
+		if (state) {
+			const newState = sessionReducer(state, action);
+			this._optimisticSessionStates.set(key, newState);
+			this._onDidChangeSessionState.fire({ session: action.session, state: newState });
+		}
+	}
+
+	/**
+	 * After applying a server action to confirmed state, recompute optimistic
+	 * state by replaying pending actions on top of confirmed.
+	 */
+	private _recomputeOptimistic(triggerAction: IStateAction): void {
+		// Root state: no pending actions (server-only), so optimistic = confirmed
+		if (isRootAction(triggerAction) && this._confirmedRootState) {
+			this._optimisticRootState = this._confirmedRootState;
+			this._onDidChangeRootState.fire(this._confirmedRootState);
+		}
+
+		// Session states: recompute only affected sessions
+		if (isSessionAction(triggerAction)) {
+			this._recomputeOptimisticSession(triggerAction.session);
+		}
+
+		// Also recompute any sessions that have pending actions
+		const affectedKeys = new Set<string>();
+		for (const pending of this._pendingActions) {
+			if (isSessionAction(pending.action)) {
+				affectedKeys.add(pending.action.session.toString());
+			}
+		}
+		for (const key of affectedKeys) {
+			const uri = URI.parse(key);
+			this._recomputeOptimisticSession(uri);
+		}
+	}
+
+	private _recomputeOptimisticSession(session: URI): void {
+		const key = session.toString();
+		const confirmed = this._confirmedSessionStates.get(key);
+		if (!confirmed) {
+			return;
+		}
+
+		let state = confirmed;
+		for (const pending of this._pendingActions) {
+			if (isSessionAction(pending.action) && pending.action.session.toString() === key) {
+				state = sessionReducer(state, pending.action);
+			}
+		}
+
+		this._optimisticSessionStates.set(key, state);
+		this._onDidChangeSessionState.fire({ session, state });
+	}
+}

--- a/src/vs/platform/agent/common/state/sessionProtocol.ts
+++ b/src/vs/platform/agent/common/state/sessionProtocol.ts
@@ -1,0 +1,201 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Protocol messages for the sessions process client-server communication.
+// See protocol.md -> Client-server protocol for the full design.
+//
+// These types define the wire format for handshake, URI-based subscription,
+// commands, notifications, and reconnection. They are transport-agnostic —
+// the actual transport (MessagePort, WebSocket, stdio) is plugged in separately.
+
+import { URI } from '../../../../base/common/uri.js';
+import type { IActionEnvelope, INotification, ISessionAction, IStateAction } from './sessionActions.js';
+import type { IRootState, ISessionState, ISessionSummary } from './sessionState.js';
+
+// ---- Client → Server messages -----------------------------------------------
+
+export interface IClientHello {
+	readonly type: 'clientHello';
+	readonly protocolVersion: number;
+	readonly clientId: string;
+	/** Subscribe to these URIs as part of the handshake (saves a round-trip). */
+	readonly initialSubscriptions?: readonly URI[];
+}
+
+export interface IClientReconnect {
+	readonly type: 'clientReconnect';
+	readonly clientId: string;
+	readonly lastSeenServerSeq: number;
+	/** URIs the client was subscribed to before disconnection. */
+	readonly subscriptions: readonly URI[];
+}
+
+export interface ISubscribe {
+	readonly type: 'subscribe';
+	/** URI to subscribe to (e.g. `agenthost:root` or `copilot:/<uuid>`). */
+	readonly resource: URI;
+}
+
+export interface IUnsubscribe {
+	readonly type: 'unsubscribe';
+	readonly resource: URI;
+}
+
+/**
+ * A client-dispatched action. The server applies it to state and
+ * reacts with side effects (e.g., starting agent processing).
+ * Used for write-ahead actions like turnStarted, turnCancelled,
+ * permissionResolved.
+ */
+export interface IClientAction {
+	readonly type: 'action';
+	readonly clientSeq: number;
+	readonly action: ISessionAction;
+}
+
+/**
+ * A command from the client requesting an imperative operation
+ * that doesn't map directly to a single state action.
+ */
+export interface IClientCommand {
+	readonly type: 'command';
+	readonly command: ISessionCommand;
+}
+
+export type IClientMessage =
+	| IClientHello
+	| IClientReconnect
+	| ISubscribe
+	| IUnsubscribe
+	| IClientAction
+	| IClientCommand;
+
+// ---- Commands (embedded in IClientCommand) ----------------------------------
+
+export interface ICreateSessionCommand {
+	readonly type: 'createSession';
+	/** URI the client has chosen for this session (client picks the ID). */
+	readonly session: URI;
+	readonly provider?: string;
+	readonly model?: string;
+	readonly workingDirectory?: string;
+}
+
+export interface IDisposeSessionCommand {
+	readonly type: 'disposeSession';
+	readonly session: URI;
+}
+
+export interface IFetchContentCommand {
+	readonly type: 'fetchContent';
+	readonly uri: URI;
+}
+
+export interface IFetchTurnsCommand {
+	readonly type: 'fetchTurns';
+	readonly session: URI;
+	readonly startTurn: number;
+	readonly count: number;
+}
+
+export interface IListSessionsCommand {
+	readonly type: 'listSessions';
+}
+
+export type ISessionCommand =
+	| ICreateSessionCommand
+	| IDisposeSessionCommand
+	| IFetchContentCommand
+	| IFetchTurnsCommand
+	| IListSessionsCommand;
+
+// ---- Server → Client messages -----------------------------------------------
+
+export interface IServerHello {
+	readonly type: 'serverHello';
+	readonly protocolVersion: number;
+	readonly serverSeq: number;
+	/** Snapshots for each URI in the client's `initialSubscriptions`. */
+	readonly snapshots: readonly IStateSnapshot[];
+}
+
+/**
+ * Response to a subscribe request. Contains the state snapshot and
+ * the server sequence at snapshot time. The client processes subsequent
+ * actions with serverSeq > fromSeq.
+ */
+export interface IStateSnapshot {
+	readonly type: 'stateSnapshot';
+	readonly resource: URI;
+	readonly state: IRootState | ISessionState;
+	readonly fromSeq: number;
+}
+
+/**
+ * A state-changing action broadcast to subscribed clients.
+ */
+export interface IActionMessage {
+	readonly type: 'action';
+	readonly envelope: IActionEnvelope<IStateAction>;
+}
+
+/**
+ * An ephemeral notification broadcast to all connected clients.
+ * Not stored in state, not replayed on reconnect.
+ */
+export interface INotificationMessage {
+	readonly type: 'notification';
+	readonly notification: INotification;
+}
+
+/**
+ * Response to a fetchContent command.
+ */
+export interface IContentResponse {
+	readonly type: 'contentResponse';
+	readonly uri: URI;
+	readonly data: string; // base64-encoded for binary safety over JSON
+	readonly mimeType?: string;
+}
+
+/**
+ * Response to a fetchTurns command.
+ */
+export interface ITurnsResponse {
+	readonly type: 'turnsResponse';
+	readonly session: URI;
+	readonly startTurn: number;
+	readonly turns: ISessionState['turns'];
+	readonly totalTurns: number;
+}
+
+/**
+ * Response to a listSessions command.
+ */
+export interface IListSessionsResponse {
+	readonly type: 'listSessionsResponse';
+	readonly sessions: readonly ISessionSummary[];
+}
+
+/**
+ * Sent on reconnection. Contains fresh snapshots for all previously
+ * subscribed URIs. Notifications are NOT replayed — the client should
+ * re-fetch the session list.
+ */
+export interface IReconnectResponse {
+	readonly type: 'reconnectResponse';
+	readonly serverSeq: number;
+	readonly snapshots: readonly IStateSnapshot[];
+}
+
+export type IServerMessage =
+	| IServerHello
+	| IStateSnapshot
+	| IActionMessage
+	| INotificationMessage
+	| IContentResponse
+	| ITurnsResponse
+	| IListSessionsResponse
+	| IReconnectResponse;

--- a/src/vs/platform/agent/common/state/sessionReducers.ts
+++ b/src/vs/platform/agent/common/state/sessionReducers.ts
@@ -1,0 +1,247 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Pure reducer functions for the sessions process protocol.
+// See protocol.md -> Reducers for the full design.
+//
+// Both the server and clients run the same reducers. This is what makes
+// write-ahead possible: the client can locally predict the result of its
+// own action using the exact same logic the server will run.
+//
+// IMPORTANT: Reducers must be pure — no side effects, no I/O, no service
+// calls. Server-side effects (e.g. forwarding to the Copilot SDK) are
+// handled by a separate dispatch layer.
+
+import type { IRootAction, ISessionAction } from './sessionActions.js';
+import {
+	type ICompletedToolCall,
+	type IRootState,
+	type ISessionState,
+	type IToolCallState,
+	type ITurn,
+	createActiveTurn,
+	SessionLifecycle,
+	SessionStatus,
+	ToolCallStatus,
+	TurnState,
+} from './sessionState.js';
+
+// ---- Root reducer -----------------------------------------------------------
+
+/**
+ * Reduces root-level actions into a new RootState.
+ * Root actions are server-only (clients observe but cannot produce them).
+ */
+export function rootReducer(state: IRootState, action: IRootAction): IRootState {
+	switch (action.type) {
+		case 'root/modelsChanged': {
+			return { ...state, models: action.models };
+		}
+		case 'root/agentsChanged': {
+			return { ...state, agents: action.agents };
+		}
+	}
+}
+
+// ---- Session reducer --------------------------------------------------------
+
+/**
+ * Reduces session-level actions into a new SessionState.
+ * Handles lifecycle, turn lifecycle, streaming deltas, tool calls, permissions.
+ */
+export function sessionReducer(state: ISessionState, action: ISessionAction): ISessionState {
+	switch (action.type) {
+		case 'session/ready': {
+			return { ...state, lifecycle: SessionLifecycle.Ready };
+		}
+		case 'session/creationFailed': {
+			return {
+				...state,
+				lifecycle: SessionLifecycle.CreationFailed,
+				creationError: action.error,
+			};
+		}
+		case 'session/turnStarted': {
+			const activeTurn = createActiveTurn(action.turnId, action.userMessage);
+			return {
+				...state,
+				activeTurn,
+				summary: { ...state.summary, status: SessionStatus.InProgress },
+			};
+		}
+		case 'session/delta': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			return {
+				...state,
+				activeTurn: {
+					...state.activeTurn,
+					streamingText: state.activeTurn.streamingText + action.content,
+				},
+			};
+		}
+		case 'session/responsePart': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			return {
+				...state,
+				activeTurn: {
+					...state.activeTurn,
+					responseParts: [...state.activeTurn.responseParts, action.part],
+				},
+			};
+		}
+		case 'session/toolStart': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			const toolCalls = new Map(state.activeTurn.toolCalls);
+			toolCalls.set(action.toolCall.toolCallId, action.toolCall);
+			return {
+				...state,
+				activeTurn: { ...state.activeTurn, toolCalls },
+			};
+		}
+		case 'session/toolComplete': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			const toolCall = state.activeTurn.toolCalls.get(action.toolCallId);
+			if (!toolCall) {
+				return state;
+			}
+			const toolCalls = new Map(state.activeTurn.toolCalls);
+			toolCalls.set(action.toolCallId, {
+				...toolCall,
+				status: action.result.success ? ToolCallStatus.Completed : ToolCallStatus.Failed,
+			});
+			return {
+				...state,
+				activeTurn: { ...state.activeTurn, toolCalls },
+			};
+		}
+		case 'session/permissionRequest': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			const pendingPermissions = new Map(state.activeTurn.pendingPermissions);
+			pendingPermissions.set(action.request.requestId, action.request);
+			let toolCalls: ReadonlyMap<string, IToolCallState> = state.activeTurn.toolCalls;
+			if (action.request.toolCallId) {
+				const toolCall = toolCalls.get(action.request.toolCallId);
+				if (toolCall) {
+					const mutable = new Map(toolCalls);
+					mutable.set(action.request.toolCallId, {
+						...toolCall,
+						status: ToolCallStatus.PendingPermission,
+					});
+					toolCalls = mutable;
+				}
+			}
+			return {
+				...state,
+				activeTurn: { ...state.activeTurn, pendingPermissions, toolCalls },
+			};
+		}
+		case 'session/permissionResolved': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			const pendingPermissions = new Map(state.activeTurn.pendingPermissions);
+			const resolved = pendingPermissions.get(action.requestId);
+			pendingPermissions.delete(action.requestId);
+			let toolCalls: ReadonlyMap<string, IToolCallState> = state.activeTurn.toolCalls;
+			if (resolved?.toolCallId) {
+				const toolCall = toolCalls.get(resolved.toolCallId);
+				if (toolCall && toolCall.status === ToolCallStatus.PendingPermission) {
+					const mutable = new Map(toolCalls);
+					mutable.set(resolved.toolCallId, {
+						...toolCall,
+						status: action.approved ? ToolCallStatus.Running : ToolCallStatus.Failed,
+					});
+					toolCalls = mutable;
+				}
+			}
+			return {
+				...state,
+				activeTurn: { ...state.activeTurn, pendingPermissions, toolCalls },
+			};
+		}
+		case 'session/turnComplete': {
+			return finalizeTurn(state, action.turnId, TurnState.Complete);
+		}
+		case 'session/turnCancelled': {
+			return finalizeTurn(state, action.turnId, TurnState.Cancelled);
+		}
+		case 'session/error': {
+			return finalizeTurn(state, action.turnId, TurnState.Error);
+		}
+		case 'session/titleChanged': {
+			return {
+				...state,
+				summary: { ...state.summary, title: action.title },
+			};
+		}
+		case 'session/usage': {
+			// Usage is informational; stored on the active turn for now,
+			// then captured on the finalized Turn.
+			return state;
+		}
+		case 'session/reasoning': {
+			if (!state.activeTurn || state.activeTurn.id !== action.turnId) {
+				return state;
+			}
+			return {
+				...state,
+				activeTurn: {
+					...state.activeTurn,
+					reasoning: state.activeTurn.reasoning + action.content,
+				},
+			};
+		}
+	}
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+/**
+ * Moves the active turn into the completed turns array and clears `activeTurn`.
+ */
+function finalizeTurn(state: ISessionState, turnId: string, turnState: TurnState): ISessionState {
+	if (!state.activeTurn || state.activeTurn.id !== turnId) {
+		return state;
+	}
+	const active = state.activeTurn;
+
+	const completedToolCalls: ICompletedToolCall[] = [];
+	for (const tc of active.toolCalls.values()) {
+		completedToolCalls.push({
+			toolCallId: tc.toolCallId,
+			toolName: tc.toolName,
+			displayName: tc.displayName,
+			success: tc.status === ToolCallStatus.Completed,
+			pastTenseMessage: tc.invocationMessage,
+			toolOutput: tc.toolInput,
+		});
+	}
+
+	const finalizedTurn: ITurn = {
+		id: active.id,
+		userMessage: active.userMessage,
+		responseParts: active.responseParts,
+		toolCalls: completedToolCalls,
+		usage: undefined,
+		state: turnState,
+	};
+
+	return {
+		...state,
+		turns: [...state.turns, finalizedTurn],
+		activeTurn: undefined,
+		summary: { ...state.summary, status: SessionStatus.Idle },
+	};
+}

--- a/src/vs/platform/agent/common/state/sessionState.ts
+++ b/src/vs/platform/agent/common/state/sessionState.ts
@@ -1,0 +1,247 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Immutable state types for the sessions process protocol.
+// See protocol.md for the full design rationale.
+//
+// These types represent the server-authoritative state tree. Both the server
+// and clients use the same types — clients hold a local copy that they keep
+// in sync via actions from the server.
+
+import { URI } from '../../../../base/common/uri.js';
+import type { AgentProvider } from '../agentService.js';
+
+// ---- Well-known URIs --------------------------------------------------------
+
+/** URI for the root state subscription. */
+export const ROOT_STATE_URI = URI.from({ scheme: 'agenthost', path: '/root' });
+
+// ---- Lightweight session metadata -------------------------------------------
+
+export const enum SessionStatus {
+	Idle = 'idle',
+	InProgress = 'in-progress',
+	Error = 'error',
+}
+
+/**
+ * Lightweight session summary used in the session list and as embedded
+ * metadata within a subscribed session. Identified by a URI.
+ */
+export interface ISessionSummary {
+	readonly resource: URI;
+	readonly provider: AgentProvider;
+	readonly title: string;
+	readonly status: SessionStatus;
+	readonly createdAt: number;
+	readonly modifiedAt: number;
+}
+
+// ---- Model info -------------------------------------------------------------
+
+export interface ISessionModelInfo {
+	readonly id: string;
+	readonly provider: AgentProvider;
+	readonly name: string;
+}
+
+// ---- Root state (subscribable at ROOT_STATE_URI) ----------------------------
+
+/**
+ * Global state shared with every client subscribed to {@link ROOT_STATE_URI}.
+ * Does **not** contain the session list — that is fetched imperatively via
+ * `listSessions()` RPC. See protocol.md -> Session list.
+ */
+export interface IRootState {
+	readonly agents: readonly IAgentInfo[];
+	readonly models: readonly ISessionModelInfo[];
+}
+
+export interface IAgentInfo {
+	readonly provider: AgentProvider;
+	readonly displayName: string;
+	readonly description: string;
+}
+
+// ---- Session lifecycle ------------------------------------------------------
+
+export const enum SessionLifecycle {
+	/** The server is asynchronously initializing the agent backend. */
+	Creating = 'creating',
+	/** The session is ready for use. */
+	Ready = 'ready',
+	/** Backend initialization failed. See {@link ISessionState.creationError}. */
+	CreationFailed = 'creationFailed',
+}
+
+// ---- Per-session state (subscribable at session URI) ------------------------
+
+/**
+ * Full state for a single session, loaded when a client subscribes to
+ * the session's URI.
+ */
+export interface ISessionState {
+	readonly summary: ISessionSummary;
+	readonly lifecycle: SessionLifecycle;
+	readonly creationError?: IErrorInfo;
+	readonly turns: readonly ITurn[];
+	readonly activeTurn: IActiveTurn | undefined;
+}
+
+// ---- Turn types -------------------------------------------------------------
+
+export interface IUserMessage {
+	readonly text: string;
+	readonly attachments?: readonly IMessageAttachment[];
+}
+
+export interface IMessageAttachment {
+	readonly type: 'file' | 'directory' | 'selection';
+	readonly path: string;
+	readonly displayName?: string;
+}
+
+/**
+ * A completed request/response cycle.
+ */
+export interface ITurn {
+	readonly id: string;
+	readonly userMessage: IUserMessage;
+	readonly responseParts: readonly IResponsePart[];
+	readonly toolCalls: readonly ICompletedToolCall[];
+	readonly usage: IUsageInfo | undefined;
+	readonly state: TurnState;
+}
+
+export const enum TurnState {
+	Complete = 'complete',
+	Cancelled = 'cancelled',
+	Error = 'error',
+}
+
+/**
+ * An in-progress turn — the assistant is actively streaming a response.
+ */
+export interface IActiveTurn {
+	readonly id: string;
+	readonly userMessage: IUserMessage;
+	readonly streamingText: string;
+	readonly responseParts: readonly IResponsePart[];
+	readonly toolCalls: ReadonlyMap<string, IToolCallState>;
+	readonly pendingPermissions: ReadonlyMap<string, IPermissionRequest>;
+	readonly reasoning: string;
+}
+
+// ---- Response parts ---------------------------------------------------------
+
+export const enum ResponsePartKind {
+	Markdown = 'markdown',
+	ContentRef = 'contentRef',
+}
+
+export interface IMarkdownResponsePart {
+	readonly kind: ResponsePartKind.Markdown;
+	readonly content: string;
+}
+
+/**
+ * A reference to large content stored outside the state tree.
+ * The client fetches the content separately via fetchContent().
+ */
+export interface IContentRef {
+	readonly kind: ResponsePartKind.ContentRef;
+	readonly uri: string;
+	readonly sizeHint?: number;
+	readonly mimeType?: string;
+}
+
+export type IResponsePart = IMarkdownResponsePart | IContentRef;
+
+// ---- Tool calls -------------------------------------------------------------
+
+export const enum ToolCallStatus {
+	Running = 'running',
+	PendingPermission = 'pending-permission',
+	Completed = 'completed',
+	Failed = 'failed',
+}
+
+export interface IToolCallState {
+	readonly toolCallId: string;
+	readonly toolName: string;
+	readonly displayName: string;
+	readonly invocationMessage: string;
+	readonly toolInput?: string;
+	readonly toolKind?: 'terminal';
+	readonly language?: string;
+	readonly status: ToolCallStatus;
+}
+
+export interface ICompletedToolCall {
+	readonly toolCallId: string;
+	readonly toolName: string;
+	readonly displayName: string;
+	readonly success: boolean;
+	readonly pastTenseMessage: string;
+	readonly toolOutput?: string;
+}
+
+// ---- Permission requests ----------------------------------------------------
+
+export interface IPermissionRequest {
+	readonly requestId: string;
+	readonly permissionKind: 'shell' | 'write' | 'mcp' | 'read' | 'url';
+	readonly toolCallId?: string;
+	readonly path?: string;
+	readonly fullCommandText?: string;
+	readonly intention?: string;
+}
+
+// ---- Usage info -------------------------------------------------------------
+
+export interface IUsageInfo {
+	readonly inputTokens?: number;
+	readonly outputTokens?: number;
+	readonly model?: string;
+	readonly cacheReadTokens?: number;
+}
+
+// ---- Error info -------------------------------------------------------------
+
+export interface IErrorInfo {
+	readonly errorType: string;
+	readonly message: string;
+	readonly stack?: string;
+}
+
+// ---- Factory helpers --------------------------------------------------------
+
+export function createRootState(): IRootState {
+	return {
+		agents: [],
+		models: [],
+	};
+}
+
+export function createSessionState(summary: ISessionSummary): ISessionState {
+	return {
+		summary,
+		lifecycle: SessionLifecycle.Creating,
+		turns: [],
+		activeTurn: undefined,
+	};
+}
+
+export function createActiveTurn(id: string, userMessage: IUserMessage): IActiveTurn {
+	return {
+		id,
+		userMessage,
+		streamingText: '',
+		responseParts: [],
+		toolCalls: new Map(),
+		pendingPermissions: new Map(),
+		reasoning: '',
+	};
+}

--- a/src/vs/platform/agent/common/state/versions/v1.ts
+++ b/src/vs/platform/agent/common/state/versions/v1.ts
@@ -1,0 +1,280 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Protocol version 1 wire types — the current tip.
+// See ../AGENTS.md for modification instructions.
+//
+// While this is the tip (PROTOCOL_VERSION === 1), you may add optional
+// fields freely. When PROTOCOL_VERSION is bumped, this file freezes and
+// a new tip is created. Delete when MIN_PROTOCOL_VERSION passes 1.
+
+import type { URI } from '../../../../../base/common/uri.js';
+import type { AgentProvider } from '../../agentService.js';
+
+// ---- State types (wire format) ----------------------------------------------
+
+export interface IV1_RootState {
+	readonly agents: readonly IV1_AgentInfo[];
+	readonly models: readonly IV1_SessionModelInfo[];
+}
+
+export interface IV1_AgentInfo {
+	readonly provider: AgentProvider;
+	readonly displayName: string;
+	readonly description: string;
+}
+
+export interface IV1_SessionModelInfo {
+	readonly id: string;
+	readonly provider: AgentProvider;
+	readonly name: string;
+}
+
+export interface IV1_SessionSummary {
+	readonly resource: URI;
+	readonly provider: AgentProvider;
+	readonly title: string;
+	readonly status: 'idle' | 'in-progress' | 'error';
+	readonly createdAt: number;
+	readonly modifiedAt: number;
+}
+
+export interface IV1_SessionState {
+	readonly summary: IV1_SessionSummary;
+	readonly lifecycle: 'creating' | 'ready' | 'creationFailed';
+	readonly creationError?: IV1_ErrorInfo;
+	readonly turns: readonly IV1_Turn[];
+	readonly activeTurn: IV1_ActiveTurn | undefined;
+}
+
+export interface IV1_UserMessage {
+	readonly text: string;
+	readonly attachments?: readonly IV1_MessageAttachment[];
+}
+
+export interface IV1_MessageAttachment {
+	readonly type: 'file' | 'directory' | 'selection';
+	readonly path: string;
+	readonly displayName?: string;
+}
+
+export interface IV1_Turn {
+	readonly id: string;
+	readonly userMessage: IV1_UserMessage;
+	readonly responseParts: readonly IV1_ResponsePart[];
+	readonly toolCalls: readonly IV1_CompletedToolCall[];
+	readonly usage: IV1_UsageInfo | undefined;
+	readonly state: 'complete' | 'cancelled' | 'error';
+}
+
+export interface IV1_ActiveTurn {
+	readonly id: string;
+	readonly userMessage: IV1_UserMessage;
+	readonly streamingText: string;
+	readonly responseParts: readonly IV1_ResponsePart[];
+	readonly toolCalls: ReadonlyMap<string, IV1_ToolCallState>;
+	readonly pendingPermissions: ReadonlyMap<string, IV1_PermissionRequest>;
+	readonly reasoning: string;
+}
+
+export interface IV1_MarkdownResponsePart {
+	readonly kind: 'markdown';
+	readonly content: string;
+}
+
+export interface IV1_ContentRef {
+	readonly kind: 'contentRef';
+	readonly uri: string;
+	readonly sizeHint?: number;
+	readonly mimeType?: string;
+}
+
+export type IV1_ResponsePart = IV1_MarkdownResponsePart | IV1_ContentRef;
+
+export interface IV1_ToolCallState {
+	readonly toolCallId: string;
+	readonly toolName: string;
+	readonly displayName: string;
+	readonly invocationMessage: string;
+	readonly toolInput?: string;
+	readonly toolKind?: 'terminal';
+	readonly language?: string;
+	readonly status: 'running' | 'pending-permission' | 'completed' | 'failed';
+}
+
+export interface IV1_CompletedToolCall {
+	readonly toolCallId: string;
+	readonly toolName: string;
+	readonly displayName: string;
+	readonly success: boolean;
+	readonly pastTenseMessage: string;
+	readonly toolOutput?: string;
+}
+
+export interface IV1_PermissionRequest {
+	readonly requestId: string;
+	readonly permissionKind: 'shell' | 'write' | 'mcp' | 'read' | 'url';
+	readonly toolCallId?: string;
+	readonly path?: string;
+	readonly fullCommandText?: string;
+	readonly intention?: string;
+}
+
+export interface IV1_UsageInfo {
+	readonly inputTokens?: number;
+	readonly outputTokens?: number;
+	readonly model?: string;
+	readonly cacheReadTokens?: number;
+}
+
+export interface IV1_ErrorInfo {
+	readonly errorType: string;
+	readonly message: string;
+	readonly stack?: string;
+}
+
+// ---- Action types (wire format) ---------------------------------------------
+
+interface IV1_SessionActionBase {
+	readonly session: URI;
+}
+
+export interface IV1_ModelsChangedAction {
+	readonly type: 'root/modelsChanged';
+	readonly models: readonly IV1_SessionModelInfo[];
+}
+
+export interface IV1_AgentsChangedAction {
+	readonly type: 'root/agentsChanged';
+	readonly agents: readonly IV1_AgentInfo[];
+}
+
+export interface IV1_SessionReadyAction extends IV1_SessionActionBase {
+	readonly type: 'session/ready';
+}
+
+export interface IV1_SessionCreationFailedAction extends IV1_SessionActionBase {
+	readonly type: 'session/creationFailed';
+	readonly error: IV1_ErrorInfo;
+}
+
+export interface IV1_TurnStartedAction extends IV1_SessionActionBase {
+	readonly type: 'session/turnStarted';
+	readonly turnId: string;
+	readonly userMessage: IV1_UserMessage;
+}
+
+export interface IV1_DeltaAction extends IV1_SessionActionBase {
+	readonly type: 'session/delta';
+	readonly turnId: string;
+	readonly content: string;
+}
+
+export interface IV1_ResponsePartAction extends IV1_SessionActionBase {
+	readonly type: 'session/responsePart';
+	readonly turnId: string;
+	readonly part: IV1_ResponsePart;
+}
+
+export interface IV1_ToolStartAction extends IV1_SessionActionBase {
+	readonly type: 'session/toolStart';
+	readonly turnId: string;
+	readonly toolCall: IV1_ToolCallState;
+}
+
+export interface IV1_ToolCompleteAction extends IV1_SessionActionBase {
+	readonly type: 'session/toolComplete';
+	readonly turnId: string;
+	readonly toolCallId: string;
+	readonly result: Omit<IV1_CompletedToolCall, 'toolCallId' | 'toolName' | 'displayName'>;
+}
+
+export interface IV1_PermissionRequestAction extends IV1_SessionActionBase {
+	readonly type: 'session/permissionRequest';
+	readonly turnId: string;
+	readonly request: IV1_PermissionRequest;
+}
+
+export interface IV1_PermissionResolvedAction extends IV1_SessionActionBase {
+	readonly type: 'session/permissionResolved';
+	readonly turnId: string;
+	readonly requestId: string;
+	readonly approved: boolean;
+}
+
+export interface IV1_TurnCompleteAction extends IV1_SessionActionBase {
+	readonly type: 'session/turnComplete';
+	readonly turnId: string;
+}
+
+export interface IV1_TurnCancelledAction extends IV1_SessionActionBase {
+	readonly type: 'session/turnCancelled';
+	readonly turnId: string;
+}
+
+export interface IV1_SessionErrorAction extends IV1_SessionActionBase {
+	readonly type: 'session/error';
+	readonly turnId: string;
+	readonly error: IV1_ErrorInfo;
+}
+
+export interface IV1_TitleChangedAction extends IV1_SessionActionBase {
+	readonly type: 'session/titleChanged';
+	readonly title: string;
+}
+
+export interface IV1_UsageAction extends IV1_SessionActionBase {
+	readonly type: 'session/usage';
+	readonly turnId: string;
+	readonly usage: IV1_UsageInfo;
+}
+
+export interface IV1_ReasoningAction extends IV1_SessionActionBase {
+	readonly type: 'session/reasoning';
+	readonly turnId: string;
+	readonly content: string;
+}
+
+export type IV1_RootAction =
+	| IV1_ModelsChangedAction
+	| IV1_AgentsChangedAction;
+
+export type IV1_SessionAction =
+	| IV1_SessionReadyAction
+	| IV1_SessionCreationFailedAction
+	| IV1_TurnStartedAction
+	| IV1_DeltaAction
+	| IV1_ResponsePartAction
+	| IV1_ToolStartAction
+	| IV1_ToolCompleteAction
+	| IV1_PermissionRequestAction
+	| IV1_PermissionResolvedAction
+	| IV1_TurnCompleteAction
+	| IV1_TurnCancelledAction
+	| IV1_SessionErrorAction
+	| IV1_TitleChangedAction
+	| IV1_UsageAction
+	| IV1_ReasoningAction;
+
+export type IV1_StateAction = IV1_RootAction | IV1_SessionAction;
+
+// ---- Notification types (wire format) ---------------------------------------
+
+export interface IV1_SessionAddedNotification {
+	readonly type: 'notify/sessionAdded';
+	readonly summary: IV1_SessionSummary;
+}
+
+export interface IV1_SessionRemovedNotification {
+	readonly type: 'notify/sessionRemoved';
+	readonly session: URI;
+}
+
+export type IV1_Notification =
+	| IV1_SessionAddedNotification
+	| IV1_SessionRemovedNotification;
+
+/** All action type strings known to v1. */
+export type IV1_ActionType = IV1_StateAction['type'];

--- a/src/vs/platform/agent/common/state/versions/versionRegistry.ts
+++ b/src/vs/platform/agent/common/state/versions/versionRegistry.ts
@@ -1,0 +1,258 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Version registry: compile-time compatibility checks + runtime action filtering.
+// See ../AGENTS.md for modification instructions.
+
+import type {
+	IAgentsChangedAction,
+	IDeltaAction,
+	IModelsChangedAction,
+	INotification,
+	IPermissionRequestAction,
+	IPermissionResolvedAction,
+	IReasoningAction,
+	IResponsePartAction,
+	IRootAction,
+	ISessionAction,
+	ISessionCreationFailedAction,
+	ISessionErrorAction,
+	ISessionReadyAction,
+	IStateAction,
+	ITitleChangedAction,
+	IToolCompleteAction,
+	IToolStartAction,
+	ITurnCancelledAction,
+	ITurnCompleteAction,
+	ITurnStartedAction,
+	IUsageAction,
+} from '../sessionActions.js';
+import type {
+	IActiveTurn,
+	IAgentInfo,
+	ICompletedToolCall,
+	IContentRef,
+	IErrorInfo,
+	IMarkdownResponsePart,
+	IMessageAttachment,
+	IPermissionRequest,
+	IRootState,
+	ISessionModelInfo,
+	ISessionState,
+	ISessionSummary,
+	IToolCallState,
+	ITurn,
+	IUsageInfo,
+	IUserMessage,
+} from '../sessionState.js';
+
+import type {
+	IV1_ActiveTurn,
+	IV1_AgentInfo,
+	IV1_AgentsChangedAction,
+	IV1_CompletedToolCall,
+	IV1_ContentRef,
+	IV1_DeltaAction,
+	IV1_ErrorInfo,
+	IV1_MarkdownResponsePart,
+	IV1_MessageAttachment,
+	IV1_ModelsChangedAction,
+	IV1_PermissionRequest,
+	IV1_PermissionRequestAction,
+	IV1_PermissionResolvedAction,
+	IV1_ReasoningAction,
+	IV1_ResponsePartAction,
+	IV1_RootState,
+	IV1_SessionCreationFailedAction,
+	IV1_SessionErrorAction,
+	IV1_SessionModelInfo,
+	IV1_SessionReadyAction,
+	IV1_SessionState,
+	IV1_SessionSummary,
+	IV1_TitleChangedAction,
+	IV1_ToolCallState,
+	IV1_ToolCompleteAction,
+	IV1_ToolStartAction,
+	IV1_Turn,
+	IV1_TurnCancelledAction,
+	IV1_TurnCompleteAction,
+	IV1_TurnStartedAction,
+	IV1_UsageAction,
+	IV1_UsageInfo,
+	IV1_UserMessage,
+} from './v1.js';
+
+// ---- Protocol version constants ---------------------------------------------
+
+/**
+ * Current protocol version. This is the version that NEW code speaks.
+ * Increment when adding new action types or changing behavior.
+ *
+ * Version history:
+ *   1 — Initial: root state, session lifecycle, streaming, tools, permissions
+ */
+export const PROTOCOL_VERSION = 1;
+
+/**
+ * Minimum protocol version we maintain backward compatibility with.
+ * Raise this to drop old compat code: delete the version file,
+ * remove its checks below, and the compiler shows what's now dead.
+ */
+export const MIN_PROTOCOL_VERSION = 1;
+
+// ---- Compile-time compatibility checks --------------------------------------
+//
+// AssertCompatible<Frozen, Current> requires BIDIRECTIONAL assignability:
+//   - Current extends Frozen: can't remove fields or change field types
+//   - Frozen extends Current: can't add required fields
+//
+// The only allowed change is adding optional fields to the living type.
+// If either direction fails, you get a compile error at the check site.
+
+type AssertCompatible<Frozen, Current extends Frozen> = Frozen extends Current ? true : never;
+
+// -- v1 state compatibility --
+
+type _v1_RootState = AssertCompatible<IV1_RootState, IRootState>;
+type _v1_AgentInfo = AssertCompatible<IV1_AgentInfo, IAgentInfo>;
+type _v1_SessionModelInfo = AssertCompatible<IV1_SessionModelInfo, ISessionModelInfo>;
+type _v1_SessionSummary = AssertCompatible<IV1_SessionSummary, ISessionSummary>;
+type _v1_SessionState = AssertCompatible<IV1_SessionState, ISessionState>;
+type _v1_UserMessage = AssertCompatible<IV1_UserMessage, IUserMessage>;
+type _v1_MessageAttachment = AssertCompatible<IV1_MessageAttachment, IMessageAttachment>;
+type _v1_Turn = AssertCompatible<IV1_Turn, ITurn>;
+type _v1_ActiveTurn = AssertCompatible<IV1_ActiveTurn, IActiveTurn>;
+type _v1_MarkdownResponsePart = AssertCompatible<IV1_MarkdownResponsePart, IMarkdownResponsePart>;
+type _v1_ContentRef = AssertCompatible<IV1_ContentRef, IContentRef>;
+type _v1_ToolCallState = AssertCompatible<IV1_ToolCallState, IToolCallState>;
+type _v1_CompletedToolCall = AssertCompatible<IV1_CompletedToolCall, ICompletedToolCall>;
+type _v1_PermissionRequest = AssertCompatible<IV1_PermissionRequest, IPermissionRequest>;
+type _v1_UsageInfo = AssertCompatible<IV1_UsageInfo, IUsageInfo>;
+type _v1_ErrorInfo = AssertCompatible<IV1_ErrorInfo, IErrorInfo>;
+
+// -- v1 action compatibility --
+
+type _v1_ModelsChanged = AssertCompatible<IV1_ModelsChangedAction, IModelsChangedAction>;
+type _v1_AgentsChanged = AssertCompatible<IV1_AgentsChangedAction, IAgentsChangedAction>;
+type _v1_SessionReady = AssertCompatible<IV1_SessionReadyAction, ISessionReadyAction>;
+type _v1_CreationFailed = AssertCompatible<IV1_SessionCreationFailedAction, ISessionCreationFailedAction>;
+type _v1_TurnStarted = AssertCompatible<IV1_TurnStartedAction, ITurnStartedAction>;
+type _v1_Delta = AssertCompatible<IV1_DeltaAction, IDeltaAction>;
+type _v1_ResponsePart = AssertCompatible<IV1_ResponsePartAction, IResponsePartAction>;
+type _v1_ToolStart = AssertCompatible<IV1_ToolStartAction, IToolStartAction>;
+type _v1_ToolComplete = AssertCompatible<IV1_ToolCompleteAction, IToolCompleteAction>;
+type _v1_PermissionRequestAction = AssertCompatible<IV1_PermissionRequestAction, IPermissionRequestAction>;
+type _v1_PermissionResolved = AssertCompatible<IV1_PermissionResolvedAction, IPermissionResolvedAction>;
+type _v1_TurnComplete = AssertCompatible<IV1_TurnCompleteAction, ITurnCompleteAction>;
+type _v1_TurnCancelled = AssertCompatible<IV1_TurnCancelledAction, ITurnCancelledAction>;
+type _v1_SessionError = AssertCompatible<IV1_SessionErrorAction, ISessionErrorAction>;
+type _v1_TitleChanged = AssertCompatible<IV1_TitleChangedAction, ITitleChangedAction>;
+type _v1_Usage = AssertCompatible<IV1_UsageAction, IUsageAction>;
+type _v1_Reasoning = AssertCompatible<IV1_ReasoningAction, IReasoningAction>;
+
+// Suppress unused-variable warnings for compile-time-only checks.
+void (0 as unknown as
+	_v1_RootState & _v1_AgentInfo & _v1_SessionModelInfo & _v1_SessionSummary &
+	_v1_SessionState & _v1_UserMessage & _v1_MessageAttachment & _v1_Turn &
+	_v1_ActiveTurn & _v1_MarkdownResponsePart & _v1_ContentRef &
+	_v1_ToolCallState & _v1_CompletedToolCall & _v1_PermissionRequest &
+	_v1_UsageInfo & _v1_ErrorInfo &
+	_v1_ModelsChanged & _v1_AgentsChanged & _v1_SessionReady & _v1_CreationFailed &
+	_v1_TurnStarted & _v1_Delta & _v1_ResponsePart & _v1_ToolStart &
+	_v1_ToolComplete & _v1_PermissionRequestAction & _v1_PermissionResolved &
+	_v1_TurnComplete & _v1_TurnCancelled & _v1_SessionError & _v1_TitleChanged &
+	_v1_Usage & _v1_Reasoning
+);
+
+// ---- Runtime action → version map -------------------------------------------
+//
+// The index signature [K in IStateAction['type']] forces TypeScript to require
+// an entry for every action type in the union. If you add a new action type
+// to ISessionAction or IRootAction but forget to register it here, you get
+// a compile error.
+//
+// The value is the protocol version that introduced that action type.
+
+/** Maps every action type string to the protocol version that introduced it. */
+export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: number } = {
+	// Root actions (v1)
+	'root/modelsChanged': 1,
+	'root/agentsChanged': 1,
+	// Session lifecycle (v1)
+	'session/ready': 1,
+	'session/creationFailed': 1,
+	// Turn lifecycle (v1)
+	'session/turnStarted': 1,
+	'session/delta': 1,
+	'session/responsePart': 1,
+	// Tool calls (v1)
+	'session/toolStart': 1,
+	'session/toolComplete': 1,
+	// Permissions (v1)
+	'session/permissionRequest': 1,
+	'session/permissionResolved': 1,
+	// Turn completion (v1)
+	'session/turnComplete': 1,
+	'session/turnCancelled': 1,
+	'session/error': 1,
+	// Metadata & informational (v1)
+	'session/titleChanged': 1,
+	'session/usage': 1,
+	'session/reasoning': 1,
+};
+
+/** Maps every notification type string to the protocol version that introduced it. */
+export const NOTIFICATION_INTRODUCED_IN: { readonly [K in INotification['type']]: number } = {
+	'notify/sessionAdded': 1,
+	'notify/sessionRemoved': 1,
+};
+
+// ---- Runtime filtering helpers ----------------------------------------------
+
+/**
+ * Returns `true` if the given action type is known to a client at `clientVersion`.
+ * The server uses this to avoid sending actions that the client can't process.
+ */
+export function isActionKnownToVersion(action: IStateAction, clientVersion: number): boolean {
+	return ACTION_INTRODUCED_IN[action.type] <= clientVersion;
+}
+
+/**
+ * Returns `true` if the given notification type is known to a client at `clientVersion`.
+ */
+export function isNotificationKnownToVersion(notification: INotification, clientVersion: number): boolean {
+	return NOTIFICATION_INTRODUCED_IN[notification.type] <= clientVersion;
+}
+
+// ---- Version-grouped action types -------------------------------------------
+//
+// Each version defines the set of action types it introduced. The cumulative
+// union for a version is built by combining all versions up to that point.
+// When you add a new protocol version, define its additions and extend the map.
+
+/** Action types introduced in v1. */
+type IRootAction_v1 = IV1_ModelsChangedAction | IV1_AgentsChangedAction;
+type ISessionAction_v1 = IV1_SessionReadyAction | IV1_SessionCreationFailedAction
+	| IV1_TurnStartedAction | IV1_DeltaAction | IV1_ResponsePartAction
+	| IV1_ToolStartAction | IV1_ToolCompleteAction
+	| IV1_PermissionRequestAction | IV1_PermissionResolvedAction
+	| IV1_TurnCompleteAction | IV1_TurnCancelledAction | IV1_SessionErrorAction
+	| IV1_TitleChangedAction | IV1_UsageAction | IV1_ReasoningAction;
+
+/**
+ * Maps protocol versions to their cumulative action type unions.
+ * Used to type-check that existing version unions remain stable.
+ */
+export interface IVersionedActionMap {
+	1: { root: IRootAction_v1; session: ISessionAction_v1 };
+}
+
+// Ensure the living union is a superset of every versioned union.
+// If you remove an action type from the living union that a version
+// still references, this fails to compile.
+type _rootSuperset = IRootAction_v1 extends IRootAction ? true : never;
+type _sessionSuperset = ISessionAction_v1 extends ISessionAction ? true : never;
+
+void (0 as unknown as _rootSuperset & _sessionSuperset);

--- a/src/vs/platform/agent/design.md
+++ b/src/vs/platform/agent/design.md
@@ -2,7 +2,7 @@
 
 > **Keep this document in sync with the code.** Any change to the agent-host protocol, tool rendering approach, or architectural boundaries must be reflected here. If you add a new `toolKind`, change how tool-specific data is populated, or modify the separation between agent-specific and generic code, update this document as part of the same change.
 
-Design decisions and principles for the agent-host feature. For process architecture and IPC details, see [architecture.md](architecture.md). For the task backlog, see [backlog.md](backlog.md).
+Design decisions and principles for the agent-host feature. For process architecture and IPC details, see [architecture.md](architecture.md). For the client-server state protocol, see [protocol.md](protocol.md). For the task backlog, see [backlog.md](backlog.md).
 
 ## Agent-agnostic protocol
 
@@ -79,3 +79,14 @@ The entire feature is controlled by `chat.agentHost.enabled` (default `false`), 
 ## Separate contributions per provider
 
 Each agent provider (Copilot) has its own independent workbench contribution class. Providers can be added, removed, or modified independently without affecting each other.
+
+## Multi-client state synchronization
+
+The sessions process uses a redux-like state model where all mutations flow through a discriminated union of actions processed by pure reducer functions. This design supports multiple connected clients seeing a synchronized view:
+
+- **Server-authoritative state**: The server holds the canonical state tree. Clients receive snapshots and incremental actions.
+- **Write-ahead with reconciliation**: Clients optimistically apply their own actions locally (e.g., approving a permission, sending a message) and reconcile when the server echoes them back. Actions carry `(clientId, clientSeq)` tags for echo matching.
+- **Lazy loading**: Clients connect with lightweight session metadata (enough for a sidebar list) and subscribe to full session state on demand. Large content (images, tool outputs) uses `ContentRef` placeholders fetched separately.
+- **Forward-compatible versioning**: A single protocol version number maps to a `ProtocolCapabilities` object. Newer clients check capabilities before using features unavailable on older servers.
+
+Details and type definitions are in [protocol.md](protocol.md) and `common/state/`.

--- a/src/vs/platform/agent/protocol.md
+++ b/src/vs/platform/agent/protocol.md
@@ -1,0 +1,404 @@
+# Sessions process protocol
+
+> **Keep this document in sync with the code.** Changes to the state model, action types, protocol messages, or versioning strategy must be reflected here. Implementation lives in `common/state/`.
+
+For process architecture and IPC details, see [architecture.md](architecture.md). For design decisions, see [design.md](design.md). For the task backlog, see [backlog.md](backlog.md).
+
+## Goal
+
+The sessions process is a portable, standalone server that multiple clients can connect to. Clients see a synchronized view of sessions and can send commands that are reflected back as state-changing actions. The protocol is designed around four requirements:
+
+1. **Synchronized multi-client state** — an immutable, redux-like state tree mutated exclusively by actions flowing through pure reducers.
+2. **Lazy loading** — clients subscribe to state by URI and load data on demand. The session list is fetched imperatively. Large content (images, long tool outputs) is stored by reference and fetched separately.
+3. **Write-ahead with reconciliation** — clients optimistically apply their own actions locally, then reconcile when the server echoes them back alongside any concurrent actions from other clients or the server itself.
+4. **Forward-compatible versioning** — newer clients can connect to older servers. A single protocol version number maps to a capabilities object; clients check capabilities before using features.
+
+## URI-based subscriptions
+
+All state is identified by URIs. Clients subscribe to a URI to receive its current state snapshot and subsequent action updates. This is the single universal mechanism for state synchronization:
+
+- **Root state** (`agenthost:root`) — always-present global state (agents, models). Clients subscribe to this on connect.
+- **Session state** (`copilot:/<uuid>`, etc.) — per-session state loaded on demand. Clients subscribe when opening a session.
+
+The `subscribe(uri)` / `unsubscribe(uri)` mechanism works identically for all resource types.
+
+## State model
+
+### Root state
+
+Subscribable at `agenthost:root`. Contains global, lightweight data that all clients need. **Does not contain the session list** — that is fetched imperatively via RPC (see Commands).
+
+```
+RootState {
+    agents: AgentInfo[]
+    models: ModelInfo[]
+}
+```
+
+### Session state
+
+Subscribable at the session's URI (e.g. `copilot:/<uuid>`). Contains the full state for a single session.
+
+```
+SessionState {
+    summary: SessionSummary
+    lifecycle: 'creating' | 'ready' | 'creationFailed'
+    creationError?: ErrorInfo
+    turns: Turn[]
+    activeTurn: ActiveTurn | undefined
+}
+```
+
+`lifecycle` tracks the asynchronous creation process. When a client creates a session, it picks a URI, sends the command, and subscribes immediately. The initial snapshot has `lifecycle: 'creating'`. The server asynchronously initializes the backend and dispatches `session/ready` or `session/creationFailed`.
+
+```
+Turn {
+    id: string
+    userMessage: UserMessage
+    responseParts: ResponsePart[]
+    toolCalls: CompletedToolCall[]
+    usage: UsageInfo | undefined
+    state: 'complete' | 'cancelled' | 'error'
+}
+
+ActiveTurn {
+    id: string
+    userMessage: UserMessage
+    streamingText: string
+    responseParts: ResponsePart[]
+    toolCalls: Map<toolCallId, ToolCallState>
+    pendingPermissions: Map<requestId, PermissionRequest>
+    reasoning: string
+}
+```
+
+### Session list
+
+The session list can be arbitrarily large and is **not** part of the state tree. Instead:
+- Clients fetch the list imperatively via `listSessions()` RPC.
+- The server sends lightweight **notifications** (`sessionAdded`, `sessionRemoved`) so connected clients can update a local cache without re-fetching.
+
+Notifications are ephemeral — not processed by reducers, not stored in state, not replayed on reconnect. On reconnect, clients re-fetch the list.
+
+### Content references
+
+Large content is **not** inlined in state. A `ContentRef` placeholder is used instead:
+
+```
+ContentRef {
+    uri: string             // scheme://sessionId/contentId
+    sizeHint?: number
+    mimeType?: string
+}
+```
+
+Clients fetch content separately via `fetchContent(uri)`. This keeps the state tree small and serializable.
+
+## Actions
+
+Actions are the sole mutation mechanism for subscribable state. They form a discriminated union keyed by `type`. Every action is wrapped in an `ActionEnvelope` for sequencing and origin tracking.
+
+### Action envelope
+
+```
+ActionEnvelope {
+    action: Action
+    serverSeq: number                                     // monotonic, assigned by server
+    origin: { clientId: string, clientSeq: number } | undefined  // undefined = server-originated
+}
+```
+
+### Root actions
+
+These mutate the root state. **All root actions are server-only** — clients observe them but cannot produce them.
+
+| Type | Payload | When |
+|---|---|---|
+| `root/modelsChanged` | `ModelInfo[]` | Available models changed |
+| `root/agentsChanged` | `AgentInfo[]` | Available agent backends changed |
+
+### Session actions
+
+All scoped to a session URI. Some are server-only (produced by the agent backend), others can be dispatched directly by clients.
+
+When a client dispatches an action, the server applies it to the state and also reacts to it as a side effect (e.g., `session/turnStarted` triggers agent processing, `session/turnCancelled` aborts it). This avoids a separate command→action translation layer for the common interactive cases.
+
+| Type | Payload | Client-dispatchable? | When |
+|---|---|---|---|
+| `session/ready` | — | No | Session backend initialized successfully |
+| `session/creationFailed` | `ErrorInfo` | No | Session backend failed to initialize |
+| `session/turnStarted` | `turnId, UserMessage` | Yes | User sent a message; server starts processing |
+| `session/delta` | `turnId, content` | No | Streaming text chunk from assistant |
+| `session/responsePart` | `turnId, ResponsePart` | No | Structured content appended |
+| `session/toolStart` | `turnId, ToolCallState` | No | Tool execution began |
+| `session/toolComplete` | `turnId, toolCallId, ToolCallResult` | No | Tool execution finished |
+| `session/permissionRequest` | `turnId, PermissionRequest` | No | Permission needed from user |
+| `session/permissionResolved` | `turnId, requestId, approved` | Yes | Permission granted or denied |
+| `session/turnComplete` | `turnId` | No | Turn finished (assistant idle) |
+| `session/turnCancelled` | `turnId` | Yes | Turn was aborted; server stops processing |
+| `session/error` | `turnId, ErrorInfo` | No | Error during turn processing |
+| `session/titleChanged` | `title` | No | Session title updated |
+| `session/usage` | `turnId, UsageInfo` | No | Token usage report |
+| `session/reasoning` | `turnId, content` | No | Reasoning/thinking text |
+
+### Notifications
+
+Notifications are ephemeral broadcasts that are **not** part of the state tree. They are not processed by reducers and are not replayed on reconnect.
+
+| Type | Payload | When |
+|---|---|---|
+| `notify/sessionAdded` | `SessionSummary` | A new session was created |
+| `notify/sessionRemoved` | session `URI` | A session was disposed |
+
+Clients use notifications to maintain a local session list cache. On reconnect, clients should re-fetch via `listSessions()` rather than relying on replayed notifications.
+
+## Commands and client-dispatched actions
+
+Clients interact with the server in two ways:
+
+1. **Dispatching actions** — the client sends an action directly (e.g., `session/turnStarted`, `session/turnCancelled`). The server applies it to state and reacts with side effects. These are write-ahead: the client applies them optimistically.
+2. **Sending commands** — imperative RPCs for operations that don't map to a single state action (session creation, fetching data, etc.).
+
+### Client-dispatched actions
+
+| Action | Server-side effect |
+|---|---|
+| `session/turnStarted` | Begins agent processing for the new turn |
+| `session/permissionResolved` | Unblocks the pending tool execution |
+| `session/turnCancelled` | Aborts the in-progress turn |
+
+### Commands
+
+| Command | Effect |
+|---|---|
+| `createSession(uri, config)` | Server creates session, client subscribes to URI |
+| `disposeSession(session)` | Server disposes session, broadcasts `sessionRemoved` notification |
+| `listSessions(filter?)` | Returns `SessionSummary[]` |
+| `fetchContent(uri)` | Returns content bytes |
+| `fetchTurns(session, range)` | Returns historical turns |
+
+### Session creation flow
+
+1. Client picks a session URI (e.g. `copilot:/<new-uuid>`)
+2. Client sends `createSession(uri, config)` command
+3. Client sends `subscribe(uri)` (can be batched with the command)
+4. Server creates the session in state with `lifecycle: 'creating'` and sends the subscription snapshot
+5. Server asynchronously initializes the agent backend
+6. On success: server dispatches `session/ready` action
+7. On failure: server dispatches `session/creationFailed` action with error details
+8. Server broadcasts `notify/sessionAdded` to all clients
+
+## Client-server protocol
+
+### Connection handshake
+
+```
+1. Client → Server:  ClientHello { protocolVersion, clientId, initialSubscriptions?: URI[] }
+2. Server → Client:  ServerHello { protocolVersion, serverSeq, snapshots[] }
+```
+
+`initialSubscriptions` allows the client to subscribe to root state (and any previously-open sessions on reconnect) in the same round-trip as the handshake. The server responds with snapshots for each.
+
+### URI subscription
+
+After handshake, clients can subscribe/unsubscribe at any time:
+
+```
+Client → Server:  Subscribe { resource: URI }
+Server → Client:  StateSnapshot { resource: URI, state, fromSeq }
+```
+
+After subscribing, the client receives all actions scoped to that URI with `serverSeq > fromSeq`. Multiple concurrent subscriptions are supported.
+
+```
+Client → Server:  Unsubscribe { resource: URI }
+```
+
+### Action delivery
+
+The server broadcasts `ActionEnvelope`s to subscribed clients:
+- Root actions go to all clients subscribed to root state.
+- Session actions go to all clients subscribed to that session's URI.
+
+Notifications go to all connected clients (no subscription required).
+
+### Reconnection
+
+```
+Client → Server:  ClientReconnect { clientId, lastSeenServerSeq, subscriptions: URI[] }
+```
+
+Server replays actions since `lastSeenServerSeq` from a bounded replay buffer. If the gap exceeds the buffer, sends fresh snapshots. Notifications are **not** replayed — the client should re-fetch the session list.
+
+## Write-ahead reconciliation
+
+### Client-side state
+
+Each client maintains per-subscription:
+- `confirmedState` — last fully server-acknowledged state
+- `pendingActions[]` — optimistically applied but not yet echoed by server
+- `optimisticState` — `confirmedState` with `pendingActions` replayed on top (computed, not stored)
+
+### Reconciliation algorithm
+
+When the client receives an `ActionEnvelope` from the server:
+
+1. **Own action echoed**: `origin.clientId === myId` and matches head of `pendingActions` → pop from pending, apply to `confirmedState`
+2. **Foreign action**: different origin → apply to `confirmedState`, rebase remaining `pendingActions`
+3. **Rejected action**: server echoed with `rejected: true` → remove from pending (optimistic effect reverted)
+4. Recompute `optimisticState` from `confirmedState` + remaining `pendingActions`
+
+### Why rebasing is simple
+
+Most session actions are **append-only** (add turn, append delta, add tool call). Pending actions still apply cleanly to an updated confirmed state because they operate on independent data (the turn the client created still exists; the content it appended is additive). The rare true conflict (two clients abort the same turn) is resolved by server-wins semantics.
+
+## Versioning
+
+### Protocol version
+
+Two constants define the version window:
+- `PROTOCOL_VERSION` — the current version that new code speaks.
+- `MIN_PROTOCOL_VERSION` — the oldest version we maintain compatibility with.
+
+Bump `PROTOCOL_VERSION` when:
+- A new feature area requires capability negotiation (e.g., client must know server supports it before sending commands)
+- Behavioral semantics of existing actions change
+
+Adding **optional** fields to existing action/state types does NOT require a bump. Adding **required** fields or removing/renaming fields **is a compile error** (see below).
+
+```
+Version history:
+  1 — Initial: core session lifecycle, streaming, tools, permissions
+```
+
+### Version type snapshots
+
+Each protocol version has a type file (`versions/v1.ts`, `versions/v2.ts`, etc.) that captures the wire format shape of every state type and action type in that version.
+
+The **latest** version file is the editable "tip" — it can be modified alongside the living types in `sessionState.ts` / `sessionActions.ts`. The compiler enforces that all changes are backwards-compatible. When `PROTOCOL_VERSION` is bumped, the previous version file becomes truly frozen and a new tip is created.
+
+The version registry (`versions/versionRegistry.ts`) performs **bidirectional assignability checks** between the version types and the living types:
+
+```typescript
+// AssertCompatible requires BOTH directions:
+//   Current extends Frozen → can't remove fields or change field types
+//   Frozen extends Current → can't add required fields
+// The only allowed evolution is adding optional fields.
+type AssertCompatible<Frozen, Current extends Frozen> = Frozen extends Current ? true : never;
+
+type _check = AssertCompatible<IV1_TurnStartedAction, ITurnStartedAction>;
+```
+
+| Change to living type | Also update tip? | Compile result |
+|---|---|---|
+| Add optional field | Yes, add it to tip too | ✅ Passes |
+| Add optional field | No, only in living type | ✅ Passes (tip is a subset) |
+| Remove a field | — | ❌ `Current extends Frozen` fails |
+| Change a field's type | — | ❌ `Current extends Frozen` fails |
+| Add required field | — | ❌ `Frozen extends Current` fails |
+
+### Exhaustive action→version map
+
+The registry also maintains an exhaustive runtime map:
+
+```typescript
+export const ACTION_INTRODUCED_IN: { readonly [K in IStateAction['type']]: number } = {
+    'root/modelsChanged': 1,
+    'session/turnStarted': 1,
+    // ...every action type must have an entry
+};
+```
+
+The index signature `[K in IStateAction['type']]` means adding a new action to the `IStateAction` union without adding it to this map is a compile error. The developer is forced to pick a version number.
+
+The server uses this for one-line filtering — no if/else chains:
+
+```typescript
+function isActionKnownToVersion(action: IStateAction, clientVersion: number): boolean {
+    return ACTION_INTRODUCED_IN[action.type] <= clientVersion;
+}
+```
+
+### Capabilities
+
+The protocol version maps to a `ProtocolCapabilities` interface for higher-level feature gating:
+
+```typescript
+interface ProtocolCapabilities {
+    // v1 — always present
+    readonly sessions: true;
+    readonly tools: true;
+    readonly permissions: true;
+    // v2+
+    readonly reasoning?: true;
+}
+```
+
+### Forward compatibility
+
+A newer client connecting to an older server:
+1. During handshake, the client learns the server's protocol version.
+2. The client derives `ProtocolCapabilities` from the server version.
+3. Command factories check capabilities before dispatching; if unsupported, the client degrades gracefully.
+4. The server only sends action types known to the client's declared version (via `isActionKnownToVersion`).
+5. As a safety net, clients silently ignore actions with unrecognized `type` values.
+
+### Raising the minimum version
+
+When `MIN_PROTOCOL_VERSION` is raised from N to N+1:
+1. Delete `versions/vN.ts`.
+2. Remove the vN compatibility checks from `versions/versionRegistry.ts`.
+3. The compiler surfaces any dead code that only existed for vN compatibility.
+4. Clean up that dead code.
+
+### Backward compatibility
+
+We do not guarantee backward compatibility (older clients connecting to newer servers). Clients should update before the server.
+
+### Adding a new protocol version (cookbook)
+
+1. Bump `PROTOCOL_VERSION` in `versions/versionRegistry.ts`.
+2. Create `versions/v{N}.ts` — freeze the current types (copy from v{N-1} and add your new types).
+3. Add your new action types to the living union in `sessionActions.ts`.
+4. Add entries to `ACTION_INTRODUCED_IN` with version N (compiler forces this).
+5. Add `AssertCompatible` checks for the new types in `versionRegistry.ts`.
+6. Add reducer cases for the new actions (in new functions if desired).
+7. Add capability fields to `ProtocolCapabilities` if needed.
+
+## Reducers
+
+State is mutated by pure reducer functions that take `(state, action) → newState`. The same reducer code runs on both server and client, which is what makes write-ahead possible: the client can locally predict the result of its own action using the same logic the server will run.
+
+```
+rootReducer(state: RootState, action: RootAction): RootState
+sessionReducer(state: SessionState, action: SessionAction): SessionState
+```
+
+Reducers are pure (no side effects, no I/O). Server-side effects (e.g. forwarding a `sendMessage` command to the Copilot SDK) are handled by a separate dispatch layer, not in the reducer.
+
+## File layout
+
+```
+src/vs/platform/agent/common/state/
+├── sessionState.ts          # Immutable state types (RootState, SessionState, Turn, etc.)
+├── sessionActions.ts        # Action + notification discriminated unions, ActionEnvelope
+├── sessionReducers.ts       # Pure reducer functions (rootReducer, sessionReducer)
+├── sessionProtocol.ts       # Protocol messages (handshake, subscribe, reconnect, RPC)
+├── sessionCapabilities.ts   # Re-exports version constants + ProtocolCapabilities
+├── sessionClientState.ts    # Client-side state manager (confirmed + pending + reconciliation)
+└── versions/
+    ├── v1.ts                # v1 wire format types (tip — editable, compiler-enforced compat)
+    └── versionRegistry.ts   # Compile-time compat checks + runtime action→version map
+```
+
+## Relationship to existing IPC contract
+
+The existing `IAgentProgressEvent` union in `agentService.ts` captures raw streaming events from the Copilot SDK. The new action types in `sessionActions.ts` are a higher-level abstraction: they represent state transitions rather than SDK events.
+
+In the server process, the mapping is:
+- `IAgentDeltaEvent` → `session/delta` action
+- `IAgentToolStartEvent` → `session/toolStart` action
+- `IAgentIdleEvent` → `session/turnComplete` action
+- etc.
+
+The existing `IAgentService` RPC interface remains unchanged. The new protocol layer sits on top: the sessions process uses `IAgentService` internally to talk to agent backends, and produces actions for connected clients.


### PR DESCRIPTION
Here's Opus and I's initial thoughts on the agent host protocol. PR description from Opus with my edits :)

I have put some effort both into the to state and trying to get a good Typescript-enforced system to avoid backwards-incompatible changes. For reviewing this PR, I recommend starting with `protocol.md` and also checking out the added `AGENTS.md` (this should probably be a skill) to see how protocol compatibility works.

---

This PR lays the groundwork for our upcoming sessions process — a standalone server that multiple clients can connect to with a synchronized view of agent sessions. 

### Why

We want to move toward a model where:
- A headless server manages sessions and talks to agent backends
- Multiple clients (VS Code windows, web UIs, CLI) can connect and see the same state
- Clients stay responsive by applying changes optimistically, then reconciling with the server

This is the **protocol design + initial type-level implementation** — no transport, no migration, no UI changes.

#### State model

This is a hybrid protocol where the agent host has an imperative method-based API for some operations -- like enumerating the sessions list or requesting binary resources, things that pure state is pretty shoddy at -- and then has subscribable state that is identified by URIs:

- **Root state** (`agenthost:root`) — agents and models available on the server. Small, always loaded.
- **Session state** (`copilot:/<uuid>`) — full state for one session (turns, tool calls, permissions, streaming text). Loaded on demand when a client subscribes.

    Note: I let Opus do its thing here with UUIDs, but we'd proably want to have the session state URI's be the same as the chat session model URIs we already have.

#### Actions & reducers

All state mutations flow through a discriminated union of **actions** processed by **pure reducer functions** (sessionReducers.ts). Server and client run the same reducers — this is what makes optimistic updates possible.

There are two ways clients interact with the server:

1. **Dispatching actions** — for operations that map directly to state mutations. The client applies the action optimistically, sends it to the server, and the server applies it + reacts with side effects. For example, `session/turnStarted` mutates state to add the turn, and the server begins agent processing as a side effect.
2. **Sending commands** — for imperative RPCs that don't map to a single state action (session creation, data fetching, disposal).

```mermaid
sequenceDiagram
    participant Client A
    participant Server
    participant Client B

    Client A->>Server: dispatch: session/turnStarted
    Note over Client A: applies action<br/>optimistically
    Server->>Client A: action: session/turnStarted (echo)
    Server->>Client B: action: session/turnStarted
    Note over Client A: confirms optimistic<br/>prediction

    Server->>Client A: action: session/delta
    Server->>Client B: action: session/delta

    Server->>Client A: action: session/toolStart
    Server->>Client B: action: session/toolStart
    Server->>Client A: action: session/permissionRequest
    Server->>Client B: action: session/permissionRequest
    Note over Client A: shows approval UI

    Client A->>Server: dispatch: session/permissionResolved (approved)
    Note over Client A: applies optimistically —<br/>tool status → running
    Server->>Client B: action: session/permissionResolved
    Server->>Client A: action: session/permissionResolved (echo)

    Note over Server: executes tool

    Server->>Client A: action: session/toolComplete
    Server->>Client B: action: session/toolComplete
    Server->>Client A: action: session/delta
    Server->>Client B: action: session/delta
    Server->>Client A: action: session/turnComplete
    Server->>Client B: action: session/turnComplete
```

Key design points:
- **Client-dispatchable actions**: `session/turnStarted`, `session/turnCancelled`, `session/permissionResolved` — these are applied to state *and* trigger server-side effects (start processing, abort, unblock tool).
- **Server-only actions**: `session/delta`, `session/toolStart`, `session/toolComplete`, etc. — produced by the agent backend, clients observe but cannot produce them.
- **Commands** are only for things that aren't state actions: `createSession`, `disposeSession`, `listSessions`, `fetchContent`, `fetchTurns`.
- **Notifications** (`notify/sessionAdded`, `notify/sessionRemoved`) are ephemeral broadcasts for the session list — not stored in state, not replayed on reconnect.

#### Write-ahead reconciliation

sessionClientState.ts implements the client-side state manager. It maintains confirmed state + a pending queue, and reconciles when the server echoes back actions (possibly interleaved with actions from other clients).

#### Protocol versioning

The versioning system prevents backwards-incompatible changes at compile time:

- **Frozen type snapshots** (`versions/v1.ts`) capture the wire format at each version. The latest is the editable "tip"; older ones are frozen.
- **Bidirectional assignability checks** (`versions/versionRegistry.ts`) make it a compile error to remove fields, change types, or add required fields to any protocol type.
- **Exhaustive action→version map** — adding a new action to the union without registering its version is a compile error.
- Adding optional fields or new action types is safe and doesn't require a version bump. Version bumps are only needed for capability boundaries (client needs to know server supports a feature before using it).

See AGENTS.md for step-by-step modification instructions.

#### File layout

```
src/vs/platform/agent/common/state/
├── AGENTS.md               # Modification instructions for agents and developers
├── sessionState.ts         # Immutable state types (RootState, SessionState, Turn, etc.)
├── sessionActions.ts       # Action + notification discriminated unions
├── sessionReducers.ts      # Pure reducer functions
├── sessionProtocol.ts      # Wire protocol messages (handshake, subscribe, commands)
├── sessionCapabilities.ts  # Version constants + ProtocolCapabilities
├── sessionClientState.ts   # Client-side state manager with reconciliation
└── versions/
    ├── v1.ts               # v1 wire format types (current tip)
    └── versionRegistry.ts  # Compile-time compat checks + action→version map
```
