### PR TITLE
Fix file icon rendering in sessions context attachments

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
+++ b/src/vs/sessions/contrib/chat/browser/media/chatWidget.css
@@ -232,6 +232,29 @@
 	padding: 0 3px;
 }
 
+.sessions-chat-attachment-pill .monaco-icon-label {
+	gap: 4px;
+}
+
+.sessions-chat-attachment-pill .monaco-icon-label::before {
+	height: auto;
+	padding: 0 0 0 2px;
+	line-height: 100% !important;
+	align-self: center;
+}
+
+.sessions-chat-attachment-pill .monaco-icon-label .monaco-icon-label-container {
+	display: flex;
+}
+
+.sessions-chat-attachment-pill .monaco-icon-label .monaco-icon-label-container .monaco-highlighted-label {
+	display: inline-flex;
+	align-items: center;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
 .sessions-chat-attachment-remove {
 	display: flex;
 	align-items: center;

--- a/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
@@ -18,11 +18,14 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
+import { FileKind, IFileService } from '../../../../platform/files/common/files.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { getIconClasses } from '../../../../editor/common/services/getIconClasses.js';
 import { basename } from '../../../../base/common/resources.js';
 import { Schemas } from '../../../../base/common/network.js';
 
@@ -73,6 +76,8 @@ export class NewChatContextAttachments extends Disposable {
 		@ISearchService private readonly searchService: ISearchService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IOpenerService private readonly openerService: IOpenerService,
+		@IModelService private readonly modelService: IModelService,
+		@ILanguageService private readonly languageService: ILanguageService,
 	) {
 		super();
 	}
@@ -98,17 +103,27 @@ export class NewChatContextAttachments extends Disposable {
 		}
 
 		this._container.style.display = '';
+		this._container.classList.add('show-file-icons');
 
 		for (const entry of this._attachedContext) {
 			const pill = dom.append(this._container, dom.$('.sessions-chat-attachment-pill'));
 			pill.tabIndex = 0;
 			pill.role = 'button';
-			const icon = entry.kind === 'image' ? Codicon.fileMedia : entry.kind === 'directory' ? Codicon.folder : Codicon.file;
-			dom.append(pill, renderIcon(icon));
+			const resource = URI.isUri(entry.value) ? entry.value : isLocation(entry.value) ? entry.value.uri : undefined;
+			if (entry.kind === 'image') {
+				dom.append(pill, renderIcon(Codicon.fileMedia));
+			} else if (entry.kind === 'directory') {
+				const iconSpan = dom.$('span');
+				iconSpan.classList.add(...getIconClasses(this.modelService, this.languageService, resource, FileKind.FOLDER));
+				dom.append(pill, iconSpan);
+			} else {
+				const iconSpan = dom.$('span');
+				iconSpan.classList.add(...getIconClasses(this.modelService, this.languageService, resource, FileKind.FILE));
+				dom.append(pill, iconSpan);
+			}
 			dom.append(pill, dom.$('span.sessions-chat-attachment-name', undefined, entry.name));
 
 			// Click to open the resource
-			const resource = URI.isUri(entry.value) ? entry.value : isLocation(entry.value) ? entry.value.uri : undefined;
 			if (resource) {
 				pill.style.cursor = 'pointer';
 				this._renderDisposables.add(registerOpenEditorListeners(pill, async () => {
@@ -390,7 +405,7 @@ export class NewChatContextAttachments extends Disposable {
 			return searchResult.results.map(result => ({
 				label: basename(result.resource),
 				description: this.labelService.getUriLabel(result.resource, { relative: true }),
-				iconClass: ThemeIcon.asClassName(Codicon.file),
+				iconClasses: getIconClasses(this.modelService, this.languageService, result.resource, FileKind.FILE),
 				id: result.resource.toString(),
 			} satisfies IQuickPickItem));
 		} catch {
@@ -434,7 +449,7 @@ export class NewChatContextAttachments extends Disposable {
 						picks.push({
 							label: child.name,
 							description: this.labelService.getUriLabel(child.resource, { relative: true }),
-							iconClass: ThemeIcon.asClassName(Codicon.file),
+							iconClasses: getIconClasses(this.modelService, this.languageService, child.resource, FileKind.FILE),
 							id: child.resource.toString(),
 						});
 					}

--- a/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatContextAttachments.ts
@@ -23,11 +23,13 @@ import { IClipboardService } from '../../../../platform/clipboard/common/clipboa
 import { IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { getIconClasses } from '../../../../editor/common/services/getIconClasses.js';
 import { basename } from '../../../../base/common/resources.js';
 import { Schemas } from '../../../../base/common/network.js';
+import { DEFAULT_LABELS_CONTAINER, ResourceLabels } from '../../../../workbench/browser/labels.js';
 
 import { IChatRequestVariableEntry, OmittedState } from '../../../../workbench/contrib/chat/common/attachments/chatVariableEntries.js';
 import { isLocation } from '../../../../editor/common/languages.js';
@@ -66,6 +68,8 @@ export class NewChatContextAttachments extends Disposable {
 		this._onDidChangeContext.fire();
 	}
 
+	private readonly _resourceLabels: ResourceLabels;
+
 	constructor(
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@ITextModelService private readonly textModelService: ITextModelService,
@@ -76,10 +80,12 @@ export class NewChatContextAttachments extends Disposable {
 		@ISearchService private readonly searchService: ISearchService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IOpenerService private readonly openerService: IOpenerService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
 	) {
 		super();
+		this._resourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));
 	}
 
 	// --- Rendering ---
@@ -95,6 +101,7 @@ export class NewChatContextAttachments extends Disposable {
 		}
 
 		this._renderDisposables.clear();
+		this._resourceLabels.clear();
 		dom.clearNode(this._container);
 
 		if (this._attachedContext.length === 0) {
@@ -112,16 +119,19 @@ export class NewChatContextAttachments extends Disposable {
 			const resource = URI.isUri(entry.value) ? entry.value : isLocation(entry.value) ? entry.value.uri : undefined;
 			if (entry.kind === 'image') {
 				dom.append(pill, renderIcon(Codicon.fileMedia));
-			} else if (entry.kind === 'directory') {
-				const iconSpan = dom.$('span');
-				iconSpan.classList.add(...getIconClasses(this.modelService, this.languageService, resource, FileKind.FOLDER));
-				dom.append(pill, iconSpan);
+				dom.append(pill, dom.$('span.sessions-chat-attachment-name', undefined, entry.name));
 			} else {
-				const iconSpan = dom.$('span');
-				iconSpan.classList.add(...getIconClasses(this.modelService, this.languageService, resource, FileKind.FILE));
-				dom.append(pill, iconSpan);
+				const label = this._resourceLabels.create(pill, { supportIcons: true });
+				this._renderDisposables.add(label);
+				if (resource) {
+					label.setFile(resource, {
+						fileKind: entry.kind === 'directory' ? FileKind.FOLDER : FileKind.FILE,
+						hidePath: true,
+					});
+				} else {
+					label.setLabel(entry.name);
+				}
 			}
-			dom.append(pill, dom.$('span.sessions-chat-attachment-name', undefined, entry.name));
 
 			// Click to open the resource
 			if (resource) {


### PR DESCRIPTION
## Summary

Fix file icons in the sessions `NewChatContextAttachments` to use the active file icon theme instead of hardcoded generic codicons.

## Problem

The context picker and attachment pills in the sessions new-chat view showed generic file/folder icons (`Codicon.file`/`Codicon.folder`) for all files, instead of language-specific icons (e.g., TypeScript `.ts` icon, Python `.py` icon) like core does.

## Changes

**Attachment pills** — Replaced hardcoded `Codicon.file`/`Codicon.folder` with `getIconClasses()` which resolves proper file icon theme classes based on file extension and language. Added `show-file-icons` CSS class to the container. Images still use `Codicon.fileMedia`.

**QuickPick file items** — Changed both `_collectFilePicksViaSearch` and `_collectFilePicksViaFileService` from `iconClass: ThemeIcon.asClassName(Codicon.file)` to `iconClasses: getIconClasses(...)`, which passes proper file icon theme classes to the QuickPick's `IconLabel` widget.

**New service injections** — Added `IModelService` and `ILanguageService` (both from the `editor` layer) plus `FileKind` and `getIconClasses` imports.