### PR TITLE
Show git warning messages as warnings instead of errors

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5627,9 +5627,18 @@ export class CommandCenter {
 							.split(/[\r\n]/)
 							.filter((line: string) => !!line);
 
-						message = hintLines.length > 0
-							? l10n.t('Git: {0}', err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
+						const selectedHint = hintLines.length > 0
+							? (err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
+							: undefined;
+
+						message = selectedHint
+							? l10n.t('Git: {0}', selectedHint)
 							: l10n.t('Git error');
+
+						if (/^warning:/i.test(selectedHint ?? '')) {
+							type = 'warning';
+							options.modal = false;
+						}
 
 						break;
 					}


### PR DESCRIPTION
fix #280834

## Summary

When Git/SSH outputs messages prefixed with `warning:` (e.g., `Warning: Permanently added 'gitlab.com' to the list of known hosts`), VS Code displays them with error-level styling (red error icon). This changes the notification to use warning-level styling (yellow warning icon) instead, which correctly reflects the severity of the message.

## Change

In the `default` case of the command error handler, check if the selected hint line starts with `warning:` (case-insensitive). If so, change the notification type from `error` to `warning` and make it non-modal.

## Test plan

- Configure SSH to connect to a new host (or remove a known host entry)
- Run a git push/pull that triggers the SSH warning
- Verify the notification shows with a yellow warning icon instead of red error icon
- Verify that actual git errors (non-warning stderr) still show as red error notifications