### PR TITLE
fix: use correct language ID for Playwright input syntax highlighting

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/tools/runPlaywrightCodeTool.ts
@@ -97,6 +97,7 @@ export class RunPlaywrightCodeTool implements IToolImpl {
 			],
 			toolResultDetails: {
 				input: params.code.trim(),
+				inputLanguage: 'javascript',
 				output: result.result
 					? [{ type: 'embed', isText: true, value: JSON.stringify(result.result, null, 2) }]
 					: [],

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatInputOutputMarkdownProgressPart.ts
@@ -44,6 +44,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		input: string,
 		output: IToolResultInputOutputDetails['output'] | undefined,
 		isError: boolean,
+		inputLanguage: string | undefined,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IModelService modelService: IModelService,
 		@ILanguageService languageService: ILanguageService,
@@ -54,10 +55,10 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 		let codeBlockIndex = codeBlockStartIndex;
 
 		// Simple factory to create code part data objects
-		const createCodePart = (data: string): IChatCollapsibleIOCodePart => ({
+		const createCodePart = (data: string, languageId = 'json'): IChatCollapsibleIOCodePart => ({
 			kind: 'code',
 			data,
-			languageId: 'json',
+			languageId,
 			codeBlockIndex: codeBlockIndex++,
 			ownerMarkdownPartId: this.codeblocksPartId,
 			options: {
@@ -82,7 +83,7 @@ export class ChatInputOutputMarkdownProgressPart extends BaseChatToolInvocationS
 			subtitle,
 			this.getAutoApproveMessageContent(),
 			context,
-			createCodePart(input),
+			createCodePart(input, inputLanguage),
 			processedOutput && processedOutput.length > 0 ? {
 				parts: processedOutput.map((o, i): ChatCollapsibleIOPart => {
 					const permalinkBasename = o.type === 'ref' || o.uri

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -228,6 +228,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				resultDetails.input,
 				resultDetails.output,
 				!!resultDetails.isError,
+				resultDetails.inputLanguage,
 			);
 		}
 
@@ -242,6 +243,7 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 				typeof this.toolInvocation.toolSpecificData.rawInput === 'string' ? this.toolInvocation.toolSpecificData.rawInput : JSON.stringify(this.toolInvocation.toolSpecificData.rawInput, null, 2),
 				undefined,
 				false,
+				undefined,
 			);
 		}
 

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -241,6 +241,8 @@ export type ToolInputOutputReference = ToolInputOutputBase & { type: 'ref'; uri:
 
 export interface IToolResultInputOutputDetails {
 	readonly input: string;
+	/** The language ID for syntax highlighting of the input (e.g. 'javascript', 'json'). Defaults to 'json'. */
+	readonly inputLanguage?: string;
 	readonly output: (ToolInputOutputEmbedded | ToolInputOutputReference)[];
 	readonly isError?: boolean;
 	/** Raw MCP tool result for MCP App UI rendering */


### PR DESCRIPTION
## Summary

- Added optional `inputLanguage?: string` field to `IToolResultInputOutputDetails` so tools can specify the language for syntax highlighting of their input code
- Updated `ChatInputOutputMarkdownProgressPart` to use the provided `inputLanguage` (falling back to `'json'` for backward compatibility)
- Set `inputLanguage: 'javascript'` in the `RunPlaywrightCodeTool` result so the input is correctly highlighted as JavaScript

Fixes #299920

## Test plan

- [ ] Enable chat tools for the integrated browser
- [ ] Ask Copilot to run a Playwright script against a page
- [ ] Expand the "Ran Playwright code" section and verify the input code is syntax-highlighted as JavaScript, not JSON