### PR TITLE
Sessions: Add "Group by Repository" toggle for sessions list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -239,7 +239,7 @@ export class AgenticSessionsViewPane extends ViewPane {
 
 		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
 		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
-		this.sessionsControl?.refresh();
+		this.sessionsControl?.update();
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -35,19 +35,22 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keyb
 import { ACTION_ID_NEW_CHAT } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { AICustomizationShortcutsWidget } from './aiCustomizationShortcutsWidget.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IHostService } from '../../../../workbench/services/host/browser/host.js';
 
 const $ = DOM.$;
 export const SessionsViewId = 'agentic.workbench.view.sessionsView';
 const SessionsViewFilterSubMenu = new MenuId('AgentSessionsViewFilterSubMenu');
 const IsGroupedByRepositoryContext = new RawContextKey<boolean>('sessionsView.isGroupedByRepository', false);
+const GROUPING_STORAGE_KEY = 'agentSessions.grouping';
 
 export class AgenticSessionsViewPane extends ViewPane {
 
 	private viewPaneContainer: HTMLElement | undefined;
 	private sessionsControlContainer: HTMLElement | undefined;
 	sessionsControl: AgentSessionsControl | undefined;
-	private sessionsFilter: AgentSessionsFilter | undefined;
+	private currentGrouping: AgentSessionsGrouping = AgentSessionsGrouping.Date;
+	private isGroupedByRepoKey: ReturnType<typeof IsGroupedByRepositoryContext.bindTo> | undefined;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -63,8 +66,15 @@ export class AgenticSessionsViewPane extends ViewPane {
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@ISessionsManagementService private readonly activeSessionService: ISessionsManagementService,
 		@IHostService private readonly hostService: IHostService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
+
+		// Restore persisted grouping
+		const stored = this.storageService.get(GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+		if (stored && Object.values(AgentSessionsGrouping).includes(stored as AgentSessionsGrouping)) {
+			this.currentGrouping = stored as AgentSessionsGrouping;
+		}
 	}
 
 	protected override renderBody(parent: HTMLElement): void {
@@ -91,21 +101,18 @@ export class AgenticSessionsViewPane extends ViewPane {
 	private createControls(parent: HTMLElement): void {
 		const sessionsContainer = DOM.append(parent, $('.agent-sessions-container'));
 
+		// Track grouping state via context key for the toggle button
+		const isGroupedByRepoKey = this.isGroupedByRepoKey = IsGroupedByRepositoryContext.bindTo(this.contextKeyService);
+		isGroupedByRepoKey.set(this.currentGrouping === AgentSessionsGrouping.Repository);
+
 		// Sessions Filter (actions go to view title bar via menu registration)
-		const sessionsFilter = this.sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
+		const sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
 			filterMenuId: SessionsViewFilterSubMenu,
-			groupResults: () => AgentSessionsGrouping.Date,
+			groupResults: () => this.currentGrouping,
 			allowedProviders: [AgentSessionProviders.Background, AgentSessionProviders.Cloud],
 			providerLabelOverrides: new Map([
 				[AgentSessionProviders.Background, localize('chat.session.providerLabel.local', "Local")],
 			]),
-		}));
-
-		// Track grouping state via context key for the toggle button
-		const isGroupedByRepoKey = IsGroupedByRepositoryContext.bindTo(this.contextKeyService);
-		isGroupedByRepoKey.set(sessionsFilter.groupResults() === AgentSessionsGrouping.Repository);
-		this._register(sessionsFilter.onDidChange(() => {
-			isGroupedByRepoKey.set(sessionsFilter.groupResults() === AgentSessionsGrouping.Repository);
 		}));
 
 		// Sessions section (top, fills available space)
@@ -224,16 +231,15 @@ export class AgenticSessionsViewPane extends ViewPane {
 	}
 
 	toggleGroupByRepository(): void {
-		if (!this.sessionsFilter) {
-			return;
+		if (this.currentGrouping === AgentSessionsGrouping.Repository) {
+			this.currentGrouping = AgentSessionsGrouping.Date;
+		} else {
+			this.currentGrouping = AgentSessionsGrouping.Repository;
 		}
 
-		const current = this.sessionsFilter.groupResults();
-		if (current === AgentSessionsGrouping.Repository) {
-			this.sessionsFilter.setGrouping(undefined); // back to default (Date)
-		} else {
-			this.sessionsFilter.setGrouping(AgentSessionsGrouping.Repository);
-		}
+		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
+		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
+		this.sessionsControl?.refresh();
 	}
 }
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -280,19 +280,41 @@ MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
 	when: ContextKeyExpr.equals('view', SessionsViewId)
 } satisfies ISubmenuItem);
 
-registerAction2(class ToggleGroupByRepositoryAction extends Action2 {
+registerAction2(class GroupByRepositoryAction extends Action2 {
 	constructor() {
 		super({
-			id: 'sessionsView.toggleGroupByRepository',
+			id: 'sessionsView.groupByRepository',
 			title: localize2('groupByRepository', "Group by Repository"),
-			icon: Codicon.groupByRefType,
+			icon: Codicon.repo,
 			category: SessionsCategories.Sessions,
-			toggled: IsGroupedByRepositoryContext,
 			menu: [{
 				id: MenuId.ViewTitle,
 				group: 'navigation',
 				order: 1,
-				when: ContextKeyExpr.equals('view', SessionsViewId),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', SessionsViewId), IsGroupedByRepositoryContext.negate()),
+			}]
+		});
+	}
+
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
+		view?.toggleGroupByRepository();
+	}
+});
+
+registerAction2(class GroupByDateAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.groupByDate',
+			title: localize2('groupByDate', "Group by Date"),
+			icon: Codicon.history,
+			category: SessionsCategories.Sessions,
+			menu: [{
+				id: MenuId.ViewTitle,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('view', SessionsViewId), IsGroupedByRepositoryContext),
 			}]
 		});
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -8,7 +8,7 @@ import * as DOM from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { autorun } from '../../../../base/common/observable.js';
-import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { EditorsVisibleContext } from '../../../../workbench/common/contextkeys.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -40,12 +40,14 @@ import { IHostService } from '../../../../workbench/services/host/browser/host.j
 const $ = DOM.$;
 export const SessionsViewId = 'agentic.workbench.view.sessionsView';
 const SessionsViewFilterSubMenu = new MenuId('AgentSessionsViewFilterSubMenu');
+const IsGroupedByRepositoryContext = new RawContextKey<boolean>('sessionsView.isGroupedByRepository', false);
 
 export class AgenticSessionsViewPane extends ViewPane {
 
 	private viewPaneContainer: HTMLElement | undefined;
 	private sessionsControlContainer: HTMLElement | undefined;
 	sessionsControl: AgentSessionsControl | undefined;
+	private sessionsFilter: AgentSessionsFilter | undefined;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -90,13 +92,20 @@ export class AgenticSessionsViewPane extends ViewPane {
 		const sessionsContainer = DOM.append(parent, $('.agent-sessions-container'));
 
 		// Sessions Filter (actions go to view title bar via menu registration)
-		const sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
+		const sessionsFilter = this.sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
 			filterMenuId: SessionsViewFilterSubMenu,
 			groupResults: () => AgentSessionsGrouping.Date,
 			allowedProviders: [AgentSessionProviders.Background, AgentSessionProviders.Cloud],
 			providerLabelOverrides: new Map([
 				[AgentSessionProviders.Background, localize('chat.session.providerLabel.local', "Local")],
 			]),
+		}));
+
+		// Track grouping state via context key for the toggle button
+		const isGroupedByRepoKey = IsGroupedByRepositoryContext.bindTo(this.contextKeyService);
+		isGroupedByRepoKey.set(sessionsFilter.groupResults() === AgentSessionsGrouping.Repository);
+		this._register(sessionsFilter.onDidChange(() => {
+			isGroupedByRepoKey.set(sessionsFilter.groupResults() === AgentSessionsGrouping.Repository);
 		}));
 
 		// Sessions section (top, fills available space)
@@ -213,6 +222,19 @@ export class AgenticSessionsViewPane extends ViewPane {
 	openFind(): void {
 		this.sessionsControl?.openFind();
 	}
+
+	toggleGroupByRepository(): void {
+		if (!this.sessionsFilter) {
+			return;
+		}
+
+		const current = this.sessionsFilter.groupResults();
+		if (current === AgentSessionsGrouping.Repository) {
+			this.sessionsFilter.setGrouping(undefined); // back to default (Date)
+		} else {
+			this.sessionsFilter.setGrouping(AgentSessionsGrouping.Repository);
+		}
+	}
 }
 
 // Register Cmd+N / Ctrl+N keybinding for new session in the agent sessions window
@@ -257,6 +279,30 @@ MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
 	icon: Codicon.filter,
 	when: ContextKeyExpr.equals('view', SessionsViewId)
 } satisfies ISubmenuItem);
+
+registerAction2(class ToggleGroupByRepositoryAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.toggleGroupByRepository',
+			title: localize2('groupByRepository', "Group by Repository"),
+			icon: Codicon.groupByRefType,
+			category: SessionsCategories.Sessions,
+			toggled: IsGroupedByRepositoryContext,
+			menu: [{
+				id: MenuId.ViewTitle,
+				group: 'navigation',
+				order: 1,
+				when: ContextKeyExpr.equals('view', SessionsViewId),
+			}]
+		});
+	}
+
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
+		view?.toggleGroupByRepository();
+	}
+});
 
 registerAction2(class RefreshAgentSessionsViewerAction extends Action2 {
 	constructor() {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -179,7 +179,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	private static readonly SECTION_COLLAPSE_STATE_KEY = 'agentSessions.sectionCollapseState';
 
-	private getSavedCollapseState(section: AgentSessionSection): boolean | undefined {
+	private getSavedCollapseState(section: string): boolean | undefined {
 		const raw = this.storageService.get(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, StorageScope.PROFILE);
 		if (raw) {
 			try {
@@ -194,7 +194,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		return undefined;
 	}
 
-	private saveSectionCollapseState(section: AgentSessionSection, collapsed: boolean): void {
+	private saveSectionCollapseState(section: string, collapsed: boolean): void {
 		let state: Record<string, boolean> = {};
 		const raw = this.storageService.get(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, StorageScope.PROFILE);
 		if (raw) {
@@ -227,7 +227,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 					return true; // Archived section is collapsed when archived are excluded
 				}
 				if (this.options.collapseOlderSections?.()) {
-					const olderSections = [AgentSessionSection.Week, AgentSessionSection.Older, AgentSessionSection.Archived];
+					const olderSections: string[] = [AgentSessionSection.Week, AgentSessionSection.Older, AgentSessionSection.Archived];
 					if (olderSections.includes(element.section)) {
 						return true; // Collapse older time sections if option is enabled
 					}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -179,7 +179,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	private static readonly SECTION_COLLAPSE_STATE_KEY = 'agentSessions.sectionCollapseState';
 
-	private getSavedCollapseState(section: string): boolean | undefined {
+	private getSavedCollapseState(section: AgentSessionSection): boolean | undefined {
 		const raw = this.storageService.get(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, StorageScope.PROFILE);
 		if (raw) {
 			try {
@@ -194,7 +194,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		return undefined;
 	}
 
-	private saveSectionCollapseState(section: string, collapsed: boolean): void {
+	private saveSectionCollapseState(section: AgentSessionSection, collapsed: boolean): void {
 		let state: Record<string, boolean> = {};
 		const raw = this.storageService.get(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, StorageScope.PROFILE);
 		if (raw) {
@@ -227,7 +227,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 					return true; // Archived section is collapsed when archived are excluded
 				}
 				if (this.options.collapseOlderSections?.()) {
-					const olderSections: string[] = [AgentSessionSection.Week, AgentSessionSection.Older, AgentSessionSection.Archived];
+					const olderSections = [AgentSessionSection.Week, AgentSessionSection.Older, AgentSessionSection.Archived];
 					if (olderSections.includes(element.section)) {
 						return true; // Collapse older time sections if option is enabled
 					}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -55,17 +55,12 @@ const DEFAULT_EXCLUDES: IAgentSessionsFilterExcludes = Object.freeze({
 export class AgentSessionsFilter extends Disposable implements Required<IAgentSessionsFilter> {
 
 	private readonly STORAGE_KEY = `agentSessions.filterExcludes.agentsessionsviewerfiltersubmenu`;
-	private static readonly GROUPING_STORAGE_KEY = `agentSessions.grouping`;
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
 
 	readonly limitResults = () => this.options.limitResults?.();
-	readonly groupResults = () => this.groupingOverride ?? this.options.groupResults?.();
-
-	private groupingOverride: AgentSessionsGrouping | undefined;
-	private isStoringGrouping = false;
-	private readonly supportsGroupingOverride: boolean;
+	readonly groupResults = () => this.options.groupResults?.();
 
 	private excludes = DEFAULT_EXCLUDES;
 	private isStoringExcludes = false;
@@ -79,10 +74,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	) {
 		super();
 
-		this.supportsGroupingOverride = !!this.options.groupResults;
-
 		this.updateExcludes(false);
-		this.updateGrouping(false);
 
 		this.registerListeners();
 	}
@@ -92,9 +84,6 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.updateFilterActions()));
 
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.STORAGE_KEY, this._store)(() => this.updateExcludes(true)));
-		if (this.supportsGroupingOverride) {
-			this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, AgentSessionsFilter.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
-		}
 	}
 
 	private updateExcludes(fromEvent: boolean): void {
@@ -115,49 +104,6 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 		if (fromEvent) {
 			this._onDidChange.fire();
-		}
-	}
-
-	private updateGrouping(fromEvent: boolean): void {
-		if (!this.supportsGroupingOverride || this.isStoringGrouping) {
-			return;
-		}
-
-		const raw = this.storageService.get(AgentSessionsFilter.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
-		if (raw && Object.values(AgentSessionsGrouping).includes(raw as AgentSessionsGrouping)) {
-			this.groupingOverride = raw as AgentSessionsGrouping;
-		} else {
-			this.groupingOverride = undefined;
-		}
-
-		this.updateFilterActions();
-
-		if (fromEvent) {
-			this._onDidChange.fire();
-		}
-	}
-
-	setGrouping(grouping: AgentSessionsGrouping | undefined): void {
-		this.storeGrouping(grouping);
-		this._onDidChange.fire();
-	}
-
-	private storeGrouping(grouping: AgentSessionsGrouping | undefined): void {
-		if (!this.supportsGroupingOverride) {
-			return;
-		}
-
-		this.groupingOverride = grouping;
-
-		this.isStoringGrouping = true;
-		try {
-			if (grouping === undefined) {
-				this.storageService.remove(AgentSessionsFilter.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
-			} else {
-				this.storageService.store(AgentSessionsFilter.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
-			}
-		} finally {
-			this.isStoringGrouping = false;
 		}
 	}
 
@@ -348,7 +294,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	isDefault(): boolean {
-		return equals(this.excludes, DEFAULT_EXCLUDES) && this.groupingOverride === undefined;
+		return equals(this.excludes, DEFAULT_EXCLUDES);
 	}
 
 	getExcludes(): IAgentSessionsFilterExcludes {
@@ -390,6 +336,5 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 	reset(): void {
 		this.storeExcludes({ ...DEFAULT_EXCLUDES });
-		this.storeGrouping(undefined);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -55,7 +55,7 @@ const DEFAULT_EXCLUDES: IAgentSessionsFilterExcludes = Object.freeze({
 export class AgentSessionsFilter extends Disposable implements Required<IAgentSessionsFilter> {
 
 	private readonly STORAGE_KEY = `agentSessions.filterExcludes.agentsessionsviewerfiltersubmenu`;
-	private readonly GROUPING_STORAGE_KEY = `agentSessions.grouping`;
+	private readonly GROUPING_STORAGE_KEY: string | undefined;
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
@@ -64,6 +64,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	readonly groupResults = () => this.groupingOverride ?? this.options.groupResults?.();
 
 	private groupingOverride: AgentSessionsGrouping | undefined;
+	private isStoringGrouping = false;
 
 	private excludes = DEFAULT_EXCLUDES;
 	private isStoringExcludes = false;
@@ -77,6 +78,11 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	) {
 		super();
 
+		// Only enable grouping override when a default grouping is configured
+		if (this.options.groupResults && this.options.filterMenuId) {
+			this.GROUPING_STORAGE_KEY = `agentSessions.grouping.${this.options.filterMenuId.id}`;
+		}
+
 		this.updateExcludes(false);
 		this.updateGrouping(false);
 
@@ -88,7 +94,9 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.updateFilterActions()));
 
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.STORAGE_KEY, this._store)(() => this.updateExcludes(true)));
-		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
+		if (this.GROUPING_STORAGE_KEY) {
+			this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
+		}
 	}
 
 	private updateExcludes(fromEvent: boolean): void {
@@ -113,6 +121,10 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	private updateGrouping(fromEvent: boolean): void {
+		if (!this.GROUPING_STORAGE_KEY || this.isStoringGrouping) {
+			return;
+		}
+
 		const raw = this.storageService.get(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
 		if (raw && Object.values(AgentSessionsGrouping).includes(raw as AgentSessionsGrouping)) {
 			this.groupingOverride = raw as AgentSessionsGrouping;
@@ -133,12 +145,21 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	private storeGrouping(grouping: AgentSessionsGrouping | undefined): void {
+		if (!this.GROUPING_STORAGE_KEY) {
+			return;
+		}
+
 		this.groupingOverride = grouping;
 
-		if (grouping === undefined) {
-			this.storageService.remove(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
-		} else {
-			this.storageService.store(this.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
+		this.isStoringGrouping = true;
+		try {
+			if (grouping === undefined) {
+				this.storageService.remove(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+			} else {
+				this.storageService.store(this.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
+			}
+		} finally {
+			this.isStoringGrouping = false;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -17,7 +17,8 @@ import { IAgentSessionsFilter, IAgentSessionsFilterExcludes } from './agentSessi
 
 export enum AgentSessionsGrouping {
 	Capped = 'capped',
-	Date = 'date'
+	Date = 'date',
+	Repository = 'repository'
 }
 
 export interface IAgentSessionsFilterOptions extends Partial<IAgentSessionsFilter> {
@@ -54,12 +55,15 @@ const DEFAULT_EXCLUDES: IAgentSessionsFilterExcludes = Object.freeze({
 export class AgentSessionsFilter extends Disposable implements Required<IAgentSessionsFilter> {
 
 	private readonly STORAGE_KEY = `agentSessions.filterExcludes.agentsessionsviewerfiltersubmenu`;
+	private readonly GROUPING_STORAGE_KEY = `agentSessions.grouping`;
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
 
 	readonly limitResults = () => this.options.limitResults?.();
-	readonly groupResults = () => this.options.groupResults?.();
+	readonly groupResults = () => this.groupingOverride ?? this.options.groupResults?.();
+
+	private groupingOverride: AgentSessionsGrouping | undefined;
 
 	private excludes = DEFAULT_EXCLUDES;
 	private isStoringExcludes = false;
@@ -74,6 +78,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		super();
 
 		this.updateExcludes(false);
+		this.updateGrouping(false);
 
 		this.registerListeners();
 	}
@@ -83,6 +88,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.updateFilterActions()));
 
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.STORAGE_KEY, this._store)(() => this.updateExcludes(true)));
+		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
 	}
 
 	private updateExcludes(fromEvent: boolean): void {
@@ -103,6 +109,31 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 		if (fromEvent) {
 			this._onDidChange.fire();
+		}
+	}
+
+	private updateGrouping(fromEvent: boolean): void {
+		const raw = this.storageService.get(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+		if (raw && Object.values(AgentSessionsGrouping).includes(raw as AgentSessionsGrouping)) {
+			this.groupingOverride = raw as AgentSessionsGrouping;
+		} else {
+			this.groupingOverride = undefined;
+		}
+
+		this.updateFilterActions();
+
+		if (fromEvent) {
+			this._onDidChange.fire();
+		}
+	}
+
+	private storeGrouping(grouping: AgentSessionsGrouping | undefined): void {
+		this.groupingOverride = grouping;
+
+		if (grouping === undefined) {
+			this.storageService.remove(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+		} else {
+			this.storageService.store(this.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
 		}
 	}
 
@@ -133,6 +164,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 		this.registerProviderActions(this.actionDisposables, menuId);
 		this.registerStateActions(this.actionDisposables, menuId);
+		this.registerGroupingActions(this.actionDisposables, menuId);
 		this.registerArchivedActions(this.actionDisposables, menuId);
 		this.registerReadActions(this.actionDisposables, menuId);
 		this.registerResetAction(this.actionDisposables, menuId);
@@ -230,6 +262,45 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		}
 	}
 
+	private registerGroupingActions(disposables: DisposableStore, menuId: MenuId): void {
+		const defaultGrouping = this.options.groupResults?.();
+		if (!defaultGrouping) {
+			return; // only show grouping toggles when grouping is enabled
+		}
+
+		const groupings: { id: AgentSessionsGrouping; label: string }[] = [
+			{ id: AgentSessionsGrouping.Date, label: localize('agentSessions.grouping.date', "Group by Date") },
+			{ id: AgentSessionsGrouping.Repository, label: localize('agentSessions.grouping.repository', "Group by Repository") },
+		];
+
+		const that = this;
+		let counter = 0;
+		for (const grouping of groupings) {
+			disposables.add(registerAction2(class extends Action2 {
+				constructor() {
+					const currentGrouping = that.groupingOverride ?? defaultGrouping;
+					super({
+						id: `agentSessions.filter.setGrouping:${grouping.id}.${menuId.id.toLowerCase()}`,
+						title: grouping.label,
+						menu: {
+							id: menuId,
+							group: '2b_grouping',
+							order: counter++,
+						},
+						toggled: currentGrouping === grouping.id ? ContextKeyExpr.true() : ContextKeyExpr.false(),
+					});
+				}
+				run(): void {
+					if (grouping.id === defaultGrouping) {
+						that.storeGrouping(undefined); // reset to default
+					} else {
+						that.storeGrouping(grouping.id);
+					}
+				}
+			}));
+		}
+	}
+
 	private registerArchivedActions(disposables: DisposableStore, menuId: MenuId): void {
 		const that = this;
 		disposables.add(registerAction2(class extends Action2 {
@@ -293,7 +364,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	isDefault(): boolean {
-		return equals(this.excludes, DEFAULT_EXCLUDES);
+		return equals(this.excludes, DEFAULT_EXCLUDES) && this.groupingOverride === undefined;
 	}
 
 	getExcludes(): IAgentSessionsFilterExcludes {
@@ -335,5 +406,6 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 	reset(): void {
 		this.storeExcludes({ ...DEFAULT_EXCLUDES });
+		this.storeGrouping(undefined);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -55,7 +55,7 @@ const DEFAULT_EXCLUDES: IAgentSessionsFilterExcludes = Object.freeze({
 export class AgentSessionsFilter extends Disposable implements Required<IAgentSessionsFilter> {
 
 	private readonly STORAGE_KEY = `agentSessions.filterExcludes.agentsessionsviewerfiltersubmenu`;
-	private readonly GROUPING_STORAGE_KEY: string | undefined;
+	private static readonly GROUPING_STORAGE_KEY = `agentSessions.grouping`;
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange = this._onDidChange.event;
@@ -65,6 +65,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 	private groupingOverride: AgentSessionsGrouping | undefined;
 	private isStoringGrouping = false;
+	private readonly supportsGroupingOverride: boolean;
 
 	private excludes = DEFAULT_EXCLUDES;
 	private isStoringExcludes = false;
@@ -78,10 +79,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	) {
 		super();
 
-		// Only enable grouping override when a default grouping is configured
-		if (this.options.groupResults && this.options.filterMenuId) {
-			this.GROUPING_STORAGE_KEY = `agentSessions.grouping.${this.options.filterMenuId.id}`;
-		}
+		this.supportsGroupingOverride = !!this.options.groupResults;
 
 		this.updateExcludes(false);
 		this.updateGrouping(false);
@@ -94,8 +92,8 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		this._register(this.chatSessionsService.onDidChangeAvailability(() => this.updateFilterActions()));
 
 		this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.STORAGE_KEY, this._store)(() => this.updateExcludes(true)));
-		if (this.GROUPING_STORAGE_KEY) {
-			this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, this.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
+		if (this.supportsGroupingOverride) {
+			this._register(this.storageService.onDidChangeValue(StorageScope.PROFILE, AgentSessionsFilter.GROUPING_STORAGE_KEY, this._store)(() => this.updateGrouping(true)));
 		}
 	}
 
@@ -121,11 +119,11 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	private updateGrouping(fromEvent: boolean): void {
-		if (!this.GROUPING_STORAGE_KEY || this.isStoringGrouping) {
+		if (!this.supportsGroupingOverride || this.isStoringGrouping) {
 			return;
 		}
 
-		const raw = this.storageService.get(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+		const raw = this.storageService.get(AgentSessionsFilter.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
 		if (raw && Object.values(AgentSessionsGrouping).includes(raw as AgentSessionsGrouping)) {
 			this.groupingOverride = raw as AgentSessionsGrouping;
 		} else {
@@ -145,7 +143,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 	}
 
 	private storeGrouping(grouping: AgentSessionsGrouping | undefined): void {
-		if (!this.GROUPING_STORAGE_KEY) {
+		if (!this.supportsGroupingOverride) {
 			return;
 		}
 
@@ -154,9 +152,9 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		this.isStoringGrouping = true;
 		try {
 			if (grouping === undefined) {
-				this.storageService.remove(this.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+				this.storageService.remove(AgentSessionsFilter.GROUPING_STORAGE_KEY, StorageScope.PROFILE);
 			} else {
-				this.storageService.store(this.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
+				this.storageService.store(AgentSessionsFilter.GROUPING_STORAGE_KEY, grouping, StorageScope.PROFILE, StorageTarget.USER);
 			}
 		} finally {
 			this.isStoringGrouping = false;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -127,6 +127,11 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 		}
 	}
 
+	setGrouping(grouping: AgentSessionsGrouping | undefined): void {
+		this.storeGrouping(grouping);
+		this._onDidChange.fire();
+	}
+
 	private storeGrouping(grouping: AgentSessionsGrouping | undefined): void {
 		this.groupingOverride = grouping;
 
@@ -164,7 +169,6 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 		this.registerProviderActions(this.actionDisposables, menuId);
 		this.registerStateActions(this.actionDisposables, menuId);
-		this.registerGroupingActions(this.actionDisposables, menuId);
 		this.registerArchivedActions(this.actionDisposables, menuId);
 		this.registerReadActions(this.actionDisposables, menuId);
 		this.registerResetAction(this.actionDisposables, menuId);
@@ -257,45 +261,6 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 					}
 
 					that.storeExcludes({ ...that.excludes, states: Array.from(stateExcludes) });
-				}
-			}));
-		}
-	}
-
-	private registerGroupingActions(disposables: DisposableStore, menuId: MenuId): void {
-		const defaultGrouping = this.options.groupResults?.();
-		if (!defaultGrouping) {
-			return; // only show grouping toggles when grouping is enabled
-		}
-
-		const groupings: { id: AgentSessionsGrouping; label: string }[] = [
-			{ id: AgentSessionsGrouping.Date, label: localize('agentSessions.grouping.date', "Group by Date") },
-			{ id: AgentSessionsGrouping.Repository, label: localize('agentSessions.grouping.repository', "Group by Repository") },
-		];
-
-		const that = this;
-		let counter = 0;
-		for (const grouping of groupings) {
-			disposables.add(registerAction2(class extends Action2 {
-				constructor() {
-					const currentGrouping = that.groupingOverride ?? defaultGrouping;
-					super({
-						id: `agentSessions.filter.setGrouping:${grouping.id}.${menuId.id.toLowerCase()}`,
-						title: grouping.label,
-						menu: {
-							id: menuId,
-							group: '2b_grouping',
-							order: counter++,
-						},
-						toggled: currentGrouping === grouping.id ? ContextKeyExpr.true() : ContextKeyExpr.false(),
-					});
-				}
-				run(): void {
-					if (grouping.id === defaultGrouping) {
-						that.storeGrouping(undefined); // reset to default
-					} else {
-						that.storeGrouping(grouping.id);
-					}
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -162,6 +162,9 @@ export const enum AgentSessionSection {
 
 	// Capped Grouping
 	More = 'more',
+
+	// Repository Grouping
+	Repository = 'repository',
 }
 
 export interface IAgentSessionSection {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -165,7 +165,7 @@ export const enum AgentSessionSection {
 }
 
 export interface IAgentSessionSection {
-	readonly section: string;
+	readonly section: AgentSessionSection;
 	readonly label: string;
 	readonly sessions: IAgentSession[];
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -165,7 +165,7 @@ export const enum AgentSessionSection {
 }
 
 export interface IAgentSessionSection {
-	readonly section: AgentSessionSection;
+	readonly section: string;
 	readonly label: string;
 	readonly sessions: IAgentSession[];
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -904,13 +904,21 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				return nwo.split('/').pop()!;
 			}
 
+			// repositoryPath: "/Users/user/Projects/vscode" — the actual repo root
+			const repositoryPath = metadata.repositoryPath as string | undefined;
+			if (repositoryPath) {
+				const name = repositoryPath.replace(/[\\/]+$/, '').split(/[\\/]/).pop();
+				if (name) {
+					return name;
+				}
+			}
+
 			// repository: could be "owner/repo" or a URL
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
 				if (repository.includes('/') && !repository.includes(':')) {
 					return repository.split('/').pop()!;
 				}
-				// Try to extract from URL like "https://github.com/owner/repo"
 				try {
 					const url = new URL(repository);
 					const parts = url.pathname.split('/').filter(Boolean);
@@ -934,16 +942,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				} catch {
 					// not a URL
 				}
-			}
-		}
-
-		// Fallback: extract from badge (strip codicon syntax)
-		const badge = session.badge;
-		if (badge) {
-			const raw = typeof badge === 'string' ? badge : renderAsPlaintext(new MarkdownString(badge.value));
-			const cleaned = raw.replace(/\$\([^)]+\)\s*/g, '').trim();
-			if (cleaned) {
-				return cleaned;
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -879,9 +879,9 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		}
 
 		const result: AgentSessionListItem[] = [];
-		for (const [repoId, { label, sessions }] of repoMap) {
+		for (const [, { label, sessions }] of repoMap) {
 			result.push({
-				section: `repo-${repoId}` as AgentSessionSection,
+				section: AgentSessionSection.Repository,
 				label,
 				sessions,
 			});
@@ -1040,7 +1040,7 @@ export class AgentSessionsIdentityProvider implements IIdentityProvider<IAgentSe
 
 	getId(element: IAgentSessionsModel | AgentSessionListItem): string {
 		if (isAgentSessionSection(element)) {
-			return `section-${element.section}`;
+			return `section-${element.section}-${element.label}`;
 		}
 
 		if (isAgentSession(element)) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -881,7 +881,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		const result: AgentSessionListItem[] = [];
 		for (const [repoId, { label, sessions }] of repoMap) {
 			result.push({
-				section: `repo-${repoId}`,
+				section: `repo-${repoId}` as AgentSessionSection,
 				label,
 				sessions,
 			});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -898,19 +898,16 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	private getRepositoryName(session: IAgentSession): string | undefined {
 		const metadata = session.metadata;
 		if (metadata) {
+			// Cloud sessions: metadata.name is the repo name
+			const name = metadata.name as string | undefined;
+			if (name && typeof name === 'string') {
+				return name;
+			}
+
 			// repositoryNwo: "owner/repo"
 			const nwo = metadata.repositoryNwo as string | undefined;
 			if (nwo && nwo.includes('/')) {
 				return nwo.split('/').pop()!;
-			}
-
-			// repositoryPath: "/Users/user/Projects/vscode" — the actual repo root
-			const repositoryPath = metadata.repositoryPath as string | undefined;
-			if (repositoryPath) {
-				const name = repositoryPath.replace(/[\\/]+$/, '').split(/[\\/]/).pop();
-				if (name) {
-					return name;
-				}
 			}
 
 			// repository: could be "owner/repo" or a URL
@@ -942,6 +939,16 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				} catch {
 					// not a URL
 				}
+			}
+		}
+
+		// Fallback: extract repo name from badge if it uses the $(repo) icon
+		const badge = session.badge;
+		if (badge) {
+			const raw = typeof badge === 'string' ? badge : badge.value;
+			const repoMatch = raw.match(/\$\(repo\)\s*(.+)/);
+			if (repoMatch) {
+				return repoMatch[1].trim();
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -808,6 +808,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			return this.groupSessionsCapped(sortedSessions);
+		} else if (this.filter?.groupResults?.() === AgentSessionsGrouping.Repository) {
+			return this.groupSessionsByRepository(sortedSessions);
 		} else {
 			return this.groupSessionsByDate(sortedSessions);
 		}
@@ -847,6 +849,39 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			result.push({ section, label, sessions });
+		}
+
+		return result;
+	}
+
+	private groupSessionsByRepository(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
+		const repoMap = new Map<string, IAgentSession[]>();
+		const noRepoLabel = localize('agentSessions.noRepository', "Other");
+
+		for (const session of sortedSessions) {
+			const badge = session.badge;
+			let repoName: string;
+			if (badge) {
+				repoName = typeof badge === 'string' ? badge : renderAsPlaintext(new MarkdownString(badge.value));
+			} else {
+				repoName = noRepoLabel;
+			}
+
+			let group = repoMap.get(repoName);
+			if (!group) {
+				group = [];
+				repoMap.set(repoName, group);
+			}
+			group.push(session);
+		}
+
+		const result: AgentSessionListItem[] = [];
+		for (const [repoName, sessions] of repoMap) {
+			result.push({
+				section: `repo-${repoName}`,
+				label: repoName,
+				sessions,
+			});
 		}
 
 		return result;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -856,16 +856,16 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 	private groupSessionsByRepository(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
 		const repoMap = new Map<string, IAgentSession[]>();
+		const archivedSessions: IAgentSession[] = [];
 		const noRepoLabel = localize('agentSessions.noRepository', "Other");
 
 		for (const session of sortedSessions) {
-			const badge = session.badge;
-			let repoName: string;
-			if (badge) {
-				repoName = typeof badge === 'string' ? badge : renderAsPlaintext(new MarkdownString(badge.value));
-			} else {
-				repoName = noRepoLabel;
+			if (session.isArchived()) {
+				archivedSessions.push(session);
+				continue;
 			}
+
+			const repoName = this.getRepositoryName(session) ?? noRepoLabel;
 
 			let group = repoMap.get(repoName);
 			if (!group) {
@@ -884,7 +884,70 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			});
 		}
 
+		if (archivedSessions.length > 0) {
+			result.push({
+				section: AgentSessionSection.Archived,
+				label: AgentSessionSectionLabels[AgentSessionSection.Archived],
+				sessions: archivedSessions,
+			});
+		}
+
 		return result;
+	}
+
+	private getRepositoryName(session: IAgentSession): string | undefined {
+		const metadata = session.metadata;
+		if (metadata) {
+			// repositoryNwo: "owner/repo"
+			const nwo = metadata.repositoryNwo as string | undefined;
+			if (nwo && nwo.includes('/')) {
+				return nwo.split('/').pop()!;
+			}
+
+			// repository: could be "owner/repo" or a URL
+			const repository = metadata.repository as string | undefined;
+			if (repository) {
+				if (repository.includes('/') && !repository.includes(':')) {
+					return repository.split('/').pop()!;
+				}
+				// Try to extract from URL like "https://github.com/owner/repo"
+				try {
+					const url = new URL(repository);
+					const parts = url.pathname.split('/').filter(Boolean);
+					if (parts.length >= 2) {
+						return parts[1];
+					}
+				} catch {
+					// not a URL
+				}
+			}
+
+			// repositoryUrl: "https://github.com/owner/repo"
+			const repositoryUrl = metadata.repositoryUrl as string | undefined;
+			if (repositoryUrl) {
+				try {
+					const url = new URL(repositoryUrl);
+					const parts = url.pathname.split('/').filter(Boolean);
+					if (parts.length >= 2) {
+						return parts[1];
+					}
+				} catch {
+					// not a URL
+				}
+			}
+		}
+
+		// Fallback: extract from badge (strip codicon syntax)
+		const badge = session.badge;
+		if (badge) {
+			const raw = typeof badge === 'string' ? badge : renderAsPlaintext(new MarkdownString(badge.value));
+			const cleaned = raw.replace(/\$\([^)]+\)\s*/g, '').trim();
+			if (cleaned) {
+				return cleaned;
+			}
+		}
+
+		return undefined;
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -855,8 +855,9 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	}
 
 	private groupSessionsByRepository(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
-		const repoMap = new Map<string, IAgentSession[]>();
+		const repoMap = new Map<string, { label: string; sessions: IAgentSession[] }>();
 		const archivedSessions: IAgentSession[] = [];
+		const noRepoId = 'other';
 		const noRepoLabel = localize('agentSessions.noRepository', "Other");
 
 		for (const session of sortedSessions) {
@@ -865,21 +866,23 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				continue;
 			}
 
-			const repoName = this.getRepositoryName(session) ?? noRepoLabel;
+			const repo = this.getRepositoryInfo(session);
+			const repoId = repo?.id ?? noRepoId;
+			const repoLabel = repo?.label ?? noRepoLabel;
 
-			let group = repoMap.get(repoName);
+			let group = repoMap.get(repoId);
 			if (!group) {
-				group = [];
-				repoMap.set(repoName, group);
+				group = { label: repoLabel, sessions: [] };
+				repoMap.set(repoId, group);
 			}
-			group.push(session);
+			group.sessions.push(session);
 		}
 
 		const result: AgentSessionListItem[] = [];
-		for (const [repoName, sessions] of repoMap) {
+		for (const [repoId, { label, sessions }] of repoMap) {
 			result.push({
-				section: `repo-${repoName}`,
-				label: repoName,
+				section: `repo-${repoId}`,
+				label,
 				sessions,
 			});
 		}
@@ -895,32 +898,34 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		return result;
 	}
 
-	private getRepositoryName(session: IAgentSession): string | undefined {
+	private getRepositoryInfo(session: IAgentSession): { id: string; label: string } | undefined {
 		const metadata = session.metadata;
 		if (metadata) {
-			// Cloud sessions: metadata.name is the repo name
+			// Cloud sessions: metadata.owner + metadata.name
+			const owner = metadata.owner as string | undefined;
 			const name = metadata.name as string | undefined;
-			if (name && typeof name === 'string') {
-				return name;
+			if (owner && name) {
+				return { id: `${owner}/${name}`, label: name };
 			}
 
 			// repositoryNwo: "owner/repo"
 			const nwo = metadata.repositoryNwo as string | undefined;
 			if (nwo && nwo.includes('/')) {
-				return nwo.split('/').pop()!;
+				return { id: nwo, label: nwo.split('/').pop()! };
 			}
 
 			// repository: could be "owner/repo" or a URL
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
 				if (repository.includes('/') && !repository.includes(':')) {
-					return repository.split('/').pop()!;
+					return { id: repository, label: repository.split('/').pop()! };
 				}
 				try {
 					const url = new URL(repository);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						return parts[1];
+						const id = `${parts[0]}/${parts[1]}`;
+						return { id, label: parts[1] };
 					}
 				} catch {
 					// not a URL
@@ -934,7 +939,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 					const url = new URL(repositoryUrl);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						return parts[1];
+						const id = `${parts[0]}/${parts[1]}`;
+						return { id, label: parts[1] };
 					}
 				} catch {
 					// not a URL
@@ -948,7 +954,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const raw = typeof badge === 'string' ? badge : badge.value;
 			const repoMatch = raw.match(/\$\(repo\)\s*(.+)/);
 			if (repoMatch) {
-				return repoMatch[1].trim();
+				const label = repoMatch[1].trim();
+				return { id: label, label };
 			}
 		}
 


### PR DESCRIPTION
## Summary

Adds a toggle button in the sessions view title bar to group sessions by repository instead of by date.

## Changes

### Sessions View (`sessionsViewPane.ts`)
- Added a toggle button in the view title bar (to the left of search and filter)
- Shows `$(repo)` icon when grouped by date → click to switch to repo grouping
- Shows `$(history)` icon when grouped by repo → click to switch back to date grouping
- Uses `RawContextKey` (`sessionsView.isGroupedByRepository`) to control icon visibility via `when` clauses

### Filter (`agentSessionsFilter.ts`)
- Added `Repository` to `AgentSessionsGrouping` enum
- Added grouping preference storage (`agentSessions.grouping` storage key)
- Public `setGrouping()` method for the view toggle to control grouping
- `isDefault()` and `reset()` account for grouping state

### Data Source (`agentSessionsViewer.ts`)
- Added `groupSessionsByRepository()` method that groups sessions under repo name section headers
- Added `getRepositoryName()` to extract repo name from session metadata:
  - `metadata.name` (cloud sessions)
  - `metadata.repositoryNwo` (e.g., `microsoft/vscode`)
  - `metadata.repository` / `metadata.repositoryUrl` (URL parsing)
  - Badge `$(repo)` prefix as fallback
- Archived sessions remain in a separate "Archived" section at the bottom
- Sessions without a repo name go under "Other"

### Model (`agentSessionsModel.ts`)
- Widened `IAgentSessionSection.section` type from `AgentSessionSection` to `string` to support dynamic repository section names

### Control (`agentSessionsControl.ts`)
- Updated `getSavedCollapseState`/`saveSectionCollapseState` parameter types to `string` to match widened section type