### PR TITLE
Optimize chat anchor widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -1430,21 +1430,27 @@ export function hookUpSymbolAttachmentDragAndContextMenu(accessor: ServicesAcces
 		e.dataTransfer?.setDragImage(widget, 0, 0);
 	}));
 
-	// Context menu (context key service created eagerly for keybinding preconditions,
-	// but resource context and provider contexts are initialized lazily on first use)
-	const scopedContextKeyService = store.add(parentContextKeyService.createScoped(widget));
-	chatAttachmentResourceContextKey.bindTo(scopedContextKeyService).set(attachment.value.uri.toString());
-	setResourceContext(accessor, scopedContextKeyService, attachment.value.uri);
-
+	// Context menu (context key service and resource contexts are initialized lazily on first context menu open)
+	let scopedContextKeyService: IScopedContextKeyService | undefined;
 	let providerContexts: ReadonlyArray<[IContextKey<boolean>, LanguageFeatureRegistry<unknown>]> | undefined;
 
+	const ensureContextKeyService = () => {
+		if (!scopedContextKeyService) {
+			scopedContextKeyService = store.add(parentContextKeyService.createScoped(widget));
+			chatAttachmentResourceContextKey.bindTo(scopedContextKeyService).set(attachment.value.uri.toString());
+			setResourceContext(accessor, scopedContextKeyService, attachment.value.uri);
+		}
+		return scopedContextKeyService;
+	};
+
 	const ensureProviderContexts = () => {
+		const cks = ensureContextKeyService();
 		if (!providerContexts) {
 			providerContexts = [
-				[EditorContextKeys.hasDefinitionProvider.bindTo(scopedContextKeyService), languageFeaturesService.definitionProvider],
-				[EditorContextKeys.hasReferenceProvider.bindTo(scopedContextKeyService), languageFeaturesService.referenceProvider],
-				[EditorContextKeys.hasImplementationProvider.bindTo(scopedContextKeyService), languageFeaturesService.implementationProvider],
-				[EditorContextKeys.hasTypeDefinitionProvider.bindTo(scopedContextKeyService), languageFeaturesService.typeDefinitionProvider],
+				[EditorContextKeys.hasDefinitionProvider.bindTo(cks), languageFeaturesService.definitionProvider],
+				[EditorContextKeys.hasReferenceProvider.bindTo(cks), languageFeaturesService.referenceProvider],
+				[EditorContextKeys.hasImplementationProvider.bindTo(cks), languageFeaturesService.implementationProvider],
+				[EditorContextKeys.hasTypeDefinitionProvider.bindTo(cks), languageFeaturesService.typeDefinitionProvider],
 			];
 		}
 	};
@@ -1466,6 +1472,8 @@ export function hookUpSymbolAttachmentDragAndContextMenu(accessor: ServicesAcces
 		const event = new StandardMouseEvent(dom.getWindow(domEvent), domEvent);
 		dom.EventHelper.stop(domEvent, true);
 
+		const cks = ensureContextKeyService();
+
 		try {
 			await updateContextKeys();
 		} catch (e) {
@@ -1473,10 +1481,10 @@ export function hookUpSymbolAttachmentDragAndContextMenu(accessor: ServicesAcces
 		}
 
 		contextMenuService.showContextMenu({
-			contextKeyService: scopedContextKeyService,
+			contextKeyService: cks,
 			getAnchor: () => event,
 			getActions: () => {
-				const menu = menuService.getMenuActions(contextMenuId, scopedContextKeyService, { arg: attachment.value });
+				const menu = menuService.getMenuActions(contextMenuId, cks, { arg: attachment.value });
 				return getFlatContextMenuActions(menu);
 			},
 		});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -23,7 +23,7 @@ import { getFlatContextMenuActions } from '../../../../../../platform/actions/br
 import { Action2, IMenuService, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { IClipboardService } from '../../../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
-import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IContextKey, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
 import { IResourceStat } from '../../../../../../platform/dnd/browser/dnd.js';
 import { ITextResourceEditorInput } from '../../../../../../platform/editor/common/editor.js';
@@ -199,10 +199,6 @@ export class InlineAnchorWidget extends Disposable {
 				iconEl.classList.add(...iconClasses);
 			};
 
-			this._register(themeService.onDidFileIconThemeChange(() => {
-				refreshIconClasses();
-			}));
-
 			let isDirectory = false;
 			fileService.stat(location.uri)
 				.then(stat => {
@@ -214,31 +210,42 @@ export class InlineAnchorWidget extends Disposable {
 				})
 				.catch(() => { });
 
-			// Context menu
-			const contextKeyService = this._register(originalContextKeyService.createScoped(element));
-			chatAttachmentResourceContextKey.bindTo(contextKeyService).set(location.uri.toString());
-			const isFolderContext = ExplorerFolderContext.bindTo(contextKeyService);
+			// Context menu (context key service created lazily on first context menu open)
+			let contextKeyService: IContextKeyService | undefined;
+			let isFolderContext: IContextKey<boolean> | undefined;
 			let contextMenuInitialized = false;
+
+			const ensureContextKeyService = () => {
+				if (!contextKeyService) {
+					contextKeyService = this._register(originalContextKeyService.createScoped(element));
+					chatAttachmentResourceContextKey.bindTo(contextKeyService).set(location.uri.toString());
+					isFolderContext = ExplorerFolderContext.bindTo(contextKeyService);
+				}
+				return contextKeyService;
+			};
+
 			this._register(dom.addDisposableListener(element, dom.EventType.CONTEXT_MENU, async domEvent => {
 				const event = new StandardMouseEvent(dom.getWindow(domEvent), domEvent);
 				dom.EventHelper.stop(domEvent, true);
 
+				const cks = ensureContextKeyService();
+
 				if (!contextMenuInitialized) {
 					contextMenuInitialized = true;
-					const resourceContextKey = new StaticResourceContextKey(contextKeyService, fileService, languageService, modelService);
+					const resourceContextKey = new StaticResourceContextKey(cks, fileService, languageService, modelService);
 					resourceContextKey.set(location.uri);
 				}
-				isFolderContext.set(isDirectory);
+				isFolderContext!.set(isDirectory);
 
 				if (this._store.isDisposed) {
 					return;
 				}
 
 				contextMenuService.showContextMenu({
-					contextKeyService,
+					contextKeyService: cks,
 					getAnchor: () => event,
 					getActions: () => {
-						const menu = menuService.getMenuActions(MenuId.ChatInlineResourceAnchorContext, contextKeyService, { arg: location.uri });
+						const menu = menuService.getMenuActions(MenuId.ChatInlineResourceAnchorContext, cks, { arg: location.uri });
 						return getFlatContextMenuActions(menu);
 					},
 				});


### PR DESCRIPTION
Lazily create scoped CKS: This can be expensive and is not needed until the context menu is shown And remove the global themeService listener. We can bring it back when the chat response is correctly fully virtualized.

fyi @mjbvz 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
