### PR TITLE
Revert "use vscode-vfs scheme for cloud session repo URIs (#298689)"

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/repoPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/repoPicker.ts
@@ -15,6 +15,7 @@ import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js'
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { INewSession } from './newSession.js';
 import { URI } from '../../../../base/common/uri.js';
+import { GITHUB_REMOTE_FILE_SCHEME } from '../../fileTreeView/browser/githubFileSystemProvider.js';
 
 const OPEN_REPO_COMMAND = 'github.copilot.chat.cloudSessions.openRepository';
 const STORAGE_KEY_LAST_REPO = 'agentSessions.lastPickedRepo';
@@ -270,7 +271,7 @@ export class RepoPicker extends Disposable {
 	}
 
 	private _setRepo(repo: IRepoItem): void {
-		this._newSession?.setRepoUri(URI.parse(`vscode-vfs://github/${repo.id}`));
+		this._newSession?.setRepoUri(URI.parse(`${GITHUB_REMOTE_FILE_SCHEME}://github/${repo.id}`));
 	}
 
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -24,6 +24,7 @@ import { AgentSessionProviders } from '../../../../workbench/contrib/chat/browse
 import { INewSession, LocalNewSession, RemoteNewSession } from '../../chat/browser/newSession.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
+import { GITHUB_REMOTE_FILE_SCHEME } from '../../fileTreeView/browser/githubFileSystemProvider.js';
 
 export const IsNewChatSessionContext = new RawContextKey<boolean>('isNewChatSession', true);
 
@@ -202,7 +203,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		}
 
 		if (session.providerType === AgentSessionProviders.Cloud) {
-			return [URI.parse(`vscode-vfs://github/${metadata.owner}/${metadata.name}`), undefined];
+			return [URI.parse(`${GITHUB_REMOTE_FILE_SCHEME}://github/${metadata.owner}/${metadata.name}`), undefined];
 		}
 
 		const workingDirectoryPath = metadata?.workingDirectoryPath as string | undefined;


### PR DESCRIPTION
This reverts the changes from PR #298689.

## Changes

Restores the use of `GITHUB_REMOTE_FILE_SCHEME` for cloud session repository URIs by:

1. **`repoPicker.ts`** - Re-adds the `GITHUB_REMOTE_FILE_SCHEME` import and uses it in `_setRepo()` instead of hardcoded `vscode-vfs` scheme
2. **`sessionsManagementService.ts`** - Re-adds the `GITHUB_REMOTE_FILE_SCHEME` import and uses it in `getRepositoryFromMetadata()` for cloud sessions

This reverts commit from PR #298689.