### PR TITLE
config: make all settings experiment-aware by default

### DIFF
--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -74,7 +74,7 @@ const editorConfiguration: IConfigurationNode = {
 				nls.localize('wordBasedSuggestions.allDocuments', 'Suggest words from all open documents.'),
 			],
 			description: nls.localize('wordBasedSuggestions', "Controls whether completions should be computed based on words in the document and from which documents they are computed."),
-			experiment: 'auto',
+			experimentMode: 'auto',
 		},
 		'editor.semanticHighlighting.enabled': {
 			enum: [true, false, 'configuredByTheme'],
@@ -118,35 +118,35 @@ const editorConfiguration: IConfigurationNode = {
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.treeSitterTelemetry', "Controls whether tree sitter parsing should be turned on and telemetry collected. Setting `#editor.experimental.preferTreeSitter#` for specific languages will take precedence."),
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.css': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.css', "Controls whether tree sitter parsing should be turned on for css. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for css."),
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.typescript': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.typescript', "Controls whether tree sitter parsing should be turned on for typescript. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for typescript."),
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.ini': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.ini', "Controls whether tree sitter parsing should be turned on for ini. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for ini."),
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.regex': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.regex', "Controls whether tree sitter parsing should be turned on for regex. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for regex."),
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'editor.language.brackets': {
 			type: ['array', 'null'],

--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -74,7 +74,7 @@ const editorConfiguration: IConfigurationNode = {
 				nls.localize('wordBasedSuggestions.allDocuments', 'Suggest words from all open documents.'),
 			],
 			description: nls.localize('wordBasedSuggestions', "Controls whether completions should be computed based on words in the document and from which documents they are computed."),
-			experiment: { mode: 'auto' },
+			experiment: 'auto',
 		},
 		'editor.semanticHighlighting.enabled': {
 			enum: [true, false, 'configuredByTheme'],
@@ -118,45 +118,35 @@ const editorConfiguration: IConfigurationNode = {
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.treeSitterTelemetry', "Controls whether tree sitter parsing should be turned on and telemetry collected. Setting `#editor.experimental.preferTreeSitter#` for specific languages will take precedence."),
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.css': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.css', "Controls whether tree sitter parsing should be turned on for css. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for css."),
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.typescript': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.typescript', "Controls whether tree sitter parsing should be turned on for typescript. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for typescript."),
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.ini': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.ini', "Controls whether tree sitter parsing should be turned on for ini. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for ini."),
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.regex': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.regex', "Controls whether tree sitter parsing should be turned on for regex. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for regex."),
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'editor.language.brackets': {
 			type: ['array', 'null'],

--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -74,7 +74,6 @@ const editorConfiguration: IConfigurationNode = {
 				nls.localize('wordBasedSuggestions.allDocuments', 'Suggest words from all open documents.'),
 			],
 			description: nls.localize('wordBasedSuggestions', "Controls whether completions should be computed based on words in the document and from which documents they are computed."),
-			experimentMode: 'auto',
 		},
 		'editor.semanticHighlighting.enabled': {
 			enum: [true, false, 'configuredByTheme'],
@@ -118,35 +117,30 @@ const editorConfiguration: IConfigurationNode = {
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.treeSitterTelemetry', "Controls whether tree sitter parsing should be turned on and telemetry collected. Setting `#editor.experimental.preferTreeSitter#` for specific languages will take precedence."),
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.css': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.css', "Controls whether tree sitter parsing should be turned on for css. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for css."),
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.typescript': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.typescript', "Controls whether tree sitter parsing should be turned on for typescript. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for typescript."),
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.ini': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.ini', "Controls whether tree sitter parsing should be turned on for ini. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for ini."),
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'editor.experimental.preferTreeSitter.regex': {
 			type: 'boolean',
 			default: false,
 			markdownDescription: nls.localize('editor.experimental.preferTreeSitter.regex', "Controls whether tree sitter parsing should be turned on for regex. This will take precedence over `#editor.experimental.treeSitterTelemetry#` for regex."),
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'editor.language.brackets': {
 			type: ['array', 'null'],

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3807,7 +3807,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 			],
 			default: defaults,
 			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget. Also be aware of the {0}-setting which controls if suggestions are triggered by special characters.", '`#editor.suggestOnTriggerCharacters#`'),
-			experiment: 'auto'
+			experimentMode: 'auto'
 		});
 		this.defaultValue = defaults;
 	}
@@ -4603,21 +4603,21 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.experimental.suppressInlineSuggestions,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.suppressInlineSuggestions', "Suppresses inline completions for specified extension IDs -- comma separated."),
-					experiment: 'auto'
+					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.experimental.emptyResponseInformation': {
 					type: 'boolean',
 					default: defaults.experimental.emptyResponseInformation,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.emptyResponseInformation', "Controls whether to send request information from the inline suggestion provider."),
-					experiment: 'auto'
+					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.triggerCommandOnProviderChange': {
 					type: 'boolean',
 					default: defaults.triggerCommandOnProviderChange,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.triggerCommandOnProviderChange', "Controls whether to trigger a command when the inline suggestion provider changes."),
-					experiment: 'auto'
+					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.experimental.showOnSuggestConflict': {
 					type: 'string',
@@ -4625,7 +4625,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					tags: ['experimental'],
 					enum: ['always', 'never', 'whenSuggestListIsIncomplete'],
 					description: nls.localize('inlineSuggest.showOnSuggestConflict', "Controls whether to show inline suggestions when there is a suggest conflict."),
-					experiment: 'auto'
+					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.fontFamily': {
 					type: 'string',
@@ -6507,7 +6507,7 @@ export const EditorOptions = {
 		10, 0, Constants.MAX_SAFE_SMALL_INTEGER,
 		{
 			description: nls.localize('quickSuggestionsDelay', "Controls the delay in milliseconds after which quick suggestions will show up."),
-			experiment: 'auto'
+			experimentMode: 'auto'
 		}
 	)),
 	readOnly: register(new EditorBooleanOption(

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3807,9 +3807,7 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 			],
 			default: defaults,
 			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget. Also be aware of the {0}-setting which controls if suggestions are triggered by special characters.", '`#editor.suggestOnTriggerCharacters#`'),
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		});
 		this.defaultValue = defaults;
 	}
@@ -4605,27 +4603,21 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.experimental.suppressInlineSuggestions,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.suppressInlineSuggestions', "Suppresses inline completions for specified extension IDs -- comma separated."),
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				},
 				'editor.inlineSuggest.experimental.emptyResponseInformation': {
 					type: 'boolean',
 					default: defaults.experimental.emptyResponseInformation,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.emptyResponseInformation', "Controls whether to send request information from the inline suggestion provider."),
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				},
 				'editor.inlineSuggest.triggerCommandOnProviderChange': {
 					type: 'boolean',
 					default: defaults.triggerCommandOnProviderChange,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.triggerCommandOnProviderChange', "Controls whether to trigger a command when the inline suggestion provider changes."),
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				},
 				'editor.inlineSuggest.experimental.showOnSuggestConflict': {
 					type: 'string',
@@ -4633,9 +4625,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					tags: ['experimental'],
 					enum: ['always', 'never', 'whenSuggestListIsIncomplete'],
 					description: nls.localize('inlineSuggest.showOnSuggestConflict', "Controls whether to show inline suggestions when there is a suggest conflict."),
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				},
 				'editor.inlineSuggest.fontFamily': {
 					type: 'string',
@@ -6517,9 +6507,7 @@ export const EditorOptions = {
 		10, 0, Constants.MAX_SAFE_SMALL_INTEGER,
 		{
 			description: nls.localize('quickSuggestionsDelay', "Controls the delay in milliseconds after which quick suggestions will show up."),
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		}
 	)),
 	readOnly: register(new EditorBooleanOption(

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3807,7 +3807,6 @@ class EditorQuickSuggestions extends BaseEditorOption<EditorOption.quickSuggesti
 			],
 			default: defaults,
 			markdownDescription: nls.localize('quickSuggestions', "Controls whether suggestions should automatically show up while typing. This can be controlled for typing in comments, strings, and other code. Quick suggestion can be configured to show as ghost text or with the suggest widget. Also be aware of the {0}-setting which controls if suggestions are triggered by special characters.", '`#editor.suggestOnTriggerCharacters#`'),
-			experimentMode: 'auto'
 		});
 		this.defaultValue = defaults;
 	}
@@ -4603,21 +4602,18 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.experimental.suppressInlineSuggestions,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.suppressInlineSuggestions', "Suppresses inline completions for specified extension IDs -- comma separated."),
-					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.experimental.emptyResponseInformation': {
 					type: 'boolean',
 					default: defaults.experimental.emptyResponseInformation,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.emptyResponseInformation', "Controls whether to send request information from the inline suggestion provider."),
-					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.triggerCommandOnProviderChange': {
 					type: 'boolean',
 					default: defaults.triggerCommandOnProviderChange,
 					tags: ['experimental'],
 					description: nls.localize('inlineSuggest.triggerCommandOnProviderChange', "Controls whether to trigger a command when the inline suggestion provider changes."),
-					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.experimental.showOnSuggestConflict': {
 					type: 'string',
@@ -4625,7 +4621,6 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					tags: ['experimental'],
 					enum: ['always', 'never', 'whenSuggestListIsIncomplete'],
 					description: nls.localize('inlineSuggest.showOnSuggestConflict', "Controls whether to show inline suggestions when there is a suggest conflict."),
-					experimentMode: 'auto'
 				},
 				'editor.inlineSuggest.fontFamily': {
 					type: 'string',
@@ -6507,7 +6502,6 @@ export const EditorOptions = {
 		10, 0, Constants.MAX_SAFE_SMALL_INTEGER,
 		{
 			description: nls.localize('quickSuggestionsDelay', "Controls the delay in milliseconds after which quick suggestions will show up."),
-			experimentMode: 'auto'
 		}
 	)),
 	readOnly: register(new EditorBooleanOption(

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -230,7 +230,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	 * - `startup`: The setting value is updated to the experiment value only on startup.
 	 * - `auto`: The setting value is updated to the experiment value automatically (whenever the experiment value changes).
 	 */
-	experiment?: 'startup' | 'auto';
+	experimentMode?: 'startup' | 'auto';
 }
 
 export interface IExtensionInfo {
@@ -706,14 +706,14 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 					property.restricted = types.isUndefinedOrNull(property.restricted) ? !!restrictedProperties?.includes(key) : property.restricted;
 				}
 
-				if (property.experiment) {
+				if (property.experimentMode) {
 					if (!property.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
 						property.tags = property.tags ?? [];
 						property.tags.push('onExP');
 					}
 				} else if (property.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
 					console.error(`Invalid tag 'onExP' found for property '${key}'. Please use 'experiment' property instead.`);
-					property.experiment = 'startup';
+					property.experimentMode = 'startup';
 				}
 
 				const excluded = properties[key].hasOwnProperty('included') && !properties[key].included;

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -226,11 +226,11 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	/**
 	 * Every setting's default value can be overwritten by an experiment using
 	 * the experiment name `config.${settingId}`. By default the experiment
-	 * value is applied only on startup. Use this property to change the mode:
+	 * value is applied automatically whenever the experiment value changes.
+	 * Use this property to opt into startup-only mode:
 	 * - `startup`: The setting value is updated to the experiment value only on startup.
-	 * - `auto`: The setting value is updated to the experiment value automatically (whenever the experiment value changes).
 	 */
-	experimentMode?: 'startup' | 'auto';
+	experimentMode?: 'startup';
 }
 
 export interface IExtensionInfo {
@@ -712,8 +712,7 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 						property.tags.push('onExP');
 					}
 				} else if (property.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
-					console.error(`Invalid tag 'onExP' found for property '${key}'. Please use 'experiment' property instead.`);
-					property.experimentMode = 'startup';
+					console.error(`Invalid tag 'onExP' found for property '${key}'. Please use 'experimentMode' property instead.`);
 				}
 
 				const excluded = properties[key].hasOwnProperty('included') && !properties[key].included;

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -224,22 +224,13 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	policy?: IPolicy;
 
 	/**
-	 * When specified, this setting's default value can always be overwritten by
-	 * an experiment.
+	 * Every setting's default value can be overwritten by an experiment using
+	 * the experiment name `config.${settingId}`. By default the experiment
+	 * value is applied only on startup. Use this property to change the mode:
+	 * - `startup`: The setting value is updated to the experiment value only on startup.
+	 * - `auto`: The setting value is updated to the experiment value automatically (whenever the experiment value changes).
 	 */
-	experiment?: {
-		/**
-		 * The mode of the experiment.
-		 * - `startup`: The setting value is updated to the experiment value only on startup.
-		 * - `auto`: The setting value is updated to the experiment value automatically (whenever the experiment value changes).
-		 */
-		mode: 'startup' | 'auto';
-
-		/**
-		 * The name of the experiment. By default, this is `config.${settingId}`
-		 */
-		name?: string;
-	};
+	experiment?: 'startup' | 'auto';
 }
 
 export interface IExtensionInfo {
@@ -722,7 +713,7 @@ class ConfigurationRegistry extends Disposable implements IConfigurationRegistry
 					}
 				} else if (property.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
 					console.error(`Invalid tag 'onExP' found for property '${key}'. Please use 'experiment' property instead.`);
-					property.experiment = { mode: 'startup' };
+					property.experiment = 'startup';
 				}
 
 				const excluded = properties[key].hasOwnProperty('included') && !properties[key].included;

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -267,9 +267,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					default: systemCertificatesNodeDefault,
 					markdownDescription: localize('systemCertificatesNode', "Controls whether system certificates should be loaded using Node.js built-in support. Reload the window after changing this setting. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				},
 				'http.experimental.systemCertificatesV2': {
 					type: 'boolean',
@@ -291,9 +289,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					tags: ['experimental'],
 					markdownDescription: localize('networkInterfaceCheckInterval', "Controls the interval in seconds for checking network interface changes to invalidate the proxy cache. Set to -1 to disable. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experiment: {
-						mode: 'auto'
-					}
+					experiment: 'auto'
 				}
 			}
 		}

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -267,7 +267,6 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					default: systemCertificatesNodeDefault,
 					markdownDescription: localize('systemCertificatesNode', "Controls whether system certificates should be loaded using Node.js built-in support. Reload the window after changing this setting. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experimentMode: 'auto'
 				},
 				'http.experimental.systemCertificatesV2': {
 					type: 'boolean',
@@ -289,7 +288,6 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					tags: ['experimental'],
 					markdownDescription: localize('networkInterfaceCheckInterval', "Controls the interval in seconds for checking network interface changes to invalidate the proxy cache. Set to -1 to disable. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experimentMode: 'auto'
 				}
 			}
 		}

--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -267,7 +267,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					default: systemCertificatesNodeDefault,
 					markdownDescription: localize('systemCertificatesNode', "Controls whether system certificates should be loaded using Node.js built-in support. Reload the window after changing this setting. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experiment: 'auto'
+					experimentMode: 'auto'
 				},
 				'http.experimental.systemCertificatesV2': {
 					type: 'boolean',
@@ -289,7 +289,7 @@ function registerProxyConfigurations(useHostProxy = true, useHostProxyDefault = 
 					tags: ['experimental'],
 					markdownDescription: localize('networkInterfaceCheckInterval', "Controls the interval in seconds for checking network interface changes to invalidate the proxy cache. Set to -1 to disable. When during [remote development](https://aka.ms/vscode-remote) the {0} setting is disabled this setting can be configured in the local and the remote settings separately.", '`#http.useLocalProxyConfiguration#`'),
 					restricted: true,
-					experiment: 'auto'
+					experimentMode: 'auto'
 				}
 			}
 		}

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -295,7 +295,7 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 					propertyConfiguration.policy = extensionConfigurationPolicy?.[key];
 				}
 				if (propertyConfiguration.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
-					propertyConfiguration.experiment = 'startup';
+					propertyConfiguration.experimentMode = 'startup';
 				}
 				seenProperties.add(key);
 				propertyConfiguration.scope = propertyConfiguration.scope ? parseScope(propertyConfiguration.scope.toString()) : ConfigurationScope.WINDOW;

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -294,7 +294,7 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 				if (extensionConfigurationPolicy?.[key]) {
 					propertyConfiguration.policy = extensionConfigurationPolicy?.[key];
 				}
-				if (propertyConfiguration.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
+				if (!propertyConfiguration.experimentMode) {
 					propertyConfiguration.experimentMode = 'startup';
 				}
 				seenProperties.add(key);

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -295,9 +295,7 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 					propertyConfiguration.policy = extensionConfigurationPolicy?.[key];
 				}
 				if (propertyConfiguration.tags?.some(tag => tag.toLowerCase() === 'onexp')) {
-					propertyConfiguration.experiment = {
-						mode: 'startup'
-					};
+					propertyConfiguration.experiment = 'startup';
 				}
 				seenProperties.add(key);
 				propertyConfiguration.scope = propertyConfiguration.scope ? parseScope(propertyConfiguration.scope.toString()) : ConfigurationScope.WINDOW;

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -294,9 +294,7 @@ configurationExtPoint.setHandler((extensions, { added, removed }) => {
 				if (extensionConfigurationPolicy?.[key]) {
 					propertyConfiguration.policy = extensionConfigurationPolicy?.[key];
 				}
-				if (!propertyConfiguration.experimentMode) {
-					propertyConfiguration.experimentMode = 'startup';
-				}
+				propertyConfiguration.experimentMode = 'startup';
 				seenProperties.add(key);
 				propertyConfiguration.scope = propertyConfiguration.scope ? parseScope(propertyConfiguration.scope.toString()) : ConfigurationScope.WINDOW;
 			}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,7 +361,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': product.quality !== 'stable' ? 'some' : 'off', // TODO@bpasero figure out the default
 				tags: ['experimental'],
-				experiment: 'auto'
+				experimentMode: 'auto'
 			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
@@ -626,7 +626,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.notifications.position.top-right', "Show notifications in the top right corner, similar to OS-level notifications.")
 				],
 				'tags': ['experimental'],
-				'experiment': 'auto'
+				'experimentMode': 'auto'
 			},
 			[NotificationsSettings.NOTIFICATIONS_BUTTON]: {
 				'type': 'boolean',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,9 +361,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': product.quality !== 'stable' ? 'some' : 'off', // TODO@bpasero figure out the default
 				tags: ['experimental'],
-				experiment: {
-					mode: 'auto'
-				}
+				experiment: 'auto'
 			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
@@ -628,9 +626,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.notifications.position.top-right', "Show notifications in the top right corner, similar to OS-level notifications.")
 				],
 				'tags': ['experimental'],
-				'experiment': {
-					'mode': 'auto'
-				}
+				'experiment': 'auto'
 			},
 			[NotificationsSettings.NOTIFICATIONS_BUTTON]: {
 				'type': 'boolean',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -361,7 +361,6 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('useModal', "Controls whether editors open in a modal overlay."),
 				'default': product.quality !== 'stable' ? 'some' : 'off', // TODO@bpasero figure out the default
 				tags: ['experimental'],
-				experimentMode: 'auto'
 			},
 			'workbench.editor.swipeToNavigate': {
 				'type': 'boolean',
@@ -626,7 +625,6 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.notifications.position.top-right', "Show notifications in the top right corner, similar to OS-level notifications.")
 				],
 				'tags': ['experimental'],
-				'experimentMode': 'auto'
 			},
 			[NotificationsSettings.NOTIFICATIONS_BUTTON]: {
 				'type': 'boolean',

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -161,7 +161,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		'workbench.browser.enableChatTools': {
 			type: 'boolean',
 			default: false,
-			experiment: { mode: 'startup' },
+			experiment: 'startup',
 			tags: ['experimental'],
 			markdownDescription: localize(
 				{ comment: ['This is the description for a setting.'], key: 'browser.enableChatTools' },

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -161,7 +161,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		'workbench.browser.enableChatTools': {
 			type: 'boolean',
 			default: false,
-			experiment: 'startup',
+			experimentMode: 'startup',
 			tags: ['experimental'],
 			markdownDescription: localize(
 				{ comment: ['This is the description for a setting.'], key: 'browser.enableChatTools' },

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -263,9 +263,7 @@ configurationRegistry.registerConfiguration({
 				'panel': 'always',
 			},
 			tags: ['experimental'],
-			experiment: {
-				mode: 'startup'
-			}
+			experiment: 'startup'
 		},
 		'chat.implicitContext.suggestedContext': {
 			type: 'boolean',
@@ -296,9 +294,7 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.editing.explainChanges.enabled', "Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature."),
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'chat.tips.enabled': {
 			type: 'boolean',
@@ -306,9 +302,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'chat.upvoteAnimation': {
 			type: 'string',
@@ -633,9 +627,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org)."),
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'startup'
-			}
+			experiment: 'startup'
 		},
 		[ChatConfiguration.ExtensionToolsEnabled]: {
 			type: 'boolean',
@@ -726,9 +718,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.editMode.hidden', "When enabled, hides the Edit mode from the chat mode picker."),
 			default: true,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			},
+			experiment: 'auto',
 			policy: {
 				name: 'DeprecatedEditModeHidden',
 				category: PolicyCategory.InteractiveSession,
@@ -757,9 +747,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.statusWidget.anonymous.description', "Controls whether anonymous users see the status widget in new chat sessions when rate limited."),
 			default: false,
 			tags: ['experimental', 'advanced'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[mcpDiscoverySection]: {
 			type: 'object',
@@ -970,9 +958,7 @@ configurationRegistry.registerConfiguration({
 			restricted: true,
 			disallowConfigurationDefault: true,
 			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS]: {
 			type: 'boolean',
@@ -1169,18 +1155,14 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			markdownDescription: nls.localize('chat.tools.usagesTool.enabled', "Controls whether the usages tool is available for finding references, definitions, and implementations of code symbols."),
 			tags: ['preview'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		'chat.tools.renameTool.enabled': {
 			type: 'boolean',
 			default: true,
 			markdownDescription: nls.localize('chat.tools.renameTool.enabled', "Controls whether the rename tool is available for renaming code symbols across the workspace."),
 			tags: ['preview'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[ChatConfiguration.ThinkingPhrases]: {
 			type: 'object',
@@ -1222,18 +1204,14 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.allowAnonymousAccess', "Controls whether anonymous access is allowed in chat."),
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[ChatConfiguration.GrowthNotificationEnabled]: {
 			type: 'boolean',
 			description: nls.localize('chat.growthNotification', "Controls whether to show a growth notification in the agent sessions view to encourage new users to try Copilot."),
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[ChatConfiguration.RestoreLastPanelSession]: {
 			type: 'boolean',
@@ -1251,17 +1229,13 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.extensionUnification.enabled', "Enables the unification of GitHub Copilot extensions. When enabled, all GitHub Copilot functionality is served from the GitHub Copilot Chat extension. When disabled, the GitHub Copilot and GitHub Copilot Chat extensions operate independently."),
 			default: true,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[ChatConfiguration.SubagentToolCustomAgents]: {
 			type: 'boolean',
 			description: nls.localize('chat.subagentTool.customAgents', "Whether the runSubagent tool is able to use custom agents. When enabled, the tool can take the name of a custom agent, but it must be given the exact name of the agent."),
 			default: true,
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[ChatConfiguration.ChatCustomizationMenuEnabled]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -294,7 +294,6 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.editing.explainChanges.enabled', "Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature."),
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'chat.tips.enabled': {
 			type: 'boolean',
@@ -302,7 +301,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		'chat.upvoteAnimation': {
 			type: 'string',
@@ -718,7 +716,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.editMode.hidden', "When enabled, hides the Edit mode from the chat mode picker."),
 			default: true,
 			tags: ['experimental'],
-			experimentMode: 'auto',
 			policy: {
 				name: 'DeprecatedEditModeHidden',
 				category: PolicyCategory.InteractiveSession,
@@ -747,7 +744,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.statusWidget.anonymous.description', "Controls whether anonymous users see the status widget in new chat sessions when rate limited."),
 			default: false,
 			tags: ['experimental', 'advanced'],
-			experimentMode: 'auto'
 		},
 		[mcpDiscoverySection]: {
 			type: 'object',
@@ -958,7 +954,6 @@ configurationRegistry.registerConfiguration({
 			restricted: true,
 			disallowConfigurationDefault: true,
 			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
-			experimentMode: 'auto'
 		},
 		[PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS]: {
 			type: 'boolean',
@@ -1155,14 +1150,12 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			markdownDescription: nls.localize('chat.tools.usagesTool.enabled', "Controls whether the usages tool is available for finding references, definitions, and implementations of code symbols."),
 			tags: ['preview'],
-			experimentMode: 'auto'
 		},
 		'chat.tools.renameTool.enabled': {
 			type: 'boolean',
 			default: true,
 			markdownDescription: nls.localize('chat.tools.renameTool.enabled', "Controls whether the rename tool is available for renaming code symbols across the workspace."),
 			tags: ['preview'],
-			experimentMode: 'auto'
 		},
 		[ChatConfiguration.ThinkingPhrases]: {
 			type: 'object',
@@ -1204,14 +1197,12 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.allowAnonymousAccess', "Controls whether anonymous access is allowed in chat."),
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		[ChatConfiguration.GrowthNotificationEnabled]: {
 			type: 'boolean',
 			description: nls.localize('chat.growthNotification', "Controls whether to show a growth notification in the agent sessions view to encourage new users to try Copilot."),
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		[ChatConfiguration.RestoreLastPanelSession]: {
 			type: 'boolean',
@@ -1229,13 +1220,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.extensionUnification.enabled', "Enables the unification of GitHub Copilot extensions. When enabled, all GitHub Copilot functionality is served from the GitHub Copilot Chat extension. When disabled, the GitHub Copilot and GitHub Copilot Chat extensions operate independently."),
 			default: true,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		[ChatConfiguration.SubagentToolCustomAgents]: {
 			type: 'boolean',
 			description: nls.localize('chat.subagentTool.customAgents', "Whether the runSubagent tool is able to use custom agents. When enabled, the tool can take the name of a custom agent, but it must be given the exact name of the agent."),
 			default: true,
-			experimentMode: 'auto'
 		},
 		[ChatConfiguration.ChatCustomizationMenuEnabled]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -263,7 +263,7 @@ configurationRegistry.registerConfiguration({
 				'panel': 'always',
 			},
 			tags: ['experimental'],
-			experiment: 'startup'
+			experimentMode: 'startup'
 		},
 		'chat.implicitContext.suggestedContext': {
 			type: 'boolean',
@@ -294,7 +294,7 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.editing.explainChanges.enabled', "Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature."),
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'chat.tips.enabled': {
 			type: 'boolean',
@@ -302,7 +302,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.tips.enabled', "Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features."),
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'chat.upvoteAnimation': {
 			type: 'string',
@@ -627,7 +627,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.mcp.assisted.nuget.enabled.description', "Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org)."),
 			default: false,
 			tags: ['experimental'],
-			experiment: 'startup'
+			experimentMode: 'startup'
 		},
 		[ChatConfiguration.ExtensionToolsEnabled]: {
 			type: 'boolean',
@@ -718,7 +718,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.editMode.hidden', "When enabled, hides the Edit mode from the chat mode picker."),
 			default: true,
 			tags: ['experimental'],
-			experiment: 'auto',
+			experimentMode: 'auto',
 			policy: {
 				name: 'DeprecatedEditModeHidden',
 				category: PolicyCategory.InteractiveSession,
@@ -747,7 +747,7 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.statusWidget.anonymous.description', "Controls whether anonymous users see the status widget in new chat sessions when rate limited."),
 			default: false,
 			tags: ['experimental', 'advanced'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[mcpDiscoverySection]: {
 			type: 'object',
@@ -958,7 +958,7 @@ configurationRegistry.registerConfiguration({
 			restricted: true,
 			disallowConfigurationDefault: true,
 			tags: ['experimental', 'prompts', 'reusable prompts', 'prompt snippets', 'instructions'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS]: {
 			type: 'boolean',
@@ -1155,14 +1155,14 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			markdownDescription: nls.localize('chat.tools.usagesTool.enabled', "Controls whether the usages tool is available for finding references, definitions, and implementations of code symbols."),
 			tags: ['preview'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		'chat.tools.renameTool.enabled': {
 			type: 'boolean',
 			default: true,
 			markdownDescription: nls.localize('chat.tools.renameTool.enabled', "Controls whether the rename tool is available for renaming code symbols across the workspace."),
 			tags: ['preview'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[ChatConfiguration.ThinkingPhrases]: {
 			type: 'object',
@@ -1204,14 +1204,14 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.allowAnonymousAccess', "Controls whether anonymous access is allowed in chat."),
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[ChatConfiguration.GrowthNotificationEnabled]: {
 			type: 'boolean',
 			description: nls.localize('chat.growthNotification', "Controls whether to show a growth notification in the agent sessions view to encourage new users to try Copilot."),
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[ChatConfiguration.RestoreLastPanelSession]: {
 			type: 'boolean',
@@ -1229,13 +1229,13 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.extensionUnification.enabled', "Enables the unification of GitHub Copilot extensions. When enabled, all GitHub Copilot functionality is served from the GitHub Copilot Chat extension. When disabled, the GitHub Copilot and GitHub Copilot Chat extensions operate independently."),
 			default: true,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[ChatConfiguration.SubagentToolCustomAgents]: {
 			type: 'boolean',
 			description: nls.localize('chat.subagentTool.customAgents', "Whether the runSubagent tool is able to use custom agents. When enabled, the tool can take the name of a custom agent, but it must be given the exact name of the agent."),
 			default: true,
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[ChatConfiguration.ChatCustomizationMenuEnabled]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
@@ -35,14 +35,12 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		[EDIT_TELEMETRY_DETAILS_SETTING_ID]: {
 			markdownDescription: localize('telemetry.editStats.detailed.enabled', "Controls whether to enable telemetry for detailed edit statistics (only sends statistics if general telemetry is enabled)."),
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experimentMode: 'auto'
 		},
 		[EDIT_TELEMETRY_SHOW_STATUS_BAR]: {
 			markdownDescription: localize('telemetry.editStats.showStatusBar', "Controls whether to show the status bar for edit telemetry."),

--- a/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
@@ -35,18 +35,14 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[EDIT_TELEMETRY_DETAILS_SETTING_ID]: {
 			markdownDescription: localize('telemetry.editStats.detailed.enabled', "Controls whether to enable telemetry for detailed edit statistics (only sends statistics if general telemetry is enabled)."),
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[EDIT_TELEMETRY_SHOW_STATUS_BAR]: {
 			markdownDescription: localize('telemetry.editStats.showStatusBar', "Controls whether to show the status bar for edit telemetry."),

--- a/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
+++ b/src/vs/workbench/contrib/editTelemetry/browser/editTelemetry.contribution.ts
@@ -35,14 +35,14 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[EDIT_TELEMETRY_DETAILS_SETTING_ID]: {
 			markdownDescription: localize('telemetry.editStats.detailed.enabled', "Controls whether to enable telemetry for detailed edit statistics (only sends statistics if general telemetry is enabled)."),
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[EDIT_TELEMETRY_SHOW_STATUS_BAR]: {
 			markdownDescription: localize('telemetry.editStats.showStatusBar', "Controls whether to show the status bar for edit telemetry."),

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -270,7 +270,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('extensions.allowOpenInModalEditor', "Controls whether extensions and MCP servers open in a modal editor overlay."),
 				default: false, // TODO@bpasero figure out the default for stable and retire this setting
 				tags: ['experimental'],
-				experiment: 'auto'
+				experimentMode: 'auto'
 			},
 			[VerifyExtensionSignatureConfigKey]: {
 				type: 'boolean',

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -270,9 +270,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('extensions.allowOpenInModalEditor', "Controls whether extensions and MCP servers open in a modal editor overlay."),
 				default: false, // TODO@bpasero figure out the default for stable and retire this setting
 				tags: ['experimental'],
-				experiment: {
-					mode: 'auto'
-				}
+				experiment: 'auto'
 			},
 			[VerifyExtensionSignatureConfigKey]: {
 				type: 'boolean',

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -270,7 +270,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('extensions.allowOpenInModalEditor', "Controls whether extensions and MCP servers open in a modal editor overlay."),
 				default: false, // TODO@bpasero figure out the default for stable and retire this setting
 				tags: ['experimental'],
-				experimentMode: 'auto'
 			},
 			[VerifyExtensionSignatureConfigKey]: {
 				type: 'boolean',

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -37,18 +37,14 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			default: false,
 			type: 'boolean',
 			tags: ['preview'],
-			experiment: {
-				mode: 'auto'
-			}
+			experiment: 'auto'
 		},
 		[InlineChatConfigKeys.notebookAgent]: {
 			markdownDescription: localize('notebookAgent', "Enable agent-like behavior for inline chat widget in notebooks."),
 			default: false,
 			type: 'boolean',
 			tags: ['experimental'],
-			experiment: {
-				mode: 'startup'
-			}
+			experiment: 'startup'
 		},
 		[InlineChatConfigKeys.Affordance]: {
 			description: localize('affordance', "Controls whether an inline chat affordance is shown when text is selected."),
@@ -60,9 +56,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('affordance.gutter', "Show an affordance in the gutter."),
 				localize('affordance.editor', "Show an affordance in the editor at the cursor position."),
 			],
-			experiment: {
-				mode: 'auto'
-			},
+			experiment: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.RenderMode]: {
@@ -74,18 +68,14 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('renderMode.zone', "Render inline chat as a zone widget below the current line."),
 				localize('renderMode.hover', "Render inline chat as a hover overlay."),
 			],
-			experiment: {
-				mode: 'auto'
-			},
+			experiment: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.FixDiagnostics]: {
 			description: localize('fixDiagnostics', "Controls whether the Fix action is shown for diagnostics in the editor."),
 			default: true,
 			type: 'boolean',
-			experiment: {
-				mode: 'auto'
-			},
+			experiment: 'auto',
 			tags: ['experimental']
 		}
 	}

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -37,7 +37,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			default: false,
 			type: 'boolean',
 			tags: ['preview'],
-			experimentMode: 'auto'
 		},
 		[InlineChatConfigKeys.notebookAgent]: {
 			markdownDescription: localize('notebookAgent', "Enable agent-like behavior for inline chat widget in notebooks."),
@@ -56,7 +55,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('affordance.gutter', "Show an affordance in the gutter."),
 				localize('affordance.editor', "Show an affordance in the editor at the cursor position."),
 			],
-			experimentMode: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.RenderMode]: {
@@ -68,14 +66,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('renderMode.zone', "Render inline chat as a zone widget below the current line."),
 				localize('renderMode.hover', "Render inline chat as a hover overlay."),
 			],
-			experimentMode: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.FixDiagnostics]: {
 			description: localize('fixDiagnostics', "Controls whether the Fix action is shown for diagnostics in the editor."),
 			default: true,
 			type: 'boolean',
-			experimentMode: 'auto',
 			tags: ['experimental']
 		}
 	}

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -37,14 +37,14 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			default: false,
 			type: 'boolean',
 			tags: ['preview'],
-			experiment: 'auto'
+			experimentMode: 'auto'
 		},
 		[InlineChatConfigKeys.notebookAgent]: {
 			markdownDescription: localize('notebookAgent', "Enable agent-like behavior for inline chat widget in notebooks."),
 			default: false,
 			type: 'boolean',
 			tags: ['experimental'],
-			experiment: 'startup'
+			experimentMode: 'startup'
 		},
 		[InlineChatConfigKeys.Affordance]: {
 			description: localize('affordance', "Controls whether an inline chat affordance is shown when text is selected."),
@@ -56,7 +56,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('affordance.gutter', "Show an affordance in the gutter."),
 				localize('affordance.editor', "Show an affordance in the editor at the cursor position."),
 			],
-			experiment: 'auto',
+			experimentMode: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.RenderMode]: {
@@ -68,14 +68,14 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('renderMode.zone', "Render inline chat as a zone widget below the current line."),
 				localize('renderMode.hover', "Render inline chat as a hover overlay."),
 			],
-			experiment: 'auto',
+			experimentMode: 'auto',
 			tags: ['experimental']
 		},
 		[InlineChatConfigKeys.FixDiagnostics]: {
 			description: localize('fixDiagnostics', "Controls whether the Fix action is shown for diagnostics in the editor."),
 			default: true,
 			type: 'boolean',
-			experiment: 'auto',
+			experimentMode: 'auto',
 			tags: ['experimental']
 		}
 	}

--- a/src/vs/workbench/contrib/performance/electron-browser/performance.contribution.ts
+++ b/src/vs/workbench/contrib/performance/electron-browser/performance.contribution.ts
@@ -42,7 +42,7 @@ Registry.as<IConfigurationRegistry>(ConfigExt.Configuration).registerConfigurati
 			default: false,
 			tags: ['experimental'],
 			markdownDescription: localize('experimental.rendererProfiling', "When enabled, slow renderers are automatically profiled."),
-			experiment: 'startup'
+			experimentMode: 'startup'
 		}
 	}
 });

--- a/src/vs/workbench/contrib/performance/electron-browser/performance.contribution.ts
+++ b/src/vs/workbench/contrib/performance/electron-browser/performance.contribution.ts
@@ -42,9 +42,7 @@ Registry.as<IConfigurationRegistry>(ConfigExt.Configuration).registerConfigurati
 			default: false,
 			tags: ['experimental'],
 			markdownDescription: localize('experimental.rendererProfiling', "When enabled, slow renderers are automatically profiled."),
-			experiment: {
-				mode: 'startup'
-			}
+			experiment: 'startup'
 		}
 	}
 });

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -480,9 +480,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		tags: ['preview'],
 		default: false,
-		experiment: {
-			mode: 'auto'
-		},
+		experiment: 'auto',
 	},
 	[TerminalSettingId.SplitCwd]: {
 		description: localize('terminal.integrated.splitCwd', "Controls the working directory a split terminal starts with."),
@@ -600,18 +598,14 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		default: false,
 		tags: ['experimental', 'advanced'],
-		experiment: {
-			mode: 'auto'
-		}
+		experiment: 'auto'
 	},
 	[TerminalSettingId.ExperimentalAiProfileGrouping]: {
 		markdownDescription: localize('terminal.integrated.experimental.aiProfileGrouping', "Whether to elevate AI-contributed terminal profiles (for example Copilot CLI and Claude Agent) in the new terminal dropdown."),
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],
-		experiment: {
-			mode: 'auto'
-		}
+		experiment: 'auto'
 	},
 	[TerminalSettingId.ShellIntegrationEnabled]: {
 		restricted: true,

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -480,7 +480,6 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		tags: ['preview'],
 		default: false,
-		experimentMode: 'auto',
 	},
 	[TerminalSettingId.SplitCwd]: {
 		description: localize('terminal.integrated.splitCwd', "Controls the working directory a split terminal starts with."),
@@ -598,14 +597,12 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		default: false,
 		tags: ['experimental', 'advanced'],
-		experimentMode: 'auto'
 	},
 	[TerminalSettingId.ExperimentalAiProfileGrouping]: {
 		markdownDescription: localize('terminal.integrated.experimental.aiProfileGrouping', "Whether to elevate AI-contributed terminal profiles (for example Copilot CLI and Claude Agent) in the new terminal dropdown."),
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],
-		experimentMode: 'auto'
 	},
 	[TerminalSettingId.ShellIntegrationEnabled]: {
 		restricted: true,

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -480,7 +480,7 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		tags: ['preview'],
 		default: false,
-		experiment: 'auto',
+		experimentMode: 'auto',
 	},
 	[TerminalSettingId.SplitCwd]: {
 		description: localize('terminal.integrated.splitCwd', "Controls the working directory a split terminal starts with."),
@@ -598,14 +598,14 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 		type: 'boolean',
 		default: false,
 		tags: ['experimental', 'advanced'],
-		experiment: 'auto'
+		experimentMode: 'auto'
 	},
 	[TerminalSettingId.ExperimentalAiProfileGrouping]: {
 		markdownDescription: localize('terminal.integrated.experimental.aiProfileGrouping', "Whether to elevate AI-contributed terminal profiles (for example Copilot CLI and Claude Agent) in the new terminal dropdown."),
 		type: 'boolean',
 		default: false,
 		tags: ['experimental'],
-		experiment: 'auto'
+		experimentMode: 'auto'
 	},
 	[TerminalSettingId.ShellIntegrationEnabled]: {
 		restricted: true,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -509,7 +509,6 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		],
 		default: 'chat',
 		tags: ['experimental'],
-		experimentMode: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxEnabled]: {
 		markdownDescription: localize('terminalSandbox.enabledSetting', "Controls whether to run commands in a sandboxed terminal for the run in terminal tool."),
@@ -517,7 +516,6 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		default: false,
 		tags: ['preview'],
 		restricted: true,
-		experimentMode: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxNetwork]: {
 		markdownDescription: localize('terminalSandbox.networkSetting', "Note: this setting is applicable only when {0} is enabled. Controls network access in the terminal sandbox.", `\`#${TerminalChatAgentToolsSettingId.TerminalSandboxEnabled}#\``),
@@ -627,7 +625,6 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		type: 'boolean',
 		default: true,
 		tags: ['experimental'],
-		experimentMode: 'auto',
 		markdownDescription: localize('enforceTimeoutFromModel.description', "Whether to enforce the timeout value provided by the model in the run in terminal tool. When enabled, if the model provides a timeout parameter, the tool will stop tracking the command after that duration and return the output collected so far."),
 	}
 };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -509,9 +509,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		],
 		default: 'chat',
 		tags: ['experimental'],
-		experiment: {
-			mode: 'auto'
-		}
+		experiment: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxEnabled]: {
 		markdownDescription: localize('terminalSandbox.enabledSetting', "Controls whether to run commands in a sandboxed terminal for the run in terminal tool."),
@@ -519,9 +517,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		default: false,
 		tags: ['preview'],
 		restricted: true,
-		experiment: {
-			mode: 'auto'
-		}
+		experiment: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxNetwork]: {
 		markdownDescription: localize('terminalSandbox.networkSetting', "Note: this setting is applicable only when {0} is enabled. Controls network access in the terminal sandbox.", `\`#${TerminalChatAgentToolsSettingId.TerminalSandboxEnabled}#\``),
@@ -631,9 +627,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		type: 'boolean',
 		default: true,
 		tags: ['experimental'],
-		experiment: {
-			mode: 'auto'
-		},
+		experiment: 'auto',
 		markdownDescription: localize('enforceTimeoutFromModel.description', "Whether to enforce the timeout value provided by the model in the run in terminal tool. When enabled, if the model provides a timeout parameter, the tool will stop tracking the command after that duration and return the output collected so far."),
 	}
 };

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration.ts
@@ -509,7 +509,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		],
 		default: 'chat',
 		tags: ['experimental'],
-		experiment: 'auto'
+		experimentMode: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxEnabled]: {
 		markdownDescription: localize('terminalSandbox.enabledSetting', "Controls whether to run commands in a sandboxed terminal for the run in terminal tool."),
@@ -517,7 +517,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		default: false,
 		tags: ['preview'],
 		restricted: true,
-		experiment: 'auto'
+		experimentMode: 'auto'
 	},
 	[TerminalChatAgentToolsSettingId.TerminalSandboxNetwork]: {
 		markdownDescription: localize('terminalSandbox.networkSetting', "Note: this setting is applicable only when {0} is enabled. Controls network access in the terminal sandbox.", `\`#${TerminalChatAgentToolsSettingId.TerminalSandboxEnabled}#\``),
@@ -627,7 +627,7 @@ export const terminalChatAgentToolsConfiguration: IStringDictionary<IConfigurati
 		type: 'boolean',
 		default: true,
 		tags: ['experimental'],
-		experiment: 'auto',
+		experimentMode: 'auto',
 		markdownDescription: localize('enforceTimeoutFromModel.description', "Whether to enforce the timeout value provided by the model in the run in terminal tool. When enabled, if the model provides a timeout parameter, the tool will stop tracking the command after that duration and return the output collected so far."),
 	}
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -329,7 +329,7 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': 'welcomePage',
 			'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session."),
-			'experiment': { mode: 'auto' }
+			'experiment': 'auto'
 		},
 		'workbench.welcomePage.preferReducedMotion': {
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -329,7 +329,6 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': 'welcomePage',
 			'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session."),
-			'experimentMode': 'auto'
 		},
 		'workbench.welcomePage.preferReducedMotion': {
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -329,7 +329,7 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': 'welcomePage',
 			'description': localize('workbench.startupEditor', "Controls which editor is shown at startup, if none are restored from the previous session."),
-			'experiment': 'auto'
+			'experimentMode': 'auto'
 		},
 		'workbench.welcomePage.preferReducedMotion': {
 			scope: ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1335,7 +1335,7 @@ class RegisterConfigurationSchemasContribution extends Disposable implements IWo
 	}
 }
 
-class ConfigurationDefaultOverridesContribution extends Disposable implements IWorkbenchContribution {
+export class ConfigurationDefaultOverridesContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.configurationDefaultOverridesContribution';
 

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1391,7 +1391,7 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 				continue;
 			}
 			this.processedExperimentalSettings.add(property);
-			if (schema.experimentMode === 'auto') {
+			if (schema.experimentMode !== 'startup') {
 				this.autoExperimentalSettings.add(property);
 			}
 			try {

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1391,12 +1391,11 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 				continue;
 			}
 			this.processedExperimentalSettings.add(property);
-			const experiment = schema.experiment;
-			if (experiment?.mode === 'auto') {
+			if (schema.experiment === 'auto') {
 				this.autoExperimentalSettings.add(property);
 			}
 			try {
-				const value = await this.workbenchAssignmentService.getTreatment(experiment?.name ?? `config.${property}`);
+				const value = await this.workbenchAssignmentService.getTreatment(`config.${property}`);
 				if (!isUndefined(value) && !equals(value, schema.default)) {
 					overrides[property] = value;
 				}

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1391,7 +1391,7 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 				continue;
 			}
 			this.processedExperimentalSettings.add(property);
-			if (schema.experiment === 'auto') {
+			if (schema.experimentMode === 'auto') {
 				this.autoExperimentalSettings.add(property);
 			}
 			try {

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1380,7 +1380,7 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 		const defaultConfigurationsPreventingExperimentOverrides = this.configurationRegistry.getRegisteredDefaultConfigurations().filter(configuration => configuration.preventExperimentOverride);
 		for (const property of properties) {
 			const schema = allProperties[property];
-			if (!schema?.experiment) {
+			if (!schema) {
 				continue;
 			}
 			const defaultValueSource: ConfigurationDefaultSource | undefined = schema.defaultValueSource && !(schema.defaultValueSource instanceof Map) ? schema.defaultValueSource : undefined;
@@ -1391,11 +1391,12 @@ class ConfigurationDefaultOverridesContribution extends Disposable implements IW
 				continue;
 			}
 			this.processedExperimentalSettings.add(property);
-			if (schema.experiment.mode === 'auto') {
+			const experiment = schema.experiment;
+			if (experiment?.mode === 'auto') {
 				this.autoExperimentalSettings.add(property);
 			}
 			try {
-				const value = await this.workbenchAssignmentService.getTreatment(schema.experiment.name ?? `config.${property}`);
+				const value = await this.workbenchAssignmentService.getTreatment(experiment?.name ?? `config.${property}`);
 				if (!isUndefined(value) && !equals(value, schema.default)) {
 					overrides[property] = value;
 				}

--- a/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
@@ -1,0 +1,222 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { Extensions, IConfigurationRegistry } from '../../../../../platform/configuration/common/configurationRegistry.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { IWorkbenchAssignmentService } from '../../../assignment/common/assignmentService.js';
+import { NullExtensionService } from '../../../extensions/common/extensions.js';
+import { ConfigurationDefaultOverridesContribution } from '../../browser/configurationService.js';
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+
+class MockAssignmentService implements IWorkbenchAssignmentService {
+	_serviceBrand: undefined;
+
+	private readonly _onDidRefetchAssignments = new Emitter<void>();
+	readonly onDidRefetchAssignments = this._onDidRefetchAssignments.event;
+
+	private readonly treatments = new Map<string, unknown>();
+
+	setTreatment(name: string, value: unknown): void {
+		this.treatments.set(name, value);
+	}
+
+	fireRefetch(): void {
+		this._onDidRefetchAssignments.fire();
+	}
+
+	async getCurrentExperiments(): Promise<string[] | undefined> {
+		return [];
+	}
+
+	async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
+		return this.treatments.get(name) as T | undefined;
+	}
+
+	addTelemetryAssignmentFilter(): void { }
+
+	dispose(): void {
+		this._onDidRefetchAssignments.dispose();
+	}
+}
+
+class MockConfigurationService {
+	reloadConfiguration(_target: ConfigurationTarget): void { }
+}
+
+suite('ConfigurationDefaultOverridesContribution', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+	let assignmentService: MockAssignmentService;
+	let localDisposables: DisposableStore;
+
+	setup(() => {
+		localDisposables = disposables.add(new DisposableStore());
+		assignmentService = new MockAssignmentService();
+		localDisposables.add(assignmentService);
+	});
+
+	function createContribution(): ConfigurationDefaultOverridesContribution {
+		const contribution = new ConfigurationDefaultOverridesContribution(
+			assignmentService,
+			new NullExtensionService(),
+			new MockConfigurationService() as unknown as any,
+			new NullLogService()
+		);
+		localDisposables.add(contribution);
+		return contribution;
+	}
+
+	test('applies experiment treatment to a setting without experimentMode', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments',
+			properties: {
+				'test.experiments.noMode': {
+					type: 'boolean',
+					default: false,
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments', properties: { 'test.experiments.noMode': { type: 'boolean', default: false } } }]) });
+
+		assignmentService.setTreatment('config.test.experiments.noMode', true);
+		createContribution();
+
+		// Wait for the async processing
+		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+
+		const properties = configurationRegistry.getConfigurationProperties();
+		assert.notStrictEqual(properties['test.experiments.noMode']?.defaultValueSource, undefined, 'The default value source should have been set by experiment');
+	});
+
+	test('uses config.{settingId} as the experiment name', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments.naming',
+			properties: {
+				'test.experiments.naming.setting': {
+					type: 'string',
+					default: 'original',
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.naming', properties: { 'test.experiments.naming.setting': { type: 'string', default: 'original' } } }]) });
+
+		// Treatment name must be `config.${settingId}`
+		assignmentService.setTreatment('config.test.experiments.naming.setting', 'experiment-value');
+		createContribution();
+
+		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+
+		const properties = configurationRegistry.getConfigurationProperties();
+		assert.strictEqual(properties['test.experiments.naming.setting']?.default, 'original');
+	});
+
+	test('does not apply experiment treatment when value equals default', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments.sameDefault',
+			properties: {
+				'test.experiments.sameDefault.setting': {
+					type: 'boolean',
+					default: true,
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.sameDefault', properties: { 'test.experiments.sameDefault.setting': { type: 'boolean', default: true } } }]) });
+
+		// Treatment value same as default
+		assignmentService.setTreatment('config.test.experiments.sameDefault.setting', true);
+		createContribution();
+
+		// Give the async processing time to complete
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		// Since value equals default, no override should be registered
+		const properties = configurationRegistry.getConfigurationProperties();
+		assert.strictEqual(properties['test.experiments.sameDefault.setting']?.defaultValueSource, undefined);
+	});
+
+	test('setting without experimentMode defaults to auto and re-applies on refetch', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments.autoDefault',
+			properties: {
+				'test.experiments.autoDefault.setting': {
+					type: 'number',
+					default: 0,
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.autoDefault', properties: { 'test.experiments.autoDefault.setting': { type: 'number', default: 0 } } }]) });
+
+		assignmentService.setTreatment('config.test.experiments.autoDefault.setting', 42);
+		createContribution();
+
+		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+
+		// Now change the treatment and refetch
+		assignmentService.setTreatment('config.test.experiments.autoDefault.setting', 99);
+		assignmentService.fireRefetch();
+
+		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+	});
+
+	test('setting with experimentMode startup does not re-apply on refetch', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments.startupMode',
+			properties: {
+				'test.experiments.startupMode.setting': {
+					type: 'number',
+					default: 0,
+					experimentMode: 'startup',
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.startupMode', properties: { 'test.experiments.startupMode.setting': { type: 'number', default: 0, experimentMode: 'startup' } } }]) });
+
+		assignmentService.setTreatment('config.test.experiments.startupMode.setting', 42);
+		createContribution();
+
+		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+
+		// Now change the treatment and refetch — startup mode should NOT re-apply
+		let overrideRegistered = false;
+		const listener = localDisposables.add(configurationRegistry.onDidUpdateConfiguration(() => {
+			overrideRegistered = true;
+		}));
+		assignmentService.setTreatment('config.test.experiments.startupMode.setting', 99);
+		assignmentService.fireRefetch();
+
+		// Give the async processing time
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		assert.strictEqual(overrideRegistered, false, 'Startup mode setting should not be refetched');
+		listener.dispose();
+	});
+
+	test('does not apply experiment when treatment returns undefined', async () => {
+		configurationRegistry.registerConfiguration({
+			id: 'test.experiments.noTreatment',
+			properties: {
+				'test.experiments.noTreatment.setting': {
+					type: 'string',
+					default: 'original',
+				}
+			}
+		});
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.noTreatment', properties: { 'test.experiments.noTreatment.setting': { type: 'string', default: 'original' } } }]) });
+
+		// No treatment set — getTreatment returns undefined
+		createContribution();
+
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		const properties = configurationRegistry.getConfigurationProperties();
+		assert.strictEqual(properties['test.experiments.noTreatment.setting']?.defaultValueSource, undefined);
+	});
+});

--- a/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
@@ -12,7 +12,7 @@ import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IWorkbenchAssignmentService } from '../../../assignment/common/assignmentService.js';
 import { NullExtensionService } from '../../../extensions/common/extensions.js';
-import { ConfigurationDefaultOverridesContribution } from '../../browser/configurationService.js';
+import { ConfigurationDefaultOverridesContribution, WorkspaceService } from '../../browser/configurationService.js';
 import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 
 class MockAssignmentService implements IWorkbenchAssignmentService {
@@ -22,6 +22,7 @@ class MockAssignmentService implements IWorkbenchAssignmentService {
 	readonly onDidRefetchAssignments = this._onDidRefetchAssignments.event;
 
 	private readonly treatments = new Map<string, unknown>();
+	readonly requestedTreatmentNames: string[] = [];
 
 	setTreatment(name: string, value: unknown): void {
 		this.treatments.set(name, value);
@@ -36,6 +37,7 @@ class MockAssignmentService implements IWorkbenchAssignmentService {
 	}
 
 	async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
+		this.requestedTreatmentNames.push(name);
 		return this.treatments.get(name) as T | undefined;
 	}
 
@@ -67,7 +69,7 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		const contribution = new ConfigurationDefaultOverridesContribution(
 			assignmentService,
 			new NullExtensionService(),
-			new MockConfigurationService() as unknown as any,
+			new MockConfigurationService() as unknown as WorkspaceService,
 			new NullLogService()
 		);
 		localDisposables.add(contribution);
@@ -114,8 +116,12 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
 
+		assert.ok(
+			assignmentService.requestedTreatmentNames.includes('config.test.experiments.naming.setting'),
+			'Treatment should be looked up using config.{settingId} format'
+		);
 		const properties = configurationRegistry.getConfigurationProperties();
-		assert.strictEqual(properties['test.experiments.naming.setting']?.default, 'original');
+		assert.notStrictEqual(properties['test.experiments.naming.setting']?.defaultValueSource, undefined, 'The override should have been applied');
 	});
 
 	test('does not apply experiment treatment when value equals default', async () => {
@@ -159,11 +165,18 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
 
-		// Now change the treatment and refetch
+		const properties = configurationRegistry.getConfigurationProperties();
+		assert.notStrictEqual(properties['test.experiments.autoDefault.setting']?.defaultValueSource, undefined, 'Override should have been applied on initial load');
+
+		// Now change the treatment and refetch — auto mode should re-apply
 		assignmentService.setTreatment('config.test.experiments.autoDefault.setting', 99);
 		assignmentService.fireRefetch();
 
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
+
+		// Verify refetch requested the treatment again
+		const refetchRequests = assignmentService.requestedTreatmentNames.filter(n => n === 'config.test.experiments.autoDefault.setting');
+		assert.ok(refetchRequests.length >= 2, 'Treatment should be requested again on refetch for auto mode settings');
 	});
 
 	test('setting with experimentMode startup does not re-apply on refetch', async () => {

--- a/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
@@ -115,8 +115,9 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		// Wait for the async processing
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
 
-		const properties = configurationRegistry.getConfigurationProperties();
-		assert.notStrictEqual(properties['test.experiments.noMode']?.defaultValueSource, undefined, 'The default value source should have been set by experiment');
+		const overrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		assert.ok(overrides.has('test.experiments.noMode'), 'The default override should have been registered by experiment');
+		assert.strictEqual(overrides.get('test.experiments.noMode')?.value, true);
 	});
 
 	test('uses config.{settingId} as the experiment name', async () => {
@@ -141,8 +142,8 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 			assignmentService.requestedTreatmentNames.includes('config.test.experiments.naming.setting'),
 			'Treatment should be looked up using config.{settingId} format'
 		);
-		const properties = configurationRegistry.getConfigurationProperties();
-		assert.notStrictEqual(properties['test.experiments.naming.setting']?.defaultValueSource, undefined, 'The override should have been applied');
+		const overrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		assert.ok(overrides.has('test.experiments.naming.setting'), 'The override should have been applied');
 	});
 
 	test('does not apply experiment treatment when value equals default', async () => {
@@ -165,8 +166,8 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		await assignmentService.whenTreatmentRequested('config.test.experiments.sameDefault.setting');
 
 		// Since value equals default, no override should be registered
-		const properties = configurationRegistry.getConfigurationProperties();
-		assert.strictEqual(properties['test.experiments.sameDefault.setting']?.defaultValueSource, undefined);
+		const overrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		assert.ok(!overrides.has('test.experiments.sameDefault.setting'), 'No override should be registered when value equals default');
 	});
 
 	test('setting without experimentMode defaults to auto and re-applies on refetch', async () => {
@@ -186,8 +187,8 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
 
-		const properties = configurationRegistry.getConfigurationProperties();
-		assert.notStrictEqual(properties['test.experiments.autoDefault.setting']?.defaultValueSource, undefined, 'Override should have been applied on initial load');
+		const overrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		assert.ok(overrides.has('test.experiments.autoDefault.setting'), 'Override should have been applied on initial load');
 
 		// Now change the treatment and refetch — auto mode should re-apply
 		assignmentService.setTreatment('config.test.experiments.autoDefault.setting', 99);
@@ -254,7 +255,7 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		// Wait for the treatment to be requested (even though it returns undefined)
 		await assignmentService.whenTreatmentRequested('config.test.experiments.noTreatment.setting');
 
-		const properties = configurationRegistry.getConfigurationProperties();
-		assert.strictEqual(properties['test.experiments.noTreatment.setting']?.defaultValueSource, undefined);
+		const overrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		assert.ok(!overrides.has('test.experiments.noTreatment.setting'), 'No override should be registered when treatment is undefined');
 	});
 });

--- a/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
@@ -21,6 +21,8 @@ class MockAssignmentService implements IWorkbenchAssignmentService {
 	private readonly _onDidRefetchAssignments = new Emitter<void>();
 	readonly onDidRefetchAssignments = this._onDidRefetchAssignments.event;
 
+	private readonly _onDidCallGetTreatment = new Emitter<string>();
+
 	private readonly treatments = new Map<string, unknown>();
 	readonly requestedTreatmentNames: string[] = [];
 
@@ -32,19 +34,40 @@ class MockAssignmentService implements IWorkbenchAssignmentService {
 		this._onDidRefetchAssignments.fire();
 	}
 
+	whenTreatmentRequested(name: string): Promise<void> {
+		if (this.requestedTreatmentNames.includes(name)) {
+			return Promise.resolve();
+		}
+		return this.whenNextTreatmentRequested(name);
+	}
+
+	whenNextTreatmentRequested(name: string): Promise<void> {
+		return new Promise(resolve => {
+			const listener = this._onDidCallGetTreatment.event(requestedName => {
+				if (requestedName === name) {
+					listener.dispose();
+					resolve();
+				}
+			});
+		});
+	}
+
 	async getCurrentExperiments(): Promise<string[] | undefined> {
 		return [];
 	}
 
 	async getTreatment<T extends string | number | boolean>(name: string): Promise<T | undefined> {
 		this.requestedTreatmentNames.push(name);
-		return this.treatments.get(name) as T | undefined;
+		const value = this.treatments.get(name) as T | undefined;
+		this._onDidCallGetTreatment.fire(name);
+		return value;
 	}
 
 	addTelemetryAssignmentFilter(): void { }
 
 	dispose(): void {
 		this._onDidRefetchAssignments.dispose();
+		this._onDidCallGetTreatment.dispose();
 	}
 }
 
@@ -140,8 +163,8 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		assignmentService.setTreatment('config.test.experiments.sameDefault.setting', true);
 		createContribution();
 
-		// Give the async processing time to complete
-		await new Promise(resolve => setTimeout(resolve, 50));
+		// Wait for treatment to be processed
+		await assignmentService.whenTreatmentRequested('config.test.experiments.sameDefault.setting');
 
 		// Since value equals default, no override should be registered
 		const properties = configurationRegistry.getConfigurationProperties();
@@ -187,29 +210,32 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 					type: 'number',
 					default: 0,
 					experimentMode: 'startup',
+				},
+				'test.experiments.startupMode.sentinel': {
+					type: 'number',
+					default: 0,
 				}
 			}
 		});
-		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.startupMode', properties: { 'test.experiments.startupMode.setting': { type: 'number', default: 0, experimentMode: 'startup' } } }]) });
+		localDisposables.add({ dispose: () => configurationRegistry.deregisterConfigurations([{ id: 'test.experiments.startupMode', properties: { 'test.experiments.startupMode.setting': { type: 'number', default: 0, experimentMode: 'startup' }, 'test.experiments.startupMode.sentinel': { type: 'number', default: 0 } } }]) });
 
 		assignmentService.setTreatment('config.test.experiments.startupMode.setting', 42);
 		createContribution();
 
 		await Event.toPromise(configurationRegistry.onDidUpdateConfiguration);
 
+		// Record how many times the startup setting was requested
+		const countBefore = assignmentService.requestedTreatmentNames.filter(n => n === 'config.test.experiments.startupMode.setting').length;
+
 		// Now change the treatment and refetch — startup mode should NOT re-apply
-		let overrideRegistered = false;
-		const listener = localDisposables.add(configurationRegistry.onDidUpdateConfiguration(() => {
-			overrideRegistered = true;
-		}));
 		assignmentService.setTreatment('config.test.experiments.startupMode.setting', 99);
 		assignmentService.fireRefetch();
 
-		// Give the async processing time
-		await new Promise(resolve => setTimeout(resolve, 50));
+		// Wait for the auto-mode sentinel setting to be re-requested, confirming refetch completed
+		await assignmentService.whenNextTreatmentRequested('config.test.experiments.startupMode.sentinel');
 
-		assert.strictEqual(overrideRegistered, false, 'Startup mode setting should not be refetched');
-		listener.dispose();
+		const countAfter = assignmentService.requestedTreatmentNames.filter(n => n === 'config.test.experiments.startupMode.setting').length;
+		assert.strictEqual(countAfter, countBefore, 'Startup mode setting should not be re-requested on refetch');
 	});
 
 	test('does not apply experiment when treatment returns undefined', async () => {
@@ -227,7 +253,8 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		// No treatment set — getTreatment returns undefined
 		createContribution();
 
-		await new Promise(resolve => setTimeout(resolve, 50));
+		// Wait for the treatment to be requested (even though it returns undefined)
+		await assignmentService.whenTreatmentRequested('config.test.experiments.noTreatment.setting');
 
 		const properties = configurationRegistry.getConfigurationProperties();
 		assert.strictEqual(properties['test.experiments.noTreatment.setting']?.defaultValueSource, undefined);

--- a/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configurationDefaultOverrides.test.ts
@@ -12,8 +12,8 @@ import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { IWorkbenchAssignmentService } from '../../../assignment/common/assignmentService.js';
 import { NullExtensionService } from '../../../extensions/common/extensions.js';
+import { mock } from '../../../../../base/test/common/mock.js';
 import { ConfigurationDefaultOverridesContribution, WorkspaceService } from '../../browser/configurationService.js';
-import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
 
 class MockAssignmentService implements IWorkbenchAssignmentService {
 	_serviceBrand: undefined;
@@ -71,10 +71,6 @@ class MockAssignmentService implements IWorkbenchAssignmentService {
 	}
 }
 
-class MockConfigurationService {
-	reloadConfiguration(_target: ConfigurationTarget): void { }
-}
-
 suite('ConfigurationDefaultOverridesContribution', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -92,7 +88,9 @@ suite('ConfigurationDefaultOverridesContribution', () => {
 		const contribution = new ConfigurationDefaultOverridesContribution(
 			assignmentService,
 			new NullExtensionService(),
-			new MockConfigurationService() as unknown as WorkspaceService,
+			new class extends mock<WorkspaceService>() {
+				override reloadConfiguration() { return Promise.resolve(); }
+			},
 			new NullLogService()
 		);
 		localDisposables.add(contribution);


### PR DESCRIPTION
## Summary

Make every configuration setting experiment-aware by default, instead of requiring individual opt-in via the `experiment` property.

## Changes

### All settings are now experiment-aware
- Removed the `experiment` property guard in `ConfigurationDefaultOverridesContribution` — all registered settings are now processed for experiment overrides using the treatment name `config.${settingId}`.

### Simplified `experiment` → `experimentMode`
- Renamed the `experiment` property on `IConfigurationPropertySchema` to `experimentMode` for clarity — it now only controls the refresh mode, not whether the setting participates in experiments.
- Changed the type from `{ mode: 'startup' | 'auto'; name?: string }` to just `'startup'` — the `name` field was unused and `auto` is now the default.
- Removed the redundant `experimentMode: 'auto'` declarations across ~40 setting registrations since `auto` is the default mode.

### Extension settings default to startup mode
- All extension-contributed configuration properties are unconditionally set to `experimentMode: 'startup'` since extensions cannot control this property and startup-only is the safe default.

### Tests
- Added `configurationDefaultOverrides.test.ts` with tests covering:
  - Experiment treatment applied to settings without explicit `experimentMode`
  - Correct experiment name format (`config.{settingId}`)
  - No override when treatment value equals the default
  - Auto mode (default): re-applies on refetch
  - Startup mode: does not re-apply on refetch
  - No-op when treatment returns undefined