### PR TITLE
 Fix `cannot read properties of undefined (reading 'filter')`

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -662,7 +662,7 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		const autoReply = this._configurationService.getValue(TerminalChatAgentToolsSettingId.AutoReplyToPrompts) || this._isAutopilotMode();
 		let model = this._chatWidgetService.getWidgetsByLocations(ChatAgentLocation.Chat)[0]?.input.currentLanguageModel;
 		if (model) {
-			const models = await this._languageModelsService.selectLanguageModels({ vendor: 'copilot', family: model.replaceAll('copilot/', '') });
+			const models = await this._safeSelectLanguageModels({ vendor: 'copilot', family: model.replaceAll('copilot/', '') });
 			model = models[0];
 		}
 		if (!model) {
@@ -964,8 +964,17 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 	}
 
 	private async _getLanguageModel(): Promise<string | undefined> {
-		const models = await this._languageModelsService.selectLanguageModels({ vendor: 'copilot', id: 'copilot-fast' });
+		const models = await this._safeSelectLanguageModels({ vendor: 'copilot', id: 'copilot-fast' });
 		return models.length ? models[0] : undefined;
+	}
+
+	private async _safeSelectLanguageModels(selector: { vendor: string; family?: string; id?: string }): Promise<string[]> {
+		try {
+			return await this._languageModelsService.selectLanguageModels(selector);
+		} catch (error) {
+			this._logService.trace('OutputMonitor: selectLanguageModels failed', error);
+			return [];
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/monitoring/outputMonitor.ts
@@ -18,7 +18,7 @@ import { ChatElicitationRequestPart } from '../../../../../chat/common/model/cha
 import { ChatModel } from '../../../../../chat/common/model/chatModel.js';
 import { ElicitationState, IChatService } from '../../../../../chat/common/chatService/chatService.js';
 import { ChatAgentLocation, ChatPermissionLevel } from '../../../../../chat/common/constants.js';
-import { ChatMessageRole, getTextResponseFromStream, ILanguageModelsService } from '../../../../../chat/common/languageModels.js';
+import { ChatMessageRole, getTextResponseFromStream, type ILanguageModelChatSelector, ILanguageModelsService } from '../../../../../chat/common/languageModels.js';
 import { IToolInvocationContext } from '../../../../../chat/common/tools/languageModelToolsService.js';
 import { ITaskService } from '../../../../../tasks/common/taskService.js';
 import { ILinkLocation } from '../../taskHelpers.js';
@@ -968,11 +968,11 @@ export class OutputMonitor extends Disposable implements IOutputMonitor {
 		return models.length ? models[0] : undefined;
 	}
 
-	private async _safeSelectLanguageModels(selector: { vendor: string; family?: string; id?: string }): Promise<string[]> {
+	private async _safeSelectLanguageModels(selector: ILanguageModelChatSelector): Promise<string[]> {
 		try {
 			return await this._languageModelsService.selectLanguageModels(selector);
 		} catch (error) {
-			this._logService.trace('OutputMonitor: selectLanguageModels failed', error);
+			this._logService.trace('OutputMonitor: selectLanguageModels failed', { selector, error });
 			return [];
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-internalbacklog/issues/7012

Cause:
- During terminal benchmark runs, model lookup for Copilot could throw from the LM selection path (`selectLanguageModels`), and that exception propagated instead of being handled.
- That unhandled throw interrupted the output-monitor flow and contributed to benchmark timeouts/failures.

Fix:
- Wrapped LM selection in a safe helper that catches errors and returns an empty model list.
- Callers now treat lookup failure as “no model available” and continue gracefully, rather than throwing.
- Result: no crash path from model lookup, so the monitor keeps running and avoids this failure mode.
