### PR TITLE
Replace revealInSideBarCommand import with REVEAL_IN_EXPLORER_COMMAND_ID constant

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -54,7 +54,7 @@ import { IFileLabelOptions, IResourceLabel, ResourceLabels } from '../../../../b
 import { StaticResourceContextKey } from '../../../../common/contextkeys.js';
 import { IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
-import { revealInSideBarCommand } from '../../../files/browser/fileActions.contribution.js';
+import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../../files/browser/fileConstants.js';
 import { CellUri } from '../../../notebook/common/notebookCommon.js';
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { toHistoryItemHoverContent } from '../../../scm/browser/scmHistory.js';
@@ -182,7 +182,7 @@ abstract class AbstractChatAttachmentWidget extends Disposable {
 	protected async openResource(resource: URI, openOptions: Partial<IOpenEditorOptions>, isDirectory?: boolean, range?: IRange): Promise<void> {
 		if (isDirectory) {
 			// Reveal Directory in explorer
-			this.commandService.executeCommand(revealInSideBarCommand.id, resource);
+			this.commandService.executeCommand(REVEAL_IN_EXPLORER_COMMAND_ID, resource);
 			return;
 		}
 


### PR DESCRIPTION

## Problem
The chat attachment widget imports `revealInSideBarCommand` from `fileActions.contribution.js`, which is a contribution module containing command registration and potential side effects. The code only needs the command ID string.

## Solution
Replace the import from the contribution module with a direct import of the command ID constant from `fileConstants.js`.

## Benefits

1. **Cleaner Architecture**: Reduces the dependency on contribution modules that may contain side effects or heavy initialization logic. Command IDs should be defined in constants, not hidden in contribution files.

2. **Better Modularity**: The chat attachment widget no longer depends on the entire `fileActions.contribution` module just to access a string constant.

3. **Reduced Risk of Circular Dependencies**: Contribution files often have complex dependency graphs. By importing from a lightweight constants file instead, we avoid potential circular dependency issues that can be hard to debug.

4. **Improved Readability**: `REVEAL_IN_EXPLORER_COMMAND_ID` is more explicit and self-documenting than `revealInSideBarCommand.id`.

5. **Easier Maintenance**: Command IDs defined in a dedicated constants file are easier to track and refactor across the codebase.

## Type
Refactoring (no behavioral changes)

## Related Files
- `src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts`
