### PR TITLE
fix: migrate AsyncIterableObject to AsyncIterableProducer in terminal…

### DIFF
--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -12,7 +12,7 @@ import { IExtHostRpcService } from './extHostRpcService.js';
 import { IExtHostTerminalService } from './extHostTerminalService.js';
 import { Emitter, type Event } from '../../../base/common/event.js';
 import { URI } from '../../../base/common/uri.js';
-import { AsyncIterableObject, Barrier, type AsyncIterableEmitter } from '../../../base/common/async.js';
+import { AsyncIterableProducer, Barrier, type AsyncIterableEmitter } from '../../../base/common/async.js';
 
 export interface IExtHostTerminalShellIntegration extends ExtHostTerminalShellIntegrationShape {
 	readonly _serviceBrand: undefined;
@@ -400,7 +400,7 @@ class InternalTerminalShellExecution {
 	private _createDataStream(): AsyncIterable<string> {
 		if (!this._dataStream) {
 			if (this._isEnded) {
-				return AsyncIterableObject.EMPTY;
+				return AsyncIterableProducer.fromArray([]);
 			}
 			this._dataStream = new ShellExecutionDataStream();
 		}
@@ -432,7 +432,7 @@ class InternalTerminalShellExecution {
 
 class ShellExecutionDataStream extends Disposable {
 	private _barrier: Barrier | undefined;
-	private _iterables: AsyncIterableObject<string>[] = [];
+	private _iterables: AsyncIterableProducer<string>[] = [];
 	private _emitters: AsyncIterableEmitter<string>[] = [];
 
 	createIterable(): AsyncIterable<string> {
@@ -440,7 +440,7 @@ class ShellExecutionDataStream extends Disposable {
 			this._barrier = new Barrier();
 		}
 		const barrier = this._barrier;
-		const iterable = new AsyncIterableObject<string>(async emitter => {
+		const iterable = new AsyncIterableProducer<string>(async emitter => {
 			this._emitters.push(emitter);
 			await barrier.wait();
 		});
@@ -459,7 +459,7 @@ class ShellExecutionDataStream extends Disposable {
 	}
 
 	async flush(): Promise<void> {
-		await Promise.all(this._iterables.map(e => e.toPromise()));
+		await Promise.all(this._iterables.map(async e => { for await (const _ of e) { /* drain */ } }));
 	}
 }
 

--- a/src/vs/workbench/api/test/common/extHostTerminalShellIntegration.test.ts
+++ b/src/vs/workbench/api/test/common/extHostTerminalShellIntegration.test.ts
@@ -64,7 +64,7 @@ suite('InternalTerminalShellIntegration', () => {
 	}
 
 	async function emitData(data: string): Promise<void> {
-		// AsyncIterableObjects are initialized in a microtask, this doesn't matter in practice
+		// AsyncIterableProducers are initialized in a microtask, this doesn't matter in practice
 		// since the events will always come through in different events.
 		await new Promise<void>(r => queueMicrotask(r));
 		si.emitData(data);


### PR DESCRIPTION
… shell integration


Fixes #256854

## Summary
Migrates the remaining [AsyncIterableObject](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:1977:0-2171:1) usage in [extHostTerminalShellIntegration.ts](cci:7://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts:0:0-0:0) to [AsyncIterableProducer](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:2368:0-2524:1) for better memory efficiency.

## Why
Each terminal output stream is consumed only once via `for await`, so [AsyncIterableProducer](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:2368:0-2524:1) (which doesn't retain emitted values in an internal `_results` array) is more appropriate and prevents potential memory leaks with long-running terminal sessions.

## Changes
- Replaced [AsyncIterableObject](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:1977:0-2171:1) with [AsyncIterableProducer](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:2368:0-2524:1) in [ShellExecutionDataStream](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts:432:0-463:1)
- Replaced `AsyncIterableObject.EMPTY` with `AsyncIterableProducer.fromArray([])`
- Updated [flush()](cci:1://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts:423:1-429:2) to drain iterables inline since [AsyncIterableProducer](cci:2://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/vscode/src/vs/base/common/async.ts:2368:0-2524:1) doesn't have `.toPromise()`
- Updated test comment
