### PR TITLE
Use outline instead of border for diff editor text borders

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/src/vs/editor/browser/widget/diffEditor/style.css
@@ -253,22 +253,22 @@
 
 .monaco-editor .line-insert,
 .monaco-editor .char-insert {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-insertedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-insertedTextBorder);
+	outline-offset: -1px;
 }
 .monaco-editor.hc-black .line-insert, .monaco-editor.hc-light .line-insert,
 .monaco-editor.hc-black .char-insert, .monaco-editor.hc-light .char-insert {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .line-delete,
 .monaco-editor .char-delete {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-removedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-removedTextBorder);
+	outline-offset: -1px;
 }
 .monaco-editor.hc-black .line-delete, .monaco-editor.hc-light .line-delete,
 .monaco-editor.hc-black .char-delete, .monaco-editor.hc-light .char-delete {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .inline-added-margin-view-zone,


### PR DESCRIPTION
## Summary
- Changed `diffEditor.removedTextBorder` and `diffEditor.insertedTextBorder` from CSS `border` to CSS `outline` with `outline-offset: -1px`
- `border` participates in layout flow, causing bordered lines (deleted/inserted) to shift their content 1px down and right relative to non-bordered (unchanged) lines
- `outline` renders identically but does not affect element sizing or layout, eliminating the displacement
- Updated high-contrast theme rules from `border-style: dashed` to `outline-style: dashed` accordingly

## Test plan
- [ ] Open a file with both additions and deletions in the diff editor
- [ ] Set `diffEditor.removedTextBorder` and `diffEditor.insertedTextBorder` to visible colors in settings
- [ ] Verify deleted and inserted lines show the colored outline without shifting text content
- [ ] Verify high-contrast themes still show dashed outlines
- [ ] Verify no visual regression with default settings (borders disabled)

Fixes #277259