### PR TITLE
Add guessableName to GB18030 encoding

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -706,7 +706,8 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 	gb18030: {
 		labelLong: 'Simplified Chinese (GB18030)',
 		labelShort: 'GB18030',
-		order: 36
+		order: 36,
+		guessableName: 'GB2312'
 	},
 	cp950: {
 		labelLong: 'Traditional Chinese (Big5)',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Currently, `jschardet` often misidentifies GB18030 encoded files as GB2312 due to their backward compatibility. However, this causes significant issues because GB18030 supports the full Unicode range (similar to UTF-8), whereas GB2312 does not.

Reproduction: If a text file containing characters like `🌟𠀚〇𡌴鉏` is saved in GB18030, jschardet may detect it as GB2312. Upon reading the file with this incorrect encoding, these unsupported characters result in garbled text (e.g., `�9�9�2�2〇�5�2鉏`).

Close: #248513