### PR TITLE
Sessions: Fix repository grouping bugs (duplicates, "Other" fallback, worktree resolution)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -14,6 +14,7 @@ import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, IMarshalledAgentSessionContext, isAgentSession, isAgentSessionSection } from './agentSessionsModel.js';
 import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionsSorter, IAgentSessionsFilter, IAgentSessionsSorterOptions } from './agentSessionsViewer.js';
+import { AgentSessionsGrouping } from './agentSessionsFilter.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
 import { IMenuService, MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -243,7 +244,10 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		const sorter = new AgentSessionsSorter(this.options);
 		const approvalModel = this.options.enableApprovalRow ? this._register(this.instantiationService.createInstance(AgentSessionApprovalModel)) : undefined;
 		const activeSessionResource = observableValue<URI | undefined>(this, undefined);
-		const sessionRenderer = this._register(this.instantiationService.createInstance(AgentSessionRenderer, this.options, approvalModel, activeSessionResource));
+		const sessionRenderer = this._register(this.instantiationService.createInstance(AgentSessionRenderer, {
+			...this.options,
+			isGroupedByRepository: () => this.options.filter.groupResults?.() === AgentSessionsGrouping.Repository,
+		}, approvalModel, activeSessionResource));
 		const sessionFilter = this._register(new AgentSessionsDataSource(this.options.filter, sorter));
 		const list = this.sessionsList = this._register(this.instantiationService.createInstance(WorkbenchCompressibleAsyncDataTree,
 			'AgentSessionsView',

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -870,12 +870,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repoId = repoName || noRepoId;
 			const repoLabel = repoName || noRepoLabel;
 
-			if (!repoName) {
-				const badge = session.badge;
-				const badgeRaw = badge ? (typeof badge === 'string' ? badge : badge.value) : 'none';
-				console.log(`[AgentSessions][Other] Session "${session.label}" — metadata: ${JSON.stringify(session.metadata)}, badge: "${badgeRaw}", providerType: "${session.providerType}"`);
-			}
-
 			let group = repoMap.get(repoId);
 			if (!group) {
 				group = { label: repoLabel, sessions: [] };

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -867,8 +867,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			const repoName = this.getRepositoryName(session);
-			const repoId = repoName ?? noRepoId;
-			const repoLabel = repoName ?? noRepoLabel;
+			const repoId = repoName || noRepoId;
+			const repoLabel = repoName || noRepoLabel;
 
 			let group = repoMap.get(repoId);
 			if (!group) {
@@ -948,18 +948,18 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			// repositoryPath: extract repo name from the directory path basename
 			const repositoryPath = metadata.repositoryPath as string | undefined;
 			if (repositoryPath) {
-				const name = this.extractRepoNameFromPath(repositoryPath);
-				if (name) {
-					return name;
+				const repoName = this.extractRepoNameFromPath(repositoryPath);
+				if (repoName) {
+					return repoName;
 				}
 			}
 
 			// workingDirectoryPath: fallback to extract name from the working directory
 			const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
 			if (workingDirectoryPath) {
-				const name = this.extractRepoNameFromPath(workingDirectoryPath);
-				if (name) {
-					return name;
+				const repoName = this.extractRepoNameFromPath(workingDirectoryPath);
+				if (repoName) {
+					return repoName;
 				}
 			}
 		}
@@ -968,7 +968,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		const badge = session.badge;
 		if (badge) {
 			const raw = typeof badge === 'string' ? badge : badge.value;
-			const badgeMatch = raw.match(/\$\((?:repo|folder)\)\s*(.+)/);
+			const badgeMatch = raw.match(/\$\((?:repo|folder|worktree)\)\s*(.+)/);
 			if (badgeMatch) {
 				return badgeMatch[1].trim();
 			}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -91,6 +91,7 @@ export interface IAgentSessionRendererOptions {
 	readonly disableHover?: boolean;
 	readonly showIsolationIcon?: boolean;
 	getHoverPosition(): HoverPosition;
+	isGroupedByRepository?(): boolean;
 }
 
 export class AgentSessionRenderer extends Disposable implements ICompressibleTreeRenderer<IAgentSession, FuzzyScore, IAgentSessionItemTemplate> {
@@ -272,11 +273,21 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 
 	private renderBadge(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): boolean {
 		const badge = session.element.badge;
-		if (badge) {
-			this.renderMarkdownOrText(badge, template.badge, template.elementDisposable);
+		if (!badge) {
+			return false;
 		}
 
-		return !!badge;
+		// When grouped by repository, hide the badge if it only shows the repo name
+		// (since the section header already displays it)
+		if (this.options.isGroupedByRepository?.()) {
+			const raw = typeof badge === 'string' ? badge : badge.value;
+			if (/^\$\((?:repo|folder|worktree)\)\s*.+/.test(raw)) {
+				return false;
+			}
+		}
+
+		this.renderMarkdownOrText(badge, template.badge, template.elementDisposable);
+		return true;
 	}
 
 	private renderMarkdownOrText(content: string | IMarkdownString, container: HTMLElement, disposables: DisposableStore): void {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -857,7 +857,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	private groupSessionsByRepository(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
 		const repoMap = new Map<string, { label: string; sessions: IAgentSession[] }>();
 		const archivedSessions: IAgentSession[] = [];
-		const noRepoId = 'other';
+		const noRepoKey = '\x00noRepo';
 		const noRepoLabel = localize('agentSessions.noRepository', "Other");
 
 		for (const session of sortedSessions) {
@@ -867,7 +867,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			const repoName = this.getRepositoryName(session);
-			const repoId = repoName || noRepoId;
+			const repoId = repoName || noRepoKey;
 			const repoLabel = repoName || noRepoLabel;
 
 			let group = repoMap.get(repoId);
@@ -914,34 +914,21 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				return nwo.split('/').pop()!;
 			}
 
-			// repository: could be "owner/repo" or a URL
+			// repository: could be "owner/repo", a URL, or git@host:owner/repo.git
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
-				if (repository.includes('/') && !repository.includes(':')) {
-					return repository.split('/').pop()!;
-				}
-				try {
-					const url = new URL(repository);
-					const parts = url.pathname.split('/').filter(Boolean);
-					if (parts.length >= 2) {
-						return parts[1];
-					}
-				} catch {
-					// not a URL
+				const repoName = this.parseRepositoryName(repository);
+				if (repoName) {
+					return repoName;
 				}
 			}
 
 			// repositoryUrl: "https://github.com/owner/repo"
 			const repositoryUrl = metadata.repositoryUrl as string | undefined;
 			if (repositoryUrl) {
-				try {
-					const url = new URL(repositoryUrl);
-					const parts = url.pathname.split('/').filter(Boolean);
-					if (parts.length >= 2) {
-						return parts[1];
-					}
-				} catch {
-					// not a URL
+				const repoName = this.parseRepositoryName(repositoryUrl);
+				if (repoName) {
+					return repoName;
 				}
 			}
 
@@ -949,6 +936,15 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repositoryPath = metadata.repositoryPath as string | undefined;
 			if (repositoryPath) {
 				const repoName = this.extractRepoNameFromPath(repositoryPath);
+				if (repoName) {
+					return repoName;
+				}
+			}
+
+			// worktreePath: extract repo name from the worktree path
+			const worktreePath = metadata.worktreePath as string | undefined;
+			if (worktreePath) {
+				const repoName = this.extractRepoNameFromPath(worktreePath);
 				if (repoName) {
 					return repoName;
 				}
@@ -971,6 +967,51 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const badgeMatch = raw.match(/\$\((?:repo|folder|worktree)\)\s*(.+)/);
 			if (badgeMatch) {
 				return badgeMatch[1].trim();
+			}
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Parses a repository name from various formats: "owner/repo", URLs,
+	 * and git@host:owner/repo.git style references.
+	 */
+	private parseRepositoryName(value: string): string | undefined {
+		// Direct "owner/repo" style (no scheme, no git@ prefix)
+		if (value.includes('/') && !value.includes('://') && !value.startsWith('git@')) {
+			let repoSegment = value.split('/').filter(Boolean).pop();
+			if (repoSegment?.endsWith('.git')) {
+				repoSegment = repoSegment.slice(0, -4);
+			}
+			return repoSegment || undefined;
+		}
+
+		// Standard URL formats (https://..., ssh://..., etc.)
+		try {
+			const url = new URL(value);
+			const parts = url.pathname.split('/').filter(Boolean);
+			if (parts.length >= 2) {
+				let repoSegment = parts[1];
+				if (repoSegment.endsWith('.git')) {
+					repoSegment = repoSegment.slice(0, -4);
+				}
+				return repoSegment || undefined;
+			}
+		} catch {
+			// not a standard URL
+		}
+
+		// git@host:owner/repo(.git) style URLs
+		if (value.startsWith('git@')) {
+			const colonIndex = value.indexOf(':');
+			if (colonIndex !== -1 && colonIndex < value.length - 1) {
+				const pathPart = value.substring(colonIndex + 1);
+				let repoSegment = pathPart.split('/').filter(Boolean).pop();
+				if (repoSegment?.endsWith('.git')) {
+					repoSegment = repoSegment.slice(0, -4);
+				}
+				return repoSegment || undefined;
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -870,6 +870,12 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repoId = repoName || noRepoId;
 			const repoLabel = repoName || noRepoLabel;
 
+			if (!repoName) {
+				const badge = session.badge;
+				const badgeRaw = badge ? (typeof badge === 'string' ? badge : badge.value) : 'none';
+				console.log(`[AgentSessions][Other] Session "${session.label}" — metadata: ${JSON.stringify(session.metadata)}, badge: "${badgeRaw}", providerType: "${session.providerType}"`);
+			}
+
 			let group = repoMap.get(repoId);
 			if (!group) {
 				group = { label: repoLabel, sessions: [] };

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -948,7 +948,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			// repositoryPath: extract repo name from the directory path basename
 			const repositoryPath = metadata.repositoryPath as string | undefined;
 			if (repositoryPath) {
-				const name = repositoryPath.split('/').filter(Boolean).pop();
+				const name = this.extractRepoNameFromPath(repositoryPath);
 				if (name) {
 					return name;
 				}
@@ -957,7 +957,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			// workingDirectoryPath: fallback to extract name from the working directory
 			const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
 			if (workingDirectoryPath) {
-				const name = workingDirectoryPath.split('/').filter(Boolean).pop();
+				const name = this.extractRepoNameFromPath(workingDirectoryPath);
 				if (name) {
 					return name;
 				}
@@ -975,6 +975,24 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		}
 
 		return undefined;
+	}
+
+	/**
+	 * Extracts the repository name from a filesystem path, handling git worktree
+	 * conventions where paths follow `<repo>.worktrees/<worktree-name>`.
+	 */
+	private extractRepoNameFromPath(dirPath: string): string | undefined {
+		const segments = dirPath.split(/[/\\]/).filter(Boolean);
+		if (segments.length < 2) {
+			return segments[0];
+		}
+
+		const parent = segments[segments.length - 2];
+		if (parent.endsWith('.worktrees')) {
+			return parent.slice(0, -'.worktrees'.length) || undefined;
+		}
+
+		return segments[segments.length - 1];
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -860,8 +860,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		const noRepoId = 'other';
 		const noRepoLabel = localize('agentSessions.noRepository', "Other");
 
-		console.log(`[AgentSessions][groupByRepo] Grouping ${sortedSessions.length} sessions by repository`);
-
 		for (const session of sortedSessions) {
 			if (session.isArchived()) {
 				archivedSessions.push(session);
@@ -872,8 +870,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repoId = repo?.id ?? noRepoId;
 			const repoLabel = repo?.label ?? noRepoLabel;
 
-			console.log(`[AgentSessions][groupByRepo] Session "${session.label}" (id: ${session.id}) => repoId: "${repoId}", repoLabel: "${repoLabel}"`);
-
 			let group = repoMap.get(repoId);
 			if (!group) {
 				group = { label: repoLabel, sessions: [] };
@@ -881,8 +877,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 			group.sessions.push(session);
 		}
-
-		console.log(`[AgentSessions][groupByRepo] Final groups:`, [...repoMap.entries()].map(([id, g]) => `"${id}" (label: "${g.label}", count: ${g.sessions.length})`));
 
 		const result: AgentSessionListItem[] = [];
 		for (const [, { label, sessions }] of repoMap) {
@@ -906,47 +900,36 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 	private getRepositoryInfo(session: IAgentSession): { id: string; label: string } | undefined {
 		const metadata = session.metadata;
-		console.log(`[AgentSessions][getRepoInfo] Session "${session.label}" (id: ${session.id}) — metadata keys: ${metadata ? JSON.stringify(Object.keys(metadata)) : 'none'}, badge: ${session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : 'none'}`);
 		if (metadata) {
-			console.log(`[AgentSessions][getRepoInfo]   metadata.owner=${JSON.stringify(metadata.owner)}, metadata.name=${JSON.stringify(metadata.name)}, metadata.repositoryNwo=${JSON.stringify(metadata.repositoryNwo)}, metadata.repository=${JSON.stringify(metadata.repository)}, metadata.repositoryUrl=${JSON.stringify(metadata.repositoryUrl)}`);
-
 			// Cloud sessions: metadata.owner + metadata.name
 			const owner = metadata.owner as string | undefined;
 			const name = metadata.name as string | undefined;
 			if (owner && name) {
-				const result = { id: `${owner}/${name}`, label: name };
-				console.log(`[AgentSessions][getRepoInfo]   => matched via owner+name: id="${result.id}", label="${result.label}"`);
-				return result;
+				return { id: name, label: name };
 			}
 
 			// repositoryNwo: "owner/repo"
 			const nwo = metadata.repositoryNwo as string | undefined;
 			if (nwo && nwo.includes('/')) {
-				const result = { id: nwo, label: nwo.split('/').pop()! };
-				console.log(`[AgentSessions][getRepoInfo]   => matched via repositoryNwo: id="${result.id}", label="${result.label}"`);
-				return result;
+				const label = nwo.split('/').pop()!;
+				return { id: label, label };
 			}
 
 			// repository: could be "owner/repo" or a URL
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
 				if (repository.includes('/') && !repository.includes(':')) {
-					const result = { id: repository, label: repository.split('/').pop()! };
-					console.log(`[AgentSessions][getRepoInfo]   => matched via repository (nwo format): id="${result.id}", label="${result.label}"`);
-					return result;
+					const label = repository.split('/').pop()!;
+					return { id: label, label };
 				}
 				try {
 					const url = new URL(repository);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						const id = `${parts[0]}/${parts[1]}`;
-						const result = { id, label: parts[1] };
-						console.log(`[AgentSessions][getRepoInfo]   => matched via repository (URL format): id="${result.id}", label="${result.label}"`);
-						return result;
+						return { id: parts[1], label: parts[1] };
 					}
-					console.log(`[AgentSessions][getRepoInfo]   => repository URL parsed but insufficient path parts: ${url.pathname}`);
 				} catch {
-					console.log(`[AgentSessions][getRepoInfo]   => repository value "${repository}" is neither nwo nor valid URL`);
+					// not a URL
 				}
 			}
 
@@ -957,32 +940,43 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 					const url = new URL(repositoryUrl);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						const id = `${parts[0]}/${parts[1]}`;
-						const result = { id, label: parts[1] };
-						console.log(`[AgentSessions][getRepoInfo]   => matched via repositoryUrl: id="${result.id}", label="${result.label}"`);
-						return result;
+						return { id: parts[1], label: parts[1] };
 					}
-					console.log(`[AgentSessions][getRepoInfo]   => repositoryUrl parsed but insufficient path parts: ${url.pathname}`);
 				} catch {
-					console.log(`[AgentSessions][getRepoInfo]   => repositoryUrl "${repositoryUrl}" is not a valid URL`);
+					// not a URL
+				}
+			}
+
+			// repositoryPath: extract repo name from the directory path basename
+			const repositoryPath = metadata.repositoryPath as string | undefined;
+			if (repositoryPath) {
+				const label = repositoryPath.split('/').filter(Boolean).pop();
+				if (label) {
+					return { id: label, label };
+				}
+			}
+
+			// workingDirectoryPath: fallback to extract name from the working directory
+			const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
+			if (workingDirectoryPath) {
+				const label = workingDirectoryPath.split('/').filter(Boolean).pop();
+				if (label) {
+					return { id: label, label };
 				}
 			}
 		}
 
-		// Fallback: extract repo name from badge if it uses the $(repo) icon
+		// Fallback: extract repo/folder name from badge
 		const badge = session.badge;
 		if (badge) {
 			const raw = typeof badge === 'string' ? badge : badge.value;
-			const repoMatch = raw.match(/\$\(repo\)\s*(.+)/);
-			if (repoMatch) {
-				const label = repoMatch[1].trim();
-				console.log(`[AgentSessions][getRepoInfo]   => matched via badge: id="${label}", label="${label}"`);
+			const badgeMatch = raw.match(/\$\((?:repo|folder)\)\s*(.+)/);
+			if (badgeMatch) {
+				const label = badgeMatch[1].trim();
 				return { id: label, label };
 			}
-			console.log(`[AgentSessions][getRepoInfo]   => badge present but no $(repo) match: "${raw}"`);
 		}
 
-		console.log(`[AgentSessions][getRepoInfo]   => NO MATCH — session will go to "Other"`);
 		return undefined;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -866,9 +866,9 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 				continue;
 			}
 
-			const repo = this.getRepositoryInfo(session);
-			const repoId = repo?.id ?? noRepoId;
-			const repoLabel = repo?.label ?? noRepoLabel;
+			const repoName = this.getRepositoryName(session);
+			const repoId = repoName ?? noRepoId;
+			const repoLabel = repoName ?? noRepoLabel;
 
 			let group = repoMap.get(repoId);
 			if (!group) {
@@ -898,35 +898,33 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		return result;
 	}
 
-	private getRepositoryInfo(session: IAgentSession): { id: string; label: string } | undefined {
+	private getRepositoryName(session: IAgentSession): string | undefined {
 		const metadata = session.metadata;
 		if (metadata) {
 			// Cloud sessions: metadata.owner + metadata.name
 			const owner = metadata.owner as string | undefined;
 			const name = metadata.name as string | undefined;
 			if (owner && name) {
-				return { id: name, label: name };
+				return name;
 			}
 
 			// repositoryNwo: "owner/repo"
 			const nwo = metadata.repositoryNwo as string | undefined;
 			if (nwo && nwo.includes('/')) {
-				const label = nwo.split('/').pop()!;
-				return { id: label, label };
+				return nwo.split('/').pop()!;
 			}
 
 			// repository: could be "owner/repo" or a URL
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
 				if (repository.includes('/') && !repository.includes(':')) {
-					const label = repository.split('/').pop()!;
-					return { id: label, label };
+					return repository.split('/').pop()!;
 				}
 				try {
 					const url = new URL(repository);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						return { id: parts[1], label: parts[1] };
+						return parts[1];
 					}
 				} catch {
 					// not a URL
@@ -940,7 +938,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 					const url = new URL(repositoryUrl);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
-						return { id: parts[1], label: parts[1] };
+						return parts[1];
 					}
 				} catch {
 					// not a URL
@@ -950,18 +948,18 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			// repositoryPath: extract repo name from the directory path basename
 			const repositoryPath = metadata.repositoryPath as string | undefined;
 			if (repositoryPath) {
-				const label = repositoryPath.split('/').filter(Boolean).pop();
-				if (label) {
-					return { id: label, label };
+				const name = repositoryPath.split('/').filter(Boolean).pop();
+				if (name) {
+					return name;
 				}
 			}
 
 			// workingDirectoryPath: fallback to extract name from the working directory
 			const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
 			if (workingDirectoryPath) {
-				const label = workingDirectoryPath.split('/').filter(Boolean).pop();
-				if (label) {
-					return { id: label, label };
+				const name = workingDirectoryPath.split('/').filter(Boolean).pop();
+				if (name) {
+					return name;
 				}
 			}
 		}
@@ -972,8 +970,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const raw = typeof badge === 'string' ? badge : badge.value;
 			const badgeMatch = raw.match(/\$\((?:repo|folder)\)\s*(.+)/);
 			if (badgeMatch) {
-				const label = badgeMatch[1].trim();
-				return { id: label, label };
+				return badgeMatch[1].trim();
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -860,6 +860,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		const noRepoId = 'other';
 		const noRepoLabel = localize('agentSessions.noRepository', "Other");
 
+		console.log(`[AgentSessions][groupByRepo] Grouping ${sortedSessions.length} sessions by repository`);
+
 		for (const session of sortedSessions) {
 			if (session.isArchived()) {
 				archivedSessions.push(session);
@@ -870,6 +872,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repoId = repo?.id ?? noRepoId;
 			const repoLabel = repo?.label ?? noRepoLabel;
 
+			console.log(`[AgentSessions][groupByRepo] Session "${session.label}" (id: ${session.id}) => repoId: "${repoId}", repoLabel: "${repoLabel}"`);
+
 			let group = repoMap.get(repoId);
 			if (!group) {
 				group = { label: repoLabel, sessions: [] };
@@ -877,6 +881,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 			group.sessions.push(session);
 		}
+
+		console.log(`[AgentSessions][groupByRepo] Final groups:`, [...repoMap.entries()].map(([id, g]) => `"${id}" (label: "${g.label}", count: ${g.sessions.length})`));
 
 		const result: AgentSessionListItem[] = [];
 		for (const [, { label, sessions }] of repoMap) {
@@ -900,35 +906,47 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 	private getRepositoryInfo(session: IAgentSession): { id: string; label: string } | undefined {
 		const metadata = session.metadata;
+		console.log(`[AgentSessions][getRepoInfo] Session "${session.label}" (id: ${session.id}) — metadata keys: ${metadata ? JSON.stringify(Object.keys(metadata)) : 'none'}, badge: ${session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : 'none'}`);
 		if (metadata) {
+			console.log(`[AgentSessions][getRepoInfo]   metadata.owner=${JSON.stringify(metadata.owner)}, metadata.name=${JSON.stringify(metadata.name)}, metadata.repositoryNwo=${JSON.stringify(metadata.repositoryNwo)}, metadata.repository=${JSON.stringify(metadata.repository)}, metadata.repositoryUrl=${JSON.stringify(metadata.repositoryUrl)}`);
+
 			// Cloud sessions: metadata.owner + metadata.name
 			const owner = metadata.owner as string | undefined;
 			const name = metadata.name as string | undefined;
 			if (owner && name) {
-				return { id: `${owner}/${name}`, label: name };
+				const result = { id: `${owner}/${name}`, label: name };
+				console.log(`[AgentSessions][getRepoInfo]   => matched via owner+name: id="${result.id}", label="${result.label}"`);
+				return result;
 			}
 
 			// repositoryNwo: "owner/repo"
 			const nwo = metadata.repositoryNwo as string | undefined;
 			if (nwo && nwo.includes('/')) {
-				return { id: nwo, label: nwo.split('/').pop()! };
+				const result = { id: nwo, label: nwo.split('/').pop()! };
+				console.log(`[AgentSessions][getRepoInfo]   => matched via repositoryNwo: id="${result.id}", label="${result.label}"`);
+				return result;
 			}
 
 			// repository: could be "owner/repo" or a URL
 			const repository = metadata.repository as string | undefined;
 			if (repository) {
 				if (repository.includes('/') && !repository.includes(':')) {
-					return { id: repository, label: repository.split('/').pop()! };
+					const result = { id: repository, label: repository.split('/').pop()! };
+					console.log(`[AgentSessions][getRepoInfo]   => matched via repository (nwo format): id="${result.id}", label="${result.label}"`);
+					return result;
 				}
 				try {
 					const url = new URL(repository);
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
 						const id = `${parts[0]}/${parts[1]}`;
-						return { id, label: parts[1] };
+						const result = { id, label: parts[1] };
+						console.log(`[AgentSessions][getRepoInfo]   => matched via repository (URL format): id="${result.id}", label="${result.label}"`);
+						return result;
 					}
+					console.log(`[AgentSessions][getRepoInfo]   => repository URL parsed but insufficient path parts: ${url.pathname}`);
 				} catch {
-					// not a URL
+					console.log(`[AgentSessions][getRepoInfo]   => repository value "${repository}" is neither nwo nor valid URL`);
 				}
 			}
 
@@ -940,10 +958,13 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 					const parts = url.pathname.split('/').filter(Boolean);
 					if (parts.length >= 2) {
 						const id = `${parts[0]}/${parts[1]}`;
-						return { id, label: parts[1] };
+						const result = { id, label: parts[1] };
+						console.log(`[AgentSessions][getRepoInfo]   => matched via repositoryUrl: id="${result.id}", label="${result.label}"`);
+						return result;
 					}
+					console.log(`[AgentSessions][getRepoInfo]   => repositoryUrl parsed but insufficient path parts: ${url.pathname}`);
 				} catch {
-					// not a URL
+					console.log(`[AgentSessions][getRepoInfo]   => repositoryUrl "${repositoryUrl}" is not a valid URL`);
 				}
 			}
 		}
@@ -955,10 +976,13 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			const repoMatch = raw.match(/\$\(repo\)\s*(.+)/);
 			if (repoMatch) {
 				const label = repoMatch[1].trim();
+				console.log(`[AgentSessions][getRepoInfo]   => matched via badge: id="${label}", label="${label}"`);
 				return { id: label, label };
 			}
+			console.log(`[AgentSessions][getRepoInfo]   => badge present but no $(repo) match: "${raw}"`);
 		}
 
+		console.log(`[AgentSessions][getRepoInfo]   => NO MATCH — session will go to "Other"`);
 		return undefined;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -857,8 +857,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	private groupSessionsByRepository(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
 		const repoMap = new Map<string, { label: string; sessions: IAgentSession[] }>();
 		const archivedSessions: IAgentSession[] = [];
-		const noRepoKey = '\x00noRepo';
-		const noRepoLabel = localize('agentSessions.noRepository', "Other");
+		const unknownKey = '\x00unknown';
+		const unknownLabel = localize('agentSessions.noRepository', "Other");
 
 		for (const session of sortedSessions) {
 			if (session.isArchived()) {
@@ -867,8 +867,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			const repoName = this.getRepositoryName(session);
-			const repoId = repoName || noRepoKey;
-			const repoLabel = repoName || noRepoLabel;
+			const repoId = repoName || unknownKey;
+			const repoLabel = repoName || unknownLabel;
 
 			let group = repoMap.get(repoId);
 			if (!group) {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -108,6 +108,8 @@ suite('AgentSessionsDataSource', () => {
 		hasChanges: boolean;
 		startTime: number;
 		endTime: number;
+		metadata: { [key: string]: unknown };
+		badge: string;
 	}> = {}): IAgentSession {
 		const now = Date.now();
 		return {
@@ -123,6 +125,8 @@ suite('AgentSessionsDataSource', () => {
 				lastRequestStarted: undefined,
 			},
 			changes: overrides.hasChanges ? { files: 1, insertions: 10, deletions: 5 } : undefined,
+			metadata: overrides.metadata,
+			badge: overrides.badge,
 			isArchived: () => overrides.isArchived ?? false,
 			setArchived: () => { },
 			isRead: () => overrides.isRead ?? true,
@@ -494,6 +498,232 @@ suite('AgentSessionsDataSource', () => {
 			assert.strictEqual(sections.length, 1);
 			assert.strictEqual(sections[0].section, AgentSessionSection.More);
 			assert.strictEqual(sections[0].sessions.length, 2);
+		});
+	});
+
+	suite('groupSessionsByRepository', () => {
+
+		test('groups sessions by metadata.owner + metadata.name (cloud sessions)', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { owner: 'microsoft', name: 'vscode' } }),
+				createMockSession({ id: '2', metadata: { owner: 'microsoft', name: 'vscode' } }),
+				createMockSession({ id: '3', metadata: { owner: 'microsoft', name: 'typescript' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 2 },
+				{ label: 'typescript', count: 1 },
+			]);
+		});
+
+		test('groups sessions by metadata.repositoryNwo', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryNwo: 'microsoft/vscode' } }),
+				createMockSession({ id: '2', metadata: { repositoryNwo: 'microsoft/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 2 },
+			]);
+		});
+
+		test('groups sessions by metadata.repository (nwo format)', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repository: 'microsoft/vscode' } }),
+				createMockSession({ id: '2', metadata: { repository: 'microsoft/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 2 },
+			]);
+		});
+
+		test('groups sessions by metadata.repository (URL format)', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repository: 'https://github.com/microsoft/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('groups sessions by metadata.repositoryUrl', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryUrl: 'https://github.com/microsoft/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('groups sessions by metadata.repositoryPath (basename)', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryPath: '/Users/user/Projects/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('groups sessions by metadata.workingDirectoryPath', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { workingDirectoryPath: '/Users/user/Projects/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('resolves worktree paths to parent repo name', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { workingDirectoryPath: '/Users/user/Projects/vscode.worktrees/copilot-branch' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('groups sessions by badge with $(repo) prefix', () => {
+			const sessions = [
+				createMockSession({ id: '1', badge: '$(repo) vscode' }),
+				createMockSession({ id: '2', badge: '$(repo) vscode' }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 2 },
+			]);
+		});
+
+		test('groups sessions by badge with $(folder) prefix', () => {
+			const sessions = [
+				createMockSession({ id: '1', badge: '$(folder) my-project' }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'my-project', count: 1 },
+			]);
+		});
+
+		test('cloud and local sessions for same repo merge into one group', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { owner: 'microsoft', name: 'vscode' } }),
+				createMockSession({ id: '2', metadata: { repositoryPath: '/Users/user/Projects/vscode' } }),
+				createMockSession({ id: '3', badge: '$(repo) vscode' }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'vscode', count: 3 },
+			]);
+		});
+
+		test('sessions without any repo info go to Other', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { isolationMode: 'workspace' } }),
+				createMockSession({ id: '2' }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+				{ label: 'Other', count: 2 },
+			]);
+		});
+
+		test('archived sessions go to Archived section', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryPath: '/path/vscode' } }),
+				createMockSession({ id: '2', isArchived: true, metadata: { repositoryPath: '/path/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => ({ label: s.label, section: s.section, count: s.sessions.length })), [
+				{ label: 'vscode', section: AgentSessionSection.Repository, count: 1 },
+				{ label: 'Archived', section: AgentSessionSection.Archived, count: 1 },
+			]);
+		});
+
+		test('metadata extraction priority: owner+name > repositoryNwo > repository > repositoryUrl > repositoryPath > workingDirectoryPath > badge', () => {
+			// owner+name takes priority over repositoryNwo
+			const sessions1 = [createMockSession({ id: '1', metadata: { owner: 'org', name: 'fromOwner', repositoryNwo: 'org/fromNwo' } })];
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const ds1 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			assert.strictEqual(getSectionsFromResult(ds1.getChildren(createMockModel(sessions1)))[0].label, 'fromOwner');
+
+			// repositoryNwo takes priority over repository
+			const sessions2 = [createMockSession({ id: '2', metadata: { repositoryNwo: 'org/fromNwo', repository: 'org/fromRepo' } })];
+			const ds2 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			assert.strictEqual(getSectionsFromResult(ds2.getChildren(createMockModel(sessions2)))[0].label, 'fromNwo');
+
+			// badge is used when no metadata fields match
+			const sessions3 = [createMockSession({ id: '3', metadata: { isolationMode: 'workspace' }, badge: '$(repo) fromBadge' })];
+			const ds3 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			assert.strictEqual(getSectionsFromResult(ds3.getChildren(createMockModel(sessions3)))[0].label, 'fromBadge');
+		});
+
+		test('empty string metadata values are treated as missing', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repositoryNwo: '', repositoryPath: '/path/vscode' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(result.map(s => s.label), ['vscode']);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -741,10 +741,12 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(sortedGroups(result), [
-				{ label: 'Other', count: 1 },
-				{ label: 'other', count: 1 },
-			]);
+			assert.strictEqual(result.length, 2, 'should have 2 separate groups');
+			const labels = result.map(s => s.label);
+			assert.ok(labels.includes('other'), 'should have a group for repo named "other"');
+			assert.ok(labels.includes('Other'), 'should have the fallback "Other" group');
+			assert.strictEqual(result.find(s => s.label === 'other')!.sessions.length, 1);
+			assert.strictEqual(result.find(s => s.label === 'Other')!.sessions.length, 1);
 		});
 
 		test('archived sessions go to Archived section', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -503,20 +503,27 @@ suite('AgentSessionsDataSource', () => {
 
 	suite('groupSessionsByRepository', () => {
 
+		function sortedGroups(result: IAgentSessionSection[]) {
+			return result
+				.map(s => ({ label: s.label, count: s.sessions.length }))
+				.sort((a, b) => a.label.localeCompare(b.label));
+		}
+
 		test('groups sessions by metadata.owner + metadata.name (cloud sessions)', () => {
+			const now = Date.now();
 			const sessions = [
-				createMockSession({ id: '1', metadata: { owner: 'microsoft', name: 'vscode' } }),
-				createMockSession({ id: '2', metadata: { owner: 'microsoft', name: 'vscode' } }),
-				createMockSession({ id: '3', metadata: { owner: 'microsoft', name: 'typescript' } }),
+				createMockSession({ id: '1', startTime: now, metadata: { owner: 'microsoft', name: 'vscode' } }),
+				createMockSession({ id: '2', startTime: now - 1, metadata: { owner: 'microsoft', name: 'vscode' } }),
+				createMockSession({ id: '3', startTime: now - 2, metadata: { owner: 'microsoft', name: 'typescript' } }),
 			];
 
 			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
-				{ label: 'vscode', count: 2 },
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'typescript', count: 1 },
+				{ label: 'vscode', count: 2 },
 			]);
 		});
 
@@ -530,7 +537,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 2 },
 			]);
 		});
@@ -545,7 +552,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 2 },
 			]);
 		});
@@ -559,7 +566,36 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('strips .git suffix from repository URLs', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repository: 'https://github.com/microsoft/vscode.git' } }),
+				createMockSession({ id: '2', metadata: { repositoryUrl: 'https://github.com/microsoft/vscode.git' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(sortedGroups(result), [
+				{ label: 'vscode', count: 2 },
+			]);
+		});
+
+		test('handles git@ SSH URLs', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { repository: 'git@github.com:microsoft/vscode.git' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 1 },
 			]);
 		});
@@ -573,7 +609,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 1 },
 			]);
 		});
@@ -587,7 +623,21 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
+				{ label: 'vscode', count: 1 },
+			]);
+		});
+
+		test('groups sessions by metadata.worktreePath', () => {
+			const sessions = [
+				createMockSession({ id: '1', metadata: { worktreePath: '/Users/user/Projects/vscode.worktrees/my-branch' } }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 1 },
 			]);
 		});
@@ -601,7 +651,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 1 },
 			]);
 		});
@@ -615,7 +665,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 1 },
 			]);
 		});
@@ -630,7 +680,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 2 },
 			]);
 		});
@@ -644,7 +694,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'my-project', count: 1 },
 			]);
 		});
@@ -660,7 +710,7 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'vscode', count: 3 },
 			]);
 		});
@@ -675,8 +725,25 @@ suite('AgentSessionsDataSource', () => {
 			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
-			assert.deepStrictEqual(result.map(s => ({ label: s.label, count: s.sessions.length })), [
+			assert.deepStrictEqual(sortedGroups(result), [
 				{ label: 'Other', count: 2 },
+			]);
+		});
+
+		test('repo named "other" does not collide with the Other fallback group', () => {
+			const now = Date.now();
+			const sessions = [
+				createMockSession({ id: '1', startTime: now, metadata: { repositoryPath: '/path/other' } }),
+				createMockSession({ id: '2', startTime: now - 1 }),
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.deepStrictEqual(sortedGroups(result), [
+				{ label: 'Other', count: 1 },
+				{ label: 'other', count: 1 },
 			]);
 		});
 
@@ -697,21 +764,25 @@ suite('AgentSessionsDataSource', () => {
 		});
 
 		test('metadata extraction priority: owner+name > repositoryNwo > repository > repositoryUrl > repositoryPath > workingDirectoryPath > badge', () => {
-			// owner+name takes priority over repositoryNwo
-			const sessions1 = [createMockSession({ id: '1', metadata: { owner: 'org', name: 'fromOwner', repositoryNwo: 'org/fromNwo' } })];
 			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+
+			// owner+name takes priority over repositoryNwo
 			const ds1 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
-			assert.strictEqual(getSectionsFromResult(ds1.getChildren(createMockModel(sessions1)))[0].label, 'fromOwner');
+			assert.strictEqual(getSectionsFromResult(ds1.getChildren(createMockModel([
+				createMockSession({ id: '1', metadata: { owner: 'org', name: 'fromOwner', repositoryNwo: 'org/fromNwo' } }),
+			])))[0].label, 'fromOwner');
 
 			// repositoryNwo takes priority over repository
-			const sessions2 = [createMockSession({ id: '2', metadata: { repositoryNwo: 'org/fromNwo', repository: 'org/fromRepo' } })];
 			const ds2 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
-			assert.strictEqual(getSectionsFromResult(ds2.getChildren(createMockModel(sessions2)))[0].label, 'fromNwo');
+			assert.strictEqual(getSectionsFromResult(ds2.getChildren(createMockModel([
+				createMockSession({ id: '2', metadata: { repositoryNwo: 'org/fromNwo', repository: 'org/fromRepo' } }),
+			])))[0].label, 'fromNwo');
 
 			// badge is used when no metadata fields match
-			const sessions3 = [createMockSession({ id: '3', metadata: { isolationMode: 'workspace' }, badge: '$(repo) fromBadge' })];
 			const ds3 = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
-			assert.strictEqual(getSectionsFromResult(ds3.getChildren(createMockModel(sessions3)))[0].label, 'fromBadge');
+			assert.strictEqual(getSectionsFromResult(ds3.getChildren(createMockModel([
+				createMockSession({ id: '3', metadata: { isolationMode: 'workspace' }, badge: '$(repo) fromBadge' }),
+			])))[0].label, 'fromBadge');
 		});
 
 		test('empty string metadata values are treated as missing', () => {


### PR DESCRIPTION
## Summary

Fixes several bugs in the "Group by Repository" feature for the sessions list in the dedicated sessions window.

## Bugs Fixed

### 1. Duplicate repository groups
Cloud sessions used `owner/repo` as the grouping ID while local sessions used just `repo` from badge parsing. This caused the same repository to appear as two separate groups (e.g., both labeled "vscode" but with different internal IDs). **Fix:** Normalize all grouping IDs to use just the repo name.

### 2. Sessions going to "Other" unnecessarily
- Sessions with `$(folder)` badge prefix (instead of `$(repo)`) were not matched by the badge regex, sending them to "Other". **Fix:** Extended regex to match `$(folder)` and `$(worktree)` prefixes too.
- Sessions with `metadata.repositoryPath` or `metadata.workingDirectoryPath` were not being used for repo extraction. **Fix:** Added these as fallback extraction sources.

### 3. Git worktree paths resolving to wrong name
Worktree paths like `/Projects/vscode.worktrees/copilot-branch` would extract `copilot-branch` instead of `vscode`. **Fix:** Added `extractRepoNameFromPath()` that detects the `.worktrees` parent directory convention and extracts the actual repo name.

### 4. Empty group labels
Sessions returning empty strings from repo extraction would create groups with blank labels. **Fix:** Changed `??` to `||` so empty strings also fall back to "Other".

## Refactoring

- Simplified `getRepositoryInfo()` → `getRepositoryName()` since `id` and `label` were always the same value after the deduplication fix. Return type changed from `{ id: string; label: string } | undefined` to `string | undefined`.

## Tests

Added comprehensive test suite (`groupSessionsByRepository`) covering:
- All metadata extraction paths (owner+name, repositoryNwo, repository, repositoryUrl, repositoryPath, workingDirectoryPath, badge)
- Cloud + local session merging into same group
- Worktree path resolution
- "Other" fallback for sessions with no repo info
- Archived sessions go to separate Archived section
- Extraction priority order
- Empty string handling