### PR TITLE
plugins/mcp: allow disabling/enabling similar to extensions

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationOverviewView.ts
@@ -193,7 +193,7 @@ export class AICustomizationOverviewView extends ViewPane {
 		const pluginSection = this.sections.find(s => s.id === AICustomizationManagementSection.Plugins);
 		if (pluginSection) {
 			this._register(autorun(reader => {
-				const plugins = this.agentPluginService.allPlugins.read(reader);
+				const plugins = this.agentPluginService.plugins.read(reader);
 				pluginSection.count = plugins.length;
 				this.updateCountElements();
 			}));

--- a/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationCounts.ts
@@ -149,6 +149,6 @@ export async function getCustomizationTotalCount(
 		return getSourceCounts(promptsService, type, filter, workspaceContextService, workspaceService)
 			.then(counts => getSourceCountsTotal(counts, filter));
 	}));
-	const pluginCount = agentPluginService?.allPlugins.get().length ?? 0;
+	const pluginCount = agentPluginService?.plugins.get().length ?? 0;
 	return results.reduce((sum, n) => sum + n, 0) + mcpService.servers.get().length + pluginCount;
 }

--- a/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
+++ b/src/vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution.ts
@@ -163,7 +163,7 @@ export class CustomizationLinkViewItem extends ActionViewItem {
 			this._updateCounts();
 		}));
 		this._viewItemDisposables.add(autorun(reader => {
-			this._agentPluginService.allPlugins.read(reader);
+			this._agentPluginService.plugins.read(reader);
 			this._updateCounts();
 		}));
 		this._viewItemDisposables.add(this._workspaceContextService.onDidChangeWorkspaceFolders(() => this._updateCounts()));
@@ -198,7 +198,7 @@ export class CustomizationLinkViewItem extends ActionViewItem {
 			const total = this._mcpService.servers.get().length;
 			this._renderTotalCount(this._countContainer, total);
 		} else if (this._config.isPlugins) {
-			const total = this._agentPluginService.allPlugins.get().length;
+			const total = this._agentPluginService.plugins.get().length;
 			this._renderTotalCount(this._countContainer, total);
 		}
 	}

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -194,7 +194,6 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 			reg.defineInstance(IWorkspaceContextService, createMockWorkspaceContextService());
 			reg.defineInstance(IAgentPluginService, new class extends mock<IAgentPluginService>() {
 				override readonly plugins = observableValue<readonly never[]>('mockPlugins', []);
-				override readonly allPlugins = observableValue<readonly never[]>('mockAllPlugins', []);
 			}());
 			// Additional services needed by CustomizationLinkViewItem
 			reg.defineInstance(ILanguageModelsService, new class extends mock<ILanguageModelsService>() {

--- a/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
@@ -1,0 +1,276 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action, IAction, IActionChangeEvent } from '../../../../base/common/actions.js';
+import { Emitter } from '../../../../base/common/event.js';
+import { IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { ActionWithDropdownActionViewItem, IActionWithDropdownActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
+import { IContextMenuProvider } from '../../../../base/browser/contextmenu.js';
+import { localize } from '../../../../nls.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { dirname, joinPath } from '../../../../base/common/resources.js';
+import { ContributionEnablementState, IEnablementModel, isContributionDisabled, isContributionEnabled } from '../common/enablement.js';
+import { IAgentPlugin, IAgentPluginService } from '../common/plugins/agentPluginService.js';
+import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
+import { IMarketplacePluginItem } from './agentPluginEditor/agentPluginItems.js';
+import { buildEnablementContextMenuGroup } from './enablementActions.js';
+import { hasKey } from '../../../../base/common/types.js';
+
+//#region Simple actions
+
+export class InstallPluginAction extends Action {
+	constructor(
+		item: IMarketplacePluginItem,
+		@IPluginInstallService pluginInstallService: IPluginInstallService,
+	) {
+		super('agentPlugin.install', localize('install', "Install"), 'extension-action label prominent install', true,
+			() => pluginInstallService.installPlugin({
+				name: item.name,
+				description: item.description,
+				version: '',
+				source: item.source,
+				sourceDescriptor: item.sourceDescriptor,
+				marketplace: item.marketplace,
+				marketplaceReference: item.marketplaceReference,
+				marketplaceType: item.marketplaceType,
+				readmeUri: item.readmeUri,
+			}));
+	}
+}
+
+export class UninstallPluginAction extends Action {
+	constructor(plugin: IAgentPlugin) {
+		super('agentPlugin.uninstall', localize('uninstall', "Uninstall"), 'extension-action label uninstall', true,
+			() => { plugin.remove(); return Promise.resolve(); });
+	}
+}
+
+export class OpenPluginFolderAction extends Action {
+	constructor(
+		plugin: IAgentPlugin,
+		@ICommandService commandService: ICommandService,
+		@IOpenerService openerService: IOpenerService,
+	) {
+		super('agentPlugin.openFolder', localize('openPluginFolder', "Open Plugin Folder"), undefined, true,
+			async () => {
+				try {
+					await commandService.executeCommand('revealFileInOS', plugin.uri);
+				} catch {
+					await openerService.open(dirname(plugin.uri));
+				}
+			});
+	}
+}
+
+export class OpenPluginReadmeAction extends Action {
+	constructor(
+		readmeUri: import('../../../../base/common/uri.js').URI,
+		@IOpenerService openerService: IOpenerService,
+	) {
+		super('agentPlugin.openReadme', localize('openReadme', "Open README"), undefined, true,
+			() => openerService.open(readmeUri));
+	}
+}
+
+//#endregion
+
+//#region Context menu
+
+/**
+ * Builds the standard context menu action groups for an installed plugin.
+ */
+export function getInstalledPluginContextMenuActions(plugin: IAgentPlugin, instantiationService: IInstantiationService): IAction[][] {
+	return instantiationService.invokeFunction(accessor => {
+		const agentPluginService = accessor.get(IAgentPluginService);
+		const workspaceService = accessor.get(IWorkspaceContextService);
+		const groups: IAction[][] = [];
+		groups.push(buildEnablementContextMenuGroup(
+			plugin.enablement.get(),
+			plugin.uri.toString(),
+			agentPluginService.enablementModel,
+			workspaceService,
+			'agentPlugin',
+		));
+		groups.push([
+			instantiationService.createInstance(OpenPluginFolderAction, plugin),
+			instantiationService.createInstance(OpenPluginReadmeAction, joinPath(plugin.uri, 'README.md')),
+		]);
+		if (plugin.fromMarketplace) {
+			groups.push([new UninstallPluginAction(plugin)]);
+		}
+		return groups;
+	});
+}
+
+//#endregion
+
+//#region Dropdown enablement actions for editor-style action bars
+
+/**
+ * Sub-action base class that auto-hides when disabled, for use inside
+ * {@link EnablementDropDownAction}.
+ */
+class EnablementSubAction extends Action {
+	private _hidden: boolean;
+	get hidden(): boolean { return this._hidden; }
+	set hidden(v: boolean) { this._hidden = v; }
+
+	constructor(id: string, label: string, cssClass: string, enabled: boolean, actionCallback: () => Promise<void>) {
+		super(id, label, cssClass, enabled, actionCallback);
+		this._hidden = !enabled;
+	}
+
+	protected override _setEnabled(value: boolean): void {
+		super._setEnabled(value);
+		this.hidden = !value;
+	}
+}
+
+interface IEnablementActionChangeEvent extends IActionChangeEvent {
+	readonly menuActions?: IAction[];
+}
+
+/**
+ * Dropdown action that aggregates enablement sub-actions and shows the
+ * first visible one as the primary button, with others in the dropdown.
+ * Hides itself entirely when all sub-actions are hidden.
+ */
+export class EnablementDropDownAction extends Action {
+	readonly menuActionClassNames = ['extension-action', 'label', 'action-dropdown'];
+	private _menuActions: IAction[] = [];
+	get menuActions(): IAction[] { return [...this._menuActions]; }
+
+	private _isHidden = false;
+	get isHidden(): boolean { return this._isHidden; }
+
+	protected override readonly _onDidChange = new Emitter<IEnablementActionChangeEvent>();
+	override get onDidChange() { return this._onDidChange.event; }
+
+	private readonly subActions: EnablementSubAction[];
+
+	constructor(id: string, subActions: EnablementSubAction[]) {
+		super(id, undefined, 'extension-action label action-dropdown');
+		this.subActions = subActions;
+		for (const a of subActions) {
+			a.onDidChange(() => this._updateDropdown());
+		}
+		this._updateDropdown();
+	}
+
+	private _updateDropdown(): void {
+		const visible = this.subActions.filter(a => !a.hidden);
+		const primary = visible[0];
+		this._menuActions = visible.length > 1 ? [...visible] : [];
+
+		if (primary) {
+			this._isHidden = false;
+			this.enabled = true;
+			this.label = primary.label;
+			this.tooltip = primary.tooltip;
+		} else {
+			this._isHidden = true;
+			this.enabled = false;
+		}
+		this._onDidChange.fire({ menuActions: this._menuActions });
+	}
+
+	override async run(): Promise<void> {
+		const primary = this.subActions.find(a => !a.hidden);
+		await primary?.run();
+	}
+
+	override dispose(): void {
+		for (const a of this.subActions) {
+			a.dispose();
+		}
+		super.dispose();
+	}
+}
+
+/**
+ * View item for {@link EnablementDropDownAction} that properly hides
+ * the dropdown chevron when there are no secondary actions.
+ */
+export class EnablementDropdownActionViewItem extends ActionWithDropdownActionViewItem {
+	constructor(
+		action: EnablementDropDownAction,
+		options: IActionViewItemOptions & IActionWithDropdownActionViewItemOptions,
+		contextMenuProvider: IContextMenuProvider,
+	) {
+		super(null, action, options, contextMenuProvider);
+		this._register(action.onDidChange(e => {
+			if (hasKey(e, { menuActions: true })) {
+				this.updateClass();
+			}
+		}));
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		this.updateClass();
+	}
+
+	protected override updateClass(): void {
+		super.updateClass();
+		if (this.element && this.dropdownMenuActionViewItem?.element) {
+			const action = this._action as EnablementDropDownAction;
+			this.element.classList.toggle('hide', action.isHidden);
+			const isMenuEmpty = action.menuActions.length === 0;
+			this.element.classList.toggle('empty', isMenuEmpty);
+			this.dropdownMenuActionViewItem.element.classList.toggle('hide', isMenuEmpty);
+		}
+	}
+}
+
+/**
+ * Creates the enable dropdown action for a plugin, containing Enable
+ * and Enable (Workspace) sub-actions.
+ */
+export function createEnablePluginDropDown(
+	plugin: IAgentPlugin,
+	enablementModel: IEnablementModel,
+	workspaceContextService: IWorkspaceContextService,
+): EnablementDropDownAction {
+	const key = plugin.uri.toString();
+	const hasWorkspace = workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY;
+
+	const enable = new EnablementSubAction('agentPlugin.enable', localize('enable', "Enable"), 'extension-action label prominent',
+		isContributionDisabled(plugin.enablement.get()),
+		() => { enablementModel.setEnabled(key, ContributionEnablementState.EnabledProfile); return Promise.resolve(); });
+
+	const enableWorkspace = new EnablementSubAction('agentPlugin.enableForWorkspace', localize('enableForWorkspace', "Enable (Workspace)"), 'extension-action label',
+		isContributionDisabled(plugin.enablement.get()) && hasWorkspace,
+		() => { enablementModel.setEnabled(key, ContributionEnablementState.EnabledWorkspace); return Promise.resolve(); });
+
+	return new EnablementDropDownAction('agentPlugin.enableDropdown', [enable, enableWorkspace]);
+}
+
+/**
+ * Creates the disable dropdown action for a plugin, containing Disable
+ * and Disable (Workspace) sub-actions.
+ */
+export function createDisablePluginDropDown(
+	plugin: IAgentPlugin,
+	enablementModel: IEnablementModel,
+	workspaceContextService: IWorkspaceContextService,
+): EnablementDropDownAction {
+	const key = plugin.uri.toString();
+	const hasWorkspace = workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY;
+
+	const disable = new EnablementSubAction('agentPlugin.disable', localize('disable', "Disable"), 'extension-action label disable',
+		isContributionEnabled(plugin.enablement.get()),
+		() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledProfile); return Promise.resolve(); });
+
+	const disableWorkspace = new EnablementSubAction('agentPlugin.disableForWorkspace', localize('disableForWorkspace', "Disable (Workspace)"), 'extension-action label disable',
+		isContributionEnabled(plugin.enablement.get()) && hasWorkspace,
+		() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledWorkspace); return Promise.resolve(); });
+
+	return new EnablementDropDownAction('agentPlugin.disableDropdown', [disable, disableWorkspace]);
+}
+
+//#endregion

--- a/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor.ts
@@ -5,7 +5,8 @@
 
 import { $, Dimension, EventType, addDisposableListener, append, reset, setParentFlowTo } from '../../../../../base/browser/dom.js';
 import { ActionBar } from '../../../../../base/browser/ui/actionbar/actionbar.js';
-import { Action } from '../../../../../base/common/actions.js';
+import { IActionViewItemOptions } from '../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { Action, IAction } from '../../../../../base/common/actions.js';
 import * as arrays from '../../../../../base/common/arrays.js';
 import { Cache, CacheResult } from '../../../../../base/common/cache.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
@@ -21,6 +22,7 @@ import { generateTokensCSSForColorMap } from '../../../../../editor/common/langu
 import { localize } from '../../../../../nls.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { IRequestService, asText } from '../../../../../platform/request/common/request.js';
@@ -36,7 +38,10 @@ import { IWebview, IWebviewService } from '../../../webview/browser/webview.js';
 import { IAgentPlugin, IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
 import { AgentPluginEditorInput } from './agentPluginEditorInput.js';
-import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem, IMarketplacePluginItem } from './agentPluginItems.js';
+import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem } from './agentPluginItems.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { EnablementStatusWidget, pluginEnablementLabels } from '../enablementStatusWidget.js';
+import { InstallPluginAction, UninstallPluginAction, createEnablePluginDropDown, createDisablePluginDropDown, EnablementDropDownAction, EnablementDropdownActionViewItem } from '../agentPluginActions.js';
 import './media/agentPluginEditor.css';
 
 interface IAgentPluginEditorTemplate {
@@ -44,6 +49,7 @@ interface IAgentPluginEditorTemplate {
 	description: HTMLElement;
 	marketplace: HTMLElement;
 	actionBar: ActionBar;
+	statusContainer: HTMLElement;
 	content: HTMLElement;
 	header: HTMLElement;
 }
@@ -92,6 +98,7 @@ export class AgentPluginEditor extends EditorPane {
 		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
 		@IPluginInstallService private readonly pluginInstallService: IPluginInstallService,
 		@ILabelService private readonly labelService: ILabelService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
 		super(AgentPluginEditor.ID, group, telemetryService, themeService, storageService);
 	}
@@ -119,9 +126,27 @@ export class AgentPluginEditor extends EditorPane {
 
 		const actionsAndStatusContainer = append(details, $('.actions-status-container'));
 		const actionBar = this._register(new ActionBar(actionsAndStatusContainer, {
+			actionViewItemProvider: (action: IAction, options: IActionViewItemOptions) => {
+				if (action instanceof EnablementDropDownAction) {
+					return new EnablementDropdownActionViewItem(
+						action,
+						{
+							...options,
+							icon: true,
+							label: true,
+							menuActionsOrProvider: { getActions: () => action.menuActions },
+							menuActionClassNames: action.menuActionClassNames,
+						},
+						this.contextMenuService,
+					);
+				}
+				return undefined;
+			},
 			focusOnlyEnabledItems: true
 		}));
 		actionBar.setFocusable(true);
+
+		const statusContainer = append(actionsAndStatusContainer, $('.status'));
 
 		const body = append(root, $('.body'));
 		const content = append(body, $('.content'));
@@ -134,6 +159,7 @@ export class AgentPluginEditor extends EditorPane {
 			name,
 			marketplace,
 			actionBar,
+			statusContainer,
 		};
 	}
 
@@ -191,7 +217,7 @@ export class AgentPluginEditor extends EditorPane {
 			template.actionBar.clear();
 
 			// Read observables to subscribe to changes
-			const allPlugins = this.agentPluginService.allPlugins.read(reader);
+			const allPlugins = this.agentPluginService.plugins.read(reader);
 
 			let currentItem = item;
 
@@ -234,8 +260,8 @@ export class AgentPluginEditor extends EditorPane {
 						return;
 					}
 				} else {
-					// Read enabled state for reactivity
-					stillInstalled.enabled.read(reader);
+					// Read enablement state for reactivity
+					stillInstalled.enablement.read(reader);
 					currentItem = this.installedPluginToItem(stillInstalled);
 				}
 			}
@@ -247,6 +273,16 @@ export class AgentPluginEditor extends EditorPane {
 			for (const action of actions) {
 				actionDisposables.add(action);
 			}
+
+			// Update enablement status widget
+			if (currentItem.kind === AgentPluginItemKind.Installed) {
+				actionDisposables.add(this.instantiationService.createInstance(
+					EnablementStatusWidget,
+					template.statusContainer,
+					currentItem.plugin.enablement,
+					pluginEnablementLabels,
+				));
+			}
 		}));
 
 		// Open readme
@@ -255,16 +291,14 @@ export class AgentPluginEditor extends EditorPane {
 
 	private getItemActions(item: IAgentPluginItem): Action[] {
 		if (item.kind === AgentPluginItemKind.Marketplace) {
-			return [this.instantiationService.createInstance(InstallPluginEditorAction, item)];
+			return [this.instantiationService.createInstance(InstallPluginAction, item)];
 		}
 
+		const workspaceService = this.instantiationService.invokeFunction(a => a.get(IWorkspaceContextService));
 		const actions: Action[] = [];
-		if (item.plugin.enabled.get()) {
-			actions.push(this.instantiationService.createInstance(DisablePluginEditorAction, item.plugin));
-		} else {
-			actions.push(this.instantiationService.createInstance(EnablePluginEditorAction, item.plugin));
-		}
-		actions.push(this.instantiationService.createInstance(UninstallPluginEditorAction, item.plugin));
+		actions.push(createEnablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
+		actions.push(createDisablePluginDropDown(item.plugin, this.agentPluginService.enablementModel, workspaceService));
+		actions.push(new UninstallPluginAction(item.plugin));
 		return actions;
 	}
 
@@ -498,75 +532,6 @@ export class AgentPluginEditor extends EditorPane {
 	layout(dimension: Dimension): void {
 		this.dimension = dimension;
 		this.layoutParticipants.forEach(p => p.layout());
-	}
-}
-
-//#region Actions
-
-class InstallPluginEditorAction extends Action {
-	static readonly ID = 'agentPlugin.editor.install';
-
-	constructor(
-		private readonly item: IMarketplacePluginItem,
-		@IPluginInstallService private readonly pluginInstallService: IPluginInstallService,
-	) {
-		super(InstallPluginEditorAction.ID, localize('install', "Install"), 'extension-action label prominent install');
-	}
-
-	override async run(): Promise<void> {
-		await this.pluginInstallService.installPlugin({
-			name: this.item.name,
-			description: this.item.description,
-			version: '',
-			source: this.item.source,
-			sourceDescriptor: this.item.sourceDescriptor,
-			marketplace: this.item.marketplace,
-			marketplaceReference: this.item.marketplaceReference,
-			marketplaceType: this.item.marketplaceType,
-			readmeUri: this.item.readmeUri,
-		});
-	}
-}
-
-class EnablePluginEditorAction extends Action {
-	static readonly ID = 'agentPlugin.editor.enable';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super(EnablePluginEditorAction.ID, localize('enable', "Enable"), 'extension-action label prominent');
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, true);
-	}
-}
-
-class DisablePluginEditorAction extends Action {
-	static readonly ID = 'agentPlugin.editor.disable';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super(DisablePluginEditorAction.ID, localize('disable', "Disable"), 'extension-action label disable');
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, false);
-	}
-}
-
-class UninstallPluginEditorAction extends Action {
-	static readonly ID = 'agentPlugin.editor.uninstall';
-
-	constructor(private readonly plugin: IAgentPlugin) {
-		super(UninstallPluginEditorAction.ID, localize('uninstall', "Uninstall"), 'extension-action label uninstall');
-	}
-
-	override async run(): Promise<void> {
-		this.plugin.remove();
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -17,11 +17,9 @@ import { Disposable, DisposableStore, disposeIfDisposable, IDisposable, isDispos
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { IPagedModel, PagedModel } from '../../../../base/common/paging.js';
-import { dirname, joinPath } from '../../../../base/common/resources.js';
-import { URI } from '../../../../base/common/uri.js';
+import { dirname } from '../../../../base/common/resources.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
@@ -45,10 +43,12 @@ import { AbstractExtensionsListView } from '../../extensions/browser/extensionsV
 import { DefaultViewsContext, extensionsFilterSubMenu, IExtensionsWorkbenchService, SearchAgentPluginsContext } from '../../extensions/common/extensions.js';
 import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IAgentPlugin, IAgentPluginService } from '../common/plugins/agentPluginService.js';
+import { isContributionEnabled } from '../common/enablement.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
 import { AgentPluginEditorInput } from './agentPluginEditor/agentPluginEditorInput.js';
 import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem, IMarketplacePluginItem } from './agentPluginEditor/agentPluginItems.js';
+import { getInstalledPluginContextMenuActions, InstallPluginAction, OpenPluginReadmeAction } from './agentPluginActions.js';
 
 export const HasInstalledAgentPluginsContext = new RawContextKey<boolean>('hasInstalledAgentPlugins', false);
 export const InstalledAgentPluginsViewId = 'workbench.views.agentPlugins.installed';
@@ -79,126 +79,6 @@ function marketplacePluginToItem(plugin: IMarketplacePlugin): IMarketplacePlugin
 //#endregion
 
 //#region Actions
-
-class InstallPluginAction extends Action {
-	static readonly ID = 'agentPlugin.install';
-
-	constructor(
-		private readonly item: IMarketplacePluginItem,
-		@IPluginInstallService private readonly pluginInstallService: IPluginInstallService,
-	) {
-		super(InstallPluginAction.ID, localize('install', "Install"), 'extension-action label prominent install');
-	}
-
-	override async run(): Promise<void> {
-		await this.pluginInstallService.installPlugin({
-			name: this.item.name,
-			description: this.item.description,
-			version: '',
-			source: this.item.source,
-			sourceDescriptor: this.item.sourceDescriptor,
-			marketplace: this.item.marketplace,
-			marketplaceReference: this.item.marketplaceReference,
-			marketplaceType: this.item.marketplaceType,
-			readmeUri: this.item.readmeUri,
-		});
-	}
-}
-
-class EnablePluginAction extends Action {
-	static readonly ID = 'agentPlugin.enable';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super(EnablePluginAction.ID, localize('enable', "Enable"));
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, true);
-	}
-}
-
-class DisablePluginAction extends Action {
-	static readonly ID = 'agentPlugin.disable';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super(DisablePluginAction.ID, localize('disable', "Disable"));
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, false);
-	}
-}
-
-class UninstallPluginAction extends Action {
-	static readonly ID = 'agentPlugin.uninstall';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-	) {
-		super(UninstallPluginAction.ID, localize('uninstall', "Uninstall"));
-	}
-
-	override async run(): Promise<void> {
-		this.plugin.remove();
-	}
-}
-
-class OpenPluginFolderAction extends Action {
-	static readonly ID = 'agentPlugin.openFolder';
-
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@ICommandService private readonly commandService: ICommandService,
-		@IOpenerService private readonly openerService: IOpenerService,
-	) {
-		super(OpenPluginFolderAction.ID, localize('openPluginFolder', "Open Plugin Folder"));
-	}
-
-	override async run(): Promise<void> {
-		try {
-			await this.commandService.executeCommand('revealFileInOS', this.plugin.uri);
-		} catch {
-			// Fallback for web where 'revealFileInOS' is not available
-			await this.openerService.open(dirname(this.plugin.uri));
-		}
-	}
-}
-
-class OpenPluginReadmeAction extends Action {
-	static readonly ID = 'agentPlugin.openReadme';
-
-	constructor(
-		private readonly readmeUri: URI,
-		@IOpenerService private readonly openerService: IOpenerService,
-	) {
-		super(OpenPluginReadmeAction.ID, localize('openReadme', "Open README"));
-	}
-
-	override async run(): Promise<void> {
-		await this.openerService.open(this.readmeUri);
-	}
-}
-
-function getInstalledPluginContextMenuActionGroups(plugin: IAgentPlugin, instantiationService: IInstantiationService): IAction[][] {
-	const groups: IAction[][] = [];
-	if (plugin.enabled.get()) {
-		groups.push([instantiationService.createInstance(DisablePluginAction, plugin)]);
-	} else {
-		groups.push([instantiationService.createInstance(EnablePluginAction, plugin)]);
-	}
-	groups.push([
-		instantiationService.createInstance(OpenPluginFolderAction, plugin),
-		instantiationService.createInstance(OpenPluginReadmeAction, joinPath(plugin.uri, 'README.md')),
-	]);
-	groups.push([instantiationService.createInstance(UninstallPluginAction, plugin)]);
-	return groups;
-}
 
 class ManagePluginAction extends Action {
 	static readonly ID = 'agentPlugin.manage';
@@ -311,7 +191,7 @@ class AgentPluginRenderer implements IPagedRenderer<IAgentPluginItem, IAgentPlug
 		data.description.textContent = element.description;
 
 		data.elementDisposables.push(autorun(reader => {
-			data.root.classList.toggle('disabled', element.kind === AgentPluginItemKind.Installed && !element.plugin.enabled.read(reader));
+			data.root.classList.toggle('disabled', element.kind === AgentPluginItemKind.Installed && !isContributionEnabled(element.plugin.enablement.read(reader)));
 		}));
 
 		data.actionbar.clear();
@@ -323,7 +203,7 @@ class AgentPluginRenderer implements IPagedRenderer<IAgentPluginItem, IAgentPlug
 		} else {
 			data.detail.textContent = element.marketplace ?? '';
 			const manageAction = this.instantiationService.createInstance(ManagePluginAction,
-				() => getInstalledPluginContextMenuActionGroups(element.plugin, this.instantiationService));
+				() => getInstalledPluginContextMenuActions(element.plugin, this.instantiationService));
 			data.elementDisposables.push(manageAction);
 			data.actionbar.push([manageAction], { icon: true, label: false });
 		}
@@ -391,7 +271,10 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
 		this._register(autorun(reader => {
-			this.agentPluginService.plugins.read(reader);
+			const plugins = this.agentPluginService.plugins.read(reader);
+			for (const plugin of plugins) {
+				plugin.enablement.read(reader);
+			}
 			if (this.list && this.isBodyVisible()) {
 				this.refreshOnPluginsChangedScheduler.schedule();
 			}
@@ -467,7 +350,7 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 	private getContextMenuActions(item: IAgentPluginItem): IAction[] {
 		let actions: IAction[];
 		if (item.kind === AgentPluginItemKind.Installed) {
-			const groups = getInstalledPluginContextMenuActionGroups(item.plugin, this.instantiationService);
+			const groups = getInstalledPluginContextMenuActions(item.plugin, this.instantiationService);
 			actions = groups.flatMap(group => [...group, new Separator()]);
 			if (actions.length > 0) {
 				actions.pop();
@@ -540,8 +423,8 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 	}
 
 	private queryInstalled(): IInstalledPluginItem[] {
-		const allPlugins = this.agentPluginService.allPlugins.get();
-		return allPlugins.map(p => installedPluginToItem(p, this.labelService));
+		const plugins = this.agentPluginService.plugins.get();
+		return plugins.map(p => installedPluginToItem(p, this.labelService));
 	}
 
 	private async queryMarketplace(text: string): Promise<IMarketplacePluginItem[]> {
@@ -616,7 +499,7 @@ export class AgentPluginsViewsContribution extends Disposable implements IWorkbe
 
 		const hasInstalledKey = HasInstalledAgentPluginsContext.bindTo(contextKeyService);
 		this._register(autorun(reader => {
-			hasInstalledKey.set(agentPluginService.allPlugins.read(reader).length > 0);
+			hasInstalledKey.set(agentPluginService.plugins.read(reader).length > 0);
 		}));
 
 		registerAction2(AgentPluginsBrowseCommand);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationGroupHeaderRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationGroupHeaderRenderer.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from '../../../../../base/browser/dom.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { IListRenderer } from '../../../../../base/browser/ui/list/list.js';
+import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+
+const $ = DOM.$;
+
+export const CUSTOMIZATION_GROUP_HEADER_HEIGHT = 36;
+export const CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
+
+/**
+ * Common shape for a collapsible group header entry used in the
+ * MCP-server and plugin list widgets.
+ */
+export interface ICustomizationGroupHeaderEntry {
+	readonly type: 'group-header';
+	readonly id: string;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	readonly count: number;
+	readonly isFirst: boolean;
+	readonly description: string;
+	collapsed: boolean;
+}
+
+interface ICustomizationGroupHeaderTemplateData {
+	readonly container: HTMLElement;
+	readonly chevron: HTMLElement;
+	readonly icon: HTMLElement;
+	readonly label: HTMLElement;
+	readonly count: HTMLElement;
+	readonly infoIcon: HTMLElement;
+	readonly disposables: DisposableStore;
+	readonly elementDisposables: DisposableStore;
+}
+
+/**
+ * Shared renderer for collapsible group headers in the AI Customization
+ * list widgets (MCP servers, plugins, etc.).
+ */
+export class CustomizationGroupHeaderRenderer<T extends ICustomizationGroupHeaderEntry> implements IListRenderer<T, ICustomizationGroupHeaderTemplateData> {
+
+	constructor(
+		readonly templateId: string,
+		private readonly hoverService: IHoverService,
+	) { }
+
+	renderTemplate(container: HTMLElement): ICustomizationGroupHeaderTemplateData {
+		const disposables = new DisposableStore();
+		const elementDisposables = new DisposableStore();
+		container.classList.add('ai-customization-group-header');
+
+		const chevron = DOM.append(container, $('.group-chevron'));
+		const icon = DOM.append(container, $('.group-icon'));
+		const labelGroup = DOM.append(container, $('.group-label-group'));
+		const label = DOM.append(labelGroup, $('.group-label'));
+		const infoIcon = DOM.append(labelGroup, $('.group-info'));
+		infoIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
+		const count = DOM.append(container, $('.group-count'));
+
+		return { container, chevron, icon, label, count, infoIcon, disposables, elementDisposables };
+	}
+
+	renderElement(element: T, _index: number, templateData: ICustomizationGroupHeaderTemplateData): void {
+		templateData.elementDisposables.clear();
+
+		templateData.chevron.className = 'group-chevron';
+		templateData.chevron.classList.add(...ThemeIcon.asClassNameArray(element.collapsed ? Codicon.chevronRight : Codicon.chevronDown));
+
+		templateData.icon.className = 'group-icon';
+		templateData.icon.classList.add(...ThemeIcon.asClassNameArray(element.icon));
+
+		templateData.label.textContent = element.label;
+		templateData.count.textContent = `${element.count}`;
+
+		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.infoIcon, () => ({
+			content: element.description,
+			appearance: {
+				compact: true,
+				skipFadeInAnimation: true,
+			}
+		})));
+
+		templateData.container.classList.toggle('collapsed', element.collapsed);
+		templateData.container.classList.toggle('has-previous-group', !element.isFirst);
+	}
+
+	disposeTemplate(templateData: ICustomizationGroupHeaderTemplateData): void {
+		templateData.elementDisposables.dispose();
+		templateData.disposables.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -17,6 +17,7 @@ import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IMcpWorkbenchService, IWorkbenchMcpServer, McpConnectionState, McpServerInstallState, IMcpService } from '../../../../contrib/mcp/common/mcpTypes.js';
+import { isContributionDisabled } from '../../common/enablement.js';
 import { McpCommandIds } from '../../../../contrib/mcp/common/mcpCommandIds.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
@@ -31,26 +32,17 @@ import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenc
 import { workspaceIcon, userIcon, extensionIcon } from './aiCustomizationIcons.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
+import { CustomizationGroupHeaderRenderer, ICustomizationGroupHeaderEntry, CUSTOMIZATION_GROUP_HEADER_HEIGHT, CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR } from './customizationGroupHeaderRenderer.js';
 
 const $ = DOM.$;
 
 const MCP_ITEM_HEIGHT = 36;
-const MCP_GROUP_HEADER_HEIGHT = 36;
-const MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
 
 /**
  * Represents a collapsible group header in the MCP server list.
  */
-interface IMcpGroupHeaderEntry {
-	readonly type: 'group-header';
-	readonly id: string;
+interface IMcpGroupHeaderEntry extends ICustomizationGroupHeaderEntry {
 	readonly scope: LocalMcpServerScope | 'builtin';
-	readonly label: string;
-	readonly icon: ThemeIcon;
-	readonly count: number;
-	readonly isFirst: boolean;
-	readonly description: string;
-	collapsed: boolean;
 }
 
 /**
@@ -79,7 +71,7 @@ type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpBuiltinIte
 class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
 	getHeight(element: IMcpListEntry): number {
 		if (element.type === 'group-header') {
-			return element.isFirst ? MCP_GROUP_HEADER_HEIGHT : MCP_GROUP_HEADER_HEIGHT_WITH_SEPARATOR;
+			return element.isFirst ? CUSTOMIZATION_GROUP_HEADER_HEIGHT : CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR;
 		}
 		if (element.type === 'server-item' && element.server.gallery && !element.server.local) {
 			return 62;
@@ -96,73 +88,6 @@ class McpServerItemDelegate implements IListVirtualDelegate<IMcpListEntry> {
 		}
 		const server = element.server;
 		return server.gallery && !server.local ? 'mcpGalleryItem' : 'mcpServerItem';
-	}
-}
-
-interface IMcpGroupHeaderTemplateData {
-	readonly container: HTMLElement;
-	readonly chevron: HTMLElement;
-	readonly icon: HTMLElement;
-	readonly label: HTMLElement;
-	readonly count: HTMLElement;
-	readonly infoIcon: HTMLElement;
-	readonly disposables: DisposableStore;
-	readonly elementDisposables: DisposableStore;
-}
-
-/**
- * Renderer for collapsible group headers (Workspace, User).
- */
-class McpGroupHeaderRenderer implements IListRenderer<IMcpGroupHeaderEntry, IMcpGroupHeaderTemplateData> {
-	readonly templateId = 'mcpGroupHeader';
-
-	constructor(
-		private readonly hoverService: IHoverService,
-	) { }
-
-	renderTemplate(container: HTMLElement): IMcpGroupHeaderTemplateData {
-		const disposables = new DisposableStore();
-		const elementDisposables = new DisposableStore();
-		container.classList.add('ai-customization-group-header');
-
-		const chevron = DOM.append(container, $('.group-chevron'));
-		const icon = DOM.append(container, $('.group-icon'));
-		const labelGroup = DOM.append(container, $('.group-label-group'));
-		const label = DOM.append(labelGroup, $('.group-label'));
-		const infoIcon = DOM.append(labelGroup, $('.group-info'));
-		infoIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
-		const count = DOM.append(container, $('.group-count'));
-
-		return { container, chevron, icon, label, count, infoIcon, disposables, elementDisposables };
-	}
-
-	renderElement(element: IMcpGroupHeaderEntry, _index: number, templateData: IMcpGroupHeaderTemplateData): void {
-		templateData.elementDisposables.clear();
-
-		templateData.chevron.className = 'group-chevron';
-		templateData.chevron.classList.add(...ThemeIcon.asClassNameArray(element.collapsed ? Codicon.chevronRight : Codicon.chevronDown));
-
-		templateData.icon.className = 'group-icon';
-		templateData.icon.classList.add(...ThemeIcon.asClassNameArray(element.icon));
-
-		templateData.label.textContent = element.label;
-		templateData.count.textContent = `${element.count}`;
-
-		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.infoIcon, () => ({
-			content: element.description,
-			appearance: {
-				compact: true,
-				skipFadeInAnimation: true,
-			}
-		})));
-
-		templateData.container.classList.toggle('collapsed', element.collapsed);
-		templateData.container.classList.toggle('has-previous-group', !element.isFirst);
-	}
-
-	disposeTemplate(templateData: IMcpGroupHeaderTemplateData): void {
-		templateData.elementDisposables.dispose();
-		templateData.disposables.dispose();
 	}
 }
 
@@ -225,12 +150,14 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 		// Find the server from IMcpService to get connection state
 		const server = this.mcpService.servers.get().find(s => s.definition.id === element.server.id);
 		templateData.disposables.add(autorun(reader => {
+			const disabled = server ? isContributionDisabled(server.enablement.read(reader)) : false;
 			const connectionState = server?.connectionState.read(reader);
-			this.updateStatus(templateData.status, connectionState?.state);
+			templateData.container.classList.toggle('disabled', disabled);
+			this.updateStatus(templateData.status, disabled ? 'disabled' : connectionState?.state);
 		}));
 	}
 
-	private updateStatus(statusElement: HTMLElement, state: McpConnectionState.Kind | undefined): void {
+	private updateStatus(statusElement: HTMLElement, state: McpConnectionState.Kind | 'disabled' | undefined): void {
 		statusElement.className = 'mcp-server-status';
 
 		if (this.workspaceService.isSessionsWindow) {
@@ -240,6 +167,11 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 		}
 
 		statusElement.style.display = '';
+		if (state === 'disabled') {
+			statusElement.textContent = localize('disabled', "Disabled");
+			statusElement.classList.add('disabled');
+			return;
+		}
 		switch (state) {
 			case McpConnectionState.Kind.Running:
 				statusElement.textContent = localize('running', "Running");
@@ -495,7 +427,7 @@ export class McpListWidget extends Disposable {
 
 		// Create list
 		const delegate = new McpServerItemDelegate();
-		const groupHeaderRenderer = new McpGroupHeaderRenderer(this.hoverService);
+		const groupHeaderRenderer = new CustomizationGroupHeaderRenderer<IMcpGroupHeaderEntry>('mcpGroupHeader', this.hoverService);
 		const localRenderer = this.instantiationService.createInstance(McpServerItemRenderer);
 		const galleryRenderer = new McpGalleryItemRenderer(this.mcpWorkbenchService);
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -783,6 +783,15 @@
 	color: var(--vscode-badge-foreground);
 }
 
+.mcp-server-item.disabled {
+	opacity: 0.5;
+}
+
+.mcp-server-item .mcp-server-status.disabled {
+	background-color: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+}
+
 /* Button group for Add Server + Browse Marketplace */
 .mcp-list-widget .list-button-group {
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -22,38 +22,30 @@ import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IContextMenuService, IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Delayer } from '../../../../../base/common/async.js';
-import { IAction, Action, Separator } from '../../../../../base/common/actions.js';
+import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { basename, dirname } from '../../../../../base/common/resources.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IAgentPlugin, IAgentPluginService } from '../../common/plugins/agentPluginService.js';
+import { isContributionEnabled } from '../../common/enablement.js';
+import { getInstalledPluginContextMenuActions } from '../agentPluginActions.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from '../../common/plugins/pluginMarketplaceService.js';
 import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
 import { AgentPluginItemKind, IAgentPluginItem, IInstalledPluginItem, IMarketplacePluginItem } from '../agentPluginEditor/agentPluginItems.js';
 import { pluginIcon } from './aiCustomizationIcons.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
+import { CustomizationGroupHeaderRenderer, ICustomizationGroupHeaderEntry, CUSTOMIZATION_GROUP_HEADER_HEIGHT, CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR } from './customizationGroupHeaderRenderer.js';
 
 const $ = DOM.$;
 
 const PLUGIN_ITEM_HEIGHT = 36;
-const PLUGIN_GROUP_HEADER_HEIGHT = 36;
-const PLUGIN_GROUP_HEADER_HEIGHT_WITH_SEPARATOR = 40;
 
 //#region Entry types
 
 /**
  * Represents a collapsible group header in the plugin list.
  */
-interface IPluginGroupHeaderEntry {
-	readonly type: 'group-header';
-	readonly id: string;
+interface IPluginGroupHeaderEntry extends ICustomizationGroupHeaderEntry {
 	readonly group: 'enabled' | 'disabled';
-	readonly label: string;
-	readonly icon: ThemeIcon;
-	readonly count: number;
-	readonly isFirst: boolean;
-	readonly description: string;
-	collapsed: boolean;
 }
 
 /**
@@ -81,7 +73,7 @@ type IPluginListEntry = IPluginGroupHeaderEntry | IPluginInstalledItemEntry | IP
 class PluginItemDelegate implements IListVirtualDelegate<IPluginListEntry> {
 	getHeight(element: IPluginListEntry): number {
 		if (element.type === 'group-header') {
-			return element.isFirst ? PLUGIN_GROUP_HEADER_HEIGHT : PLUGIN_GROUP_HEADER_HEIGHT_WITH_SEPARATOR;
+			return element.isFirst ? CUSTOMIZATION_GROUP_HEADER_HEIGHT : CUSTOMIZATION_GROUP_HEADER_HEIGHT_WITH_SEPARATOR;
 		}
 		if (element.type === 'marketplace-item') {
 			return 62;
@@ -101,72 +93,6 @@ class PluginItemDelegate implements IListVirtualDelegate<IPluginListEntry> {
 }
 
 //#endregion
-
-//#region Group Header Renderer (reuses .ai-customization-group-header CSS)
-
-interface IPluginGroupHeaderTemplateData {
-	readonly container: HTMLElement;
-	readonly chevron: HTMLElement;
-	readonly icon: HTMLElement;
-	readonly label: HTMLElement;
-	readonly count: HTMLElement;
-	readonly infoIcon: HTMLElement;
-	readonly disposables: DisposableStore;
-	readonly elementDisposables: DisposableStore;
-}
-
-class PluginGroupHeaderRenderer implements IListRenderer<IPluginGroupHeaderEntry, IPluginGroupHeaderTemplateData> {
-	readonly templateId = 'pluginGroupHeader';
-
-	constructor(
-		private readonly hoverService: IHoverService,
-	) { }
-
-	renderTemplate(container: HTMLElement): IPluginGroupHeaderTemplateData {
-		const disposables = new DisposableStore();
-		const elementDisposables = new DisposableStore();
-		container.classList.add('ai-customization-group-header');
-
-		const chevron = DOM.append(container, $('.group-chevron'));
-		const icon = DOM.append(container, $('.group-icon'));
-		const labelGroup = DOM.append(container, $('.group-label-group'));
-		const label = DOM.append(labelGroup, $('.group-label'));
-		const infoIcon = DOM.append(labelGroup, $('.group-info'));
-		infoIcon.classList.add(...ThemeIcon.asClassNameArray(Codicon.info));
-		const count = DOM.append(container, $('.group-count'));
-
-		return { container, chevron, icon, label, count, infoIcon, disposables, elementDisposables };
-	}
-
-	renderElement(element: IPluginGroupHeaderEntry, _index: number, templateData: IPluginGroupHeaderTemplateData): void {
-		templateData.elementDisposables.clear();
-
-		templateData.chevron.className = 'group-chevron';
-		templateData.chevron.classList.add(...ThemeIcon.asClassNameArray(element.collapsed ? Codicon.chevronRight : Codicon.chevronDown));
-
-		templateData.icon.className = 'group-icon';
-		templateData.icon.classList.add(...ThemeIcon.asClassNameArray(element.icon));
-
-		templateData.label.textContent = element.label;
-		templateData.count.textContent = `${element.count}`;
-
-		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.infoIcon, () => ({
-			content: element.description,
-			appearance: {
-				compact: true,
-				skipFadeInAnimation: true,
-			}
-		})));
-
-		templateData.container.classList.toggle('collapsed', element.collapsed);
-		templateData.container.classList.toggle('has-previous-group', !element.isFirst);
-	}
-
-	disposeTemplate(templateData: IPluginGroupHeaderTemplateData): void {
-		templateData.elementDisposables.dispose();
-		templateData.disposables.dispose();
-	}
-}
 
 //#endregion
 
@@ -208,14 +134,15 @@ class PluginInstalledItemRenderer implements IListRenderer<IPluginInstalledItemE
 
 		// Show enabled/disabled status
 		templateData.disposables.add(autorun(reader => {
-			const enabled = element.item.plugin.enabled.read(reader);
+			const enabled = isContributionEnabled(element.item.plugin.enablement.read(reader));
+			templateData.container.classList.toggle('disabled', !enabled);
 			templateData.status.className = 'mcp-server-status';
 			if (enabled) {
 				templateData.status.textContent = localize('enabled', "Enabled");
 				templateData.status.classList.add('running');
 			} else {
 				templateData.status.textContent = localize('disabled', "Disabled");
-				templateData.status.classList.add('stopped');
+				templateData.status.classList.add('disabled');
 			}
 		}));
 	}
@@ -302,82 +229,6 @@ class PluginMarketplaceItemRenderer implements IListRenderer<IPluginMarketplaceI
 	disposeTemplate(templateData: IPluginMarketplaceItemTemplateData): void {
 		templateData.elementDisposables.dispose();
 		templateData.templateDisposables.dispose();
-	}
-}
-
-//#endregion
-
-//#region Plugin context menu actions
-
-function getInstalledPluginContextMenuActions(plugin: IAgentPlugin, instantiationService: IInstantiationService): IAction[][] {
-	const groups: IAction[][] = [];
-	if (plugin.enabled.get()) {
-		groups.push([instantiationService.createInstance(DisablePluginAction, plugin)]);
-	} else {
-		groups.push([instantiationService.createInstance(EnablePluginAction, plugin)]);
-	}
-	groups.push([
-		instantiationService.createInstance(OpenPluginFolderAction, plugin),
-	]);
-	if (plugin.fromMarketplace) {
-		groups.push([new UninstallPluginAction(plugin)]);
-	}
-	return groups;
-}
-
-class EnablePluginAction extends Action {
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super('pluginListWidget.enable', localize('enable', "Enable"));
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, true);
-	}
-}
-
-class DisablePluginAction extends Action {
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
-	) {
-		super('pluginListWidget.disable', localize('disable', "Disable"));
-	}
-
-	override async run(): Promise<void> {
-		this.agentPluginService.setPluginEnabled(this.plugin.uri, false);
-	}
-}
-
-class OpenPluginFolderAction extends Action {
-	constructor(
-		private readonly plugin: IAgentPlugin,
-		@ICommandService private readonly commandService: ICommandService,
-		@IOpenerService private readonly openerService: IOpenerService,
-	) {
-		super('pluginListWidget.openFolder', localize('openPluginFolder', "Open Plugin Folder"));
-	}
-
-	override async run(): Promise<void> {
-		try {
-			await this.commandService.executeCommand('revealFileInOS', this.plugin.uri);
-		} catch {
-			await this.openerService.open(dirname(this.plugin.uri));
-		}
-	}
-}
-
-class UninstallPluginAction extends Action {
-	constructor(
-		private readonly plugin: IAgentPlugin,
-	) {
-		super('pluginListWidget.uninstall', localize('uninstall', "Uninstall"));
-	}
-
-	override async run(): Promise<void> {
-		this.plugin.remove();
 	}
 }
 
@@ -541,7 +392,7 @@ export class PluginListWidget extends Disposable {
 
 		// Create list
 		const delegate = new PluginItemDelegate();
-		const groupHeaderRenderer = new PluginGroupHeaderRenderer(this.hoverService);
+		const groupHeaderRenderer = new CustomizationGroupHeaderRenderer<IPluginGroupHeaderEntry>('pluginGroupHeader', this.hoverService);
 		const installedRenderer = new PluginInstalledItemRenderer();
 		const marketplaceRenderer = new PluginMarketplaceItemRenderer(this.pluginInstallService);
 
@@ -601,7 +452,10 @@ export class PluginListWidget extends Disposable {
 
 		// Listen to plugin service changes
 		this._register(autorun(reader => {
-			this.agentPluginService.allPlugins.read(reader);
+			const plugins = this.agentPluginService.plugins.read(reader);
+			for (const plugin of plugins) {
+				plugin.enablement.read(reader);
+			}
 			if (!this.browseMode) {
 				this.refresh();
 			}
@@ -669,7 +523,7 @@ export class PluginListWidget extends Disposable {
 				: plugins;
 
 			// Filter out already-installed plugins
-			const installedUris = new Set(this.agentPluginService.allPlugins.get().map(p => p.uri.toString()));
+			const installedUris = new Set(this.agentPluginService.plugins.get().map(p => p.uri.toString()));
 			this.marketplaceItems = filtered
 				.filter(p => {
 					const expectedUri = this.pluginInstallService.getPluginInstallUri(p);
@@ -711,7 +565,7 @@ export class PluginListWidget extends Disposable {
 
 	private filterPlugins(): void {
 		const query = this.searchQuery.toLowerCase().trim();
-		const allPlugins = this.agentPluginService.allPlugins.get();
+		const allPlugins = this.agentPluginService.plugins.get();
 
 		this.installedItems = allPlugins
 			.map(p => installedPluginToItem(p, this.labelService))
@@ -737,8 +591,8 @@ export class PluginListWidget extends Disposable {
 		}
 
 		// Group plugins: enabled vs disabled
-		const enabledPlugins = this.installedItems.filter(item => item.plugin.enabled.get());
-		const disabledPlugins = this.installedItems.filter(item => !item.plugin.enabled.get());
+		const enabledPlugins = this.installedItems.filter(item => isContributionEnabled(item.plugin.enablement.get()));
+		const disabledPlugins = this.installedItems.filter(item => !isContributionEnabled(item.plugin.enablement.get()));
 
 		const entries: IPluginListEntry[] = [];
 		let isFirst = true;

--- a/src/vs/workbench/contrib/chat/browser/enablementActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/enablementActions.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Action, IAction } from '../../../../base/common/actions.js';
+import { localize } from '../../../../nls.js';
+import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+import { ContributionEnablementState, IEnablementModel, isContributionDisabled } from '../common/enablement.js';
+
+/**
+ * Creates the four standard enablement actions (Enable, Enable Workspace,
+ * Disable, Disable Workspace) for a contribution identified by a string key.
+ */
+export function createEnablementActions(
+	key: string,
+	enablementModel: IEnablementModel,
+	idPrefix: string,
+): [enable: Action, enableWorkspace: Action, disable: Action, disableWorkspace: Action] {
+	return [
+		new Action(`${idPrefix}.enable`, localize('enable', "Enable"), undefined, true,
+			() => { enablementModel.setEnabled(key, ContributionEnablementState.EnabledProfile); return Promise.resolve(); }),
+		new Action(`${idPrefix}.enableForWorkspace`, localize('enableForWorkspace', "Enable (Workspace)"), undefined, true,
+			() => { enablementModel.setEnabled(key, ContributionEnablementState.EnabledWorkspace); return Promise.resolve(); }),
+		new Action(`${idPrefix}.disable`, localize('disable', "Disable"), undefined, true,
+			() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledProfile); return Promise.resolve(); }),
+		new Action(`${idPrefix}.disableForWorkspace`, localize('disableForWorkspace', "Disable (Workspace)"), undefined, true,
+			() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledWorkspace); return Promise.resolve(); }),
+	];
+}
+
+/**
+ * Builds the standard enablement context-menu action group for a
+ * contribution. Returns either the enable or disable actions depending
+ * on the current state, with workspace variants included only when a
+ * workspace is open.
+ */
+export function buildEnablementContextMenuGroup(
+	enablementState: ContributionEnablementState,
+	key: string,
+	enablementModel: IEnablementModel,
+	workspaceContextService: IWorkspaceContextService,
+	idPrefix: string,
+): IAction[] {
+	const hasWorkspace = workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY;
+	const [enable, enableWorkspace, disable, disableWorkspace] = createEnablementActions(key, enablementModel, idPrefix);
+	const actions: IAction[] = [];
+	if (isContributionDisabled(enablementState)) {
+		actions.push(enable);
+		if (hasWorkspace) {
+			actions.push(enableWorkspace);
+		}
+	} else {
+		actions.push(disable);
+		if (hasWorkspace) {
+			actions.push(disableWorkspace);
+		}
+	}
+	return actions;
+}

--- a/src/vs/workbench/contrib/chat/browser/enablementStatusWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/enablementStatusWidget.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { reset } from '../../../../base/browser/dom.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable, autorun } from '../../../../base/common/observable.js';
+import { localize } from '../../../../nls.js';
+import { IMarkdownRendererService } from '../../../../platform/markdown/browser/markdownRenderer.js';
+import { ContributionEnablementState } from '../common/enablement.js';
+
+/**
+ * A small reusable widget that renders an enablement status message inside
+ * a `.status` container, matching the style used by the extension and MCP
+ * server editors. The message is shown only when the contribution is
+ * disabled and is rendered as markdown with a theme icon prefix.
+ */
+export class EnablementStatusWidget extends Disposable {
+
+	private readonly _renderDisposables = this._register(new MutableDisposable());
+
+	constructor(
+		private readonly _container: HTMLElement,
+		enablement: IObservable<ContributionEnablementState>,
+		private readonly _labels: {
+			disabledProfile: string;
+			disabledWorkspace: string;
+		},
+		@IMarkdownRendererService private readonly _markdownRendererService: IMarkdownRendererService,
+	) {
+		super();
+		this._register(autorun(reader => {
+			this._render(enablement.read(reader));
+		}));
+	}
+
+	private _render(state: ContributionEnablementState): void {
+		reset(this._container);
+		this._renderDisposables.value = undefined;
+
+		let message: string | undefined;
+		if (state === ContributionEnablementState.DisabledProfile) {
+			message = this._labels.disabledProfile;
+		} else if (state === ContributionEnablementState.DisabledWorkspace) {
+			message = this._labels.disabledWorkspace;
+		}
+
+		if (!message) {
+			return;
+		}
+
+		const markdown = new MarkdownString('', { isTrusted: true, supportThemeIcons: true });
+		markdown.appendMarkdown(`$(${Codicon.info.id})&nbsp;`);
+		markdown.appendText(message);
+		const rendered = this._markdownRendererService.render(markdown);
+		this._renderDisposables.value = rendered;
+		this._container.appendChild(rendered.element);
+	}
+}
+
+/** Default labels for plugin enablement status. */
+export const pluginEnablementLabels = {
+	disabledProfile: localize('pluginDisabled', "This plugin is disabled."),
+	disabledWorkspace: localize('pluginDisabledWorkspace', "This plugin is disabled for this workspace."),
+};
+
+/** Default labels for MCP server enablement status. */
+export const mcpServerEnablementLabels = {
+	disabledProfile: localize('mcpServerDisabled', "This MCP server is disabled."),
+	disabledWorkspace: localize('mcpServerDisabledWorkspace', "This MCP server is disabled for this workspace."),
+};

--- a/src/vs/workbench/contrib/chat/common/enablement.ts
+++ b/src/vs/workbench/contrib/chat/common/enablement.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IReader } from '../../../../base/common/observable.js';
+import { ObservableMemento, observableMemento } from '../../../../platform/observable/common/observableMemento.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+
+export const enum ContributionEnablementState {
+	DisabledProfile,
+	DisabledWorkspace,
+	EnabledProfile,
+	EnabledWorkspace,
+}
+
+export function isContributionEnabled(state: ContributionEnablementState): boolean {
+	return state === ContributionEnablementState.EnabledProfile || state === ContributionEnablementState.EnabledWorkspace;
+}
+
+export function isContributionDisabled(state: ContributionEnablementState): boolean {
+	return !isContributionEnabled(state);
+}
+
+export interface IEnablementModel {
+	readEnabled(key: string, reader?: IReader): ContributionEnablementState;
+	setEnabled(key: string, state: ContributionEnablementState): void;
+}
+
+type EnablementMap = ReadonlyMap<string, boolean>;
+
+function mapToStorage(value: EnablementMap): string {
+	return JSON.stringify([...value]);
+}
+
+function mapFromStorage(value: string): EnablementMap {
+	const parsed = JSON.parse(value);
+	return new Map(Array.isArray(parsed) ? parsed : []);
+}
+
+/**
+ * A reusable enablement model for string-keyed contributions. Uses
+ * `observableMemento` to persist enable/disable state in both profile-scoped
+ * and workspace-scoped storage.
+ *
+ * Resolution order: if a workspace-scoped entry exists for a key, it wins.
+ * Otherwise, the profile-scoped entry is used. The default (absence of any
+ * entry) is {@link ContributionEnablementState.EnabledProfile}.
+ */
+export class EnablementModel extends Disposable implements IEnablementModel {
+	private readonly _profileState: ObservableMemento<EnablementMap>;
+	private readonly _workspaceState: ObservableMemento<EnablementMap>;
+
+	constructor(
+		storageKey: string,
+		@IStorageService storageService: IStorageService,
+	) {
+		super();
+
+		const mapMemento = observableMemento<EnablementMap>({
+			key: storageKey,
+			defaultValue: new Map(),
+			toStorage: mapToStorage,
+			fromStorage: mapFromStorage,
+		});
+
+		this._profileState = this._register(
+			mapMemento(StorageScope.PROFILE, StorageTarget.MACHINE, storageService)
+		);
+
+		this._workspaceState = this._register(
+			mapMemento(StorageScope.WORKSPACE, StorageTarget.MACHINE, storageService)
+		);
+	}
+
+	readEnabled(key: string, reader?: IReader): ContributionEnablementState {
+		const wsMap = this._workspaceState.read(reader);
+		if (wsMap.has(key)) {
+			return wsMap.get(key)!
+				? ContributionEnablementState.EnabledWorkspace
+				: ContributionEnablementState.DisabledWorkspace;
+		}
+
+		const profileMap = this._profileState.read(reader);
+		if (profileMap.has(key)) {
+			return profileMap.get(key)!
+				? ContributionEnablementState.EnabledProfile
+				: ContributionEnablementState.DisabledProfile;
+		}
+
+		return ContributionEnablementState.EnabledProfile;
+	}
+
+	setEnabled(key: string, state: ContributionEnablementState): void {
+		switch (state) {
+			case ContributionEnablementState.EnabledProfile: {
+				// Enabled-profile is the default: remove key from profile state,
+				// and also remove any workspace override.
+				this._deleteFromMap(this._profileState, key);
+				this._deleteFromMap(this._workspaceState, key);
+				break;
+			}
+			case ContributionEnablementState.DisabledProfile: {
+				// Store disabled in profile, remove workspace override.
+				this._setInMap(this._profileState, key, false);
+				this._deleteFromMap(this._workspaceState, key);
+				break;
+			}
+			case ContributionEnablementState.EnabledWorkspace: {
+				// Workspace override: always store explicitly.
+				this._setInMap(this._workspaceState, key, true);
+				break;
+			}
+			case ContributionEnablementState.DisabledWorkspace: {
+				// Workspace override: always store explicitly.
+				this._setInMap(this._workspaceState, key, false);
+				break;
+			}
+		}
+	}
+
+	private _setInMap(memento: ObservableMemento<EnablementMap>, key: string, value: boolean): void {
+		const current = memento.get();
+		if (current.get(key) === value) {
+			return;
+		}
+		const next = new Map(current);
+		next.set(key, value);
+		memento.set(next, undefined);
+	}
+
+	private _deleteFromMap(memento: ObservableMemento<EnablementMap>, key: string): void {
+		const current = memento.get();
+		if (!current.has(key)) {
+			return;
+		}
+		const next = new Map(current);
+		next.delete(key);
+		memento.set(next, undefined);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginService.ts
@@ -10,6 +10,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { SyncDescriptor0 } from '../../../../../platform/instantiation/common/descriptors.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IMcpServerConfiguration } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
+import { ContributionEnablementState, IEnablementModel } from '../enablement.js';
 import { IHookCommand } from '../promptSyntax/hookSchema.js';
 import { HookType } from '../promptSyntax/hookTypes.js';
 import { IMarketplacePlugin } from './pluginMarketplaceService.js';
@@ -46,8 +47,7 @@ export interface IAgentPlugin {
 	readonly uri: URI;
 	/** Human-readable display name for the plugin. */
 	readonly label: string;
-	readonly enabled: IObservable<boolean>;
-	setEnabled(enabled: boolean): void;
+	readonly enablement: IObservable<ContributionEnablementState>;
 	/** Removes this plugin from its discovery source (config or installed storage). */
 	remove(): void;
 	readonly hooks: IObservable<readonly IAgentPluginHook[]>;
@@ -62,13 +62,12 @@ export interface IAgentPlugin {
 export interface IAgentPluginService {
 	readonly _serviceBrand: undefined;
 	readonly plugins: IObservable<readonly IAgentPlugin[]>;
-	readonly allPlugins: IObservable<readonly IAgentPlugin[]>;
-	setPluginEnabled(pluginUri: URI, enabled: boolean): void;
+	readonly enablementModel: IEnablementModel;
 }
 
 export interface IAgentPluginDiscovery extends IDisposable {
 	readonly plugins: IObservable<readonly IAgentPlugin[]>;
-	start(): void;
+	start(enablementModel: IEnablementModel): void;
 }
 
 export function getCanonicalPluginCommandId(plugin: IAgentPlugin, commandName: string): string {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -9,7 +9,7 @@ import { untildify } from '../../../../../base/common/labels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
 import { cloneAndChange } from '../../../../../base/common/objects.js';
-import { autorun, derived, IObservable, ISettableObservable, observableValue } from '../../../../../base/common/observable.js';
+import { autorun, derived, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import {
 	posix,
 	win32
@@ -34,8 +34,10 @@ import { parseClaudeHooks } from '../promptSyntax/hookClaudeCompat.js';
 import { parseCopilotHooks } from '../promptSyntax/hookCompatibility.js';
 import { IHookCommand } from '../promptSyntax/hookSchema.js';
 import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from './agentPluginService.js';
+import { EnablementModel, IEnablementModel } from '../enablement.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 
 const COMMAND_FILE_SUFFIX = '.md';
 
@@ -195,14 +197,17 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 
 	declare readonly _serviceBrand: undefined;
 
-	public readonly allPlugins: IObservable<readonly IAgentPlugin[]>;
 	public readonly plugins: IObservable<readonly IAgentPlugin[]>;
+	public readonly enablementModel: IEnablementModel;
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super();
+
+		this.enablementModel = this._register(new EnablementModel('agentPlugins.enablement', storageService));
 
 		const pluginsEnabled = observableConfigValue(ChatConfiguration.PluginsEnabled, true, configurationService);
 
@@ -211,28 +216,16 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 			const discovery = instantiationService.createInstance(descriptor);
 			this._register(discovery);
 			discoveries.push(discovery);
-			discovery.start();
+			discovery.start(this.enablementModel);
 		}
 
 
-		this.allPlugins = derived(read => {
+		this.plugins = derived(read => {
 			if (!pluginsEnabled.read(read)) {
 				return [];
 			}
 			return this._dedupeAndSort(discoveries.flatMap(d => d.plugins.read(read)));
 		});
-
-		this.plugins = derived(reader => {
-			const all = this.allPlugins.read(reader);
-			return all.filter(p => p.enabled.read(reader));
-		});
-	}
-
-	public setPluginEnabled(pluginUri: URI, enabled: boolean): void {
-		const plugin = this.allPlugins.get().find(p => p.uri.toString() === pluginUri.toString());
-		if (plugin) {
-			plugin.setEnabled(enabled);
-		}
 	}
 
 	private _dedupeAndSort(plugins: readonly IAgentPlugin[]): readonly IAgentPlugin[] {
@@ -253,7 +246,7 @@ export class AgentPluginService extends Disposable implements IAgentPluginServic
 	}
 }
 
-type PluginEntry = IAgentPlugin & { enabled: ISettableObservable<boolean> };
+type PluginEntry = IAgentPlugin;
 
 /**
  * Describes a single discovered plugin source, before the shared
@@ -261,10 +254,7 @@ type PluginEntry = IAgentPlugin & { enabled: ISettableObservable<boolean> };
  */
 interface IPluginSource {
 	readonly uri: URI;
-	readonly enabled: boolean;
 	readonly fromMarketplace: IMarketplacePlugin | undefined;
-	/** Called when setEnabled is invoked on the plugin */
-	setEnabled(value: boolean): void;
 	/** Called when remove is invoked on the plugin */
 	remove(): void;
 }
@@ -285,6 +275,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 	public readonly plugins: IObservable<readonly IAgentPlugin[]> = this._plugins;
 
 	protected _discoverVersion = 0;
+	protected _enablementModel!: IEnablementModel;
 
 	constructor(
 		protected readonly _fileService: IFileService,
@@ -295,7 +286,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		super();
 	}
 
-	public abstract start(): void;
+	public abstract start(enablementModel: IEnablementModel): void;
 
 	protected async _refreshPlugins(): Promise<void> {
 		const version = ++this._discoverVersion;
@@ -320,7 +311,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			if (!seenPluginUris.has(key)) {
 				seenPluginUris.add(key);
 				const adapter = await this._detectPluginFormatAdapter(source.uri);
-				plugins.push(this._toPlugin(source.uri, source.enabled, adapter, source.fromMarketplace, value => source.setEnabled(value), () => source.remove()));
+				plugins.push(this._toPlugin(source.uri, adapter, source.fromMarketplace, () => source.remove()));
 			}
 		}
 
@@ -348,7 +339,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 	}
 
-	private _toPlugin(uri: URI, initialEnabled: boolean, adapter: IAgentPluginFormatAdapter, fromMarketplace: IMarketplacePlugin | undefined, setEnabledCallback: (value: boolean) => void, removeCallback: () => void): IAgentPlugin {
+	private _toPlugin(uri: URI, adapter: IAgentPluginFormatAdapter, fromMarketplace: IMarketplacePlugin | undefined, removeCallback: () => void): IAgentPlugin {
 		const key = uri.toString();
 		const existing = this._pluginEntries.get(key);
 		if (existing) {
@@ -356,7 +347,6 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 				existing.store.dispose();
 				this._pluginEntries.delete(key);
 			} else {
-				existing.plugin.enabled.set(initialEnabled, undefined);
 				return existing.plugin;
 			}
 		}
@@ -367,7 +357,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		const agents = observableValue<readonly IAgentPluginAgent[]>('agentPluginAgents', []);
 		const hooks = observableValue<readonly IAgentPluginHook[]>('agentPluginHooks', []);
 		const mcpServerDefinitions = observableValue<readonly IAgentPluginMcpServerDefinition[]>('agentPluginMcpServerDefinitions', []);
-		const enabled = observableValue<boolean>('agentPluginEnabled', initialEnabled);
+		const enablement = derived(r => this._enablementModel.readEnabled(key, r));
 
 		const commandsDir = joinPath(uri, 'commands');
 		const skillsDir = joinPath(uri, 'skills');
@@ -418,8 +408,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		const plugin: PluginEntry = {
 			uri,
 			label: fromMarketplace?.name ?? basename(uri),
-			enabled,
-			setEnabled: setEnabledCallback,
+			enablement,
 			remove: removeCallback,
 			hooks,
 			commands,
@@ -717,7 +706,8 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		this._pluginLocationsConfig = observableConfigValue<Record<string, boolean>>(ChatConfiguration.PluginLocations, {}, _configurationService);
 	}
 
-	public override start(): void {
+	public override start(enablementModel: IEnablementModel): void {
+		this._enablementModel = enablementModel;
 		const scheduler = this._register(new RunOnceScheduler(() => this._refreshPlugins(), 0));
 		this._register(autorun(reader => {
 			this._pluginLocationsConfig.read(reader);
@@ -731,7 +721,7 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		const config = this._pluginLocationsConfig.get();
 		const userHome = await this._getUserHome();
 
-		for (const [path, enabled] of Object.entries(config)) {
+		for (const [path] of Object.entries(config)) {
 			if (!path.trim()) {
 				continue;
 			}
@@ -755,9 +745,7 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 				const configKey = path;
 				sources.push({
 					uri: stat.resource,
-					enabled,
 					fromMarketplace,
-					setEnabled: (value: boolean) => this._updatePluginPathEnabled(configKey, value),
 					remove: () => this._removePluginPath(configKey),
 				});
 			}
@@ -789,44 +777,6 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 
 		return this._workspaceContextService.getWorkspace().folders.map(
 			folder => joinPath(folder.uri, path)
-		);
-	}
-
-	/**
-	 * Updates the enabled state of a plugin path in the configuration,
-	 * writing to the most specific config target where the key is defined.
-	 */
-	private _updatePluginPathEnabled(configKey: string, value: boolean): void {
-		const inspected = this._configurationService.inspect<Record<string, boolean>>(ChatConfiguration.PluginLocations);
-
-		// Walk from most specific to least specific to find where this key is defined
-		const targets = [
-			ConfigurationTarget.WORKSPACE_FOLDER,
-			ConfigurationTarget.WORKSPACE,
-			ConfigurationTarget.USER_LOCAL,
-			ConfigurationTarget.USER_REMOTE,
-			ConfigurationTarget.USER,
-			ConfigurationTarget.APPLICATION,
-		];
-
-		for (const target of targets) {
-			const mapping = getConfigValueInTarget(inspected, target);
-			if (mapping && Object.prototype.hasOwnProperty.call(mapping, configKey)) {
-				this._configurationService.updateValue(
-					ChatConfiguration.PluginLocations,
-					{ ...mapping, [configKey]: value },
-					target,
-				);
-				return;
-			}
-		}
-
-		// Key not found in any target; write to USER_LOCAL as default
-		const current = getConfigValueInTarget(inspected, ConfigurationTarget.USER_LOCAL) ?? {};
-		this._configurationService.updateValue(
-			ChatConfiguration.PluginLocations,
-			{ ...current, [configKey]: value },
-			ConfigurationTarget.USER_LOCAL,
 		);
 	}
 
@@ -875,7 +825,8 @@ export class MarketplaceAgentPluginDiscovery extends AbstractAgentPluginDiscover
 		super(fileService, pathService, logService, instantiationService);
 	}
 
-	public override start(): void {
+	public override start(enablementModel: IEnablementModel): void {
+		this._enablementModel = enablementModel;
 		const scheduler = this._register(new RunOnceScheduler(() => this._refreshPlugins(), 0));
 		this._register(autorun(reader => {
 			this._pluginMarketplaceService.installedPlugins.read(reader);
@@ -904,16 +855,9 @@ export class MarketplaceAgentPluginDiscovery extends AbstractAgentPluginDiscover
 
 			sources.push({
 				uri: stat.resource,
-				enabled: entry.enabled,
 				fromMarketplace: entry.plugin,
-				setEnabled: (value: boolean) => this._pluginMarketplaceService.setInstalledPluginEnabled(entry.pluginUri, value),
 				remove: () => {
-					// Always remove the metadata entry first so the plugin
-					// disappears from the UI immediately.
 					this._pluginMarketplaceService.removeInstalledPlugin(entry.pluginUri);
-					// For non-marketplace (direct-source) plugins, also clean up the
-					// on-disk cache. This is best-effort — failures are logged but
-					// do not block removal.
 					this._pluginRepositoryService.cleanupPluginSource(entry.plugin).catch(error => {
 						this._logService.error('[MarketplaceAgentPluginDiscovery] Failed to clean up plugin source', error);
 					});

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -721,8 +721,8 @@ export class ConfiguredAgentPluginDiscovery extends AbstractAgentPluginDiscovery
 		const config = this._pluginLocationsConfig.get();
 		const userHome = await this._getUserHome();
 
-		for (const [path] of Object.entries(config)) {
-			if (!path.trim()) {
+		for (const [path, enabled] of Object.entries(config)) {
+			if (!path.trim() || enabled === false) {
 				continue;
 			}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -46,6 +46,7 @@ import { getTarget, mapClaudeModels, mapClaudeTools } from '../languageProviders
 import { StopWatch } from '../../../../../../base/common/stopwatch.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { getCanonicalPluginCommandId, IAgentPlugin, IAgentPluginService } from '../../plugins/agentPluginService.js';
+import { isContributionEnabled } from '../../enablement.js';
 import { assertNever } from '../../../../../../base/common/assert.js';
 
 /**
@@ -249,7 +250,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 		this._register(autorun(reader => {
 			const plugins = this.agentPluginService.plugins.read(reader);
 			for (const plugin of plugins) {
-				plugin.hooks.read(reader);
+				if (isContributionEnabled(plugin.enablement.read(reader))) {
+					plugin.hooks.read(reader);
+				}
 			}
 			this._onDidPluginHooksChange.fire();
 		}));
@@ -263,6 +266,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 			const plugins = this.agentPluginService.plugins.read(reader);
 			const nextFiles: IPluginPromptPath[] = [];
 			for (const plugin of plugins) {
+				if (!isContributionEnabled(plugin.enablement.read(reader))) {
+					continue;
+				}
 				for (const item of getItems(plugin, reader)) {
 					nextFiles.push({
 						uri: item.uri,
@@ -1314,6 +1320,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 		// Collect hooks from agent plugins
 		const plugins = this.agentPluginService.plugins.get();
 		for (const plugin of plugins) {
+			if (!isContributionEnabled(plugin.enablement.get())) {
+				continue;
+			}
 			for (const hook of plugin.hooks.get()) {
 				let bucket = collectedHooks.get(hook.type);
 				if (!bucket) {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -186,8 +186,7 @@ suite('ComputeAutomaticInstructions', () => {
 
 		instaService.stub(IAgentPluginService, {
 			plugins: observableValue('testPlugins', []),
-			allPlugins: observableValue('testAllPlugins', []),
-			setPluginEnabled: () => { },
+			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { } },
 		});
 
 		service = disposables.add(instaService.createInstance(PromptsService));

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -65,7 +65,6 @@ suite('PromptsService', () => {
 	let testConfigService: TestConfigurationService;
 	let fileService: IFileService;
 	let testPluginsObservable: ISettableObservable<readonly IAgentPlugin[]>;
-	let testAllPluginsObservable: ISettableObservable<readonly IAgentPlugin[]>;
 	let workspaceTrustService: TestWorkspaceTrustManagementService;
 
 	setup(async () => {
@@ -172,12 +171,10 @@ suite('PromptsService', () => {
 		instaService.stub(IWorkspaceTrustManagementService, workspaceTrustService);
 
 		testPluginsObservable = observableValue<readonly IAgentPlugin[]>('testPlugins', []);
-		testAllPluginsObservable = observableValue<readonly IAgentPlugin[]>('testAllPlugins', []);
 
 		instaService.stub(IAgentPluginService, {
 			plugins: testPluginsObservable,
-			allPlugins: testAllPluginsObservable,
-			setPluginEnabled: () => { },
+			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { } },
 		});
 
 		service = disposables.add(instaService.createInstance(PromptsService));
@@ -3514,7 +3511,7 @@ suite('PromptsService', () => {
 
 	suite('hooks', () => {
 		const createTestPlugin = (path: string, initialHooks: readonly IAgentPluginHook[]): { plugin: IAgentPlugin; hooks: ISettableObservable<readonly IAgentPluginHook[]> } => {
-			const enabled = observableValue<boolean>('testPluginEnabled', true);
+			const enablement = observableValue('testPluginEnablement', 2 /* ContributionEnablementState.EnabledProfile */);
 			const hooks = observableValue<readonly IAgentPluginHook[]>('testPluginHooks', initialHooks);
 			const commands = observableValue<readonly IAgentPluginCommand[]>('testPluginCommands', []);
 			const skills = observableValue<readonly IAgentPluginSkill[]>('testPluginSkills', []);
@@ -3525,8 +3522,7 @@ suite('PromptsService', () => {
 				plugin: {
 					uri: URI.file(path),
 					label: basename(URI.file(path)),
-					enabled,
-					setEnabled: () => { },
+					enablement,
 					remove: () => { },
 					hooks,
 					commands,
@@ -3600,7 +3596,6 @@ suite('PromptsService', () => {
 			}]);
 
 			testPluginsObservable.set([plugin], undefined);
-			testAllPluginsObservable.set([plugin], undefined);
 
 			const result = await service.getHooks(CancellationToken.None);
 			assert.ok(result, 'Expected hooks result');
@@ -3622,7 +3617,6 @@ suite('PromptsService', () => {
 			}]);
 
 			testPluginsObservable.set([plugin], undefined);
-			testAllPluginsObservable.set([plugin], undefined);
 
 			const before = await service.getHooks(CancellationToken.None);
 			assert.ok(before, 'Expected hooks result before plugin update');
@@ -3714,7 +3708,6 @@ suite('PromptsService', () => {
 			}]);
 
 			testPluginsObservable.set([plugin], undefined);
-			testAllPluginsObservable.set([plugin], undefined);
 
 			await workspaceTrustService.setWorkspaceTrust(false);
 			const result = await service.getHooks(CancellationToken.None);

--- a/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpCommands.ts
@@ -61,10 +61,11 @@ import { TEXT_FILE_EDITOR_ID } from '../../files/common/files.js';
 import { McpCommandIds } from '../common/mcpCommandIds.js';
 import { McpContextKeys } from '../common/mcpContextKeys.js';
 import { IMcpRegistry } from '../common/mcpRegistryTypes.js';
-import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState, McpStartServerInteraction } from '../common/mcpTypes.js';
+import { HasInstalledMcpServersContext, IMcpSamplingService, IMcpServer, IMcpServerStartOpts, IMcpService, IMcpWorkbenchService, InstalledMcpServersViewId, LazyCollectionState, McpCapability, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, mcpPromptPrefix, McpServerCacheState, McpStartServerInteraction } from '../common/mcpTypes.js';
 import { McpAddConfigurationCommand, McpInstallFromManifestCommand } from './mcpCommandsAddConfiguration.js';
 import { McpResourceQuickAccess, McpResourceQuickPick } from './mcpResourceQuickAccess.js';
 import { startServerAndWaitForLiveTools } from '../common/mcpTypesUtils.js';
+import { isContributionDisabled } from '../../chat/common/enablement.js';
 import './media/mcpServerAction.css';
 import { openPanelChatAndGetWidget } from './openPanelChatAndGetWidget.js';
 
@@ -104,6 +105,7 @@ export class ListMcpServerCommand extends Action2 {
 		const mcpService = accessor.get(IMcpService);
 		const commandService = accessor.get(ICommandService);
 		const quickInput = accessor.get(IQuickInputService);
+		const mcpWorkbenchService = accessor.get(IMcpWorkbenchService);
 
 		type ItemType = { id: string } & IQuickPickItem;
 
@@ -122,11 +124,16 @@ export class ListMcpServerCommand extends Action2 {
 				{ id: '$add', label: localize('mcp.addServer', 'Add Server'), description: localize('mcp.addServer.description', 'Add a new server configuration'), alwaysShow: true, iconClass: ThemeIcon.asClassName(Codicon.add) },
 				...Object.values(servers).filter(s => s!.length).flatMap((servers): (ItemType | IQuickPickSeparator)[] => [
 					{ type: 'separator', label: servers![0].collection.label, id: servers![0].collection.id },
-					...servers!.map(server => ({
-						id: server.definition.id,
-						label: server.definition.label,
-						description: McpConnectionState.toString(server.connectionState.read(reader)),
-					})),
+					...servers!.map(server => {
+						const disabled = isContributionDisabled(server.enablement.read(reader));
+						return {
+							id: server.definition.id,
+							label: server.definition.label,
+							description: disabled
+								? localize('mcp.disabled', 'Disabled')
+								: McpConnectionState.toString(server.connectionState.read(reader)),
+						};
+					}),
 				]),
 			];
 
@@ -153,7 +160,15 @@ export class ListMcpServerCommand extends Action2 {
 		} else if (picked.id === '$add') {
 			commandService.executeCommand(McpCommandIds.AddConfiguration);
 		} else {
-			commandService.executeCommand(McpCommandIds.ServerOptions, picked.id);
+			const server = mcpService.servers.get().find(s => s.definition.id === picked.id);
+			if (server && isContributionDisabled(server.enablement.get())) {
+				const workbenchServer = mcpWorkbenchService.local.find(s => s.id === picked.id);
+				if (workbenchServer) {
+					mcpWorkbenchService.open(workbenchServer);
+				}
+			} else {
+				commandService.executeCommand(McpCommandIds.ServerOptions, picked.id);
+			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerActions.ts
@@ -37,6 +37,7 @@ import { ExtensionAction } from '../../extensions/browser/extensionsActions.js';
 import { ActionWithDropdownActionViewItem, IActionWithDropdownActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
 import { IContextMenuProvider } from '../../../../base/browser/contextmenu.js';
 import Severity from '../../../../base/common/severity.js';
+import { ContributionEnablementState, isContributionDisabled, isContributionEnabled } from '../../chat/common/enablement.js';
 
 export interface IMcpServerActionChangeEvent extends IActionChangeEvent {
 	readonly hidden?: boolean;
@@ -133,10 +134,12 @@ export class ButtonWithDropDownExtensionAction extends McpServerAction {
 		this._onDidChange.fire({ menuActions: this._menuActions });
 
 		if (this.primaryAction) {
+			this.hidden = false;
 			this.enabled = this.primaryAction.enabled;
 			this.label = this.getLabel(this.primaryAction as ExtensionAction);
 			this.tooltip = this.primaryAction.tooltip;
 		} else {
+			this.hidden = true;
 			this.enabled = false;
 		}
 	}
@@ -508,6 +511,174 @@ export class UninstallAction extends McpServerAction {
 	}
 }
 
+export class EnableMcpServerGloballyAction extends McpServerAction {
+
+	static readonly ID = 'mcpServer.enableGlobally';
+
+	constructor(
+		@IMcpService private readonly mcpService: IMcpService,
+	) {
+		super(EnableMcpServerGloballyAction.ID, localize('enableGlobally', "Enable"), McpServerAction.LABEL_ACTION_CLASS);
+		this.tooltip = localize('enableGloballyTooltip', "Enable this MCP server");
+		this.update();
+	}
+
+	update(): void {
+		this.enabled = false;
+		if (!this.mcpServer?.local) {
+			return;
+		}
+		const server = this.mcpService.servers.get().find(s => s.definition.id === this.mcpServer?.id);
+		if (!server) {
+			return;
+		}
+		const enablement = server.enablement.get();
+		this.enabled = isContributionDisabled(enablement);
+	}
+
+	override async run(): Promise<void> {
+		if (!this.mcpServer) {
+			return;
+		}
+		this.mcpService.enablementModel.setEnabled(this.mcpServer.id, ContributionEnablementState.EnabledProfile);
+	}
+}
+
+export class EnableMcpServerForWorkspaceAction extends McpServerAction {
+
+	static readonly ID = 'mcpServer.enableForWorkspace';
+
+	constructor(
+		@IMcpService private readonly mcpService: IMcpService,
+		@IWorkspaceContextService private readonly workspaceService: IWorkspaceContextService,
+	) {
+		super(EnableMcpServerForWorkspaceAction.ID, localize('enableForWorkspace', "Enable (Workspace)"), McpServerAction.LABEL_ACTION_CLASS);
+		this.tooltip = localize('enableForWorkspaceTooltip', "Enable this MCP server only in this workspace");
+		this.update();
+	}
+
+	update(): void {
+		this.enabled = false;
+		if (!this.mcpServer?.local) {
+			return;
+		}
+		if (this.workspaceService.getWorkbenchState() === WorkbenchState.EMPTY) {
+			return;
+		}
+		const server = this.mcpService.servers.get().find(s => s.definition.id === this.mcpServer?.id);
+		if (!server) {
+			return;
+		}
+		const enablement = server.enablement.get();
+		this.enabled = isContributionDisabled(enablement);
+	}
+
+	override async run(): Promise<void> {
+		if (!this.mcpServer) {
+			return;
+		}
+		this.mcpService.enablementModel.setEnabled(this.mcpServer.id, ContributionEnablementState.EnabledWorkspace);
+	}
+}
+
+export class DisableMcpServerGloballyAction extends McpServerAction {
+
+	static readonly ID = 'mcpServer.disableGlobally';
+
+	constructor(
+		@IMcpService private readonly mcpService: IMcpService,
+	) {
+		super(DisableMcpServerGloballyAction.ID, localize('disableGlobally', "Disable"), McpServerAction.LABEL_ACTION_CLASS);
+		this.tooltip = localize('disableGloballyTooltip', "Disable this MCP server");
+		this.update();
+	}
+
+	update(): void {
+		this.enabled = false;
+		if (!this.mcpServer?.local) {
+			return;
+		}
+		const server = this.mcpService.servers.get().find(s => s.definition.id === this.mcpServer?.id);
+		if (!server) {
+			return;
+		}
+		const enablement = server.enablement.get();
+		this.enabled = isContributionEnabled(enablement);
+	}
+
+	override async run(): Promise<void> {
+		if (!this.mcpServer) {
+			return;
+		}
+		this.mcpService.enablementModel.setEnabled(this.mcpServer.id, ContributionEnablementState.DisabledProfile);
+	}
+}
+
+export class DisableMcpServerForWorkspaceAction extends McpServerAction {
+
+	static readonly ID = 'mcpServer.disableForWorkspace';
+
+	constructor(
+		@IMcpService private readonly mcpService: IMcpService,
+		@IWorkspaceContextService private readonly workspaceService: IWorkspaceContextService,
+	) {
+		super(DisableMcpServerForWorkspaceAction.ID, localize('disableForWorkspace', "Disable (Workspace)"), McpServerAction.LABEL_ACTION_CLASS);
+		this.tooltip = localize('disableForWorkspaceTooltip', "Disable this MCP server only in this workspace");
+		this.update();
+	}
+
+	update(): void {
+		this.enabled = false;
+		if (!this.mcpServer?.local) {
+			return;
+		}
+		if (this.workspaceService.getWorkbenchState() === WorkbenchState.EMPTY) {
+			return;
+		}
+		const server = this.mcpService.servers.get().find(s => s.definition.id === this.mcpServer?.id);
+		if (!server) {
+			return;
+		}
+		const enablement = server.enablement.get();
+		this.enabled = isContributionEnabled(enablement);
+	}
+
+	override async run(): Promise<void> {
+		if (!this.mcpServer) {
+			return;
+		}
+		this.mcpService.enablementModel.setEnabled(this.mcpServer.id, ContributionEnablementState.DisabledWorkspace);
+	}
+}
+
+export class EnableMcpDropDownAction extends ButtonWithDropDownExtensionAction {
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super('mcpServer.enable', McpServerAction.LABEL_ACTION_CLASS, [
+			[
+				instantiationService.createInstance(EnableMcpServerGloballyAction),
+				instantiationService.createInstance(EnableMcpServerForWorkspaceAction),
+			]
+		]);
+	}
+}
+
+export class DisableMcpDropDownAction extends ButtonWithDropDownExtensionAction {
+
+	constructor(
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super('mcpServer.disable', McpServerAction.LABEL_ACTION_CLASS, [
+			[
+				instantiationService.createInstance(DisableMcpServerGloballyAction),
+				instantiationService.createInstance(DisableMcpServerForWorkspaceAction),
+			]
+		]);
+	}
+}
+
 export function getContextMenuActions(mcpServer: IWorkbenchMcpServer, isEditorAction: boolean, instantiationService: IInstantiationService): IAction[][] {
 	return instantiationService.invokeFunction(accessor => {
 		const workspaceService = accessor.get(IWorkspaceContextService);
@@ -523,6 +694,12 @@ export function getContextMenuActions(mcpServer: IWorkbenchMcpServer, isEditorAc
 			groups.push([
 				instantiationService.createInstance(StopServerAction),
 				instantiationService.createInstance(RestartServerAction),
+			]);
+			groups.push([
+				instantiationService.createInstance(EnableMcpServerGloballyAction),
+				instantiationService.createInstance(EnableMcpServerForWorkspaceAction),
+				instantiationService.createInstance(DisableMcpServerGloballyAction),
+				instantiationService.createInstance(DisableMcpServerForWorkspaceAction),
 			]);
 			groups.push([
 				instantiationService.createInstance(AuthServerAction),

--- a/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServerEditor.ts
@@ -38,7 +38,7 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IMcpServerContainer, IMcpServerEditorOptions, IMcpWorkbenchService, IWorkbenchMcpServer, McpServerContainers, McpServerInstallState } from '../common/mcpTypes.js';
 import { StarredWidget, McpServerIconWidget, McpServerStatusWidget, McpServerWidget, onClick, PublisherWidget, McpServerScopeBadgeWidget, LicenseWidget } from './mcpServerWidgets.js';
-import { ButtonWithDropDownExtensionAction, ButtonWithDropdownExtensionActionViewItem, DropDownAction, InstallAction, InstallingLabelAction, InstallInRemoteAction, InstallInWorkspaceAction, ManageMcpServerAction, McpServerStatusAction, UninstallAction } from './mcpServerActions.js';
+import { ButtonWithDropDownExtensionAction, ButtonWithDropdownExtensionActionViewItem, DisableMcpDropDownAction, DropDownAction, EnableMcpDropDownAction, InstallAction, InstallingLabelAction, InstallInRemoteAction, InstallInWorkspaceAction, ManageMcpServerAction, McpServerStatusAction, UninstallAction } from './mcpServerActions.js';
 import { McpServerEditorInput } from './mcpServerEditorInput.js';
 import { ILocalMcpServer, IGalleryMcpServerConfiguration, IMcpServerPackage, IMcpServerKeyValueInput, RegistryType } from '../../../../platform/mcp/common/mcpManagement.js';
 import { IActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
@@ -251,6 +251,8 @@ export class McpServerEditor extends EditorPane {
 					this.instantiationService.createInstance(InstallInRemoteAction, false)
 				]
 			]),
+			this.instantiationService.createInstance(EnableMcpDropDownAction),
+			this.instantiationService.createInstance(DisableMcpDropDownAction),
 			this.instantiationService.createInstance(ManageMcpServerAction, true),
 		];
 

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -37,11 +37,12 @@ import { IRemoteAgentService } from '../../../services/remote/common/remoteAgent
 import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { McpServerInstallData, McpServerInstallClassification } from '../common/mcpServer.js';
 import { HasInstalledMcpServersContext, IMcpConfigPath, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCollectionSortOrder, McpServerEnablementState, McpServerInstallState, McpServerEnablementStatus, McpServersGalleryStatusContext } from '../common/mcpTypes.js';
+import { ContributionEnablementState } from '../../chat/common/enablement.js';
 import { McpServerEditorInput } from './mcpServerEditorInput.js';
 import { IMcpGalleryManifestService } from '../../../../platform/mcp/common/mcpGalleryManifest.js';
 import { IIterativePager, IIterativePage } from '../../../../base/common/paging.js';
 import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
-import { runOnChange } from '../../../../base/common/observable.js';
+import { autorun, runOnChange } from '../../../../base/common/observable.js';
 import Severity from '../../../../base/common/severity.js';
 import { Queue } from '../../../../base/common/async.js';
 
@@ -219,6 +220,14 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		}));
 		this._register(runOnChange(mcpService.servers, () => {
 			this._local = this.sort(this._local);
+			this._onChange.fire(undefined);
+		}));
+
+		// React to enablement changes on individual servers
+		this._register(autorun(reader => {
+			for (const server of mcpService.servers.read(reader)) {
+				server.enablement.read(reader);
+			}
 			this._onChange.fire(undefined);
 		}));
 	}
@@ -743,8 +752,29 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 			return enablementStatus;
 		}
 
-		if (!this.mcpService.servers.get().find(s => s.definition.id === mcpServer.id)) {
+		const server = this.mcpService.servers.get().find(s => s.definition.id === mcpServer.id);
+		if (!server) {
 			return { state: McpServerEnablementState.Disabled };
+		}
+
+		const enablement = server.enablement.get();
+		if (enablement === ContributionEnablementState.DisabledProfile) {
+			return {
+				state: McpServerEnablementState.DisabledProfile,
+				message: {
+					severity: Severity.Info,
+					text: new MarkdownString(localize('disabled globally', "This MCP server is disabled."))
+				}
+			};
+		}
+		if (enablement === ContributionEnablementState.DisabledWorkspace) {
+			return {
+				state: McpServerEnablementState.DisabledWorkspace,
+				message: {
+					severity: Severity.Info,
+					text: new MarkdownString(localize('disabled in workspace', "This MCP server is disabled for this workspace."))
+				}
+			};
 		}
 
 		return undefined;

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -18,6 +18,7 @@ import {
 	IAgentPluginMcpServerDefinition,
 	IAgentPluginService
 } from '../../../chat/common/plugins/agentPluginService.js';
+import { isContributionEnabled } from '../../../chat/common/enablement.js';
 import { IMcpRegistry } from '../mcpRegistryTypes.js';
 import { McpCollectionSortOrder, McpServerDefinition, McpServerLaunch, McpServerTransportType, McpServerTrust } from '../mcpTypes.js';
 import { IMcpDiscovery } from './mcpDiscovery.js';
@@ -39,6 +40,9 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 			const plugins = this._agentPluginService.plugins.read(reader);
 			const seen = new ResourceSet();
 			for (const plugin of plugins) {
+				if (!isContributionEnabled(plugin.enablement.read(reader))) {
+					continue;
+				}
 				seen.add(plugin.uri);
 
 				let collectionState = this._collections.get(plugin.uri);

--- a/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpLanguageModelToolContribution.ts
@@ -23,6 +23,7 @@ import { mcpAppsEnabledConfig } from '../../../../platform/mcp/common/mcpManagem
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { isContributionEnabled } from '../../chat/common/enablement.js';
 import { ChatResponseResource, getAttachableImageExtension } from '../../chat/common/model/chatModel.js';
 import { LanguageModelPartAudience } from '../../chat/common/languageModels.js';
 import { CountTokensCallback, ILanguageModelToolsService, IPreparedToolInvocation, IToolConfirmationMessages, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, IToolResultInputOutputDetails, ToolDataSource, ToolProgress, ToolSet } from '../../chat/common/tools/languageModelToolsService.js';
@@ -59,6 +60,11 @@ export class McpLanguageModelToolContribution extends Disposable implements IWor
 
 			const toDelete = new Set(previous.keys());
 			for (const server of servers) {
+				// Skip disabled servers — don't register their tools.
+				if (!isContributionEnabled(server.enablement.read(reader))) {
+					continue;
+				}
+
 				const previousRec = previous.get(server);
 				if (previousRec) {
 					toDelete.delete(server);

--- a/src/vs/workbench/contrib/mcp/common/mcpServer.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpServer.ts
@@ -41,6 +41,7 @@ import { IMcpSandboxService } from './mcpSandboxService.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
 import { McpTaskManager } from './mcpTaskManager.js';
 import { ElicitationKind, extensionMcpCollectionPrefix, IMcpElicitationService, IMcpIcons, IMcpPotentialSandboxBlock, IMcpPrompt, IMcpPromptMessage, IMcpResource, IMcpResourceTemplate, IMcpSamplingService, IMcpServer, IMcpServerConnection, IMcpServerStartOpts, IMcpTool, IMcpToolCallContext, McpCapability, McpCollectionDefinition, McpCollectionReference, McpConnectionFailedError, McpConnectionState, McpDefinitionReference, mcpPromptReplaceSpecialChars, McpResourceURI, McpServerCacheState, McpServerDefinition, McpServerStaticToolAvailability, McpServerTransportType, McpToolName, McpToolVisibility, MpcResponseError, UserInteractionRequiredError } from './mcpTypes.js';
+import { ContributionEnablementState, IEnablementModel } from '../../chat/common/enablement.js';
 import { MCP } from './modelContextProtocol.js';
 import { McpApps } from './modelContextProtocolApps.js';
 import { UriTemplate } from './uriTemplate.js';
@@ -424,6 +425,8 @@ export class McpServer extends Disposable implements IMcpServer {
 	/** Count of running tool calls, used to detect if sampling is during an LM call */
 	public runningToolCalls = new Set<IMcpToolCallContext>();
 
+	public readonly enablement: IObservable<ContributionEnablementState>;
+
 	constructor(
 		initialCollection: McpCollectionDefinition,
 		public readonly definition: McpDefinitionReference,
@@ -431,6 +434,7 @@ export class McpServer extends Disposable implements IMcpServer {
 		private readonly _requiresExtensionActivation: boolean | undefined,
 		private readonly _primitiveCache: McpServerMetadataCache,
 		toolPrefix: string,
+		enablementModel: IEnablementModel,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@IWorkspaceContextService workspacesService: IWorkspaceContextService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
@@ -451,6 +455,7 @@ export class McpServer extends Disposable implements IMcpServer {
 
 		this.collection = initialCollection;
 		this._fullDefinitions = this._mcpRegistry.getServerDefinition(this.collection, this.definition);
+		this.enablement = derived(r => enablementModel.readEnabled(definition.id, r));
 		this._loggerId = `mcpServer.${definition.id}`;
 		this._logger = this._register(_loggerService.createLogger(this._loggerId, { hidden: true, name: `MCP: ${definition.label}` }));
 

--- a/src/vs/workbench/contrib/mcp/common/mcpService.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpService.ts
@@ -11,7 +11,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { mcpAutoStartConfig, McpAutoStartValue } from '../../../../platform/mcp/common/mcpManagement.js';
-import { StorageScope } from '../../../../platform/storage/common/storage.js';
+import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
+import { EnablementModel, isContributionEnabled } from '../../chat/common/enablement.js';
 import { IMcpRegistry } from './mcpRegistryTypes.js';
 import { McpServer, McpServerMetadataCache } from './mcpServer.js';
 import { IAutostartResult, IMcpServer, IMcpService, McpCollectionDefinition, McpConnectionState, McpDefinitionReference, McpServerCacheState, McpServerDefinition, McpStartServerInteraction, McpToolName, UserInteractionRequiredError } from './mcpTypes.js';
@@ -29,6 +30,8 @@ export class McpService extends Disposable implements IMcpService {
 
 	public get lazyCollectionState() { return this._mcpRegistry.lazyCollectionState; }
 
+	public readonly enablementModel: EnablementModel;
+
 	protected readonly userCache: McpServerMetadataCache;
 	protected readonly workspaceCache: McpServerMetadataCache;
 
@@ -36,9 +39,12 @@ export class McpService extends Disposable implements IMcpService {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IMcpRegistry private readonly _mcpRegistry: IMcpRegistry,
 		@ILogService private readonly _logService: ILogService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super();
+
+		this.enablementModel = this._register(new EnablementModel('mcp.enablement', storageService));
 
 		this.userCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.PROFILE));
 		this.workspaceCache = this._register(_instantiationService.createInstance(McpServerMetadataCache, StorageScope.WORKSPACE));
@@ -96,8 +102,11 @@ export class McpService extends Disposable implements IMcpService {
 			return;
 		}
 
-		// don't try re-running errored servers, let the user choose if they want that
-		const candidates = this.servers.get().filter(s => s.connectionState.get().state !== McpConnectionState.Kind.Error);
+		// don't try re-running errored servers or disabled servers
+		const candidates = this.servers.get().filter(s =>
+			s.connectionState.get().state !== McpConnectionState.Kind.Error
+			&& isContributionEnabled(s.enablement.get())
+		);
 
 		let todo = new Set<IMcpServer>();
 		if (autoStartConfig === McpAutoStartValue.OnlyNew) {
@@ -203,6 +212,7 @@ export class McpService extends Disposable implements IMcpService {
 				!!def.collectionDefinition.lazy,
 				def.collectionDefinition.scope === StorageScope.WORKSPACE ? this.workspaceCache : this.userCache,
 				def.toolPrefix,
+				this.enablementModel,
 			);
 
 			nextServers.push({ object, toolPrefix: def.toolPrefix });

--- a/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpTypes.ts
@@ -23,11 +23,12 @@ import { IEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { McpGalleryManifestStatus } from '../../../../platform/mcp/common/mcpGalleryManifest.js';
-import { IGalleryMcpServer, IInstallableMcpServer, IGalleryMcpServerConfiguration, IQueryOptions } from '../../../../platform/mcp/common/mcpManagement.js';
+import { IGalleryMcpServer, IGalleryMcpServerConfiguration, IInstallableMcpServer, IQueryOptions } from '../../../../platform/mcp/common/mcpManagement.js';
 import { IMcpDevModeConfig, IMcpSandboxConfiguration, IMcpServerConfiguration } from '../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolder, IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchLocalMcpServer, IWorkbencMcpServerInstallOptions } from '../../../services/mcp/common/mcpWorkbenchManagementService.js';
+import { ContributionEnablementState, IEnablementModel } from '../../chat/common/enablement.js';
 import { ToolProgress } from '../../chat/common/tools/languageModelToolsService.js';
 import { IMcpServerSamplingConfiguration } from './mcpConfiguration.js';
 import { McpServerRequestHandler } from './mcpServerRequestHandler.js';
@@ -245,6 +246,9 @@ export interface IMcpService {
 	_serviceBrand: undefined;
 	readonly servers: IObservable<readonly IMcpServer[]>;
 
+	/** The enablement model for MCP servers. */
+	readonly enablementModel: IEnablementModel;
+
 	/** Resets the cached tools. */
 	resetCaches(): void;
 
@@ -329,6 +333,7 @@ export namespace McpServerTrust {
 export interface IMcpServer extends IDisposable {
 	readonly collection: McpCollectionReference;
 	readonly definition: McpDefinitionReference;
+	readonly enablement: IObservable<ContributionEnablementState>;
 	readonly connection: IObservable<IMcpServerConnection | undefined>;
 	readonly connectionState: IObservable<McpConnectionState>;
 	readonly serverMetadata: IObservable<{
@@ -742,6 +747,8 @@ export interface IMcpServerEditorOptions extends IEditorOptions {
 export const enum McpServerEnablementState {
 	Disabled,
 	DisabledByAccess,
+	DisabledProfile,
+	DisabledWorkspace,
 	Enabled,
 }
 

--- a/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpGatewayToolBrokerChannel.test.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ContributionEnablementState } from '../../../chat/common/enablement.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { IGatewayCallToolResult } from '../../../../../platform/mcp/common/mcpGateway.js';
 import { MCP } from '../../common/modelContextProtocol.js';
@@ -268,6 +269,7 @@ function createServer(
 		definition: { id: definitionId, label: definitionId },
 		connection: observableValue(owner, undefined),
 		connectionState,
+		enablement: observableValue(owner, ContributionEnablementState.EnabledProfile),
 		serverMetadata: observableValue(owner, undefined),
 		readDefinitions: () => observableValue(owner, { server: undefined, collection: undefined }),
 		showOutput: async () => { },
@@ -306,6 +308,7 @@ function createNeverStartingServer(
 		definition: { id: definitionId, label: definitionId },
 		connection: observableValue(owner, undefined),
 		connectionState,
+		enablement: observableValue(owner, ContributionEnablementState.EnabledProfile),
 		serverMetadata: observableValue(owner, undefined),
 		readDefinitions: () => observableValue(owner, { server: undefined, collection: undefined }),
 		showOutput: async () => { },

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -35,9 +35,10 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 	let fs: McpResourceFilesystem;
 
 	setup(() => {
+		const storageService = ds.add(new TestStorageService());
 		const services = new ServiceCollection(
 			[IFileService, { registerProvider: () => { } }],
-			[IStorageService, ds.add(new TestStorageService())],
+			[IStorageService, storageService],
 			[ILoggerService, ds.add(new TestLoggerService())],
 			[IWorkspaceContextService, new TestContextService()],
 			[IWorkbenchEnvironmentService, {}],
@@ -49,7 +50,7 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 		const registry = new TestMcpRegistry(parentInsta1);
 
 		const parentInsta2 = ds.add(parentInsta1.createChild(new ServiceCollection([IMcpRegistry, registry])));
-		const mcpService = ds.add(new McpService(parentInsta2, registry, new NullLogService(), new TestConfigurationService(), ds.add(new TestStorageService())));
+		const mcpService = ds.add(new McpService(parentInsta2, registry, new NullLogService(), new TestConfigurationService(), storageService));
 		mcpService.updateCollectedServers();
 
 		const instaService = ds.add(parentInsta2.createChild(new ServiceCollection(

--- a/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/mcpResourceFilesystem.test.ts
@@ -49,7 +49,7 @@ suite('Workbench - MCP - ResourceFilesystem', () => {
 		const registry = new TestMcpRegistry(parentInsta1);
 
 		const parentInsta2 = ds.add(parentInsta1.createChild(new ServiceCollection([IMcpRegistry, registry])));
-		const mcpService = ds.add(new McpService(parentInsta2, registry, new NullLogService(), new TestConfigurationService()));
+		const mcpService = ds.add(new McpService(parentInsta2, registry, new NullLogService(), new TestConfigurationService(), ds.add(new TestStorageService())));
 		mcpService.updateCollectedServers();
 
 		const instaService = ds.add(parentInsta2.createChild(new ServiceCollection(

--- a/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
@@ -4,11 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { observableValue } from '../../../../../base/common/observable.js';
+import { ContributionEnablementState, IEnablementModel } from '../../../chat/common/enablement.js';
 import { IAutostartResult, IMcpServer, IMcpService, LazyCollectionState } from '../../common/mcpTypes.js';
+
+export class TestEnablementModel implements IEnablementModel {
+	readEnabled(_key: string): ContributionEnablementState {
+		return ContributionEnablementState.EnabledProfile;
+	}
+	setEnabled(_key: string, _state: ContributionEnablementState): void { }
+}
 
 export class TestMcpService implements IMcpService {
 	declare readonly _serviceBrand: undefined;
 	public servers = observableValue<readonly IMcpServer[]>(this, []);
+	public readonly enablementModel: IEnablementModel = new TestEnablementModel();
 	resetCaches(): void {
 
 	}


### PR DESCRIPTION
Introduces an EnablementModel which is used to allow users to enable and disable both plugins and MCP at both a workspace and global level. Accessible on the mcp/plugins editors, inline within the marketplace view, and in the chat customizations view.

Closes https://github.com/microsoft/vscode/issues/243620
Closes https://github.com/microsoft/vscode/issues/300271