### PR TITLE
fix: properly detect HKLM Windows 11 context menu overrides

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1508,7 +1508,7 @@ var
 begin
   // Check if the user has forced Windows 10 style context menus on Windows 11
   SubKey := 'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32';
-  Result := RegKeyExists(HKEY_CURRENT_USER, SubKey);
+  Result := RegKeyExists(HKEY_CURRENT_USER, SubKey) or RegKeyExists(HKEY_LOCAL_MACHINE, SubKey);
 end;
 
 function ShouldUseWindows11ContextMenu(): Boolean;

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1505,11 +1505,27 @@ end;
 function IsWindows10ContextMenuForced(): Boolean;
 var
   SubKey: String;
+  HklmDefValue: String;
 begin
-  // Check if Windows 10 style context menus are forced on Windows 11
-  // This can be set per-user (HKCU) or system-wide (HKLM)
   SubKey := 'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32';
-  Result := RegKeyExists(HKEY_CURRENT_USER, SubKey) or RegKeyExists(HKEY_LOCAL_MACHINE, SubKey);
+
+  // 1. Check if the user has forced Windows 10 style context menus via HKCU.
+  // The key does not natively exist in HKCU, so mere existence implies an override.
+  if RegKeyExists(HKEY_CURRENT_USER, SubKey) then begin
+    Result := True;
+    Exit;
+  end;
+
+  // 2. Check if a system administrator has forced it system-wide via HKLM.
+  // The key natively exists in HKLM. The override is applied by setting the default value to an empty string.
+  if RegQueryStringValue(HKEY_LOCAL_MACHINE, SubKey, '', HklmDefValue) then begin
+    if HklmDefValue = '' then begin
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  Result := False;
 end;
 
 function ShouldUseWindows11ContextMenu(): Boolean;

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1506,7 +1506,8 @@ function IsWindows10ContextMenuForced(): Boolean;
 var
   SubKey: String;
 begin
-  // Check if the user has forced Windows 10 style context menus on Windows 11
+  // Check if Windows 10 style context menus are forced on Windows 11
+  // This can be set per-user (HKCU) or system-wide (HKLM)
   SubKey := 'Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32';
   Result := RegKeyExists(HKEY_CURRENT_USER, SubKey) or RegKeyExists(HKEY_LOCAL_MACHINE, SubKey);
 end;
@@ -1515,7 +1516,7 @@ function ShouldUseWindows11ContextMenu(): Boolean;
 begin
   // Use Windows 11 context menu only if:
   // 1. Running on Windows 11 or later
-  // 2. User has NOT forced Windows 10 style context menus
+  // 2. Windows 10 style context menus are NOT forced per-user or system-wide
   Result := IsWindows11OrLater() and not IsWindows10ContextMenuForced();
 end;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The `InprocServer32` key natively exists in `HKEY_LOCAL_MACHINE` on all Windows 11 machines as the system's COM registration point for the modern context menu (`C:\Windows\System32\Windows.UI.FileExplorer.dll`). The prior implementation checking if the key merely existed (`RegKeyExists`) was fundamentally flawed, as it would evaluate to `true` on standard Windows 11 systems and unnecessarily force the classic context menu behavior (triggering the regression seen in #295187).

This PR introduces a revised fix that addresses the root issue precisely.

When a system administrator forcibly overrides the Windows 11 context menu system-wide, they do it by explicitly setting the `(default)` string value of that `InprocServer32` key to be completely empty (`""`). This empty value breaks the COM loading process and forces Explorer to natively fall back to the Windows 10 classic menus.

The updated `code.iss` logic now correctly uses `RegQueryStringValue` to query the `(default)` value in `HKEY_LOCAL_MACHINE`. If and only if it explicitly evaluates to an empty string (`""`), do we consider the system-wide override enforced. This safely enables enterprise environments to globally block the modern context menu while completely preventing regressions for standard users where the default value successfully points to the explorer dll.

**How to test them:**
1. On a clean Windows 11 machine, ensure the `InprocServer32` key exists at `HKEY_LOCAL_MACHINE\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32` and explicitly set its `(default)` String value to be completely empty (`""`) to globally disable the Windows 11 context menu.
2. Build the VS Code Windows System Installer (`node build\win32\code.iss`) containing this fix, and verify it correctly queries `HKEY_LOCAL_MACHINE` based on the empty string without failing.
3. Install the generated installer. Ensure the "Add 'Open with Code' action to Windows Explorer directory context menu" option is checked during installation.
4. Open Windows Explorer, navigate to any directory, and verify that the "Open with Code" action is correctly present in the classic context menu.

Fixes #295446
