### PR TITLE
Treat backspace in indentation as an unshift

### DIFF
--- a/src/vs/editor/common/cursor/cursorDeleteOperations.ts
+++ b/src/vs/editor/common/cursor/cursorDeleteOperations.ts
@@ -8,6 +8,7 @@ import { ReplaceCommand } from '../commands/replaceCommand.js';
 import { EditorAutoClosingEditStrategy, EditorAutoClosingStrategy } from '../config/editorOptions.js';
 import { CursorConfiguration, EditOperationResult, EditOperationType, ICursorSimpleModel, isQuote } from '../cursorCommon.js';
 import { CursorColumns } from '../core/cursorColumns.js';
+import { ShiftCommand } from '../commands/shiftCommand.js';
 import { MoveOperations } from './cursorMoveOperations.js';
 import { Range } from '../core/range.js';
 import { Selection } from '../core/selection.js';
@@ -171,7 +172,24 @@ export class DeleteOperations {
 		const commands: Array<ICommand | null> = [];
 		let shouldPushStackElementBefore = (prevEditOperationType !== EditOperationType.DeletingLeft);
 		for (let i = 0, len = selections.length; i < len; i++) {
-			const deleteRange = DeleteOperations.getDeleteLeftRange(selections[i], model, config);
+			const [useUnshift, deleteRange] = DeleteOperations.getDeleteLeftRange(selections[i], model, config);
+
+			if (useUnshift === true) {
+				// The deleteLeft leads to a decrease in indentation. Use a
+				// shift command instead of a replace command since the required
+				// new indentation level might not constructible by removing
+				// characters from the old indentation (e.g. if tabs with a size
+				// greater than the indent size are involved).
+				commands[i] = new ShiftCommand(selections[i], {
+					isUnshift: true,
+					tabSize: config.tabSize,
+					indentSize: config.indentSize,
+					insertSpaces: config.insertSpaces,
+					useTabStops: config.useTabStops,
+					autoIndent: config.autoIndent
+				}, config.languageConfigurationService);
+				continue;
+			}
 
 			// Ignore empty delete ranges, as they have no effect
 			// They happen if the cursor is at the beginning of the file.
@@ -190,9 +208,9 @@ export class DeleteOperations {
 
 	}
 
-	private static getDeleteLeftRange(selection: Selection, model: ICursorSimpleModel, config: CursorConfiguration): Range {
+	private static getDeleteLeftRange(selection: Selection, model: ICursorSimpleModel, config: CursorConfiguration): [boolean, Range] {
 		if (!selection.isEmpty()) {
-			return selection;
+			return [false, selection];
 		}
 
 		const position = selection.getPosition();
@@ -210,13 +228,29 @@ export class DeleteOperations {
 
 			if (position.column <= lastIndentationColumn) {
 				const fromVisibleColumn = config.visibleColumnFromColumn(model, position);
+				if (fromVisibleColumn % config.indentSize === 0) {
+					// The position is at an indentation level, so this delete
+					// amounts to a decrease in indentation level. However, if
+					// the previous indentation level cannot be reached by
+					// removing existing characters (for example when the indent
+					// size is smaller than the tab size and the character to
+					// remove is a tab), this will fail and not delete anything
+					// if we just return a range.
+					// see: https://github.com/microsoft/vscode/issues/275754
+
+					// Instead, signal to the caller that an 'unshift' needs to
+					// happen, which is able to transform the indentation correctly.
+					return [true, new Range(0, 0, 0, 0)];
+				}
+
+				// Remove all characters until the previous indent level
 				const toVisibleColumn = CursorColumns.prevIndentTabStop(fromVisibleColumn, config.indentSize);
 				const toColumn = config.columnFromVisibleColumn(model, position.lineNumber, toVisibleColumn);
-				return new Range(position.lineNumber, toColumn, position.lineNumber, position.column);
+				return [false, new Range(position.lineNumber, toColumn, position.lineNumber, position.column)];
 			}
 		}
 
-		return Range.fromPositions(DeleteOperations.getPositionAfterDeleteLeft(position, model), position);
+		return [false, Range.fromPositions(DeleteOperations.getPositionAfterDeleteLeft(position, model), position)];
 	}
 
 	private static getPositionAfterDeleteLeft(position: Position, model: ICursorSimpleModel): Position {


### PR DESCRIPTION
Fixes #275754.

If backspace was pressed with the cursor just after a tab character that is part of the initial indentation whitespace and the display tab size was set to something greater than the indent size, the resulting `deleteLeft` would do nothing because it could not build the new indentation level by removing some of the existing characters.

Instead, we now recognise this case and use an "unshift" command, which is able to convert the indentation correctly.

I also came across this issue while trying to implement better support for mixed tabs and spaces in indentation. The linked issue also has two videos of people reproducing the issue. I found the easiest way to reproduce it to be:

1. Create a new file
2. Press the tab key
3. Click "Select Indentation"
4. Click "Indent Using Spaces" > "2"
5. Click "Select Indentation"
6. Click "Change Tab Display Size" > "8"
7. Press the backspace key

Without this patch applied, pressing the backspace key has no effect.
With this patch applied, the tab is replaced by 6 spaces.

The interpretation of the backspace leading to a decrease in indentation instead of just removing the tab is consistent with pressing backspace inside indentation consisting entirely of spaces. If backspace is pressed within this indentation and the cursor is at a column that is a multiple of the indentation level, not just a single space is removed, but a full indentation level.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
