### PR TITLE
Update @vscode/codicons to version 0.0.45-14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-12",
+        "@vscode/codicons": "^0.0.45-14",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -3151,9 +3151,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-13",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-13.tgz",
-      "integrity": "sha512-Q0oIp4r0aBMpvf5MyTqZycs7A7CGQqCmiJvmQ2pEa4HmAqLKHz+o4xzK0zqNfbQB6y35dFY1jJn5QRIi43eTwg==",
+      "version": "0.0.45-14",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-14.tgz",
+      "integrity": "sha512-EdrK2NnxNGluUm9ZlU1C5VTLfG1cpO4C0CCXloS+8bDuTbidE1qtwaF5lHPcoDE102WBqBzWA09nVKFoN8RSOA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-12",
+    "@vscode/codicons": "^0.0.45-14",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-12",
+        "@vscode/codicons": "^0.0.45-14",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-12",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-12.tgz",
-      "integrity": "sha512-omdtI6hEzpa901Q1s53ndM2vp3ROIVFFCGdz8I6hl4DZ/eKQzEdGYlY09Lnxfh+r9PfSDoyafChGIMIXmNnsRQ==",
+      "version": "0.0.45-14",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-14.tgz",
+      "integrity": "sha512-EdrK2NnxNGluUm9ZlU1C5VTLfG1cpO4C0CCXloS+8bDuTbidE1qtwaF5lHPcoDE102WBqBzWA09nVKFoN8RSOA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-12",
+    "@vscode/codicons": "^0.0.45-14",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.23",


### PR DESCRIPTION
Update the @vscode/codicons dependency to the latest version to ensure compatibility and access to new features. No additional testing is required beyond verifying the application functionality.

