### PR TITLE
Use relative path for git clone destination

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -477,7 +477,7 @@ export class Git {
 		};
 
 		try {
-			const command = ['clone', url.includes(' ') ? encodeURI(url) : url, folderPath, '--progress'];
+			const command = ['clone', url.includes(' ') ? encodeURI(url) : url, folderName, '--progress'];
 			if (options.recursive) {
 				command.push('--recursive');
 			}


### PR DESCRIPTION
Fixes #275989

## Problem

When cloning a repo via "Clone Git Repository...", VS Code passes the absolute destination path to `git clone`. This causes git to store an absolute `core.worktree` path in `.git/config` (e.g. `C:\Users\user\repo`). When the repo is later accessed from WSL, the Windows absolute path doesn't exist in the WSL filesystem, breaking all git operations.

## Fix

Pass the relative folder name instead of the absolute path to `git clone`. Since `exec` already runs with `cwd` set to the parent directory, a relative name produces the same clone result without causing git to record an absolute worktree path.

## Test plan

- Use "Clone Git Repository..." to clone a repo on Windows
- Open `.git/config` in the cloned repo
- Verify `core.worktree` is not set (or uses a relative path)
- Access the repo from WSL and verify git commands work