### PR TITLE
chat: refactor model picker delegate and improve picker UX

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -810,7 +810,7 @@ export class ActionList<T> extends Disposable {
 			availableHeight = widgetTop > 0 ? windowHeight - widgetTop - padding : windowHeight * 0.7;
 		}
 
-		const viewportMaxHeight = Math.floor(targetWindow.innerHeight * 0.4);
+		const viewportMaxHeight = Math.floor(targetWindow.innerHeight * 0.6);
 		const maxHeight = Math.min(Math.max(availableHeight, this._actionLineHeight * 3 + filterHeight), viewportMaxHeight);
 		const height = Math.min(listHeight + filterHeight, maxHeight);
 		return height - filterHeight;

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -686,7 +686,8 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 				this._focusEditor();
 			},
 			getModels: () => this._getAvailableModels(),
-			canManageModels: () => true,
+			useGroupedModelPicker: () => true,
+			showManageModelsAction: () => true,
 		};
 
 		const pickerOptions: IChatInputPickerOptions = {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -687,7 +687,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			},
 			getModels: () => this._getAvailableModels(),
 			useGroupedModelPicker: () => true,
-			showManageModelsAction: () => true,
+			showManageModelsAction: () => false,
 		};
 
 		const pickerOptions: IChatInputPickerOptions = {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2225,7 +2225,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.renderAttachedContext();
 						},
 						getModels: () => this.getModels(),
-						canManageModels: () => {
+						useGroupedModelPicker: () => {
+							const sessionType = this.getCurrentSessionType();
+							return !sessionType || sessionType === localChatSessionType;
+						},
+						showManageModelsAction: () => {
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
 						}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2225,10 +2225,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this.renderAttachedContext();
 						},
 						getModels: () => this.getModels(),
-						useGroupedModelPicker: () => {
-							const sessionType = this.getCurrentSessionType();
-							return !sessionType || sessionType === localChatSessionType;
-						},
+						useGroupedModelPicker: () => true,
 						showManageModelsAction: () => {
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -183,195 +183,194 @@ export function buildModelPickerItems(
 			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
 		}
 	} else {
-
 		const isPro = isProUser(chatEntitlementService.entitlement);
 		let otherModels: ILanguageModelChatMetadataAndIdentifier[] = [];
-	if (models.length) {
-		// Collect all available models into lookup maps
-		const allModelsMap = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
-		const modelsByMetadataId = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
-		for (const model of models) {
-			allModelsMap.set(model.identifier, model);
-			modelsByMetadataId.set(model.metadata.id, model);
-		}
-
-		const placed = new Set<string>();
-
-		const markPlaced = (identifierOrId: string, metadataId?: string) => {
-			placed.add(identifierOrId);
-			if (metadataId) {
-				placed.add(metadataId);
+		if (models.length) {
+			// Collect all available models into lookup maps
+			const allModelsMap = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
+			const modelsByMetadataId = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
+			for (const model of models) {
+				allModelsMap.set(model.identifier, model);
+				modelsByMetadataId.set(model.metadata.id, model);
 			}
-		};
 
-		const resolveModel = (id: string) => allModelsMap.get(id) ?? modelsByMetadataId.get(id);
+			const placed = new Set<string>();
 
-		const getUnavailableReason = (entry: IModelControlEntry): 'upgrade' | 'update' | 'admin' => {
-			if (!isPro) {
-				return 'upgrade';
-			}
-			if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-				return 'update';
-			}
-			return 'admin';
-		};
-
-		// --- 1. Auto ---
-		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
-		if (autoModel) {
-			markPlaced(autoModel.identifier, autoModel.metadata.id);
-			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
-		}
-
-		// --- 2. Promoted section (selected + recently used + featured) ---
-		type PromotedItem =
-			| { kind: 'available'; model: ILanguageModelChatMetadataAndIdentifier }
-			| { kind: 'unavailable'; id: string; entry: IModelControlEntry; reason: 'upgrade' | 'update' | 'admin' };
-
-		const promotedItems: PromotedItem[] = [];
-
-		// Try to place a model by id. Returns true if handled.
-		const tryPlaceModel = (id: string): boolean => {
-			if (placed.has(id)) {
-				return false;
-			}
-			const model = resolveModel(id);
-			if (model && !placed.has(model.identifier)) {
-				markPlaced(model.identifier, model.metadata.id);
-				const entry = controlModels[model.metadata.id];
-				if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-					promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
-				} else {
-					promotedItems.push({ kind: 'available', model });
+			const markPlaced = (identifierOrId: string, metadataId?: string) => {
+				placed.add(identifierOrId);
+				if (metadataId) {
+					placed.add(metadataId);
 				}
-				return true;
+			};
+
+			const resolveModel = (id: string) => allModelsMap.get(id) ?? modelsByMetadataId.get(id);
+
+			const getUnavailableReason = (entry: IModelControlEntry): 'upgrade' | 'update' | 'admin' => {
+				if (!isPro) {
+					return 'upgrade';
+				}
+				if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+					return 'update';
+				}
+				return 'admin';
+			};
+
+			// --- 1. Auto ---
+			const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
+			if (autoModel) {
+				markPlaced(autoModel.identifier, autoModel.metadata.id);
+				items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
 			}
-			if (!model) {
-				const entry = controlModels[id];
-				if (entry && !entry.exists) {
-					markPlaced(id);
-					promotedItems.push({ kind: 'unavailable', id, entry, reason: getUnavailableReason(entry) });
+
+			// --- 2. Promoted section (selected + recently used + featured) ---
+			type PromotedItem =
+				| { kind: 'available'; model: ILanguageModelChatMetadataAndIdentifier }
+				| { kind: 'unavailable'; id: string; entry: IModelControlEntry; reason: 'upgrade' | 'update' | 'admin' };
+
+			const promotedItems: PromotedItem[] = [];
+
+			// Try to place a model by id. Returns true if handled.
+			const tryPlaceModel = (id: string): boolean => {
+				if (placed.has(id)) {
+					return false;
+				}
+				const model = resolveModel(id);
+				if (model && !placed.has(model.identifier)) {
+					markPlaced(model.identifier, model.metadata.id);
+					const entry = controlModels[model.metadata.id];
+					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+						promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
+					} else {
+						promotedItems.push({ kind: 'available', model });
+					}
 					return true;
 				}
-			}
-			return false;
-		};
-
-		// Selected model
-		if (selectedModelId && selectedModelId !== autoModel?.identifier) {
-			tryPlaceModel(selectedModelId);
-		}
-
-		// Recently used models
-		for (const id of recentModelIds) {
-			tryPlaceModel(id);
-		}
-
-		// Featured models from control manifest
-		for (const [entryId, entry] of Object.entries(controlModels)) {
-			if (!entry.featured || placed.has(entryId)) {
-				continue;
-			}
-			const model = resolveModel(entryId);
-			if (model && !placed.has(model.identifier)) {
-				markPlaced(model.identifier, model.metadata.id);
-				if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-					promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
-				} else {
-					promotedItems.push({ kind: 'available', model });
+				if (!model) {
+					const entry = controlModels[id];
+					if (entry && !entry.exists) {
+						markPlaced(id);
+						promotedItems.push({ kind: 'unavailable', id, entry, reason: getUnavailableReason(entry) });
+						return true;
+					}
 				}
-			} else if (!model && !entry.exists) {
-				markPlaced(entryId);
-				promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
+				return false;
+			};
+
+			// Selected model
+			if (selectedModelId && selectedModelId !== autoModel?.identifier) {
+				tryPlaceModel(selectedModelId);
 			}
-		}
 
-		// Render promoted section: available first, then sorted alphabetically by name
-		if (promotedItems.length > 0) {
-			promotedItems.sort((a, b) => {
-				const aAvail = a.kind === 'available' ? 0 : 1;
-				const bAvail = b.kind === 'available' ? 0 : 1;
-				if (aAvail !== bAvail) {
-					return aAvail - bAvail;
+			// Recently used models
+			for (const id of recentModelIds) {
+				tryPlaceModel(id);
+			}
+
+			// Featured models from control manifest
+			for (const [entryId, entry] of Object.entries(controlModels)) {
+				if (!entry.featured || placed.has(entryId)) {
+					continue;
 				}
-				const aName = a.kind === 'available' ? a.model.metadata.name : a.entry.label;
-				const bName = b.kind === 'available' ? b.model.metadata.name : b.entry.label;
-				return aName.localeCompare(bName);
-			});
-
-			for (const item of promotedItems) {
-				if (item.kind === 'available') {
-					items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect), item.model));
-				} else {
-					items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType));
+				const model = resolveModel(entryId);
+				if (model && !placed.has(model.identifier)) {
+					markPlaced(model.identifier, model.metadata.id);
+					if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+						promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
+					} else {
+						promotedItems.push({ kind: 'available', model });
+					}
+				} else if (!model && !entry.exists) {
+					markPlaced(entryId);
+					promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
 				}
 			}
-		}
 
-		// --- 3. Other Models (collapsible) ---
-		otherModels = models
-			.filter(m => !placed.has(m.identifier) && !placed.has(m.metadata.id))
-			.sort((a, b) => {
-				const aEntry = controlModels[a.metadata.id] ?? controlModels[a.identifier];
-				const bEntry = controlModels[b.metadata.id] ?? controlModels[b.identifier];
-				const aAvail = aEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, aEntry.minVSCodeVersion) ? 1 : 0;
-				const bAvail = bEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, bEntry.minVSCodeVersion) ? 1 : 0;
-				if (aAvail !== bAvail) {
-					return aAvail - bAvail;
-				}
-				const aCopilot = a.metadata.vendor === 'copilot' ? 0 : 1;
-				const bCopilot = b.metadata.vendor === 'copilot' ? 0 : 1;
-				if (aCopilot !== bCopilot) {
-					return aCopilot - bCopilot;
-				}
-				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
-				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
-			});
+			// Render promoted section: available first, then sorted alphabetically by name
+			if (promotedItems.length > 0) {
+				promotedItems.sort((a, b) => {
+					const aAvail = a.kind === 'available' ? 0 : 1;
+					const bAvail = b.kind === 'available' ? 0 : 1;
+					if (aAvail !== bAvail) {
+						return aAvail - bAvail;
+					}
+					const aName = a.kind === 'available' ? a.model.metadata.name : a.entry.label;
+					const bName = b.kind === 'available' ? b.model.metadata.name : b.entry.label;
+					return aName.localeCompare(bName);
+				});
 
-		if (otherModels.length > 0) {
-			if (items.length > 0) {
-				items.push({ kind: ActionListItemKind.Separator });
+				for (const item of promotedItems) {
+					if (item.kind === 'available') {
+						items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect), item.model));
+					} else {
+						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType));
+					}
+				}
 			}
-			items.push({
-				item: {
-					id: 'otherModels',
-					enabled: true,
-					checked: false,
-					class: undefined,
-					tooltip: localize('chat.modelPicker.otherModels', "Other Models"),
+
+			// --- 3. Other Models (collapsible) ---
+			otherModels = models
+				.filter(m => !placed.has(m.identifier) && !placed.has(m.metadata.id))
+				.sort((a, b) => {
+					const aEntry = controlModels[a.metadata.id] ?? controlModels[a.identifier];
+					const bEntry = controlModels[b.metadata.id] ?? controlModels[b.identifier];
+					const aAvail = aEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, aEntry.minVSCodeVersion) ? 1 : 0;
+					const bAvail = bEntry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, bEntry.minVSCodeVersion) ? 1 : 0;
+					if (aAvail !== bAvail) {
+						return aAvail - bAvail;
+					}
+					const aCopilot = a.metadata.vendor === 'copilot' ? 0 : 1;
+					const bCopilot = b.metadata.vendor === 'copilot' ? 0 : 1;
+					if (aCopilot !== bCopilot) {
+						return aCopilot - bCopilot;
+					}
+					const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
+					return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
+				});
+
+			if (otherModels.length > 0) {
+				if (items.length > 0) {
+					items.push({ kind: ActionListItemKind.Separator });
+				}
+				items.push({
+					item: {
+						id: 'otherModels',
+						enabled: true,
+						checked: false,
+						class: undefined,
+						tooltip: localize('chat.modelPicker.otherModels', "Other Models"),
+						label: localize('chat.modelPicker.otherModels', "Other Models"),
+						run: () => { /* toggle handled by isSectionToggle */ }
+					},
+					kind: ActionListItemKind.Action,
 					label: localize('chat.modelPicker.otherModels', "Other Models"),
-					run: () => { /* toggle handled by isSectionToggle */ }
-				},
-				kind: ActionListItemKind.Action,
-				label: localize('chat.modelPicker.otherModels', "Other Models"),
-				group: { title: '', icon: Codicon.chevronDown },
-				hideIcon: false,
-				section: ModelPickerSection.Other,
-				isSectionToggle: true,
-			});
-			for (const model of otherModels) {
-				const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
-				if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-					items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other));
-				} else {
-					items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, ModelPickerSection.Other), model));
+					group: { title: '', icon: Codicon.chevronDown },
+					hideIcon: false,
+					section: ModelPickerSection.Other,
+					isSectionToggle: true,
+				});
+				for (const model of otherModels) {
+					const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
+					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other));
+					} else {
+						items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, ModelPickerSection.Other), model));
+					}
 				}
 			}
-		}
 
-		if (manageModelsAction) {
-			items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
-			items.push({
-				item: manageModelsAction,
-				kind: ActionListItemKind.Action,
-				label: manageModelsAction.label,
-				group: { title: '', icon: Codicon.blank },
-				hideIcon: false,
-				section: otherModels.length ? ModelPickerSection.Other : undefined,
-				showAlways: true,
-			});
+			if (manageModelsAction) {
+				items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
+				items.push({
+					item: manageModelsAction,
+					kind: ActionListItemKind.Action,
+					label: manageModelsAction.label,
+					group: { title: '', icon: Codicon.blank },
+					hideIcon: false,
+					section: otherModels.length ? ModelPickerSection.Other : undefined,
+					showAlways: true,
+				});
+			}
 		}
-	}
 	}
 
 	return items;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -167,22 +167,7 @@ export function buildModelPickerItems(
 		}));
 	}
 
-	if (!useGroupedModelPicker) {
-		// Flat list: auto first, then all models sorted alphabetically
-		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
-		if (autoModel) {
-			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
-		}
-		const sortedModels = models
-			.filter(m => m !== autoModel)
-			.sort((a, b) => {
-				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
-				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
-			});
-		for (const model of sortedModels) {
-			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
-		}
-	} else {
+	if (useGroupedModelPicker) {
 		const isPro = isProUser(chatEntitlementService.entitlement);
 		let otherModels: ILanguageModelChatMetadataAndIdentifier[] = [];
 		if (models.length) {
@@ -370,6 +355,21 @@ export function buildModelPickerItems(
 					showAlways: true,
 				});
 			}
+		}
+	} else {
+		// Flat list: auto first, then all models sorted alphabetically
+		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
+		if (autoModel) {
+			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
+		}
+		const sortedModels = models
+			.filter(m => m !== autoModel)
+			.sort((a, b) => {
+				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
+				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
+			});
+		for (const model of sortedModels) {
+			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -150,7 +150,8 @@ export function buildModelPickerItems(
 	updateStateType: StateType,
 	onSelect: (model: ILanguageModelChatMetadataAndIdentifier) => void,
 	manageSettingsUrl: string | undefined,
-	canManageModels: boolean,
+	useGroupedModelPicker: boolean,
+	showManageModelsAction: boolean,
 	manageModelsAction: IActionWidgetDropdownAction | undefined,
 	chatEntitlementService: IChatEntitlementService,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
@@ -167,7 +168,7 @@ export function buildModelPickerItems(
 		}));
 	}
 
-	if (!canManageModels) {
+	if (!useGroupedModelPicker) {
 		// Flat list: auto first, then all models sorted alphabetically
 		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
 		if (autoModel) {
@@ -182,11 +183,10 @@ export function buildModelPickerItems(
 		for (const model of sortedModels) {
 			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
 		}
-		return items;
-	}
+	} else {
 
-	const isPro = isProUser(chatEntitlementService.entitlement);
-	let otherModels: ILanguageModelChatMetadataAndIdentifier[] = [];
+		const isPro = isProUser(chatEntitlementService.entitlement);
+		let otherModels: ILanguageModelChatMetadataAndIdentifier[] = [];
 	if (models.length) {
 		// Collect all available models into lookup maps
 		const allModelsMap = new Map<string, ILanguageModelChatMetadataAndIdentifier>();
@@ -359,19 +359,20 @@ export function buildModelPickerItems(
 				}
 			}
 		}
-	}
 
-	if (manageModelsAction) {
-		items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
-		items.push({
-			item: manageModelsAction,
-			kind: ActionListItemKind.Action,
-			label: manageModelsAction.label,
-			group: { title: '', icon: Codicon.blank },
-			hideIcon: false,
-			section: otherModels.length ? ModelPickerSection.Other : undefined,
-			showAlways: true,
-		});
+		if (manageModelsAction) {
+			items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
+			items.push({
+				item: manageModelsAction,
+				kind: ActionListItemKind.Action,
+				label: manageModelsAction.label,
+				group: { title: '', icon: Codicon.blank },
+				hideIcon: false,
+				section: otherModels.length ? ModelPickerSection.Other : undefined,
+				showAlways: true,
+			});
+		}
+	}
 	}
 
 	return items;
@@ -572,7 +573,7 @@ export class ModelPickerWidget extends Disposable {
 		const isPro = isProUser(this._entitlementService.entitlement);
 		const manifest = this._languageModelsService.getModelsControlManifest();
 		const controlModelsForTier = isPro ? manifest.paid : manifest.free;
-		const canShowManageModelsAction = this._delegate.canManageModels() && shouldShowManageModelsAction(this._entitlementService);
+		const canShowManageModelsAction = this._delegate.showManageModelsAction() && shouldShowManageModelsAction(this._entitlementService);
 		const manageModelsAction = canShowManageModelsAction ? createManageModelsAction(this._commandService) : undefined;
 		const items = buildModelPickerItems(
 			models,
@@ -583,7 +584,8 @@ export class ModelPickerWidget extends Disposable {
 			this._updateService.state.type,
 			onSelect,
 			this._productService.defaultChatAgent?.manageSettingsUrl,
-			this._delegate.canManageModels(),
+			this._delegate.useGroupedModelPicker(),
+			this._delegate.showManageModelsAction(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
 		);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -16,6 +16,7 @@ import { autorun, IObservable } from '../../../../../../base/common/observable.j
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { ActionListItemKind, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
+import { IHoverPositionOptions } from '../../../../../../base/browser/ui/hover/hover.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
@@ -76,6 +77,7 @@ type ChatModelChangeEvent = {
 function createModelItem(
 	action: IActionWidgetDropdownAction & { section?: string },
 	model?: ILanguageModelChatMetadataAndIdentifier,
+	hoverPosition?: IHoverPositionOptions,
 ): IActionListItem<IActionWidgetDropdownAction> {
 	return {
 		item: action,
@@ -85,7 +87,7 @@ function createModelItem(
 		group: { title: '', icon: action.icon ?? ThemeIcon.fromId(action.checked ? Codicon.check.id : Codicon.blank.id) },
 		hideIcon: false,
 		section: action.section,
-		hover: model ? { content: getModelHoverContent(model) } : undefined,
+		hover: model ? { content: getModelHoverContent(model), position: hoverPosition } : undefined,
 	};
 }
 
@@ -153,6 +155,7 @@ export function buildModelPickerItems(
 	useGroupedModelPicker: boolean,
 	manageModelsAction: IActionWidgetDropdownAction | undefined,
 	chatEntitlementService: IChatEntitlementService,
+	hoverPosition?: IHoverPositionOptions,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
 	if (models.length === 0) {
@@ -204,7 +207,7 @@ export function buildModelPickerItems(
 			const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
 			if (autoModel) {
 				markPlaced(autoModel.identifier, autoModel.metadata.id);
-				items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
+				items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel, hoverPosition));
 			}
 
 			// --- 2. Promoted section (selected + recently used + featured) ---
@@ -285,9 +288,9 @@ export function buildModelPickerItems(
 
 				for (const item of promotedItems) {
 					if (item.kind === 'available') {
-						items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect), item.model));
+						items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect), item.model, hoverPosition));
 					} else {
-						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType));
+						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, undefined, hoverPosition));
 					}
 				}
 			}
@@ -336,9 +339,9 @@ export function buildModelPickerItems(
 				for (const model of otherModels) {
 					const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
 					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other));
+						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other, hoverPosition));
 					} else {
-						items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, ModelPickerSection.Other), model));
+						items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, ModelPickerSection.Other), model, hoverPosition));
 					}
 				}
 			}
@@ -360,7 +363,7 @@ export function buildModelPickerItems(
 		// Flat list: auto first, then all models sorted alphabetically
 		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
 		if (autoModel) {
-			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
+			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel, hoverPosition));
 		}
 		const sortedModels = models
 			.filter(m => m !== autoModel)
@@ -369,7 +372,7 @@ export function buildModelPickerItems(
 				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
 			});
 		for (const model of sortedModels) {
-			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
+			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model, hoverPosition));
 		}
 	}
 
@@ -399,6 +402,7 @@ function createUnavailableModelItem(
 	manageSettingsUrl: string | undefined,
 	updateStateType: StateType,
 	section?: string,
+	hoverPosition?: IHoverPositionOptions,
 ): IActionListItem<IActionWidgetDropdownAction> {
 	let description: string | MarkdownString | undefined;
 
@@ -442,7 +446,7 @@ function createUnavailableModelItem(
 		hideIcon: false,
 		className: 'chat-model-picker-unavailable',
 		section,
-		hover: { content: hoverContent },
+		hover: { content: hoverContent, position: hoverPosition },
 	};
 }
 
@@ -480,6 +484,7 @@ export class ModelPickerWidget extends Disposable {
 
 	constructor(
 		private readonly _delegate: IModelPickerDelegate,
+		private readonly _hoverPosition: IHoverPositionOptions | undefined,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -585,6 +590,7 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.useGroupedModelPicker(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
+			this._hoverPosition,
 		);
 
 		const listOptions = {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -345,19 +345,19 @@ export function buildModelPickerItems(
 					}
 				}
 			}
+		}
 
-			if (manageModelsAction) {
-				items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
-				items.push({
-					item: manageModelsAction,
-					kind: ActionListItemKind.Action,
-					label: manageModelsAction.label,
-					group: { title: '', icon: Codicon.blank },
-					hideIcon: false,
-					section: otherModels.length ? ModelPickerSection.Other : undefined,
-					showAlways: true,
-				});
-			}
+		if (manageModelsAction) {
+			items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
+			items.push({
+				item: manageModelsAction,
+				kind: ActionListItemKind.Action,
+				label: manageModelsAction.label,
+				group: { title: '', icon: Codicon.blank },
+				hideIcon: false,
+				section: otherModels.length ? ModelPickerSection.Other : undefined,
+				showAlways: true,
+			});
 		}
 	} else {
 		// Flat list: auto first, then all models sorted alphabetically

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -151,7 +151,6 @@ export function buildModelPickerItems(
 	onSelect: (model: ILanguageModelChatMetadataAndIdentifier) => void,
 	manageSettingsUrl: string | undefined,
 	useGroupedModelPicker: boolean,
-	showManageModelsAction: boolean,
 	manageModelsAction: IActionWidgetDropdownAction | undefined,
 	chatEntitlementService: IChatEntitlementService,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
@@ -585,7 +584,6 @@ export class ModelPickerWidget extends Disposable {
 			onSelect,
 			this._productService.defaultChatAgent?.manageSettingsUrl,
 			this._delegate.useGroupedModelPicker(),
-			this._delegate.showManageModelsAction(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
 		);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -29,7 +29,8 @@ export interface IModelPickerDelegate {
 	readonly currentModel: IObservable<ILanguageModelChatMetadataAndIdentifier | undefined>;
 	setModel(model: ILanguageModelChatMetadataAndIdentifier): void;
 	getModels(): ILanguageModelChatMetadataAndIdentifier[];
-	canManageModels(): boolean;
+	useGroupedModelPicker(): boolean;
+	showManageModelsAction(): boolean;
 }
 
 type ChatModelChangeClassification = {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem2.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem2.ts
@@ -39,7 +39,7 @@ export class EnhancedModelPickerActionItem extends BaseActionViewItem {
 	) {
 		super(undefined, action);
 
-		this._pickerWidget = this._register(instantiationService.createInstance(ModelPickerWidget, delegate));
+		this._pickerWidget = this._register(instantiationService.createInstance(ModelPickerWidget, delegate, pickerOptions.hoverPosition));
 		this._pickerWidget.setSelectedModel(delegate.currentModel.get());
 		this._pickerWidget.setHideChevrons(pickerOptions.hideChevrons);
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -97,6 +97,7 @@ function callBuild(
 		onSelect,
 		opts.manageSettingsUrl,
 		true,
+		true,
 		stubManageModelsAction,
 		entitlementService,
 	);
@@ -472,6 +473,7 @@ suite('buildModelPickerItems', () => {
 			onSelect,
 			undefined,
 			true,
+			true,
 			undefined,
 			stubChatEntitlementService,
 		);
@@ -553,6 +555,7 @@ suite('buildModelPickerItems', () => {
 			StateType.Idle,
 			() => { },
 			'https://aka.ms/github-copilot-settings',
+			true,
 			true,
 			undefined,
 			stubChatEntitlementService,
@@ -636,6 +639,7 @@ suite('buildModelPickerItems', () => {
 			StateType.Idle,
 			onSelect,
 			undefined,
+			true,
 			true,
 			undefined,
 			anonymousEntitlementService,

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -97,7 +97,6 @@ function callBuild(
 		onSelect,
 		opts.manageSettingsUrl,
 		true,
-		true,
 		stubManageModelsAction,
 		entitlementService,
 	);
@@ -473,7 +472,6 @@ suite('buildModelPickerItems', () => {
 			onSelect,
 			undefined,
 			true,
-			true,
 			undefined,
 			stubChatEntitlementService,
 		);
@@ -555,7 +553,6 @@ suite('buildModelPickerItems', () => {
 			StateType.Idle,
 			() => { },
 			'https://aka.ms/github-copilot-settings',
-			true,
 			true,
 			undefined,
 			stubChatEntitlementService,
@@ -639,7 +636,6 @@ suite('buildModelPickerItems', () => {
 			StateType.Idle,
 			onSelect,
 			undefined,
-			true,
 			true,
 			undefined,
 			anonymousEntitlementService,


### PR DESCRIPTION
## Summary

Refactors `IModelPickerDelegate` to split `canManageModels()` into two independent flags and improves the model picker UX with hover position support and increased max height.

## Changes

### `IModelPickerDelegate` refactoring
- **`useGroupedModelPicker()`** — controls whether the picker uses grouped layout (promoted/featured/other sections) vs flat list
- **`showManageModelsAction()`** — controls whether the "Manage Models..." link appears

These were previously conflated in a single `canManageModels()` method. Now they can be independently controlled per caller:
- `chatInputPart.ts`: always uses grouped picker (`true`), manage action gated by session type
- `newChatViewPane.ts`: always uses grouped picker (`true`), manage action disabled (`false`)

### `buildModelPickerItems` restructuring
- Replaced `canManageModels` parameter with `useGroupedModelPicker`
- Flipped if/else so the grouped layout (primary path) comes first for readability
- Properly indented the grouped layout block

### Hover position support
- `ModelPickerWidget` now accepts `hoverPosition` and threads it through to `buildModelPickerItems`, `createModelItem`, and `createUnavailableModelItem`
- `EnhancedModelPickerActionItem` passes `pickerOptions.hoverPosition` to the widget

### Action list max height
- Increased viewport max height from 40% to 60% to better accommodate the grouped model picker with many models