### PR TITLE
feat: enable floating dialog panel mode

### DIFF
--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -13,7 +13,7 @@ import { isFullscreen, onDidChangeFullscreen, isChrome, isFirefox, isSafari } fr
 import { mark } from '../../base/common/performance.js';
 import { onUnexpectedError, setUnexpectedErrorHandler } from '../../base/common/errors.js';
 import { isWindows, isLinux, isWeb, isNative, isMacintosh } from '../../base/common/platform.js';
-import { Parts, Position, PanelAlignment, IWorkbenchLayoutService, SINGLE_WINDOW_PARTS, MULTI_WINDOW_PARTS, IPartVisibilityChangeEvent, positionToString } from '../../workbench/services/layout/browser/layoutService.js';
+import { Parts, Position, PanelAlignment, IWorkbenchLayoutService, SINGLE_WINDOW_PARTS, MULTI_WINDOW_PARTS, IPartVisibilityChangeEvent, positionToString, PanelMode } from '../../workbench/services/layout/browser/layoutService.js';
 import { ILayoutOffsetInfo } from '../../platform/layout/browser/layoutService.js';
 import { Part } from '../../workbench/browser/part.js';
 import { Direction, ISerializableView, ISerializedGrid, ISerializedLeafNode, ISerializedNode, IViewSize, Orientation, SerializableGrid } from '../../base/browser/ui/grid/grid.js';
@@ -1283,6 +1283,18 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		}
 
 		return this.workbenchGrid.isViewMaximized(this.panelPartView);
+	}
+
+	getPanelMode(): PanelMode {
+		return PanelMode.Pinned; // Sessions workbench only supports pinned mode
+	}
+
+	setPanelMode(_mode: PanelMode): void {
+		// No-op: Dialog mode not supported in sessions workbench
+	}
+
+	togglePanelMode(): void {
+		// No-op: Dialog mode not supported in sessions workbench
 	}
 
 	toggleMaximizedAuxiliaryBar(): void {

--- a/src/vs/sessions/browser/workbench.ts
+++ b/src/vs/sessions/browser/workbench.ts
@@ -1286,7 +1286,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 	}
 
 	getPanelMode(): PanelMode {
-		return PanelMode.Pinned; // Sessions workbench only supports pinned mode
+		return PanelMode.Dock; // Sessions workbench only supports dock mode
 	}
 
 	setPanelMode(_mode: PanelMode): void {

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -6,12 +6,12 @@
 import { Disposable } from '../../base/common/lifecycle.js';
 import { IContextKeyService, IContextKey, setConstant as setConstantContextKey } from '../../platform/contextkey/common/contextkey.js';
 import { IsMacContext, IsLinuxContext, IsWindowsContext, IsWebContext, IsMacNativeContext, IsDevelopmentContext, IsIOSContext, ProductQualityContext, IsMobileContext } from '../../platform/contextkey/common/contextkeys.js';
-import { SplitEditorsVertically, InEditorZenModeContext, AuxiliaryBarVisibleContext, SideBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelVisibleContext, EmbedderIdentifierContext, EditorTabsVisibleContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, DirtyWorkingCopiesContext, EmptyWorkspaceSupportContext, EnterMultiRootWorkspaceSupportContext, HasWebFileSystemAccess, IsMainWindowFullscreenContext, OpenFolderWorkspaceSupportContext, RemoteNameContext, VirtualWorkspaceContext, WorkbenchStateContext, WorkspaceFolderCountContext, PanelPositionContext, TemporaryWorkspaceContext, TitleBarVisibleContext, TitleBarStyleContext, IsAuxiliaryWindowFocusedContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorGroupLockedContext, MultipleEditorGroupsContext, EditorsVisibleContext, AuxiliaryBarMaximizedContext, InAutomationContext, IsSessionsWindowContext } from '../common/contextkeys.js';
+import { SplitEditorsVertically, InEditorZenModeContext, AuxiliaryBarVisibleContext, SideBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelVisibleContext, EmbedderIdentifierContext, EditorTabsVisibleContext, IsMainEditorCenteredLayoutContext, MainEditorAreaVisibleContext, DirtyWorkingCopiesContext, EmptyWorkspaceSupportContext, EnterMultiRootWorkspaceSupportContext, HasWebFileSystemAccess, IsMainWindowFullscreenContext, OpenFolderWorkspaceSupportContext, RemoteNameContext, VirtualWorkspaceContext, WorkbenchStateContext, WorkspaceFolderCountContext, PanelPositionContext, TemporaryWorkspaceContext, TitleBarVisibleContext, TitleBarStyleContext, IsAuxiliaryWindowFocusedContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorGroupLockedContext, MultipleEditorGroupsContext, EditorsVisibleContext, AuxiliaryBarMaximizedContext, InAutomationContext, IsSessionsWindowContext, PanelDialogModeContext } from '../common/contextkeys.js';
 import { preferredSideBySideGroupDirection, GroupDirection, IEditorGroupsService } from '../services/editor/common/editorGroupsService.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { IWorkbenchEnvironmentService } from '../services/environment/common/environmentService.js';
 import { WorkbenchState, IWorkspaceContextService, isTemporaryWorkspace } from '../../platform/workspace/common/workspace.js';
-import { IWorkbenchLayoutService, Parts, positionToString } from '../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, positionToString, PanelMode } from '../services/layout/browser/layoutService.js';
 import { getRemoteName } from '../../platform/remote/common/remoteHosts.js';
 import { getVirtualWorkspaceScheme } from '../../platform/workspace/common/virtualWorkspace.js';
 import { IWorkingCopyService } from '../services/workingCopy/common/workingCopyService.js';
@@ -59,6 +59,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 	private panelVisibleContext: IContextKey<boolean>;
 	private panelAlignmentContext: IContextKey<string>;
 	private panelMaximizedContext: IContextKey<boolean>;
+	private panelDialogModeContext: IContextKey<boolean>;
 	private auxiliaryBarVisibleContext: IContextKey<boolean>;
 	private auxiliaryBarMaximizedContext: IContextKey<boolean>;
 	private editorTabsVisibleContext: IContextKey<boolean>;
@@ -194,6 +195,8 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.panelMaximizedContext.set(this.layoutService.isPanelMaximized());
 		this.panelAlignmentContext = PanelAlignmentContext.bindTo(this.contextKeyService);
 		this.panelAlignmentContext.set(this.layoutService.getPanelAlignment());
+		this.panelDialogModeContext = PanelDialogModeContext.bindTo(this.contextKeyService);
+		this.panelDialogModeContext.set(this.layoutService.getPanelMode() === PanelMode.Dialog);
 
 		// Auxiliary Bar
 		this.auxiliaryBarVisibleContext = AuxiliaryBarVisibleContext.bindTo(this.contextKeyService);
@@ -248,6 +251,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 			this.mainEditorAreaVisibleContext.set(this.layoutService.isVisible(Parts.EDITOR_PART, mainWindow));
 			this.panelVisibleContext.set(this.layoutService.isVisible(Parts.PANEL_PART));
 			this.panelMaximizedContext.set(this.layoutService.isPanelMaximized());
+			this.panelDialogModeContext.set(this.layoutService.getPanelMode() === PanelMode.Dialog);
 			this.auxiliaryBarVisibleContext.set(this.layoutService.isVisible(Parts.AUXILIARYBAR_PART));
 			this.sideBarVisibleContext.set(this.layoutService.isVisible(Parts.SIDEBAR_PART));
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2033,7 +2033,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if (this.isDialogMode) {
 			this.setPanelDialogHidden(hidden, panelPart);
 		} else {
-			this.setPanelPinnedHidden(hidden, wasHidden, isPanelMaximized, skipLayout);
+			this.setPanelDockHidden(hidden, wasHidden, isPanelMaximized, skipLayout);
 		}
 
 		panelPart.setVisible(!hidden);
@@ -2060,7 +2060,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 	}
 
-	private setPanelPinnedHidden(hidden: boolean, wasHidden: boolean, isPanelMaximized: boolean, skipLayout?: boolean): void {
+	private setPanelDockHidden(hidden: boolean, wasHidden: boolean, isPanelMaximized: boolean, skipLayout?: boolean): void {
 		// Unmaximize before hiding to prevent conflict with setEditorHidden
 		if (hidden && isPanelMaximized) {
 			this.toggleMaximizedPanel();
@@ -2242,12 +2242,22 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	togglePanelMode(): void {
-		this.setPanelMode(this.getPanelMode() === PanelMode.Pinned ? PanelMode.Dialog : PanelMode.Pinned);
+		this.setPanelMode(this.getPanelMode() === PanelMode.Dock ? PanelMode.Dialog : PanelMode.Dock);
 	}
 
 	setPanelMode(mode: PanelMode): void {
 		if (mode === this.getPanelMode()) {
 			return;
+		}
+
+		// Exit maximized state before switching modes.
+		// When panel is maximized in docked mode, the editor is hidden. Switching to dialog mode
+		// while editor is hidden would leave the workbench in an invalid visual state with no
+		// background content. Similarly, switching from maximized dialog back to docked mode
+		// requires the editor to be visible for proper grid layout restoration.
+		// Must happen before mode change so isPanelMaximized() uses the correct code path.
+		if (this.isPanelMaximized()) {
+			this.toggleMaximizedPanel();
 		}
 
 		const panelPart = this.getPart(Parts.PANEL_PART);
@@ -2278,8 +2288,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 			this.layoutPanelDialog();
 		} else {
-			// Dialog → Pinned: restore panel into the grid
-			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Pinned);
+			// Dialog → Dock: restore panel into the grid
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Dock);
 			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN, LayoutClasses.PANEL_DIALOG_MAXIMIZED);
 
 			// Move panel back to original parent
@@ -3148,7 +3158,7 @@ const LayoutStateKeys = {
 	PANEL_ALIGNMENT: new RuntimeStateKey<PanelAlignment>('panel.alignment', StorageScope.PROFILE, StorageTarget.USER, 'center'),
 
 	// Panel Mode
-	PANEL_MODE: new RuntimeStateKey<PanelMode>('panel.mode', StorageScope.WORKSPACE, StorageTarget.MACHINE, PanelMode.Pinned),
+	PANEL_MODE: new RuntimeStateKey<PanelMode>('panel.mode', StorageScope.WORKSPACE, StorageTarget.MACHINE, PanelMode.Dock),
 
 	// Part Visibility
 	ACTIVITYBAR_HIDDEN: new RuntimeStateKey<boolean>('activityBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false, true),

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1706,9 +1706,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.initialized = true;
 
 			// Layout dialog panel if in dialog mode
-			if (this.getPanelMode() === PanelMode.Dialog && this.isVisible(Parts.PANEL_PART)) {
 				this.layoutPanelDialog();
-			}
 
 			// Emit as event
 			this.handleContainerDidLayout(this.mainContainer, this._mainContainerDimension);
@@ -2026,110 +2024,82 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		const isPanelMaximized = this.isPanelMaximized();
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_HIDDEN, hidden);
+		this.mainContainer.classList.toggle(LayoutClasses.PANEL_HIDDEN, hidden);
 
-		// Handle visibility based on panel mode
 		const panelPart = this.getPart(Parts.PANEL_PART);
 
-		if (this.getPanelMode() === PanelMode.Dialog) {
-			// Dialog mode: manage CSS classes and overlay
-			if (hidden) {
-				this.mainContainer.classList.add(LayoutClasses.PANEL_HIDDEN);
-				this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN);
-				this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
-			} else {
-				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
-				this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_OPEN);
-				// Restore maximized state from state model
-				if (this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED)) {
-					this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
-				}
-				this.ensurePanelDialogOverlay();
-			}
-
-			// Move panel element between overlay and original parent
-			if (!hidden && this.panelDialogOverlay) {
-				if (panelPart.element.parentElement !== this.panelDialogOverlay) {
-					this.panelDialogOverlay.appendChild(panelPart.element);
-				}
-			} else if (hidden && this.panelDialogOriginalParent) {
-				if (panelPart.element.parentElement !== this.panelDialogOriginalParent) {
-					this.panelDialogOriginalParent.appendChild(panelPart.element);
-				}
-			}
+		if (this.isDialogMode) {
+			this.setPanelDialogHidden(hidden, panelPart);
 		} else {
-			// Pinned mode: manage grid visibility
-			const panelOpensMaximized = this.panelOpensMaximized();
-
-			// Adjust CSS
-			if (hidden) {
-				this.mainContainer.classList.add(LayoutClasses.PANEL_HIDDEN);
-			} else {
-				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
-			}
-
-			// If maximized and in process of hiding, unmaximize FIRST before
-			// changing visibility to prevent conflict with setEditorHidden
-			// which would force panel visible again (fixes #281772)
-			if (hidden && isPanelMaximized) {
-				this.toggleMaximizedPanel();
-			}
-
-			// Propagate layout changes to grid
-			this.workbenchGrid.setViewVisible(this.panelPartView, !hidden);
-
-			// Don't proceed if we have already done this before
-			if (wasHidden !== hidden) {
-				// If in process of showing, toggle whether or not panel is maximized
-				if (!hidden) {
-					if (!skipLayout && isPanelMaximized !== panelOpensMaximized) {
-						this.toggleMaximizedPanel();
-					}
-				} else {
-					// If in process of hiding, remember whether the panel is maximized or not
-					this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, isPanelMaximized);
-				}
-			}
+			this.setPanelPinnedHidden(hidden, wasHidden, isPanelMaximized, skipLayout);
 		}
 
-		// Notify the panel part of visibility
 		panelPart.setVisible(!hidden);
+		this.handlePanelVisibilityChange(hidden, skipLayout);
 
-		// If panel part becomes hidden, also hide the current active panel if any
+		if (!hidden) {
+			this.layoutPanelDialog();
+		}
+	}
+
+	private setPanelDialogHidden(hidden: boolean, panelPart: Part): void {
+		this.mainContainer.classList.toggle(LayoutClasses.PANEL_DIALOG_OPEN, !hidden);
+		if (hidden) {
+			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+		} else {
+			if (this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED)) {
+				this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+			}
+			this.ensurePanelDialogOverlay();
+		}
+		const targetParent = hidden ? this.panelDialogOriginalParent : this.panelDialogOverlay;
+		if (targetParent && panelPart.element.parentElement !== targetParent) {
+			targetParent.appendChild(panelPart.element);
+		}
+	}
+
+	private setPanelPinnedHidden(hidden: boolean, wasHidden: boolean, isPanelMaximized: boolean, skipLayout?: boolean): void {
+		// Unmaximize before hiding to prevent conflict with setEditorHidden
+		if (hidden && isPanelMaximized) {
+			this.toggleMaximizedPanel();
+		}
+
+		this.workbenchGrid.setViewVisible(this.panelPartView, !hidden);
+
+		if (wasHidden !== hidden) {
+			if (!hidden) {
+				const panelOpensMaximized = this.panelOpensMaximized();
+				if (!skipLayout && isPanelMaximized !== panelOpensMaximized) {
+					this.toggleMaximizedPanel();
+				}
+			} else {
+				this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, isPanelMaximized);
+			}
+		}
+	}
+
+	private handlePanelVisibilityChange(hidden: boolean, skipLayout?: boolean): void {
 		let focusEditor = false;
+
 		if (hidden && this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel)) {
 			this.paneCompositeService.hideActivePaneComposite(ViewContainerLocation.Panel);
-			if (
-				!isIOS &&						// do not auto focus on iOS (https://github.com/microsoft/vscode/issues/127832)
-				!this.isAuxiliaryBarMaximized()	// do not auto focus when auxiliary bar is maximized
-			) {
+			if (!isIOS && !this.isAuxiliaryBarMaximized()) {
 				focusEditor = true;
 			}
-		}
-
-		// If panel part becomes visible, show last active panel or default panel
-		else if (!hidden && !this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel)) {
+		} else if (!hidden && !this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel)) {
 			let panelToOpen: string | undefined = this.paneCompositeService.getLastActivePaneCompositeId(ViewContainerLocation.Panel);
-
-			// verify that the panel we try to open has views before we default to it
-			// otherwise fall back to any view that has views still refs #111463
 			if (!panelToOpen || !this.hasViews(panelToOpen)) {
 				panelToOpen = this.viewDescriptorService
 					.getViewContainersByLocation(ViewContainerLocation.Panel)
 					.find(viewContainer => this.hasViews(viewContainer.id))?.id;
 			}
-
 			if (panelToOpen) {
 				this.openViewContainer(ViewContainerLocation.Panel, panelToOpen, !skipLayout);
 			}
 		}
 
-		// Layout dialog if in dialog mode
-		if (this.getPanelMode() === PanelMode.Dialog && !hidden) {
-			this.layoutPanelDialog();
-		}
-
 		if (focusEditor) {
-			this.editorGroupService.mainPart.activeGroup.focus(); // Pass focus to editor group if panel part is now hidden
+			this.editorGroupService.mainPart.activeGroup.focus();
 		}
 	}
 
@@ -2211,30 +2181,22 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	isPanelMaximized(): boolean {
-		// In dialog mode, check the dialog maximized CSS class
-		if (this.getPanelMode() === PanelMode.Dialog) {
+		if (this.isDialogMode) {
 			return this.isPanelDialogMaximized();
 		}
-
-		// In pinned mode, check traditional grid-based maximization
 		return (
-			this.getPanelAlignment() === 'center' || 	// the workbench grid currently prevents us from supporting panel
-			!isHorizontal(this.getPanelPosition())		// maximization with non-center panel alignment
+			this.getPanelAlignment() === 'center' ||
+			!isHorizontal(this.getPanelPosition())
 		) && !this.isVisible(Parts.EDITOR_PART, mainWindow) && !this.isAuxiliaryBarMaximized();
 	}
 
 	toggleMaximizedPanel(): void {
-		// In dialog mode, toggle the dialog between its default size and full workbench size
-		if (this.getPanelMode() === PanelMode.Dialog) {
-			const isMaximized = this.isPanelDialogMaximized();
-			this.mainContainer.classList.toggle(LayoutClasses.PANEL_DIALOG_MAXIMIZED, !isMaximized);
-			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, !isMaximized);
-			this.layoutPanelFromOverlay();
-			// Fire event to update context keys
-			this._onDidChangePartVisibility.fire({
-				partId: Parts.PANEL_PART,
-				visible: true
-			});
+		if (this.isDialogMode) {
+			const maximize = !this.isPanelDialogMaximized();
+			this.mainContainer.classList.toggle(LayoutClasses.PANEL_DIALOG_MAXIMIZED, maximize);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, maximize);
+			this.layoutPanelDialog();
+			this._onDidChangePartVisibility.fire({ partId: Parts.PANEL_PART, visible: true });
 			return;
 		}
 
@@ -2265,6 +2227,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	//#region Panel Dialog Mode
 
+	private get isDialogMode(): boolean {
+		return this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_MODE) === PanelMode.Dialog;
+	}
+
 	private isPanelDialogMaximized(): boolean {
 		return this.mainContainer.classList.contains(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
 	}
@@ -2287,29 +2253,21 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if (mode === PanelMode.Dialog) {
 			// Save current state before transitioning
 			this.panelDialogSavedAlignment = this.getPanelAlignment();
-
-			// Store the state
+			this.panelDialogOriginalParent = panelPart.element.parentElement ?? undefined;
 			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Dialog);
 
-			// Save original parent for restoration later
-			this.panelDialogOriginalParent = panelPart.element.parentElement ?? undefined;
-
-			// If panel is visible in grid, save its size and hide from grid (but don't hide the panel itself)
+			// If panel is visible in grid, save its size and hide from grid
 			if (this.isVisible(Parts.PANEL_PART) && this.workbenchGrid) {
 				this.panelDialogSavedSize = this.workbenchGrid.getViewSize(this.panelPartView);
 				this.workbenchGrid.setViewVisible(this.panelPartView, false);
 			}
 
-			// Add dialog CSS class and set up overlay
+			// Set up overlay and move panel into it
 			this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_OPEN);
 			this.ensurePanelDialogOverlay();
+			this.panelDialogOverlay?.appendChild(panelPart.element);
 
-			// Move panel element into the overlay
-			if (this.panelDialogOverlay && panelPart.element.parentElement !== this.panelDialogOverlay) {
-				this.panelDialogOverlay.appendChild(panelPart.element);
-			}
-
-			// Make sure panel is visible and layout
+			// Make sure panel is visible
 			if (!this.isVisible(Parts.PANEL_PART)) {
 				this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_HIDDEN, false);
 				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
@@ -2319,19 +2277,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		} else {
 			// Dialog → Pinned: restore panel into the grid
 			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Pinned);
-			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN);
-			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN, LayoutClasses.PANEL_DIALOG_MAXIMIZED);
 
 			// Move panel back to original parent
-			if (this.panelDialogOriginalParent && panelPart.element.parentElement !== this.panelDialogOriginalParent) {
-				this.panelDialogOriginalParent.appendChild(panelPart.element);
-			}
+			this.panelDialogOriginalParent?.appendChild(panelPart.element);
 
-			// If panel should be visible, show it in the grid
+			// If panel should be visible, show it in the grid and restore size
 			if (!this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN) && this.workbenchGrid) {
 				this.workbenchGrid.setViewVisible(this.panelPartView, true);
-
-				// Restore saved size if available
 				if (this.panelDialogSavedSize) {
 					this.workbenchGrid.resizeView(this.panelPartView, this.panelDialogSavedSize);
 				}
@@ -2378,33 +2331,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	private layoutPanelDialog(): void {
-		if (!this.panelDialogOverlay) {
+		if (!this.panelDialogOverlay || !this.isDialogMode) {
 			return;
 		}
-
 		const panelPart = this.getPart(Parts.PANEL_PART);
-		const isMaximized = this.isPanelDialogMaximized();
-
-		if (isMaximized) {
-			// Full size of the safe area
-			panelPart.layout(
-				this.panelDialogSafeArea?.clientWidth ?? this._mainContainerDimension.width,
-				this.panelDialogSafeArea?.clientHeight ?? this._mainContainerDimension.height,
-				0,
-				0
-			);
-		} else {
-			// Default centered dialog size
-			const dialogWidth = Math.min(900, Math.floor(this._mainContainerDimension.width * 0.8));
-			const dialogHeight = Math.min(600, Math.floor(this._mainContainerDimension.height * 0.7));
-			panelPart.layout(dialogWidth, dialogHeight, 0, 0);
-		}
-	}
-
-	private layoutPanelFromOverlay(): void {
-		if (this.getPanelMode() === PanelMode.Dialog && this.isVisible(Parts.PANEL_PART)) {
-			this.layoutPanelDialog();
-		}
+		const [width, height] = this.isPanelDialogMaximized()
+			? [this.panelDialogSafeArea?.clientWidth ?? this._mainContainerDimension.width,
+			   this.panelDialogSafeArea?.clientHeight ?? this._mainContainerDimension.height]
+			: [Math.min(900, Math.floor(this._mainContainerDimension.width * 0.8)),
+			   Math.min(600, Math.floor(this._mainContainerDimension.height * 0.7))];
+		panelPart.layout(width, height, 0, 0);
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1646,8 +1646,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 					if (part === sideBar) {
 						this.setSideBarHidden(!visible);
-					} else if (part === panelPart && this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN) === visible) {
-						this.setPanelHidden(!visible, true);
+					} else if (part === panelPart) {
+						// In dialog mode, the panel is removed from the grid and managed separately.
+						// When switching modes, hiding the panel from the grid fires this event with
+						// visible=false, which would incorrectly update panel state to hidden.
+						// Skip reacting to grid visibility changes in dialog mode since panel
+						// visibility is controlled through setPanelHidden() directly.
+						if (!this.isDialogMode && this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN) === visible) {
+							this.setPanelHidden(!visible, true);
+						}
 					} else if (part === auxiliaryBarPart) {
 						this.setAuxiliaryBarHidden(!visible, true);
 					} else if (part === editorPart) {
@@ -2016,11 +2023,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	private setPanelHidden(hidden: boolean, skipLayout?: boolean): void {
 		if (!this.workbenchGrid) {
 			return; // Return if not initialized fully (https://github.com/microsoft/vscode/issues/105480)
-		}
-
-		// In dialog mode, panel visibility is managed separately from the grid
-		if (this.isDialogMode) {
-			return;
 		}
 
 		if (!hidden && this.setAuxiliaryBarMaximized(false) && this.isVisible(Parts.PANEL_PART)) {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2018,6 +2018,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			return; // Return if not initialized fully (https://github.com/microsoft/vscode/issues/105480)
 		}
 
+		// In dialog mode, panel visibility is managed separately from the grid
+		if (this.isDialogMode) {
+			return;
+		}
+
 		if (!hidden && this.setAuxiliaryBarMaximized(false) && this.isVisible(Parts.PANEL_PART)) {
 			return; // return: leaving maximised auxiliary bar made this part visible
 		}
@@ -2546,8 +2551,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	//#endregion
 
 	private panelOpensMaximized(): boolean {
-		if (this.getPanelAlignment() !== 'center' && isHorizontal(this.getPanelPosition())) {
-			return false; // The workbench grid currently prevents us from supporting panel maximization with non-center panel alignment
+		// The workbench grid prevents panel maximization with non-center alignment in horizontal position.
+		// Dialog mode has no grid constraints, so this limitation doesn't apply.
+		if (!this.isDialogMode && this.getPanelAlignment() !== 'center' && isHorizontal(this.getPanelPosition())) {
+			return false;
 		}
 
 		const panelOpensMaximized = partOpensMaximizedFromString(this.configurationService.getValue<string>(WorkbenchLayoutSettings.PANEL_OPENS_MAXIMIZED));

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -11,7 +11,7 @@ import { isWindows, isLinux, isMacintosh, isWeb, isIOS } from '../../base/common
 import { EditorInputCapabilities, GroupIdentifier, isResourceEditorInput, IUntypedEditorInput, pathsToEditors } from '../common/editor.js';
 import { SidebarPart } from './parts/sidebar/sidebarPart.js';
 import { PanelPart } from './parts/panel/panelPart.js';
-import { Position, Parts, PartOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, partOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, EditorActionsLocation, shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart, IPartVisibilityChangeEvent } from '../services/layout/browser/layoutService.js';
+import { Position, Parts, PartOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, partOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, EditorActionsLocation, shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart, IPartVisibilityChangeEvent, PanelMode } from '../services/layout/browser/layoutService.js';
 import { isTemporaryWorkspace, IWorkspaceContextService, WorkbenchState } from '../../platform/workspace/common/workspace.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../platform/storage/common/storage.js';
 import { IConfigurationChangeEvent, IConfigurationService, isConfigured } from '../../platform/configuration/common/configuration.js';
@@ -100,7 +100,9 @@ enum LayoutClasses {
 	STATUSBAR_HIDDEN = 'nostatusbar',
 	FULLSCREEN = 'fullscreen',
 	MAXIMIZED = 'maximized',
-	WINDOW_BORDER = 'border'
+	WINDOW_BORDER = 'border',
+	PANEL_DIALOG_OPEN = 'panel-dialog-open',
+	PANEL_DIALOG_MAXIMIZED = 'panel-dialog-maximized'
 }
 
 interface IPathToOpen extends IPath {
@@ -212,6 +214,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	private _mainContainerDimension!: IDimension;
 	get mainContainerDimension(): IDimension { return this._mainContainerDimension; }
+
+	//#region Panel Dialog Mode
+
+	private panelDialogOverlay: HTMLElement | undefined;
+	private panelDialogSafeArea: HTMLElement | undefined;
+	private panelDialogOriginalParent: HTMLElement | undefined;
+	private panelDialogSavedAlignment: PanelAlignment | undefined;
+	private panelDialogSavedSize: IViewSize | undefined;
+
+	//#endregion
 
 	get activeContainerDimension(): IDimension {
 		return this.getContainerDimension(this.activeContainer);
@@ -1693,6 +1705,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.workbenchGrid.layout(this._mainContainerDimension.width, this._mainContainerDimension.height);
 			this.initialized = true;
 
+			// Layout dialog panel if in dialog mode
+			if (this.getPanelMode() === PanelMode.Dialog && this.isVisible(Parts.PANEL_PART)) {
+				this.layoutPanelDialog();
+			}
+
 			// Emit as event
 			this.handleContainerDidLayout(this.mainContainer, this._mainContainerDimension);
 		}
@@ -2010,24 +2027,72 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_HIDDEN, hidden);
 
-		const panelOpensMaximized = this.panelOpensMaximized();
+		// Handle visibility based on panel mode
+		const panelPart = this.getPart(Parts.PANEL_PART);
 
-		// Adjust CSS
-		if (hidden) {
-			this.mainContainer.classList.add(LayoutClasses.PANEL_HIDDEN);
+		if (this.getPanelMode() === PanelMode.Dialog) {
+			// Dialog mode: manage CSS classes and overlay
+			if (hidden) {
+				this.mainContainer.classList.add(LayoutClasses.PANEL_HIDDEN);
+				this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN);
+				this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+			} else {
+				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
+				this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_OPEN);
+				// Restore maximized state from state model
+				if (this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED)) {
+					this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+				}
+				this.ensurePanelDialogOverlay();
+			}
+
+			// Move panel element between overlay and original parent
+			if (!hidden && this.panelDialogOverlay) {
+				if (panelPart.element.parentElement !== this.panelDialogOverlay) {
+					this.panelDialogOverlay.appendChild(panelPart.element);
+				}
+			} else if (hidden && this.panelDialogOriginalParent) {
+				if (panelPart.element.parentElement !== this.panelDialogOriginalParent) {
+					this.panelDialogOriginalParent.appendChild(panelPart.element);
+				}
+			}
 		} else {
-			this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
+			// Pinned mode: manage grid visibility
+			const panelOpensMaximized = this.panelOpensMaximized();
+
+			// Adjust CSS
+			if (hidden) {
+				this.mainContainer.classList.add(LayoutClasses.PANEL_HIDDEN);
+			} else {
+				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
+			}
+
+			// If maximized and in process of hiding, unmaximize FIRST before
+			// changing visibility to prevent conflict with setEditorHidden
+			// which would force panel visible again (fixes #281772)
+			if (hidden && isPanelMaximized) {
+				this.toggleMaximizedPanel();
+			}
+
+			// Propagate layout changes to grid
+			this.workbenchGrid.setViewVisible(this.panelPartView, !hidden);
+
+			// Don't proceed if we have already done this before
+			if (wasHidden !== hidden) {
+				// If in process of showing, toggle whether or not panel is maximized
+				if (!hidden) {
+					if (!skipLayout && isPanelMaximized !== panelOpensMaximized) {
+						this.toggleMaximizedPanel();
+					}
+				} else {
+					// If in process of hiding, remember whether the panel is maximized or not
+					this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, isPanelMaximized);
+				}
+			}
 		}
 
-		// If maximized and in process of hiding, unmaximize FIRST before
-		// changing visibility to prevent conflict with setEditorHidden
-		// which would force panel visible again (fixes #281772)
-		if (hidden && isPanelMaximized) {
-			this.toggleMaximizedPanel();
-		}
-
-		// Propagate layout changes to grid
-		this.workbenchGrid.setViewVisible(this.panelPartView, !hidden);
+		// Notify the panel part of visibility
+		panelPart.setVisible(!hidden);
 
 		// If panel part becomes hidden, also hide the current active panel if any
 		let focusEditor = false;
@@ -2058,19 +2123,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			}
 		}
 
-		// Don't proceed if we have already done this before
-		if (wasHidden === hidden) {
-			return;
-		}
-
-		// If in process of showing, toggle whether or not panel is maximized
-		if (!hidden) {
-			if (!skipLayout && isPanelMaximized !== panelOpensMaximized) {
-				this.toggleMaximizedPanel();
-			}
-		} else {
-			// If in process of hiding, remember whether the panel is maximized or not
-			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, isPanelMaximized);
+		// Layout dialog if in dialog mode
+		if (this.getPanelMode() === PanelMode.Dialog && !hidden) {
+			this.layoutPanelDialog();
 		}
 
 		if (focusEditor) {
@@ -2156,6 +2211,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	isPanelMaximized(): boolean {
+		// In dialog mode, check the dialog maximized CSS class
+		if (this.getPanelMode() === PanelMode.Dialog) {
+			return this.isPanelDialogMaximized();
+		}
+
+		// In pinned mode, check traditional grid-based maximization
 		return (
 			this.getPanelAlignment() === 'center' || 	// the workbench grid currently prevents us from supporting panel
 			!isHorizontal(this.getPanelPosition())		// maximization with non-center panel alignment
@@ -2163,6 +2224,20 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	toggleMaximizedPanel(): void {
+		// In dialog mode, toggle the dialog between its default size and full workbench size
+		if (this.getPanelMode() === PanelMode.Dialog) {
+			const isMaximized = this.isPanelDialogMaximized();
+			this.mainContainer.classList.toggle(LayoutClasses.PANEL_DIALOG_MAXIMIZED, !isMaximized);
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, !isMaximized);
+			this.layoutPanelFromOverlay();
+			// Fire event to update context keys
+			this._onDidChangePartVisibility.fire({
+				partId: Parts.PANEL_PART,
+				visible: true
+			});
+			return;
+		}
+
 		const size = this.workbenchGrid.getViewSize(this.panelPartView);
 		const panelPosition = this.getPanelPosition();
 		const maximize = !this.isPanelMaximized();
@@ -2187,6 +2262,152 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, maximize);
 	}
+
+	//#region Panel Dialog Mode
+
+	private isPanelDialogMaximized(): boolean {
+		return this.mainContainer.classList.contains(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+	}
+
+	getPanelMode(): PanelMode {
+		return this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_MODE);
+	}
+
+	togglePanelMode(): void {
+		this.setPanelMode(this.getPanelMode() === PanelMode.Pinned ? PanelMode.Dialog : PanelMode.Pinned);
+	}
+
+	setPanelMode(mode: PanelMode): void {
+		if (mode === this.getPanelMode()) {
+			return;
+		}
+
+		const panelPart = this.getPart(Parts.PANEL_PART);
+
+		if (mode === PanelMode.Dialog) {
+			// Save current state before transitioning
+			this.panelDialogSavedAlignment = this.getPanelAlignment();
+
+			// Store the state
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Dialog);
+
+			// Save original parent for restoration later
+			this.panelDialogOriginalParent = panelPart.element.parentElement ?? undefined;
+
+			// If panel is visible in grid, save its size and hide from grid (but don't hide the panel itself)
+			if (this.isVisible(Parts.PANEL_PART) && this.workbenchGrid) {
+				this.panelDialogSavedSize = this.workbenchGrid.getViewSize(this.panelPartView);
+				this.workbenchGrid.setViewVisible(this.panelPartView, false);
+			}
+
+			// Add dialog CSS class and set up overlay
+			this.mainContainer.classList.add(LayoutClasses.PANEL_DIALOG_OPEN);
+			this.ensurePanelDialogOverlay();
+
+			// Move panel element into the overlay
+			if (this.panelDialogOverlay && panelPart.element.parentElement !== this.panelDialogOverlay) {
+				this.panelDialogOverlay.appendChild(panelPart.element);
+			}
+
+			// Make sure panel is visible and layout
+			if (!this.isVisible(Parts.PANEL_PART)) {
+				this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_HIDDEN, false);
+				this.mainContainer.classList.remove(LayoutClasses.PANEL_HIDDEN);
+			}
+
+			this.layoutPanelDialog();
+		} else {
+			// Dialog → Pinned: restore panel into the grid
+			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Pinned);
+			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_OPEN);
+			this.mainContainer.classList.remove(LayoutClasses.PANEL_DIALOG_MAXIMIZED);
+
+			// Move panel back to original parent
+			if (this.panelDialogOriginalParent && panelPart.element.parentElement !== this.panelDialogOriginalParent) {
+				this.panelDialogOriginalParent.appendChild(panelPart.element);
+			}
+
+			// If panel should be visible, show it in the grid
+			if (!this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN) && this.workbenchGrid) {
+				this.workbenchGrid.setViewVisible(this.panelPartView, true);
+
+				// Restore saved size if available
+				if (this.panelDialogSavedSize) {
+					this.workbenchGrid.resizeView(this.panelPartView, this.panelDialogSavedSize);
+				}
+			}
+
+			// Restore alignment only for horizontal positions
+			if (this.panelDialogSavedAlignment !== undefined && isHorizontal(this.getPanelPosition())) {
+				this.setPanelAlignment(this.panelDialogSavedAlignment);
+			}
+
+			// Clean up saved state
+			this.panelDialogSavedAlignment = undefined;
+			this.panelDialogSavedSize = undefined;
+			this.panelDialogOriginalParent = undefined;
+		}
+
+		// Fire visibility event to update context keys
+		this._onDidChangePartVisibility.fire({
+			partId: Parts.PANEL_PART,
+			visible: this.isVisible(Parts.PANEL_PART)
+		});
+	}
+
+	private ensurePanelDialogOverlay(): void {
+		if (!this.panelDialogSafeArea) {
+			this.panelDialogSafeArea = document.createElement('div');
+			this.panelDialogSafeArea.classList.add('panel-dialog-safe-area');
+			this.mainContainer.appendChild(this.panelDialogSafeArea);
+		}
+
+		if (!this.panelDialogOverlay) {
+			const backdrop = document.createElement('div');
+			backdrop.classList.add('panel-dialog-backdrop');
+			backdrop.addEventListener('mousedown', () => {
+				// Clicking backdrop hides the panel
+				this.setPartHidden(true, Parts.PANEL_PART);
+			});
+			this.mainContainer.appendChild(backdrop);
+
+			this.panelDialogOverlay = document.createElement('div');
+			this.panelDialogOverlay.classList.add('panel-dialog-overlay');
+			this.panelDialogSafeArea.appendChild(this.panelDialogOverlay);
+		}
+	}
+
+	private layoutPanelDialog(): void {
+		if (!this.panelDialogOverlay) {
+			return;
+		}
+
+		const panelPart = this.getPart(Parts.PANEL_PART);
+		const isMaximized = this.isPanelDialogMaximized();
+
+		if (isMaximized) {
+			// Full size of the safe area
+			panelPart.layout(
+				this.panelDialogSafeArea?.clientWidth ?? this._mainContainerDimension.width,
+				this.panelDialogSafeArea?.clientHeight ?? this._mainContainerDimension.height,
+				0,
+				0
+			);
+		} else {
+			// Default centered dialog size
+			const dialogWidth = Math.min(900, Math.floor(this._mainContainerDimension.width * 0.8));
+			const dialogHeight = Math.min(600, Math.floor(this._mainContainerDimension.height * 0.7));
+			panelPart.layout(dialogWidth, dialogHeight, 0, 0);
+		}
+	}
+
+	private layoutPanelFromOverlay(): void {
+		if (this.getPanelMode() === PanelMode.Dialog && this.isVisible(Parts.PANEL_PART)) {
+			this.layoutPanelDialog();
+		}
+	}
+
+	//#endregion
 
 	private panelOpensMaximized(): boolean {
 		if (this.getPanelAlignment() !== 'center' && isHorizontal(this.getPanelPosition())) {
@@ -2793,6 +3014,9 @@ const LayoutStateKeys = {
 	SIDEBAR_POSITON: new RuntimeStateKey<Position>('sideBar.position', StorageScope.WORKSPACE, StorageTarget.MACHINE, Position.LEFT),
 	PANEL_POSITION: new RuntimeStateKey<Position>('panel.position', StorageScope.WORKSPACE, StorageTarget.MACHINE, Position.BOTTOM),
 	PANEL_ALIGNMENT: new RuntimeStateKey<PanelAlignment>('panel.alignment', StorageScope.PROFILE, StorageTarget.USER, 'center'),
+
+	// Panel Mode
+	PANEL_MODE: new RuntimeStateKey<PanelMode>('panel.mode', StorageScope.WORKSPACE, StorageTarget.MACHINE, PanelMode.Pinned),
 
 	// Part Visibility
 	ACTIVITYBAR_HIDDEN: new RuntimeStateKey<boolean>('activityBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false, true),

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
+import { localize } from '../../nls.js';
 import { Event, Emitter } from '../../base/common/event.js';
 import { EventType, addDisposableListener, getClientArea, size, IDimension, isAncestorUsingFlowTo, computeScreenAwareSize, getActiveDocument, getWindows, getActiveWindow, isActiveDocument, getWindow, getWindowId, getActiveElement, Dimension } from '../../base/browser/dom.js';
 import { onDidChangeFullscreen, isFullscreen, isWCOEnabled } from '../../base/browser/browser.js';
@@ -220,6 +221,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	private panelDialogOverlay: HTMLElement | undefined;
 	private panelDialogSafeArea: HTMLElement | undefined;
 	private panelDialogOriginalParent: HTMLElement | undefined;
+	private panelDialogSavedPosition: Position | undefined;
 	private panelDialogSavedAlignment: PanelAlignment | undefined;
 	private panelDialogSavedSize: IViewSize | undefined;
 
@@ -2252,6 +2254,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		if (mode === PanelMode.Dialog) {
 			// Save current state before transitioning
+			this.panelDialogSavedPosition = this.getPanelPosition();
 			this.panelDialogSavedAlignment = this.getPanelAlignment();
 			this.panelDialogOriginalParent = panelPart.element.parentElement ?? undefined;
 			this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_MODE, PanelMode.Dialog);
@@ -2290,12 +2293,18 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				}
 			}
 
+			// Restore position if it was changed while in dialog mode
+			if (this.panelDialogSavedPosition !== undefined && this.panelDialogSavedPosition !== this.getPanelPosition()) {
+				this.setPanelPosition(this.panelDialogSavedPosition);
+			}
+
 			// Restore alignment only for horizontal positions
 			if (this.panelDialogSavedAlignment !== undefined && isHorizontal(this.getPanelPosition())) {
 				this.setPanelAlignment(this.panelDialogSavedAlignment);
 			}
 
 			// Clean up saved state
+			this.panelDialogSavedPosition = undefined;
 			this.panelDialogSavedAlignment = undefined;
 			this.panelDialogSavedSize = undefined;
 			this.panelDialogOriginalParent = undefined;
@@ -2309,24 +2318,174 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	private ensurePanelDialogOverlay(): void {
-		if (!this.panelDialogSafeArea) {
-			this.panelDialogSafeArea = document.createElement('div');
-			this.panelDialogSafeArea.classList.add('panel-dialog-safe-area');
-			this.mainContainer.appendChild(this.panelDialogSafeArea);
+		if (this.panelDialogOverlay) {
+			return;
 		}
 
-		if (!this.panelDialogOverlay) {
-			const backdrop = document.createElement('div');
-			backdrop.classList.add('panel-dialog-backdrop');
-			backdrop.addEventListener('mousedown', () => {
-				// Clicking backdrop hides the panel
-				this.setPartHidden(true, Parts.PANEL_PART);
-			});
-			this.mainContainer.appendChild(backdrop);
+		// Capture original parent before moving panel
+		if (!this.panelDialogOriginalParent) {
+			const panelPart = this.getPart(Parts.PANEL_PART);
+			this.panelDialogOriginalParent = panelPart.element.parentElement ?? undefined;
+		}
 
-			this.panelDialogOverlay = document.createElement('div');
-			this.panelDialogOverlay.classList.add('panel-dialog-overlay');
-			this.panelDialogSafeArea.appendChild(this.panelDialogOverlay);
+		// Create safe area that clips dialog to editor zone
+		const safeArea = this.panelDialogSafeArea = document.createElement('div');
+		safeArea.classList.add('panel-dialog-safe-area');
+		this.mainContainer.appendChild(safeArea);
+
+		// Create overlay (appended before backdrop for :focus-within sibling selector)
+		const overlay = this.panelDialogOverlay = document.createElement('div');
+		overlay.classList.add('panel-dialog-overlay');
+		overlay.setAttribute('role', 'dialog');
+		overlay.setAttribute('aria-label', localize('panelDialog', "Panel"));
+		safeArea.appendChild(overlay);
+
+		// Create non-interactive backdrop
+		const backdrop = document.createElement('div');
+		backdrop.classList.add('panel-dialog-backdrop');
+		safeArea.appendChild(backdrop);
+
+		// Position safe area
+		this.updatePanelDialogSafeArea();
+
+		// Drag support
+		this.setupPanelDialogDrag(overlay, safeArea);
+
+		// Resize observer for CSS resize handle
+		const resizeObserver = new ResizeObserver(() => this.onPanelDialogResized());
+		resizeObserver.observe(overlay);
+	}
+
+	private setupPanelDialogDrag(overlay: HTMLElement, safeArea: HTMLElement): void {
+		let dragStartX = 0, dragStartY = 0, overlayStartLeft = 0, overlayStartTop = 0;
+
+		const onMouseMove = (e: MouseEvent): void => {
+			const maxLeft = Math.max(0, safeArea.offsetWidth - overlay.offsetWidth);
+			const maxTop = Math.max(0, safeArea.offsetHeight - overlay.offsetHeight);
+			overlay.style.left = `${Math.max(0, Math.min(overlayStartLeft + e.clientX - dragStartX, maxLeft))}px`;
+			overlay.style.top = `${Math.max(0, Math.min(overlayStartTop + e.clientY - dragStartY, maxTop))}px`;
+		};
+
+		const onMouseUp = (): void => {
+			overlay.classList.remove('panel-dialog-dragging');
+			document.removeEventListener('mousemove', onMouseMove);
+			document.removeEventListener('mouseup', onMouseUp);
+			this.savePanelDialogBounds();
+		};
+
+		overlay.addEventListener('mousedown', (e: MouseEvent) => {
+			if (e.button !== 0) {
+				return;
+			}
+			const target = e.target as HTMLElement;
+			const titleEl = overlay.querySelector('.part.panel > .title') as HTMLElement | null;
+			if (!titleEl?.contains(target) || target.closest('a, button, .action-item, .action-label, .composite-bar, input, select')) {
+				return;
+			}
+			e.preventDefault();
+			dragStartX = e.clientX;
+			dragStartY = e.clientY;
+			overlayStartLeft = overlay.offsetLeft;
+			overlayStartTop = overlay.offsetTop;
+			overlay.classList.add('panel-dialog-dragging');
+			document.addEventListener('mousemove', onMouseMove);
+			document.addEventListener('mouseup', onMouseUp);
+		});
+	}
+
+	private onPanelDialogResized(): void {
+		if (!this.panelDialogOverlay || !this.isVisible(Parts.PANEL_PART) || !this.isDialogMode) {
+			return;
+		}
+		this.updatePanelDialogSafeArea();
+		if (!this.isPanelDialogMaximized()) {
+			this.clampPanelDialogOverlay();
+		}
+		const width = this.panelDialogOverlay.offsetWidth;
+		const height = this.panelDialogOverlay.offsetHeight;
+		if (width > 0 && height > 0) {
+			this.getPart(Parts.PANEL_PART).layout(width, height, 0, 0);
+		}
+		this.savePanelDialogBounds();
+	}
+
+	private updatePanelDialogSafeArea(): void {
+		if (!this.panelDialogSafeArea) {
+			return;
+		}
+		const titleBarH = this.isVisible(Parts.TITLEBAR_PART) ? this.titleBarPartView.minimumHeight : 0;
+		const statusBarH = this.isVisible(Parts.STATUSBAR_PART) ? this.statusBarPartView.minimumHeight : 0;
+		this.panelDialogSafeArea.style.top = `${titleBarH}px`;
+		this.panelDialogSafeArea.style.bottom = `${statusBarH}px`;
+	}
+
+	private clampPanelDialogOverlay(): void {
+		if (!this.panelDialogOverlay || !this.panelDialogSafeArea) {
+			return;
+		}
+		const safeW = this.panelDialogSafeArea.offsetWidth;
+		const safeH = this.panelDialogSafeArea.offsetHeight;
+
+		// Clamp size
+		if (this.panelDialogOverlay.offsetWidth > safeW) {
+			this.panelDialogOverlay.style.width = `${safeW}px`;
+		}
+		if (this.panelDialogOverlay.offsetHeight > safeH) {
+			this.panelDialogOverlay.style.height = `${safeH}px`;
+		}
+
+		// Clamp position
+		const maxLeft = Math.max(0, safeW - this.panelDialogOverlay.offsetWidth);
+		const maxTop = Math.max(0, safeH - this.panelDialogOverlay.offsetHeight);
+		const clampedLeft = Math.max(0, Math.min(this.panelDialogOverlay.offsetLeft, maxLeft));
+		const clampedTop = Math.max(0, Math.min(this.panelDialogOverlay.offsetTop, maxTop));
+		if (clampedLeft !== this.panelDialogOverlay.offsetLeft) {
+			this.panelDialogOverlay.style.left = `${clampedLeft}px`;
+		}
+		if (clampedTop !== this.panelDialogOverlay.offsetTop) {
+			this.panelDialogOverlay.style.top = `${clampedTop}px`;
+		}
+	}
+
+	private savePanelDialogBounds(): void {
+		if (!this.panelDialogOverlay || !this.panelDialogSafeArea) {
+			return;
+		}
+		const containerW = this.panelDialogSafeArea.offsetWidth;
+		const containerH = this.panelDialogSafeArea.offsetHeight;
+		if (containerW <= 0 || containerH <= 0) {
+			return;
+		}
+		this.storageService.store('workbench.panel.dialogBoundsRatio', JSON.stringify({
+			leftRatio: this.panelDialogOverlay.offsetLeft / containerW,
+			topRatio: this.panelDialogOverlay.offsetTop / containerH,
+			widthRatio: this.panelDialogOverlay.offsetWidth / containerW,
+			heightRatio: this.panelDialogOverlay.offsetHeight / containerH
+		}), StorageScope.PROFILE, StorageTarget.MACHINE);
+	}
+
+	private loadPanelDialogBounds(): { left: number; top: number; width: number; height: number } | undefined {
+		const raw = this.storageService.get('workbench.panel.dialogBoundsRatio', StorageScope.PROFILE);
+		if (!raw) {
+			return undefined;
+		}
+		try {
+			const { leftRatio, topRatio, widthRatio, heightRatio } = JSON.parse(raw);
+			if (typeof leftRatio !== 'number' || typeof topRatio !== 'number' || typeof widthRatio !== 'number' || typeof heightRatio !== 'number' || widthRatio <= 0 || heightRatio <= 0) {
+				return undefined;
+			}
+			const titleBarH = this.isVisible(Parts.TITLEBAR_PART) ? this.titleBarPartView.minimumHeight : 0;
+			const statusBarH = this.isVisible(Parts.STATUSBAR_PART) ? this.statusBarPartView.minimumHeight : 0;
+			const safeW = this._mainContainerDimension.width;
+			const safeH = Math.max(0, this._mainContainerDimension.height - titleBarH - statusBarH);
+			return {
+				left: Math.round(leftRatio * safeW),
+				top: Math.round(topRatio * safeH),
+				width: Math.round(widthRatio * safeW),
+				height: Math.round(heightRatio * safeH)
+			};
+		} catch {
+			return undefined;
 		}
 	}
 
@@ -2334,13 +2493,44 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if (!this.panelDialogOverlay || !this.isDialogMode) {
 			return;
 		}
-		const panelPart = this.getPart(Parts.PANEL_PART);
-		const [width, height] = this.isPanelDialogMaximized()
-			? [this.panelDialogSafeArea?.clientWidth ?? this._mainContainerDimension.width,
-			   this.panelDialogSafeArea?.clientHeight ?? this._mainContainerDimension.height]
-			: [Math.min(900, Math.floor(this._mainContainerDimension.width * 0.8)),
-			   Math.min(600, Math.floor(this._mainContainerDimension.height * 0.7))];
-		panelPart.layout(width, height, 0, 0);
+
+		// Restore persisted bounds or compute defaults
+		if (!this.panelDialogOverlay.style.width) {
+			const saved = this.loadPanelDialogBounds();
+			if (saved) {
+				this.panelDialogOverlay.style.left = `${saved.left}px`;
+				this.panelDialogOverlay.style.top = `${saved.top}px`;
+				this.panelDialogOverlay.style.width = `${saved.width}px`;
+				this.panelDialogOverlay.style.height = `${saved.height}px`;
+			} else {
+				// Default: 70% wide, 40% tall, near bottom
+				const titleBarH = this.isVisible(Parts.TITLEBAR_PART) ? this.titleBarPartView.minimumHeight : 0;
+				const statusBarH = this.isVisible(Parts.STATUSBAR_PART) ? this.statusBarPartView.minimumHeight : 0;
+				const safeW = this._mainContainerDimension.width;
+				const safeH = Math.max(0, this._mainContainerDimension.height - titleBarH - statusBarH);
+				const dialogW = Math.round(safeW * 0.7);
+				const dialogH = Math.round(safeH * 0.4);
+				const left = Math.round((safeW - dialogW) / 2);
+				const top = safeH - dialogH - 8;
+
+				this.panelDialogOverlay.style.width = `${dialogW}px`;
+				this.panelDialogOverlay.style.height = `${dialogH}px`;
+				this.panelDialogOverlay.style.left = `${left}px`;
+				this.panelDialogOverlay.style.top = `${top}px`;
+
+				// Persist ratios for proportional window resize
+				if (safeW > 0 && safeH > 0) {
+					this.storageService.store('workbench.panel.dialogBoundsRatio', JSON.stringify({
+						leftRatio: left / safeW,
+						topRatio: top / safeH,
+						widthRatio: dialogW / safeW,
+						heightRatio: dialogH / safeH
+					}), StorageScope.PROFILE, StorageTarget.MACHINE);
+				}
+			}
+		}
+
+		this.onPanelDialogResized();
 	}
 
 	//#endregion
@@ -2466,6 +2656,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	setPanelPosition(position: Position): void {
+		// In dialog mode, stash the position for later restoration
+		if (this.isDialogMode) {
+			this.panelDialogSavedPosition = position;
+			return;
+		}
+
 		if (!this.isVisible(Parts.PANEL_PART)) {
 			this.setPanelHidden(false);
 		}

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -98,3 +98,89 @@
 	display: inline-block;
 	transform: rotate(180deg);
 }
+
+/*---------------------------------------------------------------------------------------------
+ * Panel Dialog Mode
+ *--------------------------------------------------------------------------------------------*/
+
+/* Safe area for panel dialog - respects title bar and other chrome */
+.monaco-workbench .panel-dialog-safe-area {
+	position: absolute;
+	top: var(--vscode-titleBar-height, 30px);
+	left: 0;
+	right: 0;
+	bottom: 0;
+	pointer-events: none;
+	display: none;
+}
+
+.monaco-workbench.panel-dialog-open .panel-dialog-safe-area {
+	display: block;
+	z-index: 100;
+}
+
+/* Semi-transparent backdrop behind the dialog */
+.monaco-workbench .panel-dialog-backdrop {
+	position: absolute;
+	top: var(--vscode-titleBar-height, 30px);
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.4);
+	display: none;
+	z-index: 99;
+}
+
+.monaco-workbench.panel-dialog-open .panel-dialog-backdrop {
+	display: block;
+	pointer-events: auto;
+}
+
+/* Reduce backdrop opacity when the dialog is focused */
+.monaco-workbench.panel-dialog-open .panel-dialog-overlay:focus-within ~ .panel-dialog-backdrop {
+	background: rgba(0, 0, 0, 0.3);
+}
+
+/* The overlay container that holds the floating panel */
+.monaco-workbench .panel-dialog-overlay {
+	position: absolute;
+	display: none;
+	pointer-events: none;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	border-radius: 8px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+	overflow: hidden;
+}
+
+.monaco-workbench.panel-dialog-open .panel-dialog-overlay {
+	display: flex;
+	pointer-events: auto;
+	z-index: 101;
+}
+
+/* Full-size maximized dialog */
+.monaco-workbench.panel-dialog-open.panel-dialog-maximized .panel-dialog-overlay {
+	left: 0;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	transform: none;
+	width: 100% !important;
+	height: 100% !important;
+	border-radius: 0;
+}
+
+/* Panel part inside the overlay takes full size */
+.monaco-workbench .panel-dialog-overlay .part.panel {
+	width: 100% !important;
+	height: 100% !important;
+	position: relative !important;
+}
+
+/* Override nopanel hiding when in dialog mode */
+.monaco-workbench.nopanel.panel-dialog-open .panel-dialog-overlay .part.panel {
+	display: flex !important;
+	visibility: visible !important;
+}

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -103,80 +103,100 @@
  * Panel Dialog Mode
  *--------------------------------------------------------------------------------------------*/
 
-/* Safe area for panel dialog - respects title bar and other chrome */
+/* Safe area clips the floating dialog to the editor zone (below title bar, above status bar).
+   overflow: hidden prevents the dialog and native CSS resize handle from exceeding bounds. */
 .monaco-workbench .panel-dialog-safe-area {
+	display: none;
 	position: absolute;
-	top: var(--vscode-titleBar-height, 30px);
 	left: 0;
 	right: 0;
-	bottom: 0;
+	/* top and bottom are set dynamically via JS based on titlebar/statusbar heights */
+	overflow: hidden;
 	pointer-events: none;
-	display: none;
+	z-index: 900;
 }
 
 .monaco-workbench.panel-dialog-open .panel-dialog-safe-area {
 	display: block;
-	z-index: 100;
 }
 
-/* Semi-transparent backdrop behind the dialog */
+/* Semi-transparent backdrop - purely visual, non-interactive */
 .monaco-workbench .panel-dialog-backdrop {
-	position: absolute;
-	top: var(--vscode-titleBar-height, 30px);
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background: rgba(0, 0, 0, 0.4);
 	display: none;
-	z-index: 99;
+	position: absolute;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.35);
+	z-index: 0;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.15s ease-out;
 }
 
 .monaco-workbench.panel-dialog-open .panel-dialog-backdrop {
 	display: block;
-	pointer-events: auto;
 }
 
-/* Reduce backdrop opacity when the dialog is focused */
+/* Show backdrop when overlay has focus */
 .monaco-workbench.panel-dialog-open .panel-dialog-overlay:focus-within ~ .panel-dialog-backdrop {
-	background: rgba(0, 0, 0, 0.3);
+	opacity: 1;
 }
 
-/* The overlay container that holds the floating panel */
+/* The floating dialog container */
 .monaco-workbench .panel-dialog-overlay {
-	position: absolute;
 	display: none;
-	pointer-events: none;
-	left: 50%;
-	top: 50%;
-	transform: translate(-50%, -50%);
-	border-radius: 8px;
-	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+	position: absolute;
+	pointer-events: all;
+	z-index: 1;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.4);
+	border: 1px solid var(--vscode-panelTitle-border, var(--vscode-panel-border, transparent));
+	border-radius: 4px;
 	overflow: hidden;
+	resize: both;
+	min-width: 300px;
+	min-height: 120px;
+	max-width: 100%;
+	max-height: 100%;
 }
 
 .monaco-workbench.panel-dialog-open .panel-dialog-overlay {
 	display: flex;
-	pointer-events: auto;
-	z-index: 101;
+	flex-direction: column;
 }
 
-/* Full-size maximized dialog */
+/* When maximized, dialog covers the entire safe-area */
 .monaco-workbench.panel-dialog-open.panel-dialog-maximized .panel-dialog-overlay {
-	left: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	transform: none;
+	left: 0 !important;
+	top: 0 !important;
 	width: 100% !important;
 	height: 100% !important;
 	border-radius: 0;
+	resize: none;
+}
+
+/* Title bar is the drag handle */
+.monaco-workbench .panel-dialog-overlay .part.panel > .title {
+	cursor: move;
+}
+
+.monaco-workbench .panel-dialog-overlay.panel-dialog-dragging .part.panel > .title {
+	cursor: grabbing;
+}
+
+/* Interactive elements in title should not show move cursor */
+.monaco-workbench .panel-dialog-overlay .part.panel > .title a,
+.monaco-workbench .panel-dialog-overlay .part.panel > .title button,
+.monaco-workbench .panel-dialog-overlay .part.panel > .title .action-item,
+.monaco-workbench .panel-dialog-overlay .part.panel > .title .action-label,
+.monaco-workbench .panel-dialog-overlay .part.panel > .title .composite-bar {
+	cursor: default;
 }
 
 /* Panel part inside the overlay takes full size */
 .monaco-workbench .panel-dialog-overlay .part.panel {
-	width: 100% !important;
-	height: 100% !important;
-	position: relative !important;
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	overflow: hidden;
 }
 
 /* Override nopanel hiding when in dialog mode */

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -184,7 +184,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	submenu: MenuId.PanelPositionMenu,
 	title: localize('positionPanel', "Panel Position"),
 	group: '3_workbench_layout_move',
-	order: 4
+	order: 4,
+	when: PanelDialogModeContext.negate()
 });
 
 PositionPanelActionConfigs.forEach((positionPanelAction, index) => {
@@ -219,7 +220,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	submenu: MenuId.PanelAlignmentMenu,
 	title: localize('alignPanel', "Align Panel"),
 	group: '3_workbench_layout_move',
-	order: 5
+	order: 5,
+	when: PanelDialogModeContext.negate()
 });
 
 AlignPanelActionConfigs.forEach(alignPanelAction => {
@@ -272,7 +274,11 @@ registerAction2(class extends SwitchCompositeViewAction {
 	}
 });
 
-const panelMaximizationSupportedWhen = ContextKeyExpr.or(PanelAlignmentContext.isEqualTo('center'), ContextKeyExpr.and(PanelPositionContext.notEqualsTo('bottom'), PanelPositionContext.notEqualsTo('top')));
+const panelMaximizationSupportedWhen = ContextKeyExpr.or(
+	PanelDialogModeContext,
+	PanelAlignmentContext.isEqualTo('center'),
+	ContextKeyExpr.and(PanelPositionContext.notEqualsTo('bottom'), PanelPositionContext.notEqualsTo('top'))
+);
 
 registerAction2(class extends Action2 {
 	constructor() {

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -432,9 +432,9 @@ export class MoveSecondarySideBarToPanelAction extends MoveViewsBetweenPanelsAct
 registerAction2(MoveSidePanelToPanelAction);
 registerAction2(MoveSecondarySideBarToPanelAction);
 
-// --- Toggle Panel Mode (Pinned/Dialog)
+// --- Toggle Panel Mode (Dock/Dialog)
 
-const unpinIcon = registerIcon('panel-unpin', Codicon.pinned, localize('unpinPanelIcon', 'Icon to unpin the panel from the grid.'));
+const undockIcon = registerIcon('panel-undock', Codicon.pinned, localize('undockPanelIcon', 'Icon to undock the panel from the grid.'));
 
 registerAction2(class TogglePanelModeAction extends Action2 {
 
@@ -448,7 +448,7 @@ registerAction2(class TogglePanelModeAction extends Action2 {
 			f1: true,
 			toggled: {
 				condition: PanelDialogModeContext,
-				title: localize('pinPanel', "Pin Panel"),
+				title: localize('dockPanel', "Dock Panel"),
 			},
 			menu: [{
 				id: MenuId.PanelTitle,
@@ -461,7 +461,7 @@ registerAction2(class TogglePanelModeAction extends Action2 {
 				order: 1,
 				when: PanelDialogModeContext
 			}],
-			icon: unpinIcon,
+			icon: undockIcon,
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -8,7 +8,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
 import { MenuId, MenuRegistry, registerAction2, Action2, IAction2Options } from '../../../../platform/actions/common/actions.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
-import { isHorizontal, IWorkbenchLayoutService, PanelAlignment, Parts, Position, positionToString } from '../../../services/layout/browser/layoutService.js';
+import { isHorizontal, IWorkbenchLayoutService, PanelAlignment, PanelMode, Parts, Position, positionToString } from '../../../services/layout/browser/layoutService.js';
 import { IsAuxiliaryWindowContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext, PanelDialogModeContext } from '../../../common/contextkeys.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { Codicon } from '../../../../base/common/codicons.js';
@@ -305,7 +305,9 @@ registerAction2(class extends Action2 {
 	run(accessor: ServicesAccessor) {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		const notificationService = accessor.get(INotificationService);
-		if (layoutService.getPanelAlignment() !== 'center' && isHorizontal(layoutService.getPanelPosition())) {
+		// Grid-based maximization requires center alignment in horizontal position.
+		// Dialog mode has no grid constraints, so this limitation doesn't apply.
+		if (layoutService.getPanelMode() === PanelMode.Dock && layoutService.getPanelAlignment() !== 'center' && isHorizontal(layoutService.getPanelPosition())) {
 			notificationService.warn(localize('panelMaxNotSupported', "Maximizing the panel is only supported when it is center aligned."));
 			return;
 		}

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -9,7 +9,7 @@ import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
 import { MenuId, MenuRegistry, registerAction2, Action2, IAction2Options } from '../../../../platform/actions/common/actions.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { isHorizontal, IWorkbenchLayoutService, PanelAlignment, Parts, Position, positionToString } from '../../../services/layout/browser/layoutService.js';
-import { IsAuxiliaryWindowContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext } from '../../../common/contextkeys.js';
+import { IsAuxiliaryWindowContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext, PanelDialogModeContext } from '../../../common/contextkeys.js';
 import { ContextKeyExpr, ContextKeyExpression } from '../../../../platform/contextkey/common/contextkey.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
@@ -425,3 +425,41 @@ export class MoveSecondarySideBarToPanelAction extends MoveViewsBetweenPanelsAct
 }
 registerAction2(MoveSidePanelToPanelAction);
 registerAction2(MoveSecondarySideBarToPanelAction);
+
+// --- Toggle Panel Mode (Pinned/Dialog)
+
+const unpinIcon = registerIcon('panel-unpin', Codicon.pinned, localize('unpinPanelIcon', 'Icon to unpin the panel from the grid.'));
+
+registerAction2(class TogglePanelModeAction extends Action2 {
+
+	static readonly ID = 'workbench.action.togglePanelMode';
+
+	constructor() {
+		super({
+			id: 'workbench.action.togglePanelMode',
+			title: localize2('togglePanelMode', "Toggle Panel Mode"),
+			category: Categories.View,
+			f1: true,
+			toggled: {
+				condition: PanelDialogModeContext,
+				title: localize('pinPanel', "Pin Panel"),
+			},
+			menu: [{
+				id: MenuId.PanelTitle,
+				group: 'navigation',
+				order: 1,
+				when: PanelDialogModeContext.negate()
+			}, {
+				id: MenuId.PanelTitle,
+				group: 'navigation',
+				order: 1,
+				when: PanelDialogModeContext
+			}],
+			icon: unpinIcon,
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IWorkbenchLayoutService).togglePanelMode();
+	}
+});

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -8,7 +8,7 @@ import { localize } from '../../../../nls.js';
 import { IAction, Separator, SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { ActivePanelContext, PanelFocusContext } from '../../../common/contextkeys.js';
-import { IWorkbenchLayoutService, Parts, Position } from '../../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, Position, PanelMode } from '../../../services/layout/browser/layoutService.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -172,11 +172,6 @@ export class PanelPart extends AbstractPaneCompositePart {
 			}
 		}
 
-		const panelPositionMenu = this.menuService.getMenuActions(MenuId.PanelPositionMenu, this.contextKeyService, { shouldForwardArgs: true });
-		const panelAlignMenu = this.menuService.getMenuActions(MenuId.PanelAlignmentMenu, this.contextKeyService, { shouldForwardArgs: true });
-		const positionActions = getContextMenuActions(panelPositionMenu).secondary;
-		const alignActions = getContextMenuActions(panelAlignMenu).secondary;
-
 		const panelShowLabels = this.configurationService.getValue<boolean | undefined>('workbench.panel.showLabels');
 		const toggleShowLabelsAction = toAction({
 			id: 'workbench.action.panel.toggleShowLabels',
@@ -184,10 +179,23 @@ export class PanelPart extends AbstractPaneCompositePart {
 			run: () => this.configurationService.updateValue('workbench.panel.showLabels', !panelShowLabels)
 		});
 
+		const isDialogMode = this.layoutService.getPanelMode() === PanelMode.Dialog;
+
+		// Position and alignment submenus are hidden when in dialog mode
+		const positionAndAlignActions: IAction[] = isDialogMode ? [] : (() => {
+			const panelPositionMenu = this.menuService.getMenuActions(MenuId.PanelPositionMenu, this.contextKeyService, { shouldForwardArgs: true });
+			const panelAlignMenu = this.menuService.getMenuActions(MenuId.PanelAlignmentMenu, this.contextKeyService, { shouldForwardArgs: true });
+			const positionActions = getContextMenuActions(panelPositionMenu).secondary;
+			const alignActions = getContextMenuActions(panelAlignMenu).secondary;
+			return [
+				new SubmenuAction('workbench.action.panel.position', localize('panel position', "Panel Position"), positionActions),
+				new SubmenuAction('workbench.action.panel.align', localize('align panel', "Align Panel"), alignActions),
+			];
+		})();
+
 		actions.push(...[
 			new Separator(),
-			new SubmenuAction('workbench.action.panel.position', localize('panel position', "Panel Position"), positionActions),
-			new SubmenuAction('workbench.action.panel.align', localize('align panel', "Align Panel"), alignActions),
+			...positionAndAlignActions,
 			toggleShowLabelsAction,
 			toAction({ id: TogglePanelAction.ID, label: localize('hidePanel', "Hide Panel"), run: () => this.commandService.executeCommand(TogglePanelAction.ID) }),
 		]);

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -167,6 +167,7 @@ export const PanelPositionContext = new RawContextKey<string>('panelPosition', '
 export const PanelAlignmentContext = new RawContextKey<string>('panelAlignment', 'center', localize('panelAlignment', "The alignment of the panel, either 'center', 'left', 'right' or 'justify'"));
 export const PanelVisibleContext = new RawContextKey<boolean>('panelVisible', false, localize('panelVisible', "Whether the panel is visible"));
 export const PanelMaximizedContext = new RawContextKey<boolean>('panelMaximized', false, localize('panelMaximized', "Whether the panel is maximized"));
+export const PanelDialogModeContext = new RawContextKey<boolean>('panelDialogMode', false, localize('panelDialogMode', "Whether the panel is in dialog mode (floating overlay)"));
 
 //#endregion
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -85,7 +85,7 @@ export const enum PanelMode {
 	/**
 	 * Panel is docked in the workbench grid (traditional behavior).
 	 */
-	Pinned = 'pinned',
+	Dock = 'dock',
 
 	/**
 	 * Panel floats as a dialog overlay above the workbench.

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -81,6 +81,18 @@ export function isHorizontal(position: Position): boolean {
 	return position === Position.BOTTOM || position === Position.TOP;
 }
 
+export const enum PanelMode {
+	/**
+	 * Panel is docked in the workbench grid (traditional behavior).
+	 */
+	Pinned = 'pinned',
+
+	/**
+	 * Panel floats as a dialog overlay above the workbench.
+	 */
+	Dialog = 'dialog'
+}
+
 export const enum PartOpensMaximizedOptions {
 	ALWAYS,
 	NEVER,
@@ -248,6 +260,21 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 * Returns true if the panel is maximized.
 	 */
 	isPanelMaximized(): boolean;
+
+	/**
+	 * Gets the current panel mode (Pinned or Dialog).
+	 */
+	getPanelMode(): PanelMode;
+
+	/**
+	 * Sets the panel mode to either Pinned (docked in grid) or Dialog (floating overlay).
+	 */
+	setPanelMode(mode: PanelMode): void;
+
+	/**
+	 * Toggles between Pinned and Dialog panel modes.
+	 */
+	togglePanelMode(): void;
 
 	/**
 	 * Maximizes the auxiliary sidebar by hiding the editor and panel areas.

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -164,7 +164,7 @@ import { IHistoryService } from '../../services/history/common/history.js';
 import { IHostService, IToastOptions, IToastResult } from '../../services/host/browser/host.js';
 import { LabelService } from '../../services/label/common/labelService.js';
 import { ILanguageDetectionService } from '../../services/languageDetection/common/languageDetectionWorkerService.js';
-import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, PanelAlignment, Position as PartPosition, Parts, SINGLE_WINDOW_PARTS } from '../../services/layout/browser/layoutService.js';
+import { IPartVisibilityChangeEvent, IWorkbenchLayoutService, PanelAlignment, Position as PartPosition, Parts, SINGLE_WINDOW_PARTS, PanelMode } from '../../services/layout/browser/layoutService.js';
 import { ILifecycleService, InternalBeforeShutdownEvent, IWillShutdownEventJoiner, ShutdownReason, WillShutdownEvent } from '../../services/lifecycle/common/lifecycle.js';
 import { IPaneCompositePartService } from '../../services/panecomposite/browser/panecomposite.js';
 import { IPathService } from '../../services/path/common/pathService.js';
@@ -677,6 +677,9 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	async setPanelHidden(_hidden: boolean): Promise<void> { }
 	toggleMaximizedPanel(): void { }
 	isPanelMaximized(): boolean { return false; }
+	getPanelMode(): PanelMode { return PanelMode.Pinned; }
+	setPanelMode(_mode: PanelMode): void { }
+	togglePanelMode(): void { }
 	toggleMaximizedAuxiliaryBar(): void { }
 	setAuxiliaryBarMaximized(maximized: boolean): boolean { return false; }
 	isAuxiliaryBarMaximized(): boolean { return false; }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -677,7 +677,7 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	async setPanelHidden(_hidden: boolean): Promise<void> { }
 	toggleMaximizedPanel(): void { }
 	isPanelMaximized(): boolean { return false; }
-	getPanelMode(): PanelMode { return PanelMode.Pinned; }
+	getPanelMode(): PanelMode { return PanelMode.Dock; }
 	setPanelMode(_mode: PanelMode): void { }
 	togglePanelMode(): void { }
 	toggleMaximizedAuxiliaryBar(): void { }


### PR DESCRIPTION
## Overview

This PR adds a floating "dialog" mode for the panel that allows it to hover as a draggable, resizable overlay above the workbench as an alternative to the docked panel in the grid layout.

Linked Issue: #299869

![output](https://github.com/user-attachments/assets/92efcc01-2d5f-4720-8826-30321f62182a)

## Architecture

The implementation introduces a `PanelMode` enum with two states:

```typescript
export const enum PanelMode {
  Dock = 'dock',    // Traditional grid-docked behavior
  Dialog = 'dialog' // Floating overlay above the workbench
}
```

**Layout Service (`layoutService.ts`)**
- Added `PanelMode` enum export
- Added `getPanelMode()`, `setPanelMode()`, and `togglePanelMode()` to `IWorkbenchLayoutService`

**Layout Implementation (`layout.ts`)**
- **Dialog overlay structure**: Creates a safe area container clipped to the editor zone (between titlebar and statusbar) containing a backdrop and the floating panel overlay
- **State management**: Stores dialog bounds as ratios relative to container dimensions for responsive behavior
- **Drag handling**: Title bar acts as drag handle with pointer capture for smooth dragging
- **Resize handling**: Uses native CSS `resize: both` with bounds clamping to safe area
- **Mode transitions**: Cleanly saves/restores panel state (position, alignment, size) when switching modes
- **Grid isolation**: Panel is removed from workbench grid in dialog mode and re-parented to the overlay

**Panel Actions (`panelActions.ts`)**
- Added `TogglePanelModeAction` command with keyboard shortcut
- Added toggle icon in panel title bar (dock/undock)
- Updated maximize action to work in dialog mode regardless of panel alignment

**Context Keys (`contextkeys.ts`)**
- Added `PanelDialogModeContext` for conditional UI (hiding position selectors in dialog mode, etc.)

**Storage**

Dialog bounds are persisted using the storage key `workbench.panel.dialogBoundsRatio` with relative ratios:

```typescript
interface DialogBoundsRatio {
  leftRatio: number;   // 0-1 relative to container width
  topRatio: number;    // 0-1 relative to container height
  widthRatio: number;  // 0-1 relative to container width
  heightRatio: number; // 0-1 relative to container height
}
```
