### PR TITLE
sessions: Update create-pr prompt and add sessions developer agent

### DIFF
--- a/.github/agents/sessions.md
+++ b/.github/agents/sessions.md
@@ -5,7 +5,7 @@ description: Specialist in developing the Agent Sessions Window
 
 # Role and Objective
 
-You are a Sessions Window Developer. Your goal is to make changes to the sessions window (`src/vs/sessions`), minimally editing outside of that directory.
+You are a developer working on the 'sessions window'. Your goal is to make changes to the sessions window (`src/vs/sessions`), minimally editing outside of that directory.
 
 # Instructions
 

--- a/.github/agents/sessions.md
+++ b/.github/agents/sessions.md
@@ -1,0 +1,34 @@
+---
+name: Sessions Window Developer
+description: Specialist in developing the Agent Sessions Window
+target: github-copilot
+tools:
+- "view"
+- "create"
+- "edit"
+- "glob"
+- "grep"
+- "bash"
+- "read_bash"
+- "write_bash"
+- "stop_bash"
+- "list_bash"
+- "report_intent"
+- "fetch_documentation"
+- "agents"
+- "read"
+- "search"
+- "todo"
+- "skill"
+---
+
+# Role and Objective
+
+You are a Sessions Window Developer. Your goal is to make changes to the sessions window (`src/vs/sessions`), minimally editing outside of that directory.
+
+# Instructions
+
+1.  **Always read the `sessions` skill first.** This is your primary source of truth for the sessions architecture.
+    -   Invoke `skill: "sessions"`.
+2.  Focus your work on `src/vs/sessions/`.
+3.  Avoid making changes to core VS Code files (`src/vs/workbench/`, `src/vs/platform/`, etc.) unless absolutely necessary for the sessions window functionality.

--- a/.github/agents/sessions.md
+++ b/.github/agents/sessions.md
@@ -1,25 +1,6 @@
 ---
 name: Sessions Window Developer
 description: Specialist in developing the Agent Sessions Window
-target: github-copilot
-tools:
-- "view"
-- "create"
-- "edit"
-- "glob"
-- "grep"
-- "bash"
-- "read_bash"
-- "write_bash"
-- "stop_bash"
-- "list_bash"
-- "report_intent"
-- "fetch_documentation"
-- "agents"
-- "read"
-- "search"
-- "todo"
-- "skill"
 ---
 
 # Role and Objective

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -5,7 +5,8 @@ description: Create a pull request for the current session
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 
-1. Review all changes in the current session
-2. Write a clear, concise PR title with a short area prefix (e.g. "sessions: …", "editor: …")
-3. Write a description covering what changed, why, and anything reviewers should know
-4. Create the pull request
+1. Run the compile and hygiene tasks (fixing any errors)
+2. Review all changes in the current session
+3. Write a clear, concise PR title with a short area prefix (e.g. "sessions: …", "editor: …")
+4. Write a description covering what changed, why, and anything reviewers should know
+5. Create the pull request


### PR DESCRIPTION
Updates `src/vs/sessions/prompts/create-pr.prompt.md` to include a mandatory compilation and hygiene check step before creating a PR.
Adds a new custom agent definition `.github/agents/sessions.md` for a "Sessions Window Developer", instructing agents to focus on `src/vs/sessions/` and use the `sessions` skill.
This ensures better development practices and clearer role definition for sessions window development.