### PR TITLE
Fix image preview failing for git: scheme URIs

### DIFF
--- a/extensions/media-preview/src/mediaPreview.ts
+++ b/extensions/media-preview/src/mediaPreview.ts
@@ -35,7 +35,7 @@ export abstract class MediaPreview extends Disposable {
 			enableScripts: true,
 			enableForms: false,
 			localResourceRoots: [
-				Utils.dirname(_resource),
+				Utils.dirname(_resource).with({ query: '', fragment: '' }),
 				extensionRoot,
 			]
 		};


### PR DESCRIPTION
Fixes #274039

## Problem

When staging a PNG (or any binary image file) and opening it in the git diff viewer, the image preview shows "An error occurred while loading the image."

## Root Cause

`MediaPreview` sets `localResourceRoots` to `Utils.dirname(resource)`. For `git:` scheme URIs like `git:///path/image.png?{"path":"...","ref":"HEAD"}`, `Utils.dirname()` preserves the query string — producing a root with a file-specific query parameter.

When the webview loads the image, `getResourceToLoad()` strips the query from the request URI before comparing it against roots. But `isEqualOrParent()` requires `base.query === parentCandidate.query`, so the empty-query request never matches the query-bearing root. The resource is denied (401) and the image fails to load.

## Fix

Strip query and fragment from the dirname used in `localResourceRoots`. These are file-specific components that should not be part of a directory root used for access validation.

## Test plan

- Stage a PNG file for commit
- Open it in the git diff viewer (click in Source Control panel)
- Verify the image preview loads without error
- Verify regular (non-git) image preview still works