### PR TITLE
mcp: move to askquestions for elicitations

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2671,7 +2671,7 @@ export namespace ChatResponseQuestionCarouselPart {
 				type: questionTypeToString(q.type),
 				title: q.title,
 				message: q.message ? MarkdownString.from(q.message) : undefined,
-				options: q.options,
+				options: q.options?.map(opt => ({ id: opt.id, label: opt.label, value: String(opt.value) })),
 				defaultValue: q.defaultValue,
 				allowFreeformInput: q.allowFreeformInput
 			})),

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -20,7 +20,7 @@ import { Button } from '../../../../../../base/browser/ui/button/button.js';
 import { InputBox } from '../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { DomScrollableElement } from '../../../../../../base/browser/ui/scrollbar/scrollableElement.js';
 import { Checkbox } from '../../../../../../base/browser/ui/toggle/toggle.js';
-import { IChatQuestion, IChatQuestionCarousel } from '../../../common/chatService/chatService.js';
+import { IChatQuestion, IChatQuestionCarousel, IChatQuestionAnswerValue, IChatQuestionValidation, IChatSingleSelectAnswer, IChatMultiSelectAnswer } from '../../../common/chatService/chatService.js';
 import { ChatQuestionCarouselData } from '../../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { IChatContentPart, IChatContentPartRenderContext } from './chatContentParts.js';
 import { IChatRendererContent, isResponseVM } from '../../../common/model/chatViewModel.js';
@@ -37,7 +37,7 @@ import './media/chatQuestionCarousel.css';
 const PREVIOUS_QUESTION_ACTION_ID = 'workbench.action.chat.previousQuestion';
 const NEXT_QUESTION_ACTION_ID = 'workbench.action.chat.nextQuestion';
 export interface IChatQuestionCarouselOptions {
-	onSubmit: (answers: Map<string, unknown> | undefined) => void;
+	onSubmit: (answers: Map<string, IChatQuestionAnswerValue> | undefined) => void;
 	shouldAutoFocus?: boolean;
 }
 
@@ -48,7 +48,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	public readonly onDidChangeHeight: Event<void> = this._onDidChangeHeight.event;
 
 	private _currentIndex = 0;
-	private readonly _answers = new Map<string, unknown>();
+	private readonly _answers = new Map<string, IChatQuestionAnswerValue>();
 
 	private _questionContainer: HTMLElement | undefined;
 	private _closeButtonContainer: HTMLElement | undefined;
@@ -76,6 +76,8 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 */
 	private readonly _interactiveUIStore: MutableDisposable<DisposableStore> = this._register(new MutableDisposable());
 	private readonly _inChatQuestionCarouselContextKey: IContextKey<boolean>;
+	private _validationMessageElement: HTMLElement | undefined;
+	private _currentValidationError: string | undefined;
 
 	constructor(
 		public readonly carousel: IChatQuestionCarousel,
@@ -199,6 +201,19 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			this._answers.delete(currentQuestion.id);
 		}
 
+		// Validate on change to update the Next button state
+		if (currentQuestion?.validation && typeof answer === 'string' && answer !== '') {
+			const error = this.getValidationError(answer, currentQuestion.validation);
+			if (error) {
+				this.showValidationError(error);
+			} else {
+				this.clearValidationError();
+			}
+		} else {
+			this.clearValidationError();
+		}
+
+		this.updateFooterState();
 		this.persistDraftState();
 	}
 
@@ -233,6 +248,10 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	private handleNextOrSubmit(): void {
 		this.saveCurrentAnswer();
 
+		if (!this.validateCurrentQuestion()) {
+			return;
+		}
+
 		if (this._currentIndex < this.carousel.questions.length - 1) {
 			// Move to next question
 			this._currentIndex++;
@@ -240,6 +259,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			this.renderCurrentQuestion(true);
 		} else {
 			// Submit
+			if (!this.validateRequiredFields()) {
+				return;
+			}
 			this._options.onSubmit(this._answers);
 			this.hideAndShowSummary();
 		}
@@ -250,6 +272,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	 */
 	private submit(): void {
 		this.saveCurrentAnswer();
+		if (!this.validateCurrentQuestion()) {
+			return;
+		}
+		if (!this.validateRequiredFields()) {
+			return;
+		}
 		this._options.onSubmit(this._answers);
 		this.hideAndShowSummary();
 	}
@@ -417,8 +445,8 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	/**
 	 * Collects default values for all questions in the carousel.
 	 */
-	private getDefaultAnswers(): Map<string, unknown> {
-		const answers = new Map<string, unknown>();
+	private getDefaultAnswers(): Map<string, IChatQuestionAnswerValue> {
+		const answers = new Map<string, IChatQuestionAnswerValue>();
 		for (const question of this.carousel.questions) {
 			const defaultAnswer = this.getDefaultAnswerForQuestion(question);
 			if (defaultAnswer !== undefined) {
@@ -431,10 +459,10 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	/**
 	 * Gets the default answer for a specific question.
 	 */
-	private getDefaultAnswerForQuestion(question: IChatQuestion): unknown {
+	private getDefaultAnswerForQuestion(question: IChatQuestion): IChatQuestionAnswerValue | undefined {
 		switch (question.type) {
 			case 'text':
-				return question.defaultValue;
+				return typeof question.defaultValue === 'string' ? question.defaultValue : undefined;
 
 			case 'singleSelect': {
 				const defaultOptionId = typeof question.defaultValue === 'string' ? question.defaultValue : undefined;
@@ -443,8 +471,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 					: undefined;
 				const selectedValue = defaultOption?.value;
 
-				// Always return structured format for single-select (freeform is always shown)
-				return selectedValue !== undefined ? { selectedValue, freeformValue: undefined } : undefined;
+				return selectedValue !== undefined ? { selectedValue, freeformValue: undefined } satisfies IChatSingleSelectAnswer : undefined;
 			}
 
 			case 'multiSelect': {
@@ -456,12 +483,11 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 					.map(opt => opt.value)
 					.filter(v => v !== undefined) ?? [];
 
-				// Always return structured format for multi-select (freeform is always shown)
-				return selectedValues.length > 0 ? { selectedValues, freeformValue: undefined } : undefined;
+				return selectedValues.length > 0 ? { selectedValues, freeformValue: undefined } satisfies IChatMultiSelectAnswer : undefined;
 			}
 
 			default:
-				return question.defaultValue;
+				return typeof question.defaultValue === 'string' ? question.defaultValue : Array.isArray(question.defaultValue) ? { selectedValues: question.defaultValue } : undefined;
 		}
 	}
 
@@ -558,14 +584,25 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const headerRow = dom.$('.chat-question-header-row');
 		const titleRow = dom.$('.chat-question-title-row');
 
+		// Render carousel-level message if present (e.g. from MCP elicitation)
+		if (this.carousel.message && this._currentIndex === 0) {
+			const messageMd = isMarkdownString(this.carousel.message) ? MarkdownString.lift(this.carousel.message) : new MarkdownString(this.carousel.message);
+			const carouselMessage = dom.$('.chat-question-carousel-message');
+			const renderedMessage = questionRenderStore.add(this._markdownRendererService.render(messageMd));
+			carouselMessage.appendChild(renderedMessage.element);
+			headerRow.appendChild(carouselMessage);
+		}
+
 		const questionText = question.message ?? question.title;
 		if (questionText) {
 			const title = dom.$('.chat-question-title');
 			const messageContent = this.getQuestionText(questionText);
 			title.setAttribute('aria-label', messageContent);
 
-			const messageMd = isMarkdownString(questionText) ? MarkdownString.lift(questionText) : new MarkdownString(questionText);
-			const renderedTitle = questionRenderStore.add(this._markdownRendererService.render(messageMd));
+			const titleText = question.required
+				? new MarkdownString(`${isMarkdownString(questionText) ? questionText.value : questionText} *`)
+				: (isMarkdownString(questionText) ? MarkdownString.lift(questionText) : new MarkdownString(questionText));
+			const renderedTitle = questionRenderStore.add(this._markdownRendererService.render(titleText));
 			title.appendChild(renderedTitle.element);
 			titleRow.appendChild(title);
 		}
@@ -578,6 +615,13 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 
 		this._questionContainer.appendChild(headerRow);
+
+		// Render description if present
+		if (question.description) {
+			const descriptionEl = dom.$('.chat-question-description');
+			descriptionEl.textContent = question.description;
+			this._questionContainer.appendChild(descriptionEl);
+		}
 
 		// Render input based on question type
 		const inputContainer = dom.$('.chat-question-input-container');
@@ -592,6 +636,11 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const inputScrollableNode = inputScrollable.getDomNode();
 		inputScrollableNode.classList.add('chat-question-input-scrollable');
 		this._questionContainer.appendChild(inputScrollableNode);
+
+		// Validation message element below the scrollable area (not inside it)
+		this._validationMessageElement = dom.$('.chat-question-validation-message');
+		this._validationMessageElement.style.display = 'none';
+		this._questionContainer.appendChild(this._validationMessageElement);
 
 		const isSingleQuestion = this.carousel.questions.length === 1;
 
@@ -715,7 +764,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			this._prevButton.enabled = this._currentIndex > 0;
 		}
 		if (this._nextButton) {
-			this._nextButton.enabled = this._currentIndex < this.carousel.questions.length - 1;
+			const canAdvance = this._currentIndex < this.carousel.questions.length - 1;
+			const question = this.carousel.questions[this._currentIndex];
+			const answer = this._answers.get(question?.id);
+			const hasAnswer = answer !== undefined && answer !== '';
+			const hasValidationError = !!this._currentValidationError;
+			this._nextButton.enabled = canAdvance && (!question?.required || hasAnswer) && !hasValidationError;
 		}
 		if (this._stepIndicator) {
 			this._stepIndicator.textContent = localize(
@@ -814,8 +868,22 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const inputBox = this._inputBoxes.add(new InputBox(container, undefined, {
 			placeholder: localize('chat.questionCarousel.enterText', 'Enter your answer'),
 			inputBoxStyles: defaultInputBoxStyles,
+			validationOptions: question.validation ? {
+				validation: (value: string) => {
+					if (!value && !question.required) {
+						return null;
+					}
+					const error = this.getValidationError(value, question.validation!);
+					if (error) {
+						return { type: 2 /* MessageType.WARNING */, content: error };
+					}
+					return null;
+				}
+			} : undefined,
 		}));
-		this._inputBoxes.add(inputBox.onDidChange(() => this.saveCurrentAnswer()));
+		this._inputBoxes.add(inputBox.onDidChange(() => {
+			this.saveCurrentAnswer();
+		}));
 
 		// Restore previous answer if exists
 		const previousAnswer = this._answers.get(question.id);
@@ -843,12 +911,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 
 		// Restore previous answer if exists
 		const previousAnswer = this._answers.get(question.id);
-		const previousFreeform = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { freeformValue: true })
-			? (previousAnswer as { freeformValue?: string }).freeformValue
-			: undefined;
-		const previousSelectedValue = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { selectedValue: true })
-			? (previousAnswer as { selectedValue?: unknown }).selectedValue
-			: previousAnswer;
+		const prevSingle = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { selectedValue: true }) ? previousAnswer as IChatSingleSelectAnswer : undefined;
+		const previousFreeform = prevSingle?.freeformValue;
+		const previousSelectedValue = prevSingle?.selectedValue;
 
 		// Get default option id (for singleSelect, defaultValue is a single string)
 		const defaultOptionId = typeof question.defaultValue === 'string' ? question.defaultValue : undefined;
@@ -959,36 +1024,45 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			selectContainer.setAttribute('aria-activedescendant', listItems[selectedIndex].id);
 		}
 
-		// Always show freeform input for single-select questions
-		const freeformContainer = dom.$('.chat-question-freeform');
+		// Show freeform input only when explicitly allowed
+		let freeformTextarea: HTMLTextAreaElement | undefined;
+		if (question.allowFreeformInput !== false) {
+			const freeformContainer = dom.$('.chat-question-freeform');
 
-		const freeformNumber = dom.$('.chat-question-freeform-number');
-		freeformNumber.textContent = `${options.length + 1}`;
-		freeformContainer.appendChild(freeformNumber);
+			const freeformNumber = dom.$('.chat-question-freeform-number');
+			freeformNumber.textContent = `${options.length + 1}`;
+			freeformContainer.appendChild(freeformNumber);
 
-		const freeformTextarea = dom.$<HTMLTextAreaElement>('textarea.chat-question-freeform-textarea');
-		freeformTextarea.placeholder = localize('chat.questionCarousel.enterCustomAnswer', 'Enter custom answer');
-		freeformTextarea.rows = 1;
+			freeformTextarea = dom.$<HTMLTextAreaElement>('textarea.chat-question-freeform-textarea');
+			freeformTextarea.placeholder = localize('chat.questionCarousel.enterCustomAnswer', 'Enter custom answer');
+			freeformTextarea.rows = 1;
 
-		if (previousFreeform !== undefined) {
-			freeformTextarea.value = previousFreeform;
-		}
-
-		// Setup auto-resize behavior
-		const autoResize = this.setupTextareaAutoResize(freeformTextarea);
-
-		// clear when we start typing in freeform
-		this._inputBoxes.add(dom.addDisposableListener(freeformTextarea, dom.EventType.INPUT, () => {
-			if (freeformTextarea.value.length > 0) {
-				updateSelection(-1);
-			} else {
-				this.saveCurrentAnswer();
+			if (previousFreeform !== undefined) {
+				freeformTextarea.value = previousFreeform;
 			}
-		}));
 
-		freeformContainer.appendChild(freeformTextarea);
-		container.appendChild(freeformContainer);
-		this._freeformTextareas.set(question.id, freeformTextarea);
+			// Setup auto-resize behavior
+			const autoResize = this.setupTextareaAutoResize(freeformTextarea);
+
+			// clear when we start typing in freeform
+			const capturedFreeform = freeformTextarea;
+			this._inputBoxes.add(dom.addDisposableListener(capturedFreeform, dom.EventType.INPUT, () => {
+				if (capturedFreeform.value.length > 0) {
+					updateSelection(-1);
+				} else {
+					this.saveCurrentAnswer();
+				}
+			}));
+
+			freeformContainer.appendChild(freeformTextarea);
+			container.appendChild(freeformContainer);
+			this._freeformTextareas.set(question.id, freeformTextarea);
+
+			// Resize textarea if it has restored content
+			if (previousFreeform !== undefined) {
+				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(capturedFreeform), () => autoResize()));
+			}
+		}
 
 		// Keyboard navigation for the list
 		this._inputBoxes.add(dom.addDisposableListener(selectContainer, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
@@ -1017,7 +1091,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 				if (numberIndex < listItems.length) {
 					e.preventDefault();
 					updateSelection(numberIndex);
-				} else if (numberIndex === listItems.length) {
+				} else if (freeformTextarea && numberIndex === listItems.length) {
 					e.preventDefault();
 					updateSelection(-1);
 					freeformTextarea.focus();
@@ -1030,16 +1104,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			}
 		}));
 
-		// Resize textarea if it has restored content
-		if (previousFreeform !== undefined) {
-			this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => autoResize()));
-		}
-
 		// focus on the row when first rendered or textarea if it has content
 		if (this._shouldAutoFocus()) {
-			if (previousFreeform) {
-				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => {
-					freeformTextarea.focus();
+			if (freeformTextarea && previousFreeform) {
+				const capturedFreeform = freeformTextarea;
+				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(capturedFreeform), () => {
+					capturedFreeform.focus();
 				}));
 			} else if (listItems.length > 0) {
 				const focusIndex = selectedIndex >= 0 ? selectedIndex : 0;
@@ -1065,12 +1135,9 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 
 		// Restore previous answer if exists
 		const previousAnswer = this._answers.get(question.id);
-		const previousFreeform = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { freeformValue: true })
-			? (previousAnswer as { freeformValue?: string }).freeformValue
-			: undefined;
-		const previousSelectedValues = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { selectedValues: true })
-			? (previousAnswer as { selectedValues?: unknown[] }).selectedValues
-			: (Array.isArray(previousAnswer) ? previousAnswer : []);
+		const prevMulti = typeof previousAnswer === 'object' && previousAnswer !== null && hasKey(previousAnswer, { selectedValues: true }) ? previousAnswer as IChatMultiSelectAnswer : undefined;
+		const previousFreeform = prevMulti?.freeformValue;
+		const previousSelectedValues = prevMulti?.selectedValues ?? [];
 
 		// Get default option ids (for multiSelect, defaultValue can be string or string[])
 		const defaultOptionIds: string[] = Array.isArray(question.defaultValue)
@@ -1164,29 +1231,37 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 
 		this._multiSelectCheckboxes.set(question.id, checkboxes);
 
-		// Always show freeform input for multi-select questions
-		const freeformContainer = dom.$('.chat-question-freeform');
+		// Show freeform input only when explicitly allowed
+		let freeformTextarea: HTMLTextAreaElement | undefined;
+		if (question.allowFreeformInput !== false) {
+			const freeformContainer = dom.$('.chat-question-freeform');
 
-		// Number indicator for freeform (comes after all options)
-		const freeformNumber = dom.$('.chat-question-freeform-number');
-		freeformNumber.textContent = `${options.length + 1}`;
-		freeformContainer.appendChild(freeformNumber);
+			// Number indicator for freeform (comes after all options)
+			const freeformNumber = dom.$('.chat-question-freeform-number');
+			freeformNumber.textContent = `${options.length + 1}`;
+			freeformContainer.appendChild(freeformNumber);
 
-		const freeformTextarea = dom.$<HTMLTextAreaElement>('textarea.chat-question-freeform-textarea');
-		freeformTextarea.placeholder = localize('chat.questionCarousel.enterCustomAnswer', 'Enter custom answer');
-		freeformTextarea.rows = 1;
+			freeformTextarea = dom.$<HTMLTextAreaElement>('textarea.chat-question-freeform-textarea');
+			freeformTextarea.placeholder = localize('chat.questionCarousel.enterCustomAnswer', 'Enter custom answer');
+			freeformTextarea.rows = 1;
 
-		if (previousFreeform !== undefined) {
-			freeformTextarea.value = previousFreeform;
+			if (previousFreeform !== undefined) {
+				freeformTextarea.value = previousFreeform;
+			}
+
+			// Setup auto-resize behavior
+			const autoResize = this.setupTextareaAutoResize(freeformTextarea);
+			this._inputBoxes.add(dom.addDisposableListener(freeformTextarea, dom.EventType.INPUT, () => this.saveCurrentAnswer()));
+
+			freeformContainer.appendChild(freeformTextarea);
+			container.appendChild(freeformContainer);
+			this._freeformTextareas.set(question.id, freeformTextarea);
+
+			// Resize textarea if it has restored content
+			if (previousFreeform !== undefined) {
+				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => autoResize()));
+			}
 		}
-
-		// Setup auto-resize behavior
-		const autoResize = this.setupTextareaAutoResize(freeformTextarea);
-		this._inputBoxes.add(dom.addDisposableListener(freeformTextarea, dom.EventType.INPUT, () => this.saveCurrentAnswer()));
-
-		freeformContainer.appendChild(freeformTextarea);
-		container.appendChild(freeformContainer);
-		this._freeformTextareas.set(question.id, freeformTextarea);
 
 		// Keyboard navigation for the list
 		this._inputBoxes.add(dom.addDisposableListener(selectContainer, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
@@ -1221,23 +1296,19 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 				if (numberIndex < checkboxes.length) {
 					e.preventDefault();
 					checkboxes[numberIndex].domNode.click();
-				} else if (numberIndex === checkboxes.length) {
+				} else if (freeformTextarea && numberIndex === checkboxes.length) {
 					e.preventDefault();
 					freeformTextarea.focus();
 				}
 			}
 		}));
 
-		// Resize textarea if it has restored content
-		if (previousFreeform !== undefined) {
-			this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => autoResize()));
-		}
-
 		// Focus on the appropriate row when rendered or textarea if it has content
 		if (this._shouldAutoFocus()) {
-			if (previousFreeform) {
-				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(freeformTextarea), () => {
-					freeformTextarea.focus();
+			if (freeformTextarea && previousFreeform) {
+				const capturedFreeform = freeformTextarea;
+				this._inputBoxes.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(capturedFreeform), () => {
+					capturedFreeform.focus();
 				}));
 			} else if (listItems.length > 0) {
 				const initialFocusIndex = firstCheckedIndex >= 0 ? firstCheckedIndex : 0;
@@ -1249,7 +1320,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		}
 	}
 
-	private getCurrentAnswer(): unknown {
+	private getCurrentAnswer(): IChatQuestionAnswerValue | undefined {
 		const question = this.carousel.questions[this._currentIndex];
 		if (!question) {
 			return undefined;
@@ -1258,12 +1329,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		switch (question.type) {
 			case 'text': {
 				const inputBox = this._textInputBoxes.get(question.id);
-				return inputBox?.value ?? question.defaultValue;
+				return inputBox?.value ?? (typeof question.defaultValue === 'string' ? question.defaultValue : Array.isArray(question.defaultValue) ? { selectedValues: question.defaultValue } : undefined);
 			}
 
 			case 'singleSelect': {
 				const data = this._singleSelectItems.get(question.id);
-				let selectedValue: unknown = undefined;
+				let selectedValue: string | undefined = undefined;
 				if (data && data.selectedIndex >= 0) {
 					selectedValue = question.options?.[data.selectedIndex]?.value;
 				}
@@ -1278,17 +1349,17 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 				const freeformValue = freeformTextarea?.value !== '' ? freeformTextarea?.value : undefined;
 				if (freeformValue) {
 					// Freeform takes priority - ignore selectedValue
-					return { selectedValue: undefined, freeformValue };
+					return { selectedValue: undefined, freeformValue } satisfies IChatSingleSelectAnswer;
 				}
 				if (selectedValue !== undefined) {
-					return { selectedValue, freeformValue: undefined };
+					return { selectedValue, freeformValue: undefined } satisfies IChatSingleSelectAnswer;
 				}
 				return undefined;
 			}
 
 			case 'multiSelect': {
 				const checkboxes = this._multiSelectCheckboxes.get(question.id);
-				const selectedValues: unknown[] = [];
+				const selectedValues: string[] = [];
 				if (checkboxes) {
 					checkboxes.forEach((checkbox, index) => {
 						if (checkbox.checked) {
@@ -1307,13 +1378,13 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 				// Return whatever was selected - defaults are applied at render time when
 				// checkboxes are initially checked, so empty selection means user unchecked all
 				if (freeformValue || selectedValues.length > 0) {
-					return { selectedValues, freeformValue };
+					return { selectedValues, freeformValue } satisfies IChatMultiSelectAnswer;
 				}
 				return undefined;
 			}
 
 			default:
-				return question.defaultValue;
+				return typeof question.defaultValue === 'string' ? question.defaultValue : Array.isArray(question.defaultValue) ? { selectedValues: question.defaultValue } : undefined;
 		}
 	}
 
@@ -1374,44 +1445,35 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	/**
 	 * Formats an answer for display in the summary.
 	 */
-	private formatAnswerForSummary(question: IChatQuestion, answer: unknown): string {
+	private formatAnswerForSummary(question: IChatQuestion, answer: IChatQuestionAnswerValue): string {
 		switch (question.type) {
 			case 'text':
 				return String(answer);
 
 			case 'singleSelect': {
-				if (typeof answer === 'object' && answer !== null && hasKey(answer, { selectedValue: true })) {
-					const { selectedValue, freeformValue } = answer as { selectedValue?: unknown; freeformValue?: string };
-					const selectedLabel = question.options?.find(opt => opt.value === selectedValue)?.label;
+				if (typeof answer === 'object') {
+					const { selectedValue, freeformValue } = answer as IChatSingleSelectAnswer;
+					const selectedLabel = selectedValue !== undefined ? question.options?.find(opt => opt.value === selectedValue)?.label : undefined;
 					// For singleSelect, freeform takes priority over selection
 					if (freeformValue) {
 						return freeformValue;
 					}
 					return selectedLabel ?? String(selectedValue ?? '');
 				}
-				// Handle case where selectedValue was stripped during JSON serialization (undefined values are omitted by JSON.stringify)
-				if (typeof answer === 'object' && answer !== null && hasKey(answer, { freeformValue: true })) {
-					return (answer as { freeformValue?: string }).freeformValue ?? '';
-				}
 				const label = question.options?.find(opt => opt.value === answer)?.label;
 				return label ?? String(answer);
 			}
 
 			case 'multiSelect': {
-				if (typeof answer === 'object' && answer !== null && hasKey(answer, { selectedValues: true })) {
-					const { selectedValues, freeformValue } = answer as { selectedValues?: unknown[]; freeformValue?: string };
-					const labels = (selectedValues ?? [])
+				if (typeof answer === 'object' && hasKey(answer, { selectedValues: true })) {
+					const { selectedValues, freeformValue } = answer;
+					const labels = selectedValues
 						.map(v => question.options?.find(opt => opt.value === v)?.label ?? String(v));
 					// For multiSelect, combine selections and freeform with comma separator
 					if (freeformValue) {
 						labels.push(freeformValue);
 					}
 					return labels.join(localize('chat.questionCarousel.listSeparator', ', '));
-				}
-				if (Array.isArray(answer)) {
-					return answer
-						.map(v => question.options?.find(opt => opt.value === v)?.label ?? String(v))
-						.join(localize('chat.questionCarousel.listSeparator', ', '));
 				}
 				return String(answer);
 			}
@@ -1424,6 +1486,131 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 	private getQuestionText(questionText: string | IMarkdownString): string {
 		const md = typeof questionText === 'string' ? new MarkdownString(questionText) : questionText;
 		return renderAsPlaintext(md);
+	}
+
+	/**
+	 * Validates the current question's answer against its validation rules.
+	 * Returns true if valid, false if validation errors were shown.
+	 */
+	private validateCurrentQuestion(): boolean {
+		const question = this.carousel.questions[this._currentIndex];
+		if (!question) {
+			return true;
+		}
+
+		const answer = this._answers.get(question.id);
+
+		// Check required
+		if (question.required && (answer === undefined || answer === '')) {
+			this.showValidationError(localize('chat.questionCarousel.required', 'This field is required'));
+			return false;
+		}
+
+		// Validate text inputs
+		if (question.type === 'text' && question.validation && typeof answer === 'string' && answer !== '') {
+			const error = this.getValidationError(answer, question.validation);
+			if (error) {
+				this.showValidationError(error);
+				return false;
+			}
+		}
+
+		this.clearValidationError();
+		return true;
+	}
+
+	/**
+	 * Validates that all required questions have been answered.
+	 * Returns true if all required fields are satisfied.
+	 */
+	private validateRequiredFields(): boolean {
+		for (let i = 0; i < this.carousel.questions.length; i++) {
+			const question = this.carousel.questions[i];
+			if (!question.required) {
+				continue;
+			}
+			const answer = this._answers.get(question.id);
+			if (answer === undefined || answer === '') {
+				// Navigate to the unanswered required question
+				this.saveCurrentAnswer();
+				this._currentIndex = i;
+				this.persistDraftState();
+				this.renderCurrentQuestion(true);
+				this.showValidationError(localize('chat.questionCarousel.required', 'This field is required'));
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Returns a validation error message for the given value, or undefined if valid.
+	 */
+	private getValidationError(value: string, validation: IChatQuestionValidation): string | undefined {
+		if (validation.minLength !== undefined && value.length < validation.minLength) {
+			return localize('chat.questionCarousel.validation.minLength', 'Minimum length is {0}', validation.minLength);
+		}
+		if (validation.maxLength !== undefined && value.length > validation.maxLength) {
+			return localize('chat.questionCarousel.validation.maxLength', 'Maximum length is {0}', validation.maxLength);
+		}
+		if (validation.format) {
+			switch (validation.format) {
+				case 'email':
+					if (!value.includes('@')) {
+						return localize('chat.questionCarousel.validation.email', 'Please enter a valid email address');
+					}
+					break;
+				case 'uri':
+					if (!URL.canParse(value)) {
+						return localize('chat.questionCarousel.validation.uri', 'Please enter a valid URI');
+					}
+					break;
+				case 'date': {
+					const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+					if (!dateRegex.test(value) || isNaN(new Date(value).getTime())) {
+						return localize('chat.questionCarousel.validation.date', 'Please enter a valid date (YYYY-MM-DD)');
+					}
+					break;
+				}
+				case 'date-time':
+					if (isNaN(new Date(value).getTime())) {
+						return localize('chat.questionCarousel.validation.dateTime', 'Please enter a valid date-time');
+					}
+					break;
+			}
+		}
+		if (validation.isInteger !== undefined || validation.minimum !== undefined || validation.maximum !== undefined) {
+			const num = Number(value);
+			if (isNaN(num)) {
+				return localize('chat.questionCarousel.validation.number', 'Please enter a valid number');
+			}
+			if (validation.isInteger && !Number.isInteger(num)) {
+				return localize('chat.questionCarousel.validation.integer', 'Please enter a valid integer');
+			}
+			if (validation.minimum !== undefined && num < validation.minimum) {
+				return localize('chat.questionCarousel.validation.minimum', 'Minimum value is {0}', validation.minimum);
+			}
+			if (validation.maximum !== undefined && num > validation.maximum) {
+				return localize('chat.questionCarousel.validation.maximum', 'Maximum value is {0}', validation.maximum);
+			}
+		}
+		return undefined;
+	}
+
+	private showValidationError(message: string): void {
+		this._currentValidationError = message;
+		if (this._validationMessageElement) {
+			this._validationMessageElement.textContent = message;
+			this._validationMessageElement.style.display = '';
+		}
+	}
+
+	private clearValidationError(): void {
+		this._currentValidationError = undefined;
+		if (this._validationMessageElement) {
+			this._validationMessageElement.textContent = '';
+			this._validationMessageElement.style.display = 'none';
+		}
 	}
 
 	hasSameContent(other: IChatRendererContent, _followingContent: IChatRendererContent[], element: ChatTreeItem): boolean {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatQuestionCarousel.css
@@ -386,6 +386,32 @@
 	}
 }
 
+/* carousel-level message (e.g. from MCP elicitation) */
+.interactive-session .chat-question-carousel-container .chat-question-carousel-message {
+	padding: 8px 16px 0;
+	font-size: var(--vscode-chat-font-size-body-s);
+	color: var(--vscode-descriptionForeground);
+
+	.rendered-markdown p {
+		margin: 0;
+	}
+}
+
+/* field description below question title */
+.interactive-session .chat-question-carousel-container .chat-question-description {
+	padding: 4px 16px;
+	font-size: var(--vscode-chat-font-size-body-s);
+	color: var(--vscode-descriptionForeground);
+}
+
+/* validation error message below input area */
+.interactive-session .chat-question-carousel-container .chat-question-validation-message {
+	padding: 0 16px 4px;
+	font-size: var(--vscode-chat-font-size-body-s);
+	color: var(--vscode-editorWarning-foreground);
+	flex-shrink: 0;
+}
+
 /* summary (after finished) */
 .interactive-session .chat-question-carousel-summary {
 	display: flex;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -56,7 +56,7 @@ import { IChatAgentMetadata } from '../../common/participants/chatAgents.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { IChatTextEditGroup } from '../../common/model/chatModel.js';
 import { chatSubcommandLeader } from '../../common/requestParser/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, ChatRequestQueueKind, IChatConfirmation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatPullRequestContent, IChatQuestionCarousel, IChatService, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, isChatFollowup } from '../../common/chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatErrorLevel, ChatRequestQueueKind, IChatConfirmation, IChatContentReference, IChatDisabledClaudeHooksPart, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatPullRequestContent, IChatQuestionAnswerValue, IChatQuestionAnswers, IChatQuestionCarousel, IChatService, IChatTask, IChatTaskSerialized, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, isChatFollowup } from '../../common/chatService/chatService.js';
 import { ChatQuestionCarouselData } from '../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { localChatSessionType } from '../../common/chatSessionsService.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
@@ -2164,9 +2164,9 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		const responseId = isResponseVM(context.element) ? context.element.requestId : undefined;
 		const requestMessageText = isResponseVM(context.element) ? this.getRequestMessageText(context.element) : undefined;
 
-		const handleSubmit = async (answers: Map<string, unknown> | undefined, part: ChatQuestionCarouselPart) => {
+		const handleSubmit = async (answers: Map<string, IChatQuestionAnswerValue> | undefined, part: ChatQuestionCarouselPart) => {
 			// Mark the carousel as used and store the answers
-			const answersRecord = answers ? Object.fromEntries(answers) : undefined;
+			const answersRecord: IChatQuestionAnswers | undefined = answers ? Object.fromEntries(answers) : undefined;
 			carousel.data = answersRecord ?? {};
 			carousel.isUsed = true;
 			if (carousel instanceof ChatQuestionCarouselData) {
@@ -2318,7 +2318,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		context: IChatContentPartRenderContext,
 		carousel: IChatQuestionCarousel,
 		part: ChatQuestionCarouselPart,
-		submit: (answers: Map<string, unknown> | undefined) => Promise<void>,
+		submit: (answers: Map<string, IChatQuestionAnswerValue> | undefined) => Promise<void>,
 		modelName: string | undefined,
 		requestMessageText: string | undefined,
 	): void {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatQuestionCarouselAutoReply.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatQuestionCarouselAutoReply.ts
@@ -15,7 +15,7 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { IChatQuestion, IChatQuestionCarousel } from '../../common/chatService/chatService.js';
+import { IChatQuestion, IChatQuestionAnswerValue, IChatQuestionCarousel, IChatSingleSelectAnswer } from '../../common/chatService/chatService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { ChatMessageRole, getTextResponseFromStream, ILanguageModelsService } from '../../common/languageModels.js';
 import { Event } from '../../../../../base/common/event.js';
@@ -59,7 +59,7 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 
 	async autoReply(
 		carousel: IChatQuestionCarousel,
-		submit: (answers: Map<string, unknown> | undefined) => Promise<void>,
+		submit: (answers: Map<string, IChatQuestionAnswerValue> | undefined) => Promise<void>,
 		modelName: string | undefined,
 		requestMessageText: string | undefined,
 		token: CancellationToken,
@@ -186,7 +186,7 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 		carousel: IChatQuestionCarousel,
 		requestMessageText: string | undefined,
 		token: CancellationToken,
-	): Promise<Map<string, unknown>> {
+	): Promise<Map<string, IChatQuestionAnswerValue>> {
 		const prompt = this.buildPrompt(carousel, requestMessageText, false);
 		const response = await this.languageModelsService.sendChatRequest(
 			modelId,
@@ -217,13 +217,13 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 
 	// #region Answer parsing and resolution
 
-	private parseAnswers(responseText: string, carousel: IChatQuestionCarousel): Map<string, unknown> {
+	private parseAnswers(responseText: string, carousel: IChatQuestionCarousel): Map<string, IChatQuestionAnswerValue> {
 		const parsed = this.tryParseJsonObject(responseText);
 		if (!parsed) {
 			return new Map();
 		}
 
-		const answers = new Map<string, unknown>();
+		const answers = new Map<string, IChatQuestionAnswerValue>();
 		for (const question of carousel.questions) {
 			const rawAnswer = parsed[question.id];
 			const resolved = this.resolveAnswerFromRaw(question, rawAnswer);
@@ -236,10 +236,10 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 
 	private mergeAnswers(
 		carousel: IChatQuestionCarousel,
-		resolvedAnswers: Map<string, unknown>,
-		fallbackAnswers: Map<string, unknown>,
-	): Map<string, unknown> {
-		const merged = new Map<string, unknown>();
+		resolvedAnswers: Map<string, IChatQuestionAnswerValue>,
+		fallbackAnswers: Map<string, IChatQuestionAnswerValue>,
+	): Map<string, IChatQuestionAnswerValue> {
+		const merged = new Map<string, IChatQuestionAnswerValue>();
 		for (const question of carousel.questions) {
 			const fallback = fallbackAnswers.get(question.id);
 			if (this.hasDefaultValue(question) && fallback !== undefined) {
@@ -270,7 +270,7 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 		}
 	}
 
-	private resolveAnswerFromRaw(question: IChatQuestion, raw: unknown): unknown | undefined {
+	private resolveAnswerFromRaw(question: IChatQuestion, raw: unknown): IChatQuestionAnswerValue | undefined {
 		switch (question.type) {
 			case 'text': {
 				if (typeof raw === 'string') {
@@ -305,7 +305,7 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 
 				const match = selectedInput ? this.matchQuestionOption(question, selectedInput) : undefined;
 				if (match) {
-					return { selectedValue: match.value, freeformValue: undefined };
+					return { selectedValue: match.value, freeformValue: undefined } satisfies IChatSingleSelectAnswer;
 				}
 				return undefined;
 			}
@@ -341,7 +341,7 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 		}
 	}
 
-	private matchQuestionOption(question: IChatQuestion, rawInput: string): { id: string; value: unknown } | undefined {
+	private matchQuestionOption(question: IChatQuestion, rawInput: string): { id: string; value: string } | undefined {
 		const options = question.options ?? [];
 		if (!options.length) {
 			return undefined;
@@ -374,8 +374,8 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 
 	// #region Fallback answers
 
-	buildFallbackCarouselAnswers(carousel: IChatQuestionCarousel, requestMessageText: string | undefined): Map<string, unknown> {
-		const answers = new Map<string, unknown>();
+	buildFallbackCarouselAnswers(carousel: IChatQuestionCarousel, requestMessageText: string | undefined): Map<string, IChatQuestionAnswerValue> {
+		const answers = new Map<string, IChatQuestionAnswerValue>();
 		for (const question of carousel.questions) {
 			const answer = this.getFallbackAnswerForQuestion(question, requestMessageText);
 			if (answer !== undefined) {
@@ -385,12 +385,12 @@ export class ChatQuestionCarouselAutoReply extends Disposable {
 		return answers;
 	}
 
-	private getFallbackAnswerForQuestion(question: IChatQuestion, requestMessageText: string | undefined): unknown {
+	private getFallbackAnswerForQuestion(question: IChatQuestion, requestMessageText: string | undefined): IChatQuestionAnswerValue | undefined {
 		const fallbackFreeform = requestMessageText?.trim() || localize('chat.questionCarousel.autoReplyFallback', 'OK');
 
 		switch (question.type) {
 			case 'text':
-				return question.defaultValue ?? fallbackFreeform;
+				return typeof question.defaultValue === 'string' ? question.defaultValue : Array.isArray(question.defaultValue) ? { selectedValues: question.defaultValue } : fallbackFreeform;
 			case 'singleSelect': {
 				const defaultOptionId = typeof question.defaultValue === 'string' ? question.defaultValue : undefined;
 				const defaultOption = defaultOptionId ? question.options?.find(opt => opt.id === defaultOptionId) : undefined;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -351,6 +351,18 @@ export interface IChatConfirmation {
 }
 
 /**
+ * Validation rules for a question in a question carousel.
+ */
+export interface IChatQuestionValidation {
+	minLength?: number;
+	maxLength?: number;
+	format?: 'email' | 'uri' | 'date' | 'date-time';
+	minimum?: number;
+	maximum?: number;
+	isInteger?: boolean;
+}
+
+/**
  * Represents an individual question in a question carousel.
  */
 export interface IChatQuestion {
@@ -358,10 +370,31 @@ export interface IChatQuestion {
 	type: 'text' | 'singleSelect' | 'multiSelect';
 	title: string;
 	message?: string | IMarkdownString;
-	options?: { id: string; label: string; value: unknown }[];
+	description?: string;
+	options?: { id: string; label: string; value: string }[];
 	defaultValue?: string | string[];
 	allowFreeformInput?: boolean;
+	required?: boolean;
+	validation?: IChatQuestionValidation;
 }
+
+/** Answer shape for a single-select question. */
+export interface IChatSingleSelectAnswer {
+	selectedValue?: string;
+	freeformValue?: string;
+}
+
+/** Answer shape for a multi-select question. */
+export interface IChatMultiSelectAnswer {
+	selectedValues: string[];
+	freeformValue?: string;
+}
+
+/** Union of all possible answer values in a question carousel. */
+export type IChatQuestionAnswerValue = string | IChatSingleSelectAnswer | IChatMultiSelectAnswer;
+
+/** Record mapping question IDs to their typed answer values. */
+export type IChatQuestionAnswers = Record<string, IChatQuestionAnswerValue>;
 
 /**
  * A carousel for presenting multiple questions inline in the chat response.
@@ -373,9 +406,13 @@ export interface IChatQuestionCarousel {
 	/** Unique identifier for resolving the carousel answers back to the extension */
 	resolveId?: string;
 	/** Storage for collected answers when user submits */
-	data?: Record<string, unknown>;
+	data?: IChatQuestionAnswers;
 	/** Whether the carousel has been submitted/skipped */
 	isUsed?: boolean;
+	/** Top-level message shown above the questions (e.g. from MCP elicitation message) */
+	message?: string | IMarkdownString;
+	/** Source attribution (e.g. MCP server) */
+	source?: ToolDataSource;
 	kind: 'questionCarousel';
 }
 
@@ -1459,8 +1496,8 @@ export interface IChatService {
 	readonly onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
 
-	readonly onDidReceiveQuestionCarouselAnswer: Event<{ requestId: string; resolveId: string; answers: Record<string, unknown> | undefined }>;
-	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: Record<string, unknown> | undefined): void;
+	readonly onDidReceiveQuestionCarouselAnswer: Event<{ requestId: string; resolveId: string; answers: IChatQuestionAnswers | undefined }>;
+	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: IChatQuestionAnswers | undefined): void;
 
 	readonly onDidDisposeSession: Event<{ readonly sessionResource: URI[]; readonly reason: 'cleared' }>;
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -40,7 +40,7 @@ import { ChatModel, ChatRequestModel, ChatRequestRemovalReason, IChatModel, ICha
 import { ChatModelStore, IStartSessionProps } from '../model/chatModelStore.js';
 import { chatAgentLeader, ChatRequestAgentPart, ChatRequestAgentSubcommandPart, ChatRequestSlashCommandPart, ChatRequestTextPart, chatSubcommandLeader, getPromptText, IParsedChatRequest } from '../requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../requestParser/chatRequestParser.js';
-import { ChatMcpServersStarting, ChatPendingRequestChangeClassification, ChatPendingRequestChangeEvent, ChatPendingRequestChangeEventName, ChatRequestQueueKind, ChatSendResult, ChatSendResultQueued, ChatSendResultSent, ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatCompleteResponse, IChatDetail, IChatFollowup, IChatModelReference, IChatProgress, IChatSendRequestOptions, IChatSendRequestResponseState, IChatService, IChatSessionContext, IChatSessionStartOptions, IChatUserActionEvent, ResponseModelState } from './chatService.js';
+import { ChatMcpServersStarting, ChatPendingRequestChangeClassification, ChatPendingRequestChangeEvent, ChatPendingRequestChangeEventName, ChatRequestQueueKind, ChatSendResult, ChatSendResultQueued, ChatSendResultSent, ChatStopCancellationNoopClassification, ChatStopCancellationNoopEvent, ChatStopCancellationNoopEventName, IChatCompleteResponse, IChatDetail, IChatFollowup, IChatModelReference, IChatProgress, IChatQuestionAnswers, IChatSendRequestOptions, IChatSendRequestResponseState, IChatService, IChatSessionContext, IChatSessionStartOptions, IChatUserActionEvent, ResponseModelState } from './chatService.js';
 import { ChatRequestTelemetry, ChatServiceTelemetry } from './chatServiceTelemetry.js';
 import { IChatSessionsService } from '../chatSessionsService.js';
 import { ChatSessionStore, IChatSessionEntryMetadata } from '../model/chatSessionStore.js';
@@ -116,7 +116,7 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
 	public readonly onDidPerformUserAction: Event<IChatUserActionEvent> = this._onDidPerformUserAction.event;
 
-	private readonly _onDidReceiveQuestionCarouselAnswer = this._register(new Emitter<{ requestId: string; resolveId: string; answers: Record<string, unknown> | undefined }>());
+	private readonly _onDidReceiveQuestionCarouselAnswer = this._register(new Emitter<{ requestId: string; resolveId: string; answers: IChatQuestionAnswers | undefined }>());
 	public readonly onDidReceiveQuestionCarouselAnswer = this._onDidReceiveQuestionCarouselAnswer.event;
 
 	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResource: URI[]; reason: 'cleared' }>());
@@ -271,7 +271,7 @@ export class ChatService extends Disposable implements IChatService {
 		}
 	}
 
-	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: Record<string, unknown> | undefined): void {
+	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: IChatQuestionAnswers | undefined): void {
 		this._onDidReceiveQuestionCarouselAnswer.fire({ requestId, resolveId, answers });
 	}
 

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatQuestionCarouselData.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DeferredPromise } from '../../../../../../base/common/async.js';
-import { IChatQuestion, IChatQuestionCarousel } from '../../chatService/chatService.js';
+import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { IChatQuestion, IChatQuestionAnswers, IChatQuestionCarousel } from '../../chatService/chatService.js';
+import { ToolDataSource } from '../../tools/languageModelToolsService.js';
 
 /**
  * Runtime representation of a question carousel with a {@link DeferredPromise}
@@ -13,16 +15,18 @@ import { IChatQuestion, IChatQuestionCarousel } from '../../chatService/chatServ
  */
 export class ChatQuestionCarouselData implements IChatQuestionCarousel {
 	public readonly kind = 'questionCarousel' as const;
-	public readonly completion = new DeferredPromise<{ answers: Record<string, unknown> | undefined }>();
-	public draftAnswers: Record<string, unknown> | undefined;
+	public readonly completion = new DeferredPromise<{ answers: IChatQuestionAnswers | undefined }>();
+	public draftAnswers: IChatQuestionAnswers | undefined;
 	public draftCurrentIndex: number | undefined;
 
 	constructor(
 		public questions: IChatQuestion[],
 		public allowSkip: boolean,
 		public resolveId?: string,
-		public data?: Record<string, unknown>,
+		public data?: IChatQuestionAnswers,
 		public isUsed?: boolean,
+		public message?: string | IMarkdownString,
+		public source?: ToolDataSource,
 	) { }
 
 	toJSON(): IChatQuestionCarousel {
@@ -33,6 +37,8 @@ export class ChatQuestionCarouselData implements IChatQuestionCarousel {
 			resolveId: this.resolveId,
 			data: this.data,
 			isUsed: this.isUsed,
+			message: this.message,
+			source: this.source,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
@@ -386,14 +386,20 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 						skipped: false
 					};
 				}
-			} else if (hasKey(answer, { selectedValues: true })) {
+			} else if (Array.isArray(answer)) {
+				result.answers[question.header] = {
+					selected: answer.map(a => String(a)),
+					freeText: null,
+					skipped: false
+				};
+			} else if (typeof answer === 'object' && hasKey(answer, { selectedValues: true })) {
 				const { selectedValues, freeformValue } = answer as IChatMultiSelectAnswer;
 				result.answers[question.header] = {
 					selected: selectedValues,
 					freeText: freeformValue ?? null,
 					skipped: false
 				};
-			} else if (hasKey(answer, { selectedValue: true }) || hasKey(answer, { freeformValue: true })) {
+			} else if (typeof answer === 'object' && (hasKey(answer, { selectedValue: true }) || hasKey(answer, { freeformValue: true }))) {
 				const { selectedValue, freeformValue } = answer as IChatSingleSelectAnswer;
 				if (freeformValue) {
 					result.answers[question.header] = {

--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool.ts
@@ -8,9 +8,10 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IJSONSchema, IJSONSchemaMap } from '../../../../../../base/common/jsonSchema.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { hasKey } from '../../../../../../base/common/types.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
 import { localize } from '../../../../../../nls.js';
-import { IChatQuestion, IChatService } from '../../chatService/chatService.js';
+import { IChatQuestion, IChatQuestionAnswers, IChatQuestionAnswerValue, IChatMultiSelectAnswer, IChatService, IChatSingleSelectAnswer } from '../../chatService/chatService.js';
 import { ChatQuestionCarouselData } from '../../model/chatProgressTypes/chatQuestionCarouselData.js';
 import { IChatRequestModel } from '../../model/chatModel.js';
 import { ChatPermissionLevel } from '../../constants.js';
@@ -336,7 +337,7 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 		};
 	}
 
-	protected convertCarouselAnswers(questions: IQuestion[], carouselAnswers: Record<string, unknown> | undefined, idToHeaderMap: Map<string, string>): IAnswerResult {
+	protected convertCarouselAnswers(questions: IQuestion[], carouselAnswers: IChatQuestionAnswers | undefined, idToHeaderMap: Map<string, string>): IAnswerResult {
 		const result: IAnswerResult = { answers: {} };
 
 		if (carouselAnswers) {
@@ -362,7 +363,7 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 
 			// Look up the answer using the internal ID that was used in the carousel
 			const internalId = headerToIdMap.get(question.header);
-			const answer = internalId ? carouselAnswers[internalId] : undefined;
+			const answer: IChatQuestionAnswerValue | undefined = internalId ? carouselAnswers[internalId] : undefined;
 			this.logService.trace(`[AskQuestionsTool] Processing question "${question.header}" (internal ID: ${internalId}), raw answer: ${JSON.stringify(answer)}, type: ${typeof answer}`);
 
 			if (answer === undefined) {
@@ -385,73 +386,36 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 						skipped: false
 					};
 				}
-			} else if (Array.isArray(answer)) {
+			} else if (hasKey(answer, { selectedValues: true })) {
+				const { selectedValues, freeformValue } = answer as IChatMultiSelectAnswer;
 				result.answers[question.header] = {
-					selected: answer.map(a => String(a)),
-					freeText: null,
+					selected: selectedValues,
+					freeText: freeformValue ?? null,
 					skipped: false
 				};
-			} else if (typeof answer === 'object' && answer !== null) {
-				const answerObj = answer as Record<string, unknown>;
-				const freeformValue = typeof answerObj.freeformValue === 'string' && answerObj.freeformValue ? answerObj.freeformValue : null;
-				const selectedValues = Array.isArray(answerObj.selectedValues) ? answerObj.selectedValues.map(v => String(v)) : undefined;
-				const selectedValue = answerObj.selectedValue;
-				const label = typeof answerObj.label === 'string' ? answerObj.label : undefined;
-
-				if (selectedValues) {
-					result.answers[question.header] = {
-						selected: selectedValues,
-						freeText: freeformValue,
-						skipped: false
-					};
-				} else if (typeof selectedValue === 'string') {
-					if (question.options?.some(opt => opt.label === selectedValue)) {
-						result.answers[question.header] = {
-							selected: [selectedValue],
-							freeText: freeformValue,
-							skipped: false
-						};
-					} else {
-						result.answers[question.header] = {
-							selected: [],
-							freeText: freeformValue ?? selectedValue,
-							skipped: false
-						};
-					}
-				} else if (Array.isArray(selectedValue)) {
-					result.answers[question.header] = {
-						selected: selectedValue.map(v => String(v)),
-						freeText: freeformValue,
-						skipped: false
-					};
-				} else if (selectedValue === undefined || selectedValue === null) {
-					if (freeformValue) {
-						result.answers[question.header] = {
-							selected: [],
-							freeText: freeformValue,
-							skipped: false
-						};
-					} else {
-						result.answers[question.header] = {
-							selected: [],
-							freeText: null,
-							skipped: true
-						};
-					}
-				} else if (freeformValue) {
+			} else if (hasKey(answer, { selectedValue: true }) || hasKey(answer, { freeformValue: true })) {
+				const { selectedValue, freeformValue } = answer as IChatSingleSelectAnswer;
+				if (freeformValue) {
 					result.answers[question.header] = {
 						selected: [],
 						freeText: freeformValue,
 						skipped: false
 					};
-				} else if (label) {
-					result.answers[question.header] = {
-						selected: [label],
-						freeText: null,
-						skipped: false
-					};
+				} else if (selectedValue !== undefined) {
+					if (question.options?.some(opt => opt.label === selectedValue)) {
+						result.answers[question.header] = {
+							selected: [selectedValue],
+							freeText: null,
+							skipped: false
+						};
+					} else {
+						result.answers[question.header] = {
+							selected: [],
+							freeText: selectedValue,
+							skipped: false
+						};
+					}
 				} else {
-					this.logService.warn(`[AskQuestionsTool] Unknown answer object format for "${question.header}": ${JSON.stringify(answer)}`);
 					result.answers[question.header] = {
 						selected: [],
 						freeText: null,
@@ -459,7 +423,7 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 					};
 				}
 			} else {
-				this.logService.warn(`[AskQuestionsTool] Unknown answer format for "${question.header}": ${typeof answer}`);
+				this.logService.warn(`[AskQuestionsTool] Unknown answer format for "${question.header}": ${JSON.stringify(answer)}`);
 				result.answers[question.header] = {
 					selected: [],
 					freeText: null,
@@ -517,8 +481,8 @@ export class AskQuestionsTool extends Disposable implements IToolImpl {
 	 * Build carousel answer data keyed by carousel question IDs for rendering
 	 * the completed summary in the UI during autopilot mode.
 	 */
-	private buildAutopilotCarouselAnswers(questions: IQuestion[], carousel: ChatQuestionCarouselData, idToHeaderMap: Map<string, string>): Record<string, unknown> {
-		const data: Record<string, unknown> = {};
+	private buildAutopilotCarouselAnswers(questions: IQuestion[], carousel: ChatQuestionCarouselData, idToHeaderMap: Map<string, string>): IChatQuestionAnswers {
+		const data: IChatQuestionAnswers = {};
 		// Build reverse map: original header -> internal carousel question ID
 		const headerToIdMap = new Map<string, string>();
 		for (const [internalId, originalHeader] of idToHeaderMap) {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -17,7 +17,7 @@ import { workbenchInstantiationService } from '../../../../../test/browser/workb
 import { LocalAgentsSessionsController } from '../../../browser/agentSessions/localAgentSessionsController.js';
 import { ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
 import { IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
-import { ChatRequestQueueKind, IChatDetail, IChatService, IChatSessionStartOptions, ResponseModelState } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, IChatDetail, IChatQuestionAnswers, IChatService, IChatSessionStartOptions, ResponseModelState } from '../../../common/chatService/chatService.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
@@ -173,7 +173,7 @@ class MockChatService implements IChatService {
 
 	readonly onDidReceiveQuestionCarouselAnswer = Event.None;
 
-	notifyQuestionCarouselAnswer(_requestId: string, _resolveId: string, _answers: Record<string, unknown> | undefined): void { }
+	notifyQuestionCarouselAnswer(_requestId: string, _resolveId: string, _answers: IChatQuestionAnswers | undefined): void { }
 
 	async transferChatSession(): Promise<void> { }
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatQuestionCarouselPart.test.ts
@@ -9,7 +9,7 @@ import { MarkdownString } from '../../../../../../../base/common/htmlContent.js'
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
 import { ChatQuestionCarouselPart, IChatQuestionCarouselOptions } from '../../../../browser/widget/chatContentParts/chatQuestionCarouselPart.js';
-import { IChatQuestionCarousel } from '../../../../common/chatService/chatService.js';
+import { IChatQuestionAnswerValue, IChatQuestionCarousel } from '../../../../common/chatService/chatService.js';
 import { IChatContentPartRenderContext } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
 import { ChatQuestionCarouselData } from '../../../../common/model/chatProgressTypes/chatQuestionCarouselData.js';
 
@@ -29,7 +29,7 @@ suite('ChatQuestionCarouselPart', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let widget: ChatQuestionCarouselPart;
-	let submittedAnswers: Map<string, unknown> | undefined | null = null;
+	let submittedAnswers: Map<string, IChatQuestionAnswerValue> | undefined | null = null;
 
 	function createWidget(carousel: IChatQuestionCarousel): ChatQuestionCarouselPart {
 		const instantiationService = workbenchInstantiationService(undefined, store);
@@ -203,7 +203,7 @@ suite('ChatQuestionCarouselPart', () => {
 			assert.strictEqual(checkboxes.length, 3, 'Should have 3 checkboxes');
 		});
 
-		test('freeform textarea is always rendered for singleSelect', () => {
+		test('freeform textarea is rendered for singleSelect by default', () => {
 			const carousel = createMockCarousel([
 				{
 					id: 'q1',
@@ -217,10 +217,10 @@ suite('ChatQuestionCarouselPart', () => {
 			createWidget(carousel);
 
 			const freeformTextarea = widget.domNode.querySelector('.chat-question-freeform-textarea');
-			assert.ok(freeformTextarea, 'Freeform textarea should always be rendered for singleSelect');
+			assert.ok(freeformTextarea, 'Freeform textarea should be rendered by default for singleSelect');
 		});
 
-		test('freeform textarea is always rendered for multiSelect', () => {
+		test('freeform textarea is rendered for multiSelect by default', () => {
 			const carousel = createMockCarousel([
 				{
 					id: 'q1',
@@ -234,7 +234,45 @@ suite('ChatQuestionCarouselPart', () => {
 			createWidget(carousel);
 
 			const freeformTextarea = widget.domNode.querySelector('.chat-question-freeform-textarea');
-			assert.ok(freeformTextarea, 'Freeform textarea should always be rendered for multiSelect');
+			assert.ok(freeformTextarea, 'Freeform textarea should be rendered by default for multiSelect');
+		});
+
+		test('freeform textarea is hidden when allowFreeformInput is false for singleSelect', () => {
+			const carousel = createMockCarousel([
+				{
+					id: 'q1',
+					type: 'singleSelect',
+					title: 'Choose one',
+					allowFreeformInput: false,
+					options: [
+						{ id: 'a', label: 'Option A', value: 'a' },
+						{ id: 'b', label: 'Option B', value: 'b' }
+					]
+				}
+			]);
+			createWidget(carousel);
+
+			const freeformTextarea = widget.domNode.querySelector('.chat-question-freeform-textarea');
+			assert.strictEqual(freeformTextarea, null, 'Freeform textarea should not be rendered when allowFreeformInput is false');
+		});
+
+		test('freeform textarea is hidden when allowFreeformInput is false for multiSelect', () => {
+			const carousel = createMockCarousel([
+				{
+					id: 'q1',
+					type: 'multiSelect',
+					title: 'Choose multiple',
+					allowFreeformInput: false,
+					options: [
+						{ id: 'a', label: 'Option A', value: 'a' },
+						{ id: 'b', label: 'Option B', value: 'b' }
+					]
+				}
+			]);
+			createWidget(carousel);
+
+			const freeformTextarea = widget.domNode.querySelector('.chat-question-freeform-textarea');
+			assert.strictEqual(freeformTextarea, null, 'Freeform textarea should not be rendered when allowFreeformInput is false');
 		});
 
 		test('default options are pre-selected for singleSelect', () => {
@@ -725,6 +763,165 @@ suite('ChatQuestionCarouselPart', () => {
 			assert.ok(summary, 'Should show summary container');
 			const skippedMessage = summary?.querySelector('.chat-question-summary-skipped');
 			assert.ok(skippedMessage, 'Should show skipped message when no data');
+		});
+	});
+
+	suite('Description and Message', () => {
+		test('renders question description when provided', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Email', description: 'Enter your email address' }
+			]);
+			createWidget(carousel);
+
+			const desc = widget.domNode.querySelector('.chat-question-description');
+			assert.ok(desc, 'Description element should be rendered');
+			assert.strictEqual(desc?.textContent, 'Enter your email address');
+		});
+
+		test('does not render description element when not provided', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name' }
+			]);
+			createWidget(carousel);
+
+			const desc = widget.domNode.querySelector('.chat-question-description');
+			assert.strictEqual(desc, null, 'Description element should not exist when not provided');
+		});
+
+		test('renders carousel-level message on first question', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name' },
+				{ id: 'q2', type: 'text', title: 'Email' }
+			]);
+			carousel.message = 'Please fill in the following:';
+			createWidget(carousel);
+
+			const message = widget.domNode.querySelector('.chat-question-carousel-message');
+			assert.ok(message, 'Carousel message should be rendered');
+			assert.ok(message?.textContent?.includes('Please fill in the following:'));
+		});
+
+		test('renders carousel-level message as markdown', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name' }
+			]);
+			carousel.message = new MarkdownString('**Important:** Fill this form');
+			createWidget(carousel);
+
+			const message = widget.domNode.querySelector('.chat-question-carousel-message');
+			assert.ok(message, 'Carousel message should be rendered');
+			assert.ok(message?.querySelector('.rendered-markdown'), 'Message should be rendered as markdown');
+		});
+
+		test('shows required indicator on required questions', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name', required: true }
+			]);
+			createWidget(carousel);
+
+			const title = widget.domNode.querySelector('.chat-question-title');
+			assert.ok(title?.textContent?.includes('*'), 'Required indicator (*) should be shown');
+		});
+
+		test('does not show required indicator on optional questions', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Nickname' }
+			]);
+			createWidget(carousel);
+
+			const title = widget.domNode.querySelector('.chat-question-title');
+			assert.ok(title?.textContent);
+			assert.ok(!title?.textContent?.includes('*'), 'Required indicator should not be shown');
+		});
+	});
+
+	suite('Validation', () => {
+		test('renders validation message element', () => {
+			const carousel = createMockCarousel([
+				{
+					id: 'q1',
+					type: 'text',
+					title: 'Email',
+					validation: { format: 'email' }
+				}
+			]);
+			createWidget(carousel);
+
+			const validationMsg = widget.domNode.querySelector('.chat-question-validation-message') as HTMLElement | null;
+			assert.ok(validationMsg, 'Validation message element should exist');
+			assert.strictEqual(validationMsg?.style.display, 'none', 'Validation message should be hidden initially');
+		});
+
+		test('blocks submit on required empty text field', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name', required: true }
+			]);
+			createWidget(carousel);
+
+			// Try to submit without entering a value
+			const submitButton = widget.domNode.querySelector('.chat-question-submit-button') as HTMLButtonElement;
+			assert.ok(submitButton, 'Submit button should exist');
+			submitButton.click();
+
+			// Should show validation error and not submit
+			const validationMsg = widget.domNode.querySelector('.chat-question-validation-message');
+			assert.ok(validationMsg?.textContent, 'Validation error should be shown');
+			assert.strictEqual(submittedAnswers, null, 'Should not have submitted');
+		});
+
+		test('next button is disabled when required text field is empty', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name', required: true },
+				{ id: 'q2', type: 'text', title: 'Age' }
+			]);
+			createWidget(carousel);
+
+			// Next button should be disabled since required field has no answer
+			const nextButton = widget.domNode.querySelector('.chat-question-nav-next') as HTMLButtonElement;
+			assert.ok(nextButton, 'Next button should exist');
+			assert.ok(nextButton.classList.contains('disabled'), 'Next button should be disabled when required field is empty');
+		});
+
+		test('allows submit on required field with value', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Name', required: true }
+			]);
+			createWidget(carousel);
+
+			// Enter a value in the text input
+			const inputBox = widget.domNode.querySelector('.monaco-inputbox input') as HTMLInputElement;
+			assert.ok(inputBox, 'Input should exist');
+			inputBox.value = 'John';
+			inputBox.dispatchEvent(new Event('input', { bubbles: true }));
+
+			// Submit
+			const submitButton = widget.domNode.querySelector('.chat-question-submit-button') as HTMLButtonElement;
+			submitButton.click();
+
+			assert.ok(submittedAnswers !== null, 'Should have submitted');
+		});
+
+		test('validates required field across questions on submit', () => {
+			const carousel = createMockCarousel([
+				{ id: 'q1', type: 'text', title: 'Optional' },
+				{ id: 'q2', type: 'text', title: 'Required', required: true }
+			]);
+			createWidget(carousel);
+
+			// Navigate to q2 without filling q1 (optional, so allowed)
+			widget.navigateToNextQuestion();
+
+			// Go back to q1 and try to submit (q2 required but empty)
+			widget.navigateToPreviousQuestion();
+
+			// Cmd+Enter should check all required fields
+			const submitButton = widget.domNode.querySelector('.chat-question-submit-button') as HTMLButtonElement;
+			if (submitButton) {
+				submitButton.click();
+			}
+
+			// Should not submit because q2 is required but empty
+			assert.strictEqual(submittedAnswers, null, 'Should not submit when required field is empty');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -10,7 +10,7 @@ import { IObservable, observableValue } from '../../../../../../base/common/obse
 import { URI } from '../../../../../../base/common/uri.js';
 import { IChatModel, IChatRequestModel, IChatRequestVariableData, ISerializableChatData } from '../../../common/model/chatModel.js';
 import { IParsedChatRequest } from '../../../common/requestParser/chatParserTypes.js';
-import { ChatRequestQueueKind, ChatSendResult, IChatCompleteResponse, IChatDetail, IChatModelReference, IChatProgress, IChatProviderInfo, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionStartOptions, IChatUserActionEvent } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, ChatSendResult, IChatCompleteResponse, IChatDetail, IChatModelReference, IChatProgress, IChatProviderInfo, IChatQuestionAnswers, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionStartOptions, IChatUserActionEvent } from '../../../common/chatService/chatService.js';
 import { ChatAgentLocation } from '../../../common/constants.js';
 
 export class MockChatService implements IChatService {
@@ -117,8 +117,8 @@ export class MockChatService implements IChatService {
 	notifyUserAction(event: IChatUserActionEvent): void {
 		throw new Error('Method not implemented.');
 	}
-	readonly onDidReceiveQuestionCarouselAnswer: Event<{ requestId: string; resolveId: string; answers: Record<string, unknown> | undefined }> = undefined!;
-	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: Record<string, unknown> | undefined): void {
+	readonly onDidReceiveQuestionCarouselAnswer: Event<{ requestId: string; resolveId: string; answers: IChatQuestionAnswers | undefined }> = undefined!;
+	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: IChatQuestionAnswers | undefined): void {
 		throw new Error('Method not implemented.');
 	}
 	readonly onDidDisposeSession: Event<{ sessionResource: URI[]; reason: 'cleared' }> = undefined!;

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
@@ -8,10 +8,10 @@ import { NullTelemetryService } from '../../../../../../../platform/telemetry/co
 import { NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { AskQuestionsTool, IAnswerResult, IQuestion, IQuestionAnswer } from '../../../../common/tools/builtinTools/askQuestionsTool.js';
-import { IChatService } from '../../../../common/chatService/chatService.js';
+import { IChatQuestionAnswers, IChatService } from '../../../../common/chatService/chatService.js';
 
 class TestableAskQuestionsTool extends AskQuestionsTool {
-	public testConvertCarouselAnswers(questions: IQuestion[], carouselAnswers: Record<string, unknown> | undefined): IAnswerResult {
+	public testConvertCarouselAnswers(questions: IQuestion[], carouselAnswers: IChatQuestionAnswers | undefined): IAnswerResult {
 		// Create an identity map where each header is also the internal ID
 		// This simulates the simple case for testing the answer conversion logic
 		const idToHeaderMap = new Map<string, string>();

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/askQuestionsTool.test.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { NullTelemetryService } from '../../../../../../../platform/telemetry/common/telemetryUtils.js';
-import { NullLogService } from '../../../../../../../platform/log/common/log.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
-import { AskQuestionsTool, IAnswerResult, IQuestion, IQuestionAnswer } from '../../../../common/tools/builtinTools/askQuestionsTool.js';
+import { NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { NullTelemetryService } from '../../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { IChatQuestionAnswers, IChatService } from '../../../../common/chatService/chatService.js';
+import { AskQuestionsTool, IAnswerResult, IQuestion, IQuestionAnswer } from '../../../../common/tools/builtinTools/askQuestionsTool.js';
 
 class TestableAskQuestionsTool extends AskQuestionsTool {
 	public testConvertCarouselAnswers(questions: IQuestion[], carouselAnswers: IChatQuestionAnswers | undefined): IAnswerResult {
@@ -70,7 +70,7 @@ suite('AskQuestionsTool - convertCarouselAnswers', () => {
 			{ header: 'Features', question: 'Pick features', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] }
 		];
 
-		const result = tool.testConvertCarouselAnswers(questions, { Features: ['A', 'B'] });
+		const result = tool.testConvertCarouselAnswers(questions, { Features: { selectedValues: ['A', 'B'] } });
 
 		assert.deepStrictEqual(result.answers['Features'], { selected: ['A', 'B'], freeText: null, skipped: false });
 	});
@@ -131,7 +131,7 @@ suite('AskQuestionsTool - convertCarouselAnswers', () => {
 		const result = tool.testConvertCarouselAnswers(questions, {
 			Q1: 'text',
 			Q2: { selectedValue: 'A' },
-			Q3: ['x', 'y']
+			Q3: { selectedValues: ['x', 'y'] }
 		});
 
 		assert.strictEqual(result.answers['Q1'].freeText, 'text');

--- a/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpElicitationService.ts
@@ -12,13 +12,15 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { isDefined } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { localize } from '../../../../nls.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { ChatElicitationRequestPart } from '../../chat/common/model/chatProgressTypes/chatElicitationRequestPart.js';
+import { ChatQuestionCarouselData } from '../../chat/common/model/chatProgressTypes/chatQuestionCarouselData.js';
 import { ChatModel } from '../../chat/common/model/chatModel.js';
-import { ElicitationState, IChatService } from '../../chat/common/chatService/chatService.js';
+import { ElicitationState, IChatQuestion, IChatQuestionAnswers, IChatQuestionValidation, IChatService } from '../../chat/common/chatService/chatService.js';
 import { ElicitationKind, ElicitResult, IFormModeElicitResult, IMcpElicitationService, IMcpServer, IMcpToolCallContext, IUrlModeElicitResult, McpConnectionState, MpcResponseError } from '../common/mcpTypes.js';
 import { mcpServerToSourceData } from '../common/mcpTypesUtils.js';
 import { MCP } from '../common/modelContextProtocol.js';
@@ -88,40 +90,51 @@ export class McpElicitationService implements IMcpElicitationService {
 			if (chatModel instanceof ChatModel) {
 				const request = chatModel.getRequests().at(-1);
 				if (request) {
-					const part = new ChatElicitationRequestPart(
-						localize('mcp.elicit.title', 'Request for Input'),
-						elicitation.message,
-						localize('msg.subtitle', "{0} (MCP Server)", server.definition.label),
-						localize('mcp.elicit.accept', 'Respond'),
-						localize('mcp.elicit.reject', 'Cancel'),
-						async () => {
-							const p = this._doElicitForm(elicitation, token);
-							resolve(p);
-							const result = await p;
-							part.acceptedResult = result.content;
-							return result.action === 'accept' ? ElicitationState.Accepted : ElicitationState.Rejected;
-						},
-						() => {
-							resolve({ action: 'decline' });
-							return Promise.resolve(ElicitationState.Rejected);
-						},
-						mcpServerToSourceData(server),
+					const { questions, idToPropertyMap } = this._convertSchemaToQuestions(elicitation);
+					const carousel = new ChatQuestionCarouselData(
+						questions,
+						/* allowSkip */ true,
+						/* resolveId */ undefined,
+						/* data */ undefined,
+						/* isUsed */ undefined,
+						/* message */ new MarkdownString(elicitation.message),
+						/* source */ mcpServerToSourceData(server),
 					);
-					chatModel.acceptResponseProgress(request, part);
+
+					chatModel.acceptResponseProgress(request, carousel);
+
+					store.add(token.onCancellationRequested(() => {
+						carousel.completion.complete({ answers: undefined });
+					}));
+
+					carousel.completion.p.then(result => {
+						if (!result.answers) {
+							resolve({ action: 'cancel' });
+						} else {
+							const content = this._convertCarouselAnswersToElicitResult(
+								result.answers,
+								idToPropertyMap,
+								elicitation.requestedSchema.properties,
+							);
+							resolve({ action: 'accept', content });
+						}
+					});
+					return;
 				}
-			} else {
-				const handle = this._notificationService.notify({
-					message: elicitation.message,
-					source: localize('mcp.elicit.source', 'MCP Server ({0})', server.definition.label),
-					severity: Severity.Info,
-					actions: {
-						primary: [store.add(new Action('mcp.elicit.give', localize('mcp.elicit.give', 'Respond'), undefined, true, () => resolve(this._doElicitForm(elicitation, token))))],
-						secondary: [store.add(new Action('mcp.elicit.cancel', localize('mcp.elicit.cancel', 'Cancel'), undefined, true, () => resolve({ action: 'decline' })))],
-					}
-				});
-				store.add(handle.onDidClose(() => resolve({ action: 'cancel' })));
-				store.add(token.onCancellationRequested(() => resolve({ action: 'cancel' })));
 			}
+
+			// Fallback: no chat session → notification + quickpick
+			const handle = this._notificationService.notify({
+				message: elicitation.message,
+				source: localize('mcp.elicit.source', 'MCP Server ({0})', server.definition.label),
+				severity: Severity.Info,
+				actions: {
+					primary: [store.add(new Action('mcp.elicit.give', localize('mcp.elicit.give', 'Respond'), undefined, true, () => resolve(this._doElicitForm(elicitation, token))))],
+					secondary: [store.add(new Action('mcp.elicit.cancel', localize('mcp.elicit.cancel', 'Cancel'), undefined, true, () => resolve({ action: 'decline' })))],
+				}
+			});
+			store.add(handle.onDidClose(() => resolve({ action: 'cancel' })));
+			store.add(token.onCancellationRequested(() => resolve({ action: 'cancel' })));
 
 		}).finally(() => store.dispose());
 
@@ -517,5 +530,192 @@ export class McpElicitationService implements IMcpElicitationService {
 			return { isValid: false, message: localize('mcp.elicit.validation.maximum', 'Maximum value is {0}', schema.maximum) };
 		}
 		return { isValid: true, parsedValue: parsed };
+	}
+
+	/**
+	 * Converts an MCP elicitation schema into IChatQuestion[] for the carousel UI.
+	 * Returns the questions and a map from question ID to schema property name.
+	 */
+	private _convertSchemaToQuestions(elicitation: MCP.ElicitRequestFormParams | Pre20251125ElicitationParams): { questions: IChatQuestion[]; idToPropertyMap: Map<string, string> } {
+		const properties = Object.entries(elicitation.requestedSchema.properties);
+		const requiredFields = new Set(elicitation.requestedSchema.required || []);
+		const questions: IChatQuestion[] = [];
+		const idToPropertyMap = new Map<string, string>();
+
+		for (const [propertyName, schema] of properties) {
+			const id = generateUuid();
+			idToPropertyMap.set(id, propertyName);
+
+			const title = schema.title || propertyName;
+			const description = schema.description;
+			const isRequired = requiredFields.has(propertyName);
+
+			if (schema.type === 'boolean') {
+				questions.push({
+					id,
+					type: 'singleSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: [
+						{ id: 'true', label: localize('mcp.elicit.true', 'True'), value: 'true' },
+						{ id: 'false', label: localize('mcp.elicit.false', 'False'), value: 'false' },
+					],
+					defaultValue: schema.default !== undefined ? String(schema.default) : undefined,
+				});
+			} else if (isLegacyTitledEnumSchema(schema)) {
+				questions.push({
+					id,
+					type: 'singleSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: schema.enum.map((v, i) => ({
+						id: v,
+						label: schema.enumNames[i] ? `${v} - ${schema.enumNames[i]}` : v,
+						value: v,
+					})),
+					defaultValue: schema.default,
+				});
+			} else if (isTitledSingleEnumSchema(schema)) {
+				questions.push({
+					id,
+					type: 'singleSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: schema.oneOf.map(({ const: value, title: optTitle }) => ({
+						id: value,
+						label: optTitle ? `${value} - ${optTitle}` : value,
+						value,
+					})),
+					defaultValue: schema.default,
+				});
+			} else if (isUntitledEnumSchema(schema)) {
+				questions.push({
+					id,
+					type: 'singleSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: schema.enum.map(v => ({ id: v, label: v, value: v })),
+					defaultValue: schema.default,
+				});
+			} else if (isTitledMultiEnumSchema(schema)) {
+				questions.push({
+					id,
+					type: 'multiSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: schema.items.anyOf.map(({ const: value, title: optTitle }) => ({
+						id: value,
+						label: optTitle ? `${value} - ${optTitle}` : value,
+						value,
+					})),
+					defaultValue: schema.default,
+				});
+			} else if (isUntitledMultiEnumSchema(schema)) {
+				questions.push({
+					id,
+					type: 'multiSelect',
+					title,
+					description,
+					required: isRequired,
+					allowFreeformInput: false,
+					options: schema.items.enum.map(v => ({ id: v, label: v, value: v })),
+					defaultValue: schema.default,
+				});
+			} else {
+				// String, number, integer → text input with validation
+				const validation: IChatQuestionValidation = {};
+				if (schema.type === 'string') {
+					if (schema.minLength !== undefined) { validation.minLength = schema.minLength; }
+					if (schema.maxLength !== undefined) { validation.maxLength = schema.maxLength; }
+					if (schema.format) { validation.format = schema.format; }
+				} else if (schema.type === 'number' || schema.type === 'integer') {
+					if (schema.minimum !== undefined) { validation.minimum = schema.minimum; }
+					if (schema.maximum !== undefined) { validation.maximum = schema.maximum; }
+					if (schema.type === 'integer') { validation.isInteger = true; }
+				}
+
+				questions.push({
+					id,
+					type: 'text',
+					title,
+					description,
+					required: isRequired,
+					defaultValue: schema.default !== undefined ? String(schema.default) : undefined,
+					validation: Object.keys(validation).length > 0 ? validation : undefined,
+				});
+			}
+		}
+
+		return { questions, idToPropertyMap };
+	}
+
+	/**
+	 * Converts carousel answers (keyed by question ID) back into the
+	 * MCP ElicitResult content format (keyed by schema property names),
+	 * coercing types as needed.
+	 */
+	private _convertCarouselAnswersToElicitResult(
+		answers: IChatQuestionAnswers,
+		idToPropertyMap: Map<string, string>,
+		schemaProperties: Record<string, MCP.PrimitiveSchemaDefinition>,
+	): Record<string, string | number | boolean | string[]> {
+		const content: Record<string, string | number | boolean | string[]> = {};
+
+		for (const [questionId, answer] of Object.entries(answers)) {
+			const propertyName = idToPropertyMap.get(questionId);
+			if (!propertyName) {
+				continue;
+			}
+
+			const schema = schemaProperties[propertyName];
+			if (!schema) {
+				continue;
+			}
+
+			// Extract the raw value from structured answers
+			let rawValue: unknown = answer;
+			if (typeof answer === 'object' && answer !== null) {
+				const obj = answer as Record<string, unknown>;
+				if ('selectedValue' in obj) {
+					rawValue = obj.selectedValue;
+				} else if ('selectedValues' in obj) {
+					rawValue = obj.selectedValues;
+				} else if ('freeformValue' in obj && obj.freeformValue) {
+					rawValue = obj.freeformValue;
+				}
+			}
+
+			if (rawValue === undefined || rawValue === null) {
+				continue;
+			}
+
+			// Type coercion based on schema
+			if (schema.type === 'boolean') {
+				content[propertyName] = rawValue === 'true' || rawValue === true;
+			} else if (schema.type === 'number' || schema.type === 'integer') {
+				const num = Number(rawValue);
+				if (!isNaN(num)) {
+					content[propertyName] = num;
+				}
+			} else if (schema.type === 'array') {
+				if (Array.isArray(rawValue)) {
+					content[propertyName] = rawValue.map(v => String(v));
+				}
+			} else {
+				content[propertyName] = String(rawValue);
+			}
+		}
+
+		return content;
 	}
 }


### PR DESCRIPTION
This reuses the askquestions UI to make elicitation requests. This is a nicer UX than the quickpick flow.

It adds data validation to askquestions, as required by MCP, and also switches the answer types from `unknown` to `IChatQuestionAnswerValue` which is a bit more predictable to manage.

cc @meganrogge