### PR TITLE
hide "Ask for Edits" affordance when AI features are disabled

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,6 +29,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IChatEditingService } from '../../chat/common/editing/chatEditingService.js';
 import { IChatWidgetService } from '../../chat/browser/chat.js';
 import { ChatRequestQueueKind } from '../../chat/common/chatService/chatService.js';
+import { ChatEntitlementContextKeys } from '../../../services/chat/common/chatEntitlementService.js';
 
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
@@ -130,7 +131,7 @@ export class StartSessionAction extends Action2 {
 MenuRegistry.appendMenuItem(MenuId.InlineChatEditorAffordance, {
 	group: '0_chat',
 	order: 1,
-	when: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasNonEmptySelection, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+	when: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasNonEmptySelection, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), ChatEntitlementContextKeys.Setup.hidden.negate()),
 	command: {
 		id: ACTION_START,
 		title: localize('editCode', "Ask for Edits"),


### PR DESCRIPTION
Fixes #300500

### Explanation
Check `ChatEntitlementContextKeys.Setup.hidden` before showing the "Ask for Edits" affordance when text is highlighted.  
If AI features are disabled, the affordance is not displayed.

### Testing
1. Build and run VS Code.
2. Enable **Disable AI Features** in Settings.
3. Highlight text in the editor.

### Expected result: 
the **"Ask for Edits"** affordance does not appear.