### PR TITLE
chat: fix stale pending divider headers from persisting

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -657,6 +657,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			dispose(coalesce(templateData.renderedParts));
 			templateData.renderedParts = undefined;
 			dom.clearNode(templateData.value);
+		} else if (isPendingDividerVM(templateData.currentElement)) {
+			dom.clearNode(templateData.value);
 		}
 
 		// This template item is no longer in use, or having another element rendered into it,


### PR DESCRIPTION
When templates are reused for different tree items, the DOM content from pending dividers was not being cleaned up. This caused old 'Steering' or 'Queued' divider headers to persist visually even after they were no longer in the list.

The fix checks if the previous element in a template was a pending divider, and if so, clears the templateData.value node when the template is reused for a new element.

- Adds a check in clearRenderedParts() to clear templateData.value when
  the previous element was a pending divider
- Ensures stale divider headers don't remain visible after pending requests
  are processed and removed from the queue

Fixes https://github.com/microsoft/vscode/issues/299853

(Commit message generated by Copilot)