### PR TITLE
add `closeOnResult` for editor's find widget

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1745,6 +1745,10 @@ export interface IEditorFindOptions {
 	 */
 	loop?: boolean;
 	/**
+	 * Controls whether to close the Find Widget after an explicit find navigation command lands on a match.
+	 */
+	closeOnResult?: boolean;
+	/**
 	 * @internal
 	 * Controls how the find widget search history should be stored
 	 */
@@ -1772,6 +1776,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, IEditorFindOptions,
 			globalFindClipboard: false,
 			addExtraSpaceOnTop: true,
 			loop: true,
+			closeOnResult: false,
 			history: 'workspace',
 			replaceHistory: 'workspace',
 		};
@@ -1821,6 +1826,11 @@ class EditorFind extends BaseEditorOption<EditorOption.find, IEditorFindOptions,
 					default: defaults.loop,
 					description: nls.localize('find.loop', "Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.")
 				},
+				'editor.find.closeOnResult': {
+					type: 'boolean',
+					default: defaults.closeOnResult,
+					description: nls.localize('find.closeOnResult', "Controls whether the Find Widget closes after an explicit find navigation command lands on a result.")
+				},
 				'editor.find.history': {
 					type: 'string',
 					enum: ['never', 'workspace'],
@@ -1867,6 +1877,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, IEditorFindOptions,
 			globalFindClipboard: boolean(input.globalFindClipboard, this.defaultValue.globalFindClipboard),
 			addExtraSpaceOnTop: boolean(input.addExtraSpaceOnTop, this.defaultValue.addExtraSpaceOnTop),
 			loop: boolean(input.loop, this.defaultValue.loop),
+			closeOnResult: boolean(input.closeOnResult, this.defaultValue.closeOnResult),
 			history: stringSet<'never' | 'workspace'>(input.history, this.defaultValue.history, ['never', 'workspace']),
 			replaceHistory: stringSet<'never' | 'workspace'>(input.replaceHistory, this.defaultValue.replaceHistory, ['never', 'workspace']),
 		};

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -729,10 +729,22 @@ async function matchFindAction(editor: ICodeEditor, next: boolean): Promise<void
 	const wasFindWidgetVisible = controller.getState().isRevealed;
 
 	const runMatch = (): boolean => {
+		const previousSelection = controller.editor.getSelection();
 		const result = next ? controller.moveToNextMatch() : controller.moveToPrevMatch();
+
+		let landedOnMatch = false;
 		if (result) {
+			const currentSelection = controller.editor.getSelection();
+			if (!previousSelection && currentSelection) {
+				landedOnMatch = true;
+			} else if (previousSelection && currentSelection && !previousSelection.equalsSelection(currentSelection)) {
+				landedOnMatch = true;
+			}
+		}
+
+		if (landedOnMatch) {
 			controller.editor.pushUndoStop();
-			if (shouldCloseOnResult && wasFindWidgetVisible && controller.getState().matchesCount > 0) {
+			if (shouldCloseOnResult && wasFindWidgetVisible && controller.isFindInputFocused()) {
 				controller.closeFindWidget();
 			}
 			return true;

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -725,11 +725,16 @@ async function matchFindAction(editor: ICodeEditor, next: boolean): Promise<void
 	if (!controller) {
 		return;
 	}
+	const shouldCloseOnResult = editor.getOption(EditorOption.find).closeOnResult;
+	const wasFindWidgetVisible = controller.getState().isRevealed;
 
 	const runMatch = (): boolean => {
 		const result = next ? controller.moveToNextMatch() : controller.moveToPrevMatch();
 		if (result) {
 			controller.editor.pushUndoStop();
+			if (shouldCloseOnResult && wasFindWidgetVisible && controller.getState().matchesCount > 0) {
+				controller.closeFindWidget();
+			}
 			return true;
 		}
 		return false;

--- a/src/vs/editor/contrib/find/test/browser/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/browser/findController.test.ts
@@ -292,6 +292,67 @@ suite('FindController', () => {
 		});
 	});
 
+	test('editor.find.closeOnResult: closes find widget when a match is found from explicit navigation', async () => {
+		await withAsyncTestCodeEditor([
+			'ABC',
+			'ABC',
+			'XYZ',
+		], { serviceCollection: serviceCollection, find: { closeOnResult: true } }, async (editor, _, instantiationService) => {
+			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
+			const findState = findController.getState();
+
+			await executeAction(instantiationService, editor, StartFindAction);
+			assert.strictEqual(findState.isRevealed, true);
+
+			findState.change({ searchString: 'ABC' }, true);
+			await editor.runAction(NextMatchFindAction);
+
+			assert.strictEqual(findState.isRevealed, false);
+			findController.dispose();
+		});
+	});
+
+	test('editor.find.closeOnResult: keeps find widget open when no match is found', async () => {
+		await withAsyncTestCodeEditor([
+			'ABC',
+			'DEF',
+			'XYZ',
+		], { serviceCollection: serviceCollection, find: { closeOnResult: true } }, async (editor, _, instantiationService) => {
+			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
+			const findState = findController.getState();
+
+			await executeAction(instantiationService, editor, StartFindAction);
+			assert.strictEqual(findState.isRevealed, true);
+
+			findState.change({ searchString: 'NO_MATCH' }, true);
+			await editor.runAction(NextMatchFindAction);
+
+			assert.strictEqual(findState.matchesCount, 0);
+			assert.strictEqual(findState.isRevealed, true);
+			findController.dispose();
+		});
+	});
+
+	test('editor.find.closeOnResult: disabled keeps find widget open after navigation', async () => {
+		await withAsyncTestCodeEditor([
+			'ABC',
+			'ABC',
+			'XYZ',
+		], { serviceCollection: serviceCollection, find: { closeOnResult: false } }, async (editor, _, instantiationService) => {
+			const findController = editor.registerAndInstantiateContribution(TestFindController.ID, TestFindController);
+			const findState = findController.getState();
+
+			await executeAction(instantiationService, editor, StartFindAction);
+			assert.strictEqual(findState.isRevealed, true);
+
+			findState.change({ searchString: 'ABC' }, true);
+			await editor.runAction(NextMatchFindAction);
+
+			assert.strictEqual(findState.isRevealed, true);
+			findController.dispose();
+		});
+	});
+
 	test('issue #9043: Clear search scope when find widget is hidden', async () => {
 		await withAsyncTestCodeEditor([
 			'var x = (3 * 5)',

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4255,6 +4255,10 @@ declare namespace monaco.editor {
 		 * Controls whether the search result and diff result automatically restarts from the beginning (or the end) when no further matches can be found
 		 */
 		loop?: boolean;
+		/**
+		 * Controls whether to close the Find Widget after an explicit find navigation command lands on a match.
+		 */
+		closeOnResult?: boolean;
 	}
 
 	export type GoToLocationValues = 'peek' | 'gotoAndPeek' | 'goto';

--- a/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorFindAccessibilityHelp.ts
@@ -300,6 +300,7 @@ class EditorFindAccessibilityHelpProvider extends Disposable implements IAccessi
 			content.push(localize('find.settingSeed', "- `editor.find.seedSearchStringFromSelection`: Controls when selection text is used to seed Find."));
 			content.push(localize('find.settingAutoSelection', "- `editor.find.autoFindInSelection`: Automatically enables Find in Selection based on selection type."));
 			content.push(localize('find.settingLoop', "- `editor.find.loop`: Wraps search at the beginning or end of the file."));
+			content.push(localize('find.settingCloseOnResult', "- `editor.find.closeOnResult`: Closes the Find dialog after an explicit find navigation command lands on a match."));
 			content.push(localize('find.settingExtraSpace', "- `editor.find.addExtraSpaceOnTop`: Adds extra scroll space so matches are not hidden behind the Find dialog."));
 			content.push(localize('find.settingHistory', "- `editor.find.history`: Controls whether Find search history is stored."));
 			content.push(localize('find.settingOccurrences', "- `editor.occurrencesHighlight`: Highlights other occurrences of the current symbol."));


### PR DESCRIPTION
fixes #264818

<img width="885" height="187" alt="Screenshot 2026-03-06 at 3 21 47 PM" src="https://github.com/user-attachments/assets/8f4def7d-46ea-495d-9695-9293b6cf4270" />
