### PR TITLE
fix: include sessions built-in prompts in esbuild resource patterns

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -273,6 +273,9 @@ const desktopResourcePatterns = [
 	'vs/workbench/services/extensionManagement/common/media/*.png',
 	'vs/workbench/browser/parts/editor/media/*.png',
 	'vs/workbench/contrib/debug/browser/media/*.png',
+
+	// Sessions - built-in prompts
+	'vs/sessions/prompts/*.prompt.md',
 ];
 
 // Resources for server target (minimal - no UI)


### PR DESCRIPTION
The new esbuild-based CI pipeline (core-ci) uses curated resource patterns in build/next/index.ts to copy non-JS assets into the bundle output. When built-in .prompt.md files were added for the sessions window, they were included in the legacy pipeline's vscodeResourceIncludes (build/gulpfile.vscode.ts) but not in the desktopResourcePatterns used by the esbuild pipeline.

This caused the prompt files to be missing from release builds (out-vscode-min), even though they worked correctly when running from sources (where copyAllNonTsFiles copies everything).

Add 'vs/sessions/prompts/*.prompt.md' to desktopResourcePatterns to match the existing entry in vscodeResourceIncludes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
