### PR TITLE
plugins: initial support for workspace plugins

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -413,7 +413,9 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 
 	async show(query: string): Promise<IPagedModel<IAgentPluginItem>> {
 		this.currentQuery = query;
-		const text = query.replace(/@agentPlugins/i, '').trim().toLowerCase();
+		const stripped = query.replace(/@agentPlugins/i, '').trim();
+		const isRecommended = /^@recommended$/i.test(stripped);
+		const text = isRecommended ? '' : stripped.toLowerCase();
 
 		let installed = this.queryInstalled();
 		if (text) {
@@ -423,14 +425,38 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 			);
 		}
 
+		// When @recommended, filter to plugins listed in workspace recommendations.
+		if (isRecommended) {
+			const recommended = this.pluginMarketplaceService.recommendedPlugins.get();
+			installed = installed.filter(p => {
+				const marketplace = p.plugin.fromMarketplace;
+				if (!marketplace) {
+					return false;
+				}
+				const key = `${marketplace.name}@${marketplace.marketplace}`;
+				return recommended.has(key);
+			});
+		}
+
 		let items: IAgentPluginItem[] = installed;
 
 		if (!this.listOptions.installedOnly) {
 			const marketplacePlugins = await this.queryMarketplacePlugins();
-			const lowerText = text.toLowerCase();
-			const marketplace = marketplacePlugins
-				.filter(p => p.name.toLowerCase().includes(lowerText) || p.description.toLowerCase().includes(lowerText))
-				.map(marketplacePluginToItem);
+			let filteredMp = marketplacePlugins;
+
+			if (isRecommended) {
+				// When @recommended, filter marketplace plugins to those in recommendations.
+				const recommended = this.pluginMarketplaceService.recommendedPlugins.get();
+				filteredMp = filteredMp.filter(p => {
+					const key = `${p.name}@${p.marketplace}`;
+					return recommended.has(key);
+				});
+			} else {
+				const lowerText = text.toLowerCase();
+				filteredMp = filteredMp.filter(p => p.name.toLowerCase().includes(lowerText) || p.description.toLowerCase().includes(lowerText));
+			}
+
+			const marketplace = filteredMp.map(marketplacePluginToItem);
 
 			// Filter out marketplace items that are already installed
 			const installedPaths = new Set(installed.map(i => i.plugin.uri.toString()));

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -149,7 +149,9 @@ import { AgentPluginService, ConfiguredAgentPluginDiscovery, MarketplaceAgentPlu
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
+import { WorkspacePluginSettingsService, IWorkspacePluginSettingsService } from '../common/plugins/claudePluginSettings.js';
 import { AgentPluginsViewsContribution } from './agentPluginsView.js';
+import { AgentPluginRecommendations } from './claudePluginRecommendations.js';
 import { AgentPluginEditor } from './agentPluginEditor/agentPluginEditor.js';
 import { AgentPluginEditorInput } from './agentPluginEditor/agentPluginEditorInput.js';
 import { AgentPluginRepositoryService } from './agentPluginRepositoryService.js';
@@ -1766,6 +1768,7 @@ registerWorkbenchContribution2(PromptLanguageFeaturesProvider.ID, PromptLanguage
 registerWorkbenchContribution2(ChatWindowNotifier.ID, ChatWindowNotifier, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(ChatRepoInfoContribution.ID, ChatRepoInfoContribution, WorkbenchPhase.Eventually);
 registerWorkbenchContribution2(AgentPluginsViewsContribution.ID, AgentPluginsViewsContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AgentPluginRecommendations.ID, AgentPluginRecommendations, WorkbenchPhase.Eventually);
 
 registerChatActions();
 registerChatAccessibilityActions();
@@ -1812,6 +1815,7 @@ registerSingleton(IChatAgentNameService, ChatAgentNameService, InstantiationType
 registerSingleton(IChatVariablesService, ChatVariablesService, InstantiationType.Delayed);
 registerSingleton(IAgentPluginService, AgentPluginService, InstantiationType.Delayed);
 registerSingleton(IPluginMarketplaceService, PluginMarketplaceService, InstantiationType.Delayed);
+registerSingleton(IWorkspacePluginSettingsService, WorkspacePluginSettingsService, InstantiationType.Delayed);
 registerSingleton(IAgentPluginRepositoryService, AgentPluginRepositoryService, InstantiationType.Delayed);
 registerSingleton(IPluginInstallService, PluginInstallService, InstantiationType.Delayed);
 registerSingleton(ILanguageModelToolsService, LanguageModelToolsService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -149,7 +149,7 @@ import { AgentPluginService, ConfiguredAgentPluginDiscovery, MarketplaceAgentPlu
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
-import { WorkspacePluginSettingsService, IWorkspacePluginSettingsService } from '../common/plugins/claudePluginSettings.js';
+import { WorkspacePluginSettingsService, IWorkspacePluginSettingsService } from '../common/plugins/workspacePluginSettingsService.js';
 import { AgentPluginsViewsContribution } from './agentPluginsView.js';
 import { AgentPluginRecommendations } from './claudePluginRecommendations.js';
 import { AgentPluginEditor } from './agentPluginEditor/agentPluginEditor.js';

--- a/src/vs/workbench/contrib/chat/browser/claudePluginRecommendations.ts
+++ b/src/vs/workbench/contrib/chat/browser/claudePluginRecommendations.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { localize } from '../../../../nls.js';
+import { INotificationService, NeverShowAgainScope, Severity } from '../../../../platform/notification/common/notification.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
+import { IChatService } from '../common/chatService/chatService.js';
+import { IPluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
+
+export class AgentPluginRecommendations extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.agentPluginRecommendations';
+
+	private _hasNotified = false;
+
+	constructor(
+		@IChatService private readonly _chatService: IChatService,
+		@IPluginMarketplaceService private readonly _pluginMarketplaceService: IPluginMarketplaceService,
+		@INotificationService private readonly _notificationService: INotificationService,
+		@IExtensionsWorkbenchService private readonly _extensionsWorkbenchService: IExtensionsWorkbenchService,
+	) {
+		super();
+
+		this._register(this._chatService.onDidSubmitRequest(() => {
+			if (!this._hasNotified) {
+				this._hasNotified = true;
+				this._checkForRecommendedPlugins();
+			}
+		}));
+	}
+
+	private _checkForRecommendedPlugins(): void {
+		const recommended = this._pluginMarketplaceService.recommendedPlugins.get();
+		if (recommended.size === 0) {
+			return;
+		}
+
+		// Build a set of installed plugin keys ("name@marketplace") from
+		// storage without triggering any network fetch.
+		const installedKeys = new Set<string>();
+		for (const entry of this._pluginMarketplaceService.installedPlugins.get()) {
+			const key = `${entry.plugin.name}@${entry.plugin.marketplace}`;
+			installedKeys.add(key);
+		}
+
+		let uninstalledCount = 0;
+		for (const key of recommended) {
+			if (!installedKeys.has(key)) {
+				uninstalledCount++;
+			}
+		}
+
+		if (uninstalledCount === 0) {
+			return;
+		}
+
+		this._notificationService.prompt(
+			Severity.Info,
+			uninstalledCount === 1
+				? localize('agentPluginRecommendation.one', "This workspace recommends 1 agent plugin.")
+				: localize('agentPluginRecommendation.many', "This workspace recommends {0} agent plugins.", uninstalledCount),
+			[{
+				label: localize('showPlugins', "Show Plugins"),
+				run: () => {
+					this._extensionsWorkbenchService.openSearch('@agentPlugins @recommended');
+				}
+			}],
+			{
+				neverShowAgain: {
+					id: 'agentPluginRecommendations.dismissed',
+					scope: NeverShowAgainScope.WORKSPACE,
+					isSecondary: true,
+				}
+			}
+		);
+	}
+}

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -165,7 +165,7 @@ Each `PluginSourceKind` has a strategy that knows how to compute cache paths, pr
 |-----|-------------|
 | `chat.plugins.installed.v1` | Installed marketplace plugins |
 | `chat.plugins.trustedMarketplaces.v1` | User-trusted marketplace canonical IDs |
-| `chat.plugins.lastFetchedPlugins.v2` | Cached marketplace fetch results (5 min TTL) |
+| `chat.plugins.lastFetchedPlugins.v2` | Last marketplace fetch results (persisted until next fetch) |
 | `chat.plugins.marketplaces.githubCache.v1` | GitHub API response cache (8 hour TTL) |
 | `chat.plugins.lastUpdateCheck.v1` | Timestamp of last periodic update check |
 

--- a/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
+++ b/src/vs/workbench/contrib/chat/common/plugins/AGENTS_PLUGINS.md
@@ -1,0 +1,201 @@
+# Agent Plugins Architecture
+
+Agent plugins are a modular extension system that allows external packages of prompts, hooks, skills, agents, and MCP server definitions to be discovered, installed, and contributed into the chat experience. This document describes the architecture of the `src/vs/workbench/contrib/chat/common/plugins/` layer and its browser-side implementations.
+
+## Directory Structure
+
+### Common layer (`common/plugins/`)
+| File | Role |
+|------|------|
+| `agentPluginService.ts` | Core interfaces (`IAgentPlugin`, `IAgentPluginService`, `IAgentPluginDiscovery`) and the discovery registry singleton |
+| `agentPluginServiceImpl.ts` | `AgentPluginService` implementation, `AbstractAgentPluginDiscovery` base class, format adapters (Copilot / Claude) |
+| `agentPluginRepositoryService.ts` | `IAgentPluginRepositoryService` — abstract repository clone/pull/cache operations |
+| `pluginMarketplaceService.ts` | `IPluginMarketplaceService` — marketplace metadata, installed-plugin storage, trusted-marketplace tracking, periodic update checks |
+| `pluginInstallService.ts` | `IPluginInstallService` — install/update orchestration interface |
+| `pluginSource.ts` | `IPluginSource` — per-source-kind strategy interface (install path, ensure, update, cleanup) |
+
+### Browser layer (`browser/`)
+| File | Role |
+|------|------|
+| `agentPluginRepositoryService.ts` | Browser implementation of `IAgentPluginRepositoryService` (git clone/pull via Git service) |
+| `pluginSources.ts` | Concrete `IPluginSource` implementations: `GitHubPluginSource`, `GitUrlPluginSource`, `NpmPluginSource`, `PipPluginSource`, `RelativePathPluginSource` |
+| `pluginInstallService.ts` | Browser implementation of `IPluginInstallService` |
+| `agentPluginsView.ts` | Installed-plugins tree view UI |
+| `agentPluginActions.ts` | Context-menu actions for plugins |
+| `agentPluginEditor/` | Rich editor for browsing a single plugin's contents |
+
+## Core Interfaces
+
+### IAgentPlugin
+
+Represents a single discovered plugin:
+
+```
+uri              – Unique filesystem URI for the plugin root
+label            – Human-readable display name
+enablement       – Observable enable/disable state (ContributionEnablementState)
+hooks            – Observable list of IAgentPluginHook
+commands         – Observable list of IAgentPluginCommand  (*.md files in commands/)
+skills           – Observable list of IAgentPluginSkill    (dirs with SKILL.md in skills/)
+agents           – Observable list of IAgentPluginAgent    (*.md files in agents/)
+mcpServerDefinitions – Observable list of IAgentPluginMcpServerDefinition
+fromMarketplace  – Set when the plugin was installed from a marketplace
+remove()         – Removes this plugin from its discovery source
+```
+
+### IAgentPluginService
+
+Main entry point consumed by the rest of the workbench:
+
+```
+plugins          – IObservable<readonly IAgentPlugin[]>  (aggregate of all discoveries, deduped by URI)
+enablementModel  – Shared IEnablementModel for plugin enable/disable state
+```
+
+Registered as `InstantiationType.Delayed` — only instantiated when first injected.
+
+### IAgentPluginDiscovery
+
+Strategy for finding plugins from a particular source:
+
+```
+plugins  – IObservable<readonly IAgentPlugin[]>
+start(enablementModel) – Begin watching the source
+```
+
+Discoveries are registered into the global `agentPluginDiscoveryRegistry` singleton and instantiated by `AgentPluginService` on startup.
+
+## Discovery & Plugin Reading
+
+### AbstractAgentPluginDiscovery
+
+Shared base class that handles:
+
+1. **Format detection** — auto-detects whether a plugin uses the Copilot or Claude format based on path conventions and manifest existence.
+2. **Content reading** — reads commands, skills, agents, hooks, and MCP server definitions from the filesystem.
+3. **File watching** — watches plugin directories for changes and re-reads contents on a 200 ms debounced scheduler.
+4. **Observable propagation** — sets the `plugins` observable on each refresh cycle.
+
+Subclasses implement `_discoverPluginSources()` to determine *which* plugin URIs exist.
+
+### Discovery Implementations
+
+**ConfiguredAgentPluginDiscovery** — resolves `chat.pluginLocations` configuration entries (absolute, tilde-expanded, or workspace-relative paths) and watches for config changes.
+
+**MarketplaceAgentPluginDiscovery** — discovers plugins from `IPluginMarketplaceService.installedPlugins` and delegates to the install/repository services for on-disk availability.
+
+### Plugin Formats
+
+Two format adapters implement `IAgentPluginFormatAdapter`:
+
+| | Copilot | Claude |
+|-|---------|--------|
+| Manifest | `plugin.json` | `.claude-plugin/plugin.json` |
+| Hooks config | `hooks.json` | `hooks/hooks.json` |
+| Hook parser | `parseCopilotHooks()` | `parseClaudeHooks()` |
+| Special handling | — | `${CLAUDE_PLUGIN_ROOT}` token replacement, `CLAUDE_PLUGIN_ROOT` env var injection |
+
+Auto-detection logic: if the plugin URI path contains `.claude` or a `.claude-plugin/plugin.json` manifest exists, the Claude adapter is used; otherwise, the Copilot adapter is used.
+
+### Plugin Contents (Filesystem Layout)
+
+```
+<plugin-root>/
+├── plugin.json  OR  .claude-plugin/plugin.json   # manifest
+├── hooks.json   OR  hooks/hooks.json              # hook definitions
+├── .mcp.json                                      # MCP server definitions (optional)
+├── commands/
+│   ├── do-thing.md                                # → IAgentPluginCommand
+│   └── other.md
+├── skills/
+│   └── my-skill/
+│       └── SKILL.md                               # → IAgentPluginSkill
+└── agents/
+    └── helper.md                                  # → IAgentPluginAgent
+```
+
+## Marketplace & Installation
+
+### IPluginMarketplaceService
+
+Manages the catalog of available and installed plugins:
+
+- **Fetch** — reads `chat.pluginMarketplaces` config (GitHub shorthand, Git URLs, or file URIs), fetches `marketplace.json` from each, and returns parsed `IMarketplacePlugin` entries.
+- **Installed storage** — persists installed plugins in application-scoped storage (`chat.plugins.installed.v1`). Each entry tracks `{ pluginUri, plugin, enabled }`.
+- **Trust** — marketplace canonical IDs must be explicitly trusted before install proceeds (`chat.plugins.trustedMarketplaces.v1`).
+- **Auto-update** — checks for upstream changes approximately every 24 hours when `extensions.autoUpdate` is enabled; sets `hasUpdatesAvailable` observable.
+- **GitHub caching** — caches raw GitHub API responses with an 8-hour TTL to avoid repeated fetches.
+
+### Marketplace Definition Files
+
+Checked in order per repository:
+1. `.github/plugin/marketplace.json` → `MarketplaceType.Copilot`
+2. `.claude-plugin/marketplace.json` → `MarketplaceType.Claude`
+
+### IPluginInstallService
+
+Orchestrates install and update workflows:
+
+- `installPlugin()` — checks marketplace trust, delegates to the appropriate source strategy to ensure files are locally available, and registers the plugin in installed storage.
+- `updatePlugin()` / `updateAllPlugins()` — pulls latest changes for cloned repositories and re-runs package-manager installs where applicable.
+
+### Plugin Source Strategies (IPluginSource)
+
+Each `PluginSourceKind` has a strategy that knows how to compute cache paths, provision files, update, and clean up:
+
+| Kind | Provisioning | Cache path |
+|------|-------------|------------|
+| `RelativePath` | No-op (lives inside marketplace repo) | `<cacheRoot>/github.com/<owner>/<repo>/<path>` |
+| `GitHub` | `git clone` / `git pull` | `<cacheRoot>/github.com/<owner>/<repo>[/ref_<ref>]` |
+| `GitUrl` | `git clone` / `git pull` | `<cacheRoot>/<host>/<path>[/ref_<ref>]` |
+| `Npm` | `npm install` in terminal | `<cacheRoot>/npm/<sanitized-package>/` |
+| `Pip` | `pip install` in terminal | `<cacheRoot>/pip/<package>/` |
+
+## Configuration & Storage Keys
+
+### Configuration
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `chat.pluginsEnabled` | boolean | `true` | Master switch for the plugin system |
+| `chat.pluginLocations` | `Record<string, boolean>` | `{}` | Local plugin directories to discover |
+| `chat.pluginMarketplaces` | `string[]` | `[]` | Marketplace references to fetch from |
+
+### Storage (ApplicationScope, MachineTarget)
+| Key | Description |
+|-----|-------------|
+| `chat.plugins.installed.v1` | Installed marketplace plugins |
+| `chat.plugins.trustedMarketplaces.v1` | User-trusted marketplace canonical IDs |
+| `chat.plugins.lastFetchedPlugins.v2` | Cached marketplace fetch results (5 min TTL) |
+| `chat.plugins.marketplaces.githubCache.v1` | GitHub API response cache (8 hour TTL) |
+| `chat.plugins.lastUpdateCheck.v1` | Timestamp of last periodic update check |
+
+### Enablement Storage
+| Key | Description |
+|-----|-------------|
+| `agentPlugins.enablement` | Per-plugin enable/disable state (shared `EnablementModel`) |
+
+## Reactivity Model
+
+The entire system is built on `IObservable`:
+
+1. **Configuration observables** (`observableConfigValue`) — push changes when settings are modified.
+2. **Discovery observables** — each `IAgentPluginDiscovery` exposes an `IObservable<readonly IAgentPlugin[]>` updated on filesystem changes.
+3. **Service-level derived** — `AgentPluginService.plugins` is a `derived()` that aggregates all discovery observables, dedupes by URI, and sorts.
+4. **Per-plugin observables** — each `IAgentPlugin` has observable properties for hooks, commands, skills, agents, and MCP definitions that update independently on file changes.
+5. **UI bindings** — views and editors use `autorun()` / `derived()` to reactively render plugin state.
+
+## Integration Points
+
+- **Chat prompts** — plugin hooks are contributed to the prompt system via the hook infrastructure.
+- **MCP servers** — plugins can define MCP server configurations (stdio or SSE) that are registered with the MCP platform.
+- **AI Customization UI** — the AI customization views aggregate plugin stats alongside MCP servers, prompts, and other customization surfaces.
+- **Extension API** — the plugin system is internal; there is no public `vscode` API surface for third-party access.
+
+## Key Design Patterns
+
+- **Strategy pattern** — format adapters (`IAgentPluginFormatAdapter`) and source strategies (`IPluginSource`) allow the system to support multiple plugin formats and installation mechanisms without coupling.
+- **Discovery registry** — `agentPluginDiscoveryRegistry` decouples discovery implementations from the core service via `SyncDescriptor0<IAgentPluginDiscovery>` registration.
+- **Disposable management** — plugin entries are tracked in a `Map` keyed by URI string, each with its own `DisposableStore` for file watchers. Removal or format changes dispose the store.
+- **Debounced refresh** — filesystem changes trigger a 200 ms `RunOnceScheduler` to batch rapid edits into a single re-read.
+- **Deduplication** — multiple discoveries may produce the same plugin URI; the service dedupes via `ResourceSet` and sorts by URI for stable ordering.
+- **Lazy instantiation** — the service is registered as `InstantiationType.Delayed` and only created on first injection.

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+
+export const enum MarketplaceReferenceKind {
+	GitHubShorthand = 'githubShorthand',
+	GitUri = 'gitUri',
+	LocalFileUri = 'localFileUri',
+}
+
+export interface IMarketplaceReference {
+	readonly rawValue: string;
+	readonly displayLabel: string;
+	readonly cloneUrl: string;
+	readonly canonicalId: string;
+	readonly cacheSegments: readonly string[];
+	readonly kind: MarketplaceReferenceKind;
+	readonly githubRepo?: string;
+	readonly localRepositoryUri?: URI;
+}
+
+export function parseMarketplaceReferences(values: readonly unknown[]): IMarketplaceReference[] {
+	const byCanonicalId = new Map<string, IMarketplaceReference>();
+
+	for (const value of values) {
+		if (typeof value !== 'string') {
+			continue;
+		}
+
+		const parsed = parseMarketplaceReference(value);
+		if (!parsed) {
+			continue;
+		}
+
+		if (!byCanonicalId.has(parsed.canonicalId)) {
+			byCanonicalId.set(parsed.canonicalId, parsed);
+		}
+	}
+
+	return [...byCanonicalId.values()];
+}
+
+/**
+ * Merges two sets of marketplace references, deduplicating by canonical ID.
+ * The first set takes precedence when IDs collide.
+ */
+export function deduplicateMarketplaceReferences(primary: readonly IMarketplaceReference[], secondary: readonly IMarketplaceReference[]): IMarketplaceReference[] {
+	const byCanonicalId = new Map<string, IMarketplaceReference>();
+	for (const ref of primary) {
+		byCanonicalId.set(ref.canonicalId, ref);
+	}
+	for (const ref of secondary) {
+		if (!byCanonicalId.has(ref.canonicalId)) {
+			byCanonicalId.set(ref.canonicalId, ref);
+		}
+	}
+	return [...byCanonicalId.values()];
+}
+
+export function parseMarketplaceReference(value: string): IMarketplaceReference | undefined {
+	const rawValue = value.trim();
+	if (!rawValue) {
+		return undefined;
+	}
+
+	const uriReference = parseUriMarketplaceReference(rawValue);
+	if (uriReference) {
+		return uriReference;
+	}
+
+	const scpReference = parseScpMarketplaceReference(rawValue);
+	if (scpReference) {
+		return scpReference;
+	}
+
+	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(rawValue);
+	if (shorthandMatch) {
+		const owner = shorthandMatch[1];
+		const repo = shorthandMatch[2];
+		return {
+			rawValue,
+			displayLabel: `${owner}/${repo}`,
+			cloneUrl: `https://github.com/${owner}/${repo}.git`,
+			canonicalId: getGitHubCanonicalId(owner, repo),
+			cacheSegments: ['github.com', owner, repo],
+			kind: MarketplaceReferenceKind.GitHubShorthand,
+			githubRepo: `${owner}/${repo}`,
+		};
+	}
+
+	return undefined;
+}
+
+function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
+	let uri: URI;
+	try {
+		uri = URI.parse(rawValue);
+	} catch {
+		return undefined;
+	}
+
+	const scheme = uri.scheme.toLowerCase();
+	if (scheme === 'file' && /^file:\/\//i.test(rawValue)) {
+		const localRepositoryUri = URI.file(uri.fsPath);
+		return {
+			rawValue,
+			displayLabel: localRepositoryUri.fsPath,
+			cloneUrl: rawValue,
+			canonicalId: `file:${localRepositoryUri.toString().toLowerCase()}`,
+			cacheSegments: [],
+			kind: MarketplaceReferenceKind.LocalFileUri,
+			localRepositoryUri,
+		};
+	}
+
+	if (scheme !== 'http' && scheme !== 'https' && scheme !== 'ssh') {
+		return undefined;
+	}
+
+	if (!uri.authority) {
+		return undefined;
+	}
+
+	const normalizedPath = normalizeGitRepoPath(uri.path);
+	if (!normalizedPath) {
+		return undefined;
+	}
+
+	const gitSuffix = '.git';
+	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
+	const pathHasGitSuffix = normalizedPath.toLowerCase().endsWith(gitSuffix);
+	const pathWithoutGit = pathHasGitSuffix ? normalizedPath.slice(1, normalizedPath.length - gitSuffix.length) : normalizedPath.slice(1);
+	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
+	// Always normalize the canonical path to include .git so that URLs with and without the suffix deduplicate.
+	const canonicalPath = pathHasGitSuffix ? normalizedPath.slice(1).toLowerCase() : `${normalizedPath.slice(1).toLowerCase()}${gitSuffix}`;
+	return {
+		rawValue,
+		displayLabel: rawValue,
+		cloneUrl: rawValue,
+		canonicalId: `git:${uri.authority.toLowerCase()}/${canonicalPath}`,
+		cacheSegments: [sanitizedAuthority, ...pathSegments],
+		kind: MarketplaceReferenceKind.GitUri,
+	};
+}
+
+function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
+	const match = /^([^@\s]+)@([^:\s]+):(.+\.git)$/i.exec(rawValue);
+	if (!match) {
+		return undefined;
+	}
+
+	const authority = match[2];
+	const pathWithGit = match[3].replace(/^\/+/, '');
+	if (!pathWithGit.toLowerCase().endsWith('.git')) {
+		return undefined;
+	}
+
+	const pathSegments = pathWithGit.slice(0, -4).split('/').map(sanitizePathSegment);
+	return {
+		rawValue,
+		displayLabel: rawValue,
+		cloneUrl: rawValue,
+		canonicalId: `git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`,
+		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments],
+		kind: MarketplaceReferenceKind.GitUri,
+	};
+}
+
+/**
+ * Normalizes a Git repository path and validates that it has at least two segments
+ * (i.e., at least one owner/repo pair below the root). Accepts paths with or without
+ * a `.git` suffix — the suffix is preserved in the returned value so callers can decide
+ * how to treat it.
+ */
+function normalizeGitRepoPath(path: string): string | undefined {
+	const gitSuffix = '.git';
+	const trimmed = path.replace(/\/+/g, '/').replace(/\/+$/g, '');
+
+	const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+	// Strip .git suffix (if present) only for the purposes of validating path depth.
+	const pathWithoutGit = withLeadingSlash.toLowerCase().endsWith(gitSuffix)
+		? withLeadingSlash.slice(1, withLeadingSlash.length - gitSuffix.length)
+		: withLeadingSlash.slice(1);
+	if (!pathWithoutGit || !pathWithoutGit.includes('/')) {
+		return undefined;
+	}
+
+	return withLeadingSlash;
+}
+
+function getGitHubCanonicalId(owner: string, repo: string): string {
+	return `github:${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+function sanitizePathSegment(value: string): string {
+	return value.replace(/[\\/:*?"<>|]/g, '_');
+}

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -26,27 +26,15 @@ import { ChatConfiguration } from '../constants.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
 import { IWorkspacePluginSettingsService } from './workspacePluginSettingsService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
+import { type IMarketplaceReference, deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from './marketplaceReference.js';
+
+// Re-export marketplace reference types for downstream consumers.
+export { deduplicateMarketplaceReferences, MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from './marketplaceReference.js';
+export type { IMarketplaceReference } from './marketplaceReference.js';
 
 export const enum MarketplaceType {
 	Copilot = 'copilot',
 	Claude = 'claude',
-}
-
-export const enum MarketplaceReferenceKind {
-	GitHubShorthand = 'githubShorthand',
-	GitUri = 'gitUri',
-	LocalFileUri = 'localFileUri',
-}
-
-export interface IMarketplaceReference {
-	readonly rawValue: string;
-	readonly displayLabel: string;
-	readonly cloneUrl: string;
-	readonly canonicalId: string;
-	readonly cacheSegments: readonly string[];
-	readonly kind: MarketplaceReferenceKind;
-	readonly githubRepo?: string;
-	readonly localRepositoryUri?: URI;
 }
 
 export const enum PluginSourceKind {
@@ -751,183 +739,6 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		this._logService.debug(`[PluginMarketplaceService] No marketplace.json found in ${reference.rawValue}`);
 		return [];
 	}
-}
-
-export function parseMarketplaceReferences(values: readonly unknown[]): IMarketplaceReference[] {
-	const byCanonicalId = new Map<string, IMarketplaceReference>();
-
-	for (const value of values) {
-		if (typeof value !== 'string') {
-			continue;
-		}
-
-		const parsed = parseMarketplaceReference(value);
-		if (!parsed) {
-			continue;
-		}
-
-		if (!byCanonicalId.has(parsed.canonicalId)) {
-			byCanonicalId.set(parsed.canonicalId, parsed);
-		}
-	}
-
-	return [...byCanonicalId.values()];
-}
-
-/**
- * Merges two sets of marketplace references, deduplicating by canonical ID.
- * The first set takes precedence when IDs collide.
- */
-export function deduplicateMarketplaceReferences(primary: readonly IMarketplaceReference[], secondary: readonly IMarketplaceReference[]): IMarketplaceReference[] {
-	const byCanonicalId = new Map<string, IMarketplaceReference>();
-	for (const ref of primary) {
-		byCanonicalId.set(ref.canonicalId, ref);
-	}
-	for (const ref of secondary) {
-		if (!byCanonicalId.has(ref.canonicalId)) {
-			byCanonicalId.set(ref.canonicalId, ref);
-		}
-	}
-	return [...byCanonicalId.values()];
-}
-
-export function parseMarketplaceReference(value: string): IMarketplaceReference | undefined {
-	const rawValue = value.trim();
-	if (!rawValue) {
-		return undefined;
-	}
-
-	const uriReference = parseUriMarketplaceReference(rawValue);
-	if (uriReference) {
-		return uriReference;
-	}
-
-	const scpReference = parseScpMarketplaceReference(rawValue);
-	if (scpReference) {
-		return scpReference;
-	}
-
-	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(rawValue);
-	if (shorthandMatch) {
-		const owner = shorthandMatch[1];
-		const repo = shorthandMatch[2];
-		return {
-			rawValue,
-			displayLabel: `${owner}/${repo}`,
-			cloneUrl: `https://github.com/${owner}/${repo}.git`,
-			canonicalId: getGitHubCanonicalId(owner, repo),
-			cacheSegments: ['github.com', owner, repo],
-			kind: MarketplaceReferenceKind.GitHubShorthand,
-			githubRepo: `${owner}/${repo}`,
-		};
-	}
-
-	return undefined;
-}
-
-function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
-	let uri: URI;
-	try {
-		uri = URI.parse(rawValue);
-	} catch {
-		return undefined;
-	}
-
-	const scheme = uri.scheme.toLowerCase();
-	if (scheme === 'file' && /^file:\/\//i.test(rawValue)) {
-		const localRepositoryUri = URI.file(uri.fsPath);
-		return {
-			rawValue,
-			displayLabel: localRepositoryUri.fsPath,
-			cloneUrl: rawValue,
-			canonicalId: `file:${localRepositoryUri.toString().toLowerCase()}`,
-			cacheSegments: [],
-			kind: MarketplaceReferenceKind.LocalFileUri,
-			localRepositoryUri,
-		};
-	}
-
-	if (scheme !== 'http' && scheme !== 'https' && scheme !== 'ssh') {
-		return undefined;
-	}
-
-	if (!uri.authority) {
-		return undefined;
-	}
-
-	const normalizedPath = normalizeGitRepoPath(uri.path);
-	if (!normalizedPath) {
-		return undefined;
-	}
-
-	const gitSuffix = '.git';
-	const sanitizedAuthority = sanitizePathSegment(uri.authority.toLowerCase());
-	const pathHasGitSuffix = normalizedPath.toLowerCase().endsWith(gitSuffix);
-	const pathWithoutGit = pathHasGitSuffix ? normalizedPath.slice(1, normalizedPath.length - gitSuffix.length) : normalizedPath.slice(1);
-	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
-	// Always normalize the canonical path to include .git so that URLs with and without the suffix deduplicate.
-	const canonicalPath = pathHasGitSuffix ? normalizedPath.slice(1).toLowerCase() : `${normalizedPath.slice(1).toLowerCase()}${gitSuffix}`;
-	return {
-		rawValue,
-		displayLabel: rawValue,
-		cloneUrl: rawValue,
-		canonicalId: `git:${uri.authority.toLowerCase()}/${canonicalPath}`,
-		cacheSegments: [sanitizedAuthority, ...pathSegments],
-		kind: MarketplaceReferenceKind.GitUri,
-	};
-}
-
-function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference | undefined {
-	const match = /^([^@\s]+)@([^:\s]+):(.+\.git)$/i.exec(rawValue);
-	if (!match) {
-		return undefined;
-	}
-
-	const authority = match[2];
-	const pathWithGit = match[3].replace(/^\/+/, '');
-	if (!pathWithGit.toLowerCase().endsWith('.git')) {
-		return undefined;
-	}
-
-	const pathSegments = pathWithGit.slice(0, -4).split('/').map(sanitizePathSegment);
-	return {
-		rawValue,
-		displayLabel: rawValue,
-		cloneUrl: rawValue,
-		canonicalId: `git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`,
-		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments],
-		kind: MarketplaceReferenceKind.GitUri,
-	};
-}
-
-/**
- * Normalizes a Git repository path and validates that it has at least two segments
- * (i.e., at least one owner/repo pair below the root). Accepts paths with or without
- * a `.git` suffix — the suffix is preserved in the returned value so callers can decide
- * how to treat it.
- */
-function normalizeGitRepoPath(path: string): string | undefined {
-	const gitSuffix = '.git';
-	const trimmed = path.replace(/\/+/g, '/').replace(/\/+$/g, '');
-
-	const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
-	// Strip .git suffix (if present) only for the purposes of validating path depth.
-	const pathWithoutGit = withLeadingSlash.toLowerCase().endsWith(gitSuffix)
-		? withLeadingSlash.slice(1, withLeadingSlash.length - gitSuffix.length)
-		: withLeadingSlash.slice(1);
-	if (!pathWithoutGit || !pathWithoutGit.includes('/')) {
-		return undefined;
-	}
-
-	return withLeadingSlash;
-}
-
-function getGitHubCanonicalId(owner: string, repo: string): string {
-	return `github:${owner.toLowerCase()}/${repo.toLowerCase()}`;
-}
-
-function sanitizePathSegment(value: string): string {
-	return value.replace(/[\\/:*?"<>|]/g, '_');
 }
 
 function normalizeMarketplacePath(value: string): string {

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -10,7 +10,7 @@ import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Lazy } from '../../../../../base/common/lazy.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { revive } from '../../../../../base/common/marshalling.js';
-import { IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { derived, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { isEqual, isEqualOrParent, joinPath, normalizePath, relativePath } from '../../../../../base/common/resources.js';
 import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -24,6 +24,8 @@ import type { Dto } from '../../../../services/extensions/common/proxyIdentifier
 import { AutoUpdateConfigurationKey, AutoUpdateConfigurationValue } from '../../../extensions/common/extensions.js';
 import { ChatConfiguration } from '../constants.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
+import { IWorkspacePluginSettingsService } from './claudePluginSettings.js';
+import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 
 export const enum MarketplaceType {
 	Copilot = 'copilot',
@@ -163,6 +165,12 @@ export interface IPluginMarketplaceService {
 	 * synchronous outdated-detection instead of calling fetchMarketplacePlugins.
 	 */
 	readonly lastFetchedPlugins: IObservable<readonly IMarketplacePlugin[]>;
+	/**
+	 * Set of recommended plugin keys (`"pluginName@marketplaceName"`) aggregated
+	 * from workspace-defined settings (e.g. `.claude/settings.json`). Providers
+	 * may be added over time; consumers should not assume a specific source.
+	 */
+	readonly recommendedPlugins: IObservable<ReadonlySet<string>>;
 	/** Resets {@link hasUpdatesAvailable} to `false`. */
 	clearUpdatesAvailable(): void;
 	fetchMarketplacePlugins(token: CancellationToken): Promise<IMarketplacePlugin[]>;
@@ -191,9 +199,6 @@ const GITHUB_MARKETPLACE_CACHE_STORAGE_KEY = 'chat.plugins.marketplaces.githubCa
 /** Interval between periodic plugin update checks (24 hours). */
 const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const PLUGIN_UPDATE_LAST_CHECK_STORAGE_KEY = 'chat.plugins.lastUpdateCheck.v1';
-
-/** TTL for the lastFetchedPlugins cache (5 minutes). */
-const LAST_FETCHED_PLUGINS_TTL_MS = 5 * 60 * 1000;
 
 interface IGitHubMarketplaceCacheEntry {
 	readonly plugins: readonly IMarketplacePlugin[];
@@ -249,11 +254,10 @@ const trustedMarketplacesMemento = observableMemento<readonly string[]>({
 interface IStoredLastFetchedPlugins {
 	readonly plugins: readonly IMarketplacePlugin[];
 	readonly fetchedAt: number;
-	readonly configFingerprint: string;
 }
 
 const lastFetchedPluginsMemento = observableMemento<IStoredLastFetchedPlugins>({
-	defaultValue: { plugins: [], fetchedAt: 0, configFingerprint: '' },
+	defaultValue: { plugins: [], fetchedAt: 0 },
 	key: 'chat.plugins.lastFetchedPlugins.v2',
 	toStorage: value => JSON.stringify(value),
 	fromStorage: value => {
@@ -261,7 +265,7 @@ const lastFetchedPluginsMemento = observableMemento<IStoredLastFetchedPlugins>({
 		if (parsed && Array.isArray(parsed.plugins)) {
 			return parsed;
 		}
-		return { plugins: [], fetchedAt: 0, configFingerprint: '' };
+		return { plugins: [], fetchedAt: 0 };
 	},
 });
 
@@ -279,6 +283,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 	readonly installedPlugins: IObservable<readonly IMarketplaceInstalledPlugin[]>;
 	readonly hasUpdatesAvailable: IObservable<boolean> = this._hasUpdatesAvailable;
 	readonly lastFetchedPlugins: IObservable<readonly IMarketplacePlugin[]>;
+	readonly recommendedPlugins: IObservable<ReadonlySet<string>>;
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -287,6 +292,8 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		@IAgentPluginRepositoryService private readonly _pluginRepositoryService: IAgentPluginRepositoryService,
 		@ILogService private readonly _logService: ILogService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@IWorkspacePluginSettingsService private readonly _workspacePluginSettingsService: IWorkspacePluginSettingsService,
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustService: IWorkspaceTrustManagementService,
 	) {
 		super();
 
@@ -314,10 +321,33 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			}))
 		);
 
-		this.onDidChangeMarketplaces = Event.filter(
-			_configurationService.onDidChangeConfiguration,
-			e => e.affectsConfiguration(ChatConfiguration.PluginsEnabled) || e.affectsConfiguration(ChatConfiguration.PluginMarketplaces),
-		) as Event<unknown> as Event<void>;
+		// Aggregate recommended plugin keys from all providers.
+		// Currently sourced from Claude workspace settings; more providers can be
+		// added here via additional observables in the derived computation.
+		// Only expose recommendations when the workspace is trusted.
+		const workspaceTrusted = observableFromEvent(this, this._workspaceTrustService.onDidChangeTrust, () => this._workspaceTrustService.isWorkspaceTrusted());
+		this.recommendedPlugins = derived(reader => {
+			if (!workspaceTrusted.read(reader)) {
+				return new Set<string>();
+			}
+			const enabledMap = this._workspacePluginSettingsService.enabledPlugins.read(reader);
+			const keys = new Set<string>();
+			for (const [key, value] of enabledMap) {
+				if (value) {
+					keys.add(key);
+				}
+			}
+			return keys;
+		});
+
+		this.onDidChangeMarketplaces = Event.any(
+			Event.filter(
+				_configurationService.onDidChangeConfiguration,
+				e => e.affectsConfiguration(ChatConfiguration.PluginsEnabled) || e.affectsConfiguration(ChatConfiguration.PluginMarketplaces),
+			) as Event<unknown> as Event<void>,
+			Event.fromObservableLight(this._workspacePluginSettingsService.extraMarketplaces),
+			Event.map(this._workspaceTrustService.onDidChangeTrust, () => { }),
+		);
 
 		this._register(runWhenGlobalIdle(() => {
 			// Schedule periodic update checks when auto-update is enabled.
@@ -347,16 +377,18 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		}
 
 		const configuredRefs = this._configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-		const refs = parseMarketplaceReferences(configuredRefs);
+		const configRefs = parseMarketplaceReferences(configuredRefs);
 
-		// Return cached results if recent and the marketplace config is unchanged.
-		const configFingerprint = refs.map(r => r.canonicalId).sort().join('\n');
-		const stored = this._lastFetchedPluginsStore.get();
-		if (stored.configFingerprint === configFingerprint && Date.now() - stored.fetchedAt < LAST_FETCHED_PLUGINS_TTL_MS) {
-			const cached = this.lastFetchedPlugins.get();
-			if (cached.length > 0) {
-				return [...cached];
-			}
+		// Merge marketplace references from Claude workspace settings.
+		// Workspace-defined refs take precedence (are primary) so that their
+		// displayLabel overrides any matching global marketplace entry.
+		// Only include workspace-sourced refs when the workspace is trusted.
+		let allRefs: IMarketplaceReference[];
+		if (this._workspaceTrustService.isWorkspaceTrusted()) {
+			const workspaceEntries = this._workspacePluginSettingsService.extraMarketplaces.get();
+			allRefs = deduplicateMarketplaceReferences(workspaceEntries.map(e => e.reference), configRefs);
+		} else {
+			allRefs = configRefs;
 		}
 
 		for (const value of configuredRefs) {
@@ -366,7 +398,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 		}
 
 		const results = await Promise.all(
-			refs.map(ref => {
+			allRefs.map(ref => {
 				if (ref.kind === MarketplaceReferenceKind.GitHubShorthand && ref.githubRepo) {
 					return this._fetchFromGitHubRepo(ref, ref.githubRepo, token);
 				}
@@ -374,7 +406,7 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			})
 		);
 		const plugins = results.flat();
-		this._lastFetchedPluginsStore.set({ plugins, fetchedAt: Date.now(), configFingerprint }, undefined);
+		this._lastFetchedPluginsStore.set({ plugins, fetchedAt: Date.now() }, undefined);
 		return plugins;
 	}
 
@@ -383,7 +415,11 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 
 		const cached = this._getCachedGitHubMarketplacePlugins(cache, reference.canonicalId);
 		if (cached) {
-			return cached;
+			return cached.map(c => ({
+				...c,
+				marketplace: reference.displayLabel,
+				marketplaceReference: reference,
+			}));
 		}
 
 		let repoMayBePrivate = true;
@@ -735,6 +771,23 @@ export function parseMarketplaceReferences(values: readonly unknown[]): IMarketp
 		}
 	}
 
+	return [...byCanonicalId.values()];
+}
+
+/**
+ * Merges two sets of marketplace references, deduplicating by canonical ID.
+ * The first set takes precedence when IDs collide.
+ */
+export function deduplicateMarketplaceReferences(primary: readonly IMarketplaceReference[], secondary: readonly IMarketplaceReference[]): IMarketplaceReference[] {
+	const byCanonicalId = new Map<string, IMarketplaceReference>();
+	for (const ref of primary) {
+		byCanonicalId.set(ref.canonicalId, ref);
+	}
+	for (const ref of secondary) {
+		if (!byCanonicalId.has(ref.canonicalId)) {
+			byCanonicalId.set(ref.canonicalId, ref);
+		}
+	}
 	return [...byCanonicalId.values()];
 }
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -24,7 +24,7 @@ import type { Dto } from '../../../../services/extensions/common/proxyIdentifier
 import { AutoUpdateConfigurationKey, AutoUpdateConfigurationValue } from '../../../extensions/common/extensions.js';
 import { ChatConfiguration } from '../constants.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
-import { IWorkspacePluginSettingsService } from './claudePluginSettings.js';
+import { IWorkspacePluginSettingsService } from './workspacePluginSettingsService.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 
 export const enum MarketplaceType {

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -14,7 +14,7 @@ import { createDecorator } from '../../../../../platform/instantiation/common/in
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { CLAUDE_CONFIG_FOLDER } from '../promptSyntax/config/promptFileLocations.js';
-import { IMarketplaceReference, parseMarketplaceReference } from './pluginMarketplaceService.js';
+import { IMarketplaceReference, parseMarketplaceReference } from './marketplaceReference.js';
 
 const SETTINGS_FILENAME = 'settings.json';
 const SETTINGS_LOCAL_FILENAME = 'settings.local.json';

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { autorun, derived, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { joinPath } from '../../../../../base/common/resources.js';
@@ -194,19 +195,21 @@ class WorkspaceSettingsReader extends Disposable {
 			const dirs = settingsDirs.read(reader);
 			watcherStore.clear();
 
+			// Coalesce rapid file-change events into a single read.
+			const scheduler = new RunOnceScheduler(() => this._readSettings(dirs, logPrefix, fileService), 100);
+			watcherStore.add(scheduler);
+
 			for (const dir of dirs) {
-				watcherStore.add(fileService.watch(dir, { recursive: false, excludes: [] }));
+				const watcher = fileService.createWatcher(dir, { recursive: false, excludes: [] });
+				watcherStore.add(watcher);
+				watcherStore.add(watcher.onDidChange(e => {
+					if (e.affects(joinPath(dir, SETTINGS_FILENAME)) || e.affects(joinPath(dir, SETTINGS_LOCAL_FILENAME))) {
+						scheduler.schedule();
+					}
+				}));
 			}
 
-			watcherStore.add(fileService.onDidFilesChange(e => {
-				for (const dir of dirs) {
-					if (e.affects(joinPath(dir, SETTINGS_FILENAME)) || e.affects(joinPath(dir, SETTINGS_LOCAL_FILENAME))) {
-						this._readSettings(dirs, logPrefix, fileService);
-						return;
-					}
-				}
-			}));
-
+			// Perform initial read immediately.
 			this._readSettings(dirs, logPrefix, fileService);
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/workspacePluginSettingsService.ts
@@ -1,0 +1,309 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { parse as parseJSONC } from '../../../../../base/common/json.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { autorun, derived, IObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { CLAUDE_CONFIG_FOLDER } from '../promptSyntax/config/promptFileLocations.js';
+import { IMarketplaceReference, parseMarketplaceReference } from './pluginMarketplaceService.js';
+
+const SETTINGS_FILENAME = 'settings.json';
+const SETTINGS_LOCAL_FILENAME = 'settings.local.json';
+
+/** Copilot CLI settings folder inside `.github/`. */
+const COPILOT_CONFIG_FOLDER = '.github/copilot';
+
+/**
+ * Minimal representation of a marketplace entry from `extraKnownMarketplaces`.
+ */
+export interface IWorkspaceMarketplaceEntry {
+	readonly name: string;
+	readonly reference: IMarketplaceReference;
+}
+
+export const IWorkspacePluginSettingsService = createDecorator<IWorkspacePluginSettingsService>('workspacePluginSettingsService');
+
+export interface IWorkspacePluginSettingsService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Marketplace references parsed from `extraKnownMarketplaces` in workspace
+	 * settings files (`.claude/settings.json`, `.github/copilot/settings.json`).
+	 */
+	readonly extraMarketplaces: IObservable<readonly IWorkspaceMarketplaceEntry[]>;
+
+	/**
+	 * Plugin recommendation map parsed from `enabledPlugins` in workspace
+	 * settings files.
+	 * Keys are `"pluginName@marketplaceName"`, values indicate recommendation.
+	 */
+	readonly enabledPlugins: IObservable<ReadonlyMap<string, boolean>>;
+}
+
+// --- Parsing helpers ---------------------------------------------------------
+
+interface IMarketplaceSourceJson {
+	readonly source?: string;
+	readonly repo?: string;
+	readonly url?: string;
+	readonly path?: string;
+}
+
+interface IExtraMarketplaceJson {
+	readonly source?: string | IMarketplaceSourceJson;
+	readonly repo?: string;
+	readonly url?: string;
+	readonly path?: string;
+}
+
+/**
+ * Converts a single `extraKnownMarketplaces` entry into an
+ * {@link IMarketplaceReference} by mapping the source format to
+ * existing marketplace reference parsing.
+ */
+function marketplaceEntryToReference(entry: IExtraMarketplaceJson): IMarketplaceReference | undefined {
+	// Two shapes supported:
+	// 1. { source: "github", repo: "owner/repo" }   →  GitHub shorthand
+	// 2. { source: { source: "github", repo: "owner/repo" } }  →  nested
+	// 3. { source: "git", url: "https://..." }       →  Git URI
+
+	let sourceType: string | undefined;
+	let repo: string | undefined;
+	let url: string | undefined;
+
+	if (typeof entry.source === 'object' && entry.source !== null) {
+		const nested = entry.source;
+		sourceType = nested.source;
+		repo = nested.repo;
+		url = nested.url;
+	} else {
+		sourceType = entry.source as string | undefined;
+		repo = entry.repo;
+		url = entry.url;
+	}
+
+	if (sourceType === 'github' && typeof repo === 'string') {
+		return parseMarketplaceReference(repo);
+	}
+
+	if (sourceType === 'git' && typeof url === 'string') {
+		return parseMarketplaceReference(url);
+	}
+
+	return undefined;
+}
+
+/**
+ * Parses `enabledPlugins` from a JSON object.
+ */
+function parseEnabledPlugins(json: unknown): ReadonlyMap<string, boolean> {
+	const result = new Map<string, boolean>();
+
+	if (!json || typeof json !== 'object' || Array.isArray(json)) {
+		return result;
+	}
+
+	const obj = json as Record<string, unknown>;
+	for (const [key, value] of Object.entries(obj)) {
+		if (typeof value === 'boolean') {
+			result.set(key, value);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Parses `extraKnownMarketplaces` from a JSON object.
+ */
+function parseExtraMarketplaces(json: unknown, logPrefix: string, logService: ILogService): readonly IWorkspaceMarketplaceEntry[] {
+	const entries: IWorkspaceMarketplaceEntry[] = [];
+
+	if (!json || typeof json !== 'object' || Array.isArray(json)) {
+		return entries;
+	}
+
+	const obj = json as Record<string, unknown>;
+	for (const [name, value] of Object.entries(obj)) {
+		if (!value || typeof value !== 'object') {
+			logService.debug(`${logPrefix} Ignoring non-object extraKnownMarketplaces entry: ${name}`);
+			continue;
+		}
+
+		const reference = marketplaceEntryToReference(value as IExtraMarketplaceJson);
+		if (!reference) {
+			logService.debug(`${logPrefix} Could not parse marketplace reference for: ${name}`);
+			continue;
+		}
+
+		// Override displayLabel with the user-chosen marketplace name so that
+		// fetched plugins use this name in their `marketplace` field, which is
+		// what `enabledPlugins` keys reference (e.g. "plugin@claude-settings").
+		entries.push({ name, reference: { ...reference, displayLabel: name } });
+	}
+
+	return entries;
+}
+
+// --- Settings reader (reusable per config folder) ----------------------------
+
+interface IWorkspaceSettingsData {
+	readonly marketplaces: readonly IWorkspaceMarketplaceEntry[];
+	readonly enabledPlugins: ReadonlyMap<string, boolean>;
+}
+
+const EMPTY_DATA: IWorkspaceSettingsData = { marketplaces: [], enabledPlugins: new Map() };
+
+/**
+ * Reads `enabledPlugins` and `extraKnownMarketplaces` from a pair of
+ * `settings.json` / `settings.local.json` files inside a given config
+ * folder (e.g. `.claude/` or `.github/copilot/`) across all workspace
+ * folders. Watches for changes and exposes results as an observable.
+ */
+class WorkspaceSettingsReader extends Disposable {
+
+	private readonly _data = observableValue<IWorkspaceSettingsData>('data', EMPTY_DATA);
+	readonly data: IObservable<IWorkspaceSettingsData> = this._data;
+
+	constructor(
+		/** Workspace-relative config folder (e.g. `.claude`). */
+		configFolder: string,
+		logPrefix: string,
+		fileService: IFileService,
+		workspaceContextService: IWorkspaceContextService,
+		private readonly _logService: ILogService,
+	) {
+		super();
+
+		const settingsDirs = observableFromEvent(
+			this,
+			workspaceContextService.onDidChangeWorkspaceFolders,
+			() => workspaceContextService.getWorkspace().folders.map(f => joinPath(f.uri, configFolder)),
+		);
+
+		const watcherStore = this._register(new DisposableStore());
+		this._register(autorun(reader => {
+			const dirs = settingsDirs.read(reader);
+			watcherStore.clear();
+
+			for (const dir of dirs) {
+				watcherStore.add(fileService.watch(dir, { recursive: false, excludes: [] }));
+			}
+
+			watcherStore.add(fileService.onDidFilesChange(e => {
+				for (const dir of dirs) {
+					if (e.affects(joinPath(dir, SETTINGS_FILENAME)) || e.affects(joinPath(dir, SETTINGS_LOCAL_FILENAME))) {
+						this._readSettings(dirs, logPrefix, fileService);
+						return;
+					}
+				}
+			}));
+
+			this._readSettings(dirs, logPrefix, fileService);
+		}));
+	}
+
+	private async _readSettings(dirs: readonly URI[], logPrefix: string, fileService: IFileService): Promise<void> {
+		const allMarketplaces: IWorkspaceMarketplaceEntry[] = [];
+		const mergedEnabled = new Map<string, boolean>();
+
+		for (const dir of dirs) {
+			const sharedUri = joinPath(dir, SETTINGS_FILENAME);
+			const localUri = joinPath(dir, SETTINGS_LOCAL_FILENAME);
+
+			for (const uri of [sharedUri, localUri]) {
+				try {
+					const content = await fileService.readFile(uri);
+					const json = parseJSONC(content.value.toString());
+
+					if (!json || typeof json !== 'object') {
+						continue;
+					}
+
+					const root = json as Record<string, unknown>;
+
+					const marketplaces = parseExtraMarketplaces(root.extraKnownMarketplaces, logPrefix, this._logService);
+					for (const entry of marketplaces) {
+						if (!allMarketplaces.some(e => e.reference.canonicalId === entry.reference.canonicalId)) {
+							allMarketplaces.push(entry);
+						}
+					}
+
+					const enabled = parseEnabledPlugins(root.enabledPlugins);
+					for (const [key, value] of enabled) {
+						mergedEnabled.set(key, value);
+					}
+				} catch {
+					this._logService.debug(`${logPrefix} Could not read ${uri.toString()}`);
+				}
+			}
+		}
+
+		this._data.set({ marketplaces: allMarketplaces, enabledPlugins: mergedEnabled }, undefined);
+	}
+}
+
+// --- Aggregating service implementation --------------------------------------
+
+export class WorkspacePluginSettingsService extends Disposable implements IWorkspacePluginSettingsService {
+	declare readonly _serviceBrand: undefined;
+
+	readonly extraMarketplaces: IObservable<readonly IWorkspaceMarketplaceEntry[]>;
+	readonly enabledPlugins: IObservable<ReadonlyMap<string, boolean>>;
+
+	constructor(
+		@IFileService fileService: IFileService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+		@ILogService logService: ILogService,
+	) {
+		super();
+
+		const claudeReader = this._register(new WorkspaceSettingsReader(
+			CLAUDE_CONFIG_FOLDER, '[ClaudePluginSettings]',
+			fileService, workspaceContextService, logService,
+		));
+
+		const copilotReader = this._register(new WorkspaceSettingsReader(
+			COPILOT_CONFIG_FOLDER, '[CopilotPluginSettings]',
+			fileService, workspaceContextService, logService,
+		));
+
+		// Merge marketplaces from all readers, deduplicating by canonical ID.
+		this.extraMarketplaces = derived(reader => {
+			const claude = claudeReader.data.read(reader).marketplaces;
+			const copilot = copilotReader.data.read(reader).marketplaces;
+			const byCanonicalId = new Map<string, IWorkspaceMarketplaceEntry>();
+			for (const entry of [...claude, ...copilot]) {
+				if (!byCanonicalId.has(entry.reference.canonicalId)) {
+					byCanonicalId.set(entry.reference.canonicalId, entry);
+				}
+			}
+			return [...byCanonicalId.values()];
+		});
+
+		// Merge enabledPlugins from all readers. Claude entries take
+		// precedence for keys that exist in both (first-writer wins).
+		this.enabledPlugins = derived(reader => {
+			const claude = claudeReader.data.read(reader).enabledPlugins;
+			const copilot = copilotReader.data.read(reader).enabledPlugins;
+			const merged = new Map<string, boolean>();
+			for (const [key, value] of claude) {
+				merged.set(key, value);
+			}
+			for (const [key, value] of copilot) {
+				if (!merged.has(key)) {
+					merged.set(key, value);
+				}
+			}
+			return merged;
+		});
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -16,6 +16,10 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
 import { ChatConfiguration } from '../../../common/constants.js';
 import { MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
+import { IWorkspacePluginSettingsService } from '../../../common/plugins/claudePluginSettings.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { Emitter } from '../../../../../../base/common/event.js';
+import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 
 suite('PluginMarketplaceService', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -159,6 +163,14 @@ suite('PluginMarketplaceService - getMarketplacePluginMetadata', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IRequestService, {} as unknown as IRequestService);
 		instantiationService.stub(IStorageService, store.add(new InMemoryStorageService()));
+		instantiationService.stub(IWorkspacePluginSettingsService, {
+			extraMarketplaces: observableValue('test.extraMarketplaces', []),
+			enabledPlugins: observableValue('test.enabledPlugins', new Map()),
+		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
+		instantiationService.stub(IWorkspaceTrustManagementService, {
+			isWorkspaceTrusted: () => true,
+			onDidChangeTrust: new Emitter<boolean>().event,
+		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));
 	}

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { Event } from '../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
@@ -12,14 +15,11 @@ import { TestInstantiationService } from '../../../../../../platform/instantiati
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { IRequestService } from '../../../../../../platform/request/common/request.js';
 import { IStorageService, InMemoryStorageService } from '../../../../../../platform/storage/common/storage.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
-import { ChatConfiguration } from '../../../common/constants.js';
-import { MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
-import { IWorkspacePluginSettingsService } from '../../../common/plugins/claudePluginSettings.js';
-import { observableValue } from '../../../../../../base/common/observable.js';
-import { Emitter } from '../../../../../../base/common/event.js';
 import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+import { IAgentPluginRepositoryService } from '../../../common/plugins/agentPluginRepositoryService.js';
+import { MarketplaceReferenceKind, MarketplaceType, PluginMarketplaceService, PluginSourceKind, getPluginSourceLabel, parseMarketplaceReference, parseMarketplaceReferences, parsePluginSource } from '../../../common/plugins/pluginMarketplaceService.js';
+import { IWorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
 
 suite('PluginMarketplaceService', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -169,7 +169,7 @@ suite('PluginMarketplaceService - getMarketplacePluginMetadata', () => {
 		} as Partial<IWorkspacePluginSettingsService> as IWorkspacePluginSettingsService);
 		instantiationService.stub(IWorkspaceTrustManagementService, {
 			isWorkspaceTrusted: () => true,
-			onDidChangeTrust: new Emitter<boolean>().event,
+			onDidChangeTrust: Event.None,
 		} as Partial<IWorkspaceTrustManagementService> as IWorkspaceTrustManagementService);
 
 		return store.add(instantiationService.createInstance(PluginMarketplaceService));

--- a/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
@@ -8,6 +8,8 @@ import { VSBuffer } from '../../../../../../base/common/buffer.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
+import { waitForState } from '../../../../../../base/common/observable.js';
 import { FileService } from '../../../../../../platform/files/common/fileService.js';
 import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
@@ -58,7 +60,7 @@ suite('WorkspacePluginSettingsService', () => {
 
 	// --- enabledPlugins parsing ---
 
-	test('parses enabledPlugins from Claude settings', async () => {
+	test('parses enabledPlugins from Claude settings', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: {
 				'my-plugin@my-marketplace': true,
@@ -67,17 +69,15 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-
-		// Allow async read to settle.
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.enabledPlugins, v => v.size > 0);
 
 		const enabled = service.enabledPlugins.get();
 		assert.strictEqual(enabled.get('my-plugin@my-marketplace'), true);
 		assert.strictEqual(enabled.get('disabled-plugin@my-marketplace'), false);
 		assert.strictEqual(enabled.size, 2);
-	});
+	}));
 
-	test('settings.local.json overrides settings.json for enabledPlugins', async () => {
+	test('settings.local.json overrides settings.json for enabledPlugins', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: {
 				'my-plugin@mp': true,
@@ -91,14 +91,14 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.enabledPlugins, v => v.size > 0);
 
 		const enabled = service.enabledPlugins.get();
 		assert.strictEqual(enabled.get('my-plugin@mp'), false, 'local should override shared');
 		assert.strictEqual(enabled.get('other-plugin@mp'), true, 'non-overridden key preserved');
-	});
+	}));
 
-	test('merges enabledPlugins from Claude and Copilot settings', async () => {
+	test('merges enabledPlugins from Claude and Copilot settings', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: { 'from-claude@mp': true }
 		}));
@@ -107,14 +107,14 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.enabledPlugins, v => v.size >= 2);
 
 		const enabled = service.enabledPlugins.get();
 		assert.strictEqual(enabled.get('from-claude@mp'), true);
 		assert.strictEqual(enabled.get('from-copilot@mp'), true);
-	});
+	}));
 
-	test('Claude enabledPlugins take precedence over Copilot for same key', async () => {
+	test('Claude enabledPlugins take precedence over Copilot for same key', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: { 'shared-plugin@mp': false }
 		}));
@@ -123,15 +123,15 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.enabledPlugins, v => v.size > 0);
 
 		const enabled = service.enabledPlugins.get();
 		assert.strictEqual(enabled.get('shared-plugin@mp'), false, 'Claude should win');
-	});
+	}));
 
 	// --- extraKnownMarketplaces parsing ---
 
-	test('parses GitHub shorthand from extraKnownMarketplaces', async () => {
+	test('parses GitHub shorthand from extraKnownMarketplaces', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			extraKnownMarketplaces: {
 				'my-marketplace': {
@@ -142,16 +142,16 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.extraMarketplaces, v => v.length > 0);
 
 		const marketplaces = service.extraMarketplaces.get();
 		assert.strictEqual(marketplaces.length, 1);
 		assert.strictEqual(marketplaces[0].name, 'my-marketplace');
 		assert.strictEqual(marketplaces[0].reference.displayLabel, 'my-marketplace');
 		assert.strictEqual(marketplaces[0].reference.githubRepo, 'owner/repo');
-	});
+	}));
 
-	test('parses nested source object from extraKnownMarketplaces', async () => {
+	test('parses nested source object from extraKnownMarketplaces', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			extraKnownMarketplaces: {
 				'nested-mp': {
@@ -164,15 +164,15 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.extraMarketplaces, v => v.length > 0);
 
 		const marketplaces = service.extraMarketplaces.get();
 		assert.strictEqual(marketplaces.length, 1);
 		assert.strictEqual(marketplaces[0].reference.githubRepo, 'nested-owner/nested-repo');
 		assert.strictEqual(marketplaces[0].reference.displayLabel, 'nested-mp');
-	});
+	}));
 
-	test('deduplicates marketplaces across Claude and Copilot by canonical ID', async () => {
+	test('deduplicates marketplaces across Claude and Copilot by canonical ID', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			extraKnownMarketplaces: {
 				'claude-name': { source: 'github', repo: 'owner/repo' }
@@ -185,27 +185,28 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.extraMarketplaces, v => v.length > 0);
 
 		const marketplaces = service.extraMarketplaces.get();
 		assert.strictEqual(marketplaces.length, 1, 'should deduplicate by canonical ID');
 		assert.strictEqual(marketplaces[0].name, 'claude-name', 'Claude entry should win');
-	});
+	}));
 
 	// --- Invalid input handling ---
 
-	test('ignores invalid enabledPlugins shapes', async () => {
+	test('ignores invalid enabledPlugins shapes', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: 'not-an-object'
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		// Give the async read a chance to complete with faked timers.
+		await new Promise<void>(r => queueMicrotask(r));
 
 		assert.strictEqual(service.enabledPlugins.get().size, 0);
-	});
+	}));
 
-	test('ignores non-boolean values in enabledPlugins', async () => {
+	test('ignores non-boolean values in enabledPlugins', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			enabledPlugins: {
 				'valid@mp': true,
@@ -215,14 +216,14 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.enabledPlugins, v => v.size > 0);
 
 		const enabled = service.enabledPlugins.get();
 		assert.strictEqual(enabled.size, 1);
 		assert.strictEqual(enabled.get('valid@mp'), true);
-	});
+	}));
 
-	test('ignores non-object marketplace entries', async () => {
+	test('ignores non-object marketplace entries', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		await writeClaudeSettings(JSON.stringify({
 			extraKnownMarketplaces: {
 				'valid': { source: 'github', repo: 'owner/repo' },
@@ -232,18 +233,18 @@ suite('WorkspacePluginSettingsService', () => {
 		}));
 
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await waitForState(service.extraMarketplaces, v => v.length > 0);
 
 		const marketplaces = service.extraMarketplaces.get();
 		assert.strictEqual(marketplaces.length, 1);
 		assert.strictEqual(marketplaces[0].name, 'valid');
-	});
+	}));
 
-	test('returns empty observables when no settings files exist', async () => {
+	test('returns empty observables when no settings files exist', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
 		const service = createService();
-		await new Promise(r => setTimeout(r, 50));
+		await new Promise<void>(r => queueMicrotask(r));
 
 		assert.strictEqual(service.enabledPlugins.get().size, 0);
 		assert.strictEqual(service.extraMarketplaces.get().length, 0);
-	});
+	}));
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
@@ -15,10 +15,6 @@ import { InMemoryFileSystemProvider } from '../../../../../../platform/files/com
 import { NullLogService } from '../../../../../../platform/log/common/log.js';
 import { TestContextService } from '../../../../../test/common/workbenchTestServices.js';
 import { testWorkspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
-// Import the marketplace module first to avoid circular initialization issues
-// (workspacePluginSettingsService imports from pluginMarketplaceService which
-// imports back from workspacePluginSettingsService).
-import '../../../common/plugins/pluginMarketplaceService.js';
 import { WorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
 
 suite('WorkspacePluginSettingsService', () => {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/workspacePluginSettingsService.test.ts
@@ -1,0 +1,249 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { Schemas } from '../../../../../../base/common/network.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../../../platform/files/common/fileService.js';
+import { InMemoryFileSystemProvider } from '../../../../../../platform/files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../../../platform/log/common/log.js';
+import { TestContextService } from '../../../../../test/common/workbenchTestServices.js';
+import { testWorkspace } from '../../../../../../platform/workspace/test/common/testWorkspace.js';
+// Import the marketplace module first to avoid circular initialization issues
+// (workspacePluginSettingsService imports from pluginMarketplaceService which
+// imports back from workspacePluginSettingsService).
+import '../../../common/plugins/pluginMarketplaceService.js';
+import { WorkspacePluginSettingsService } from '../../../common/plugins/workspacePluginSettingsService.js';
+
+suite('WorkspacePluginSettingsService', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const logService = new NullLogService();
+
+	let fileService: FileService;
+	let workspaceContextService: TestContextService;
+	const workspaceRoot = URI.from({ scheme: Schemas.inMemory, path: '/workspace' });
+
+	setup(() => {
+		workspaceContextService = new TestContextService(testWorkspace(workspaceRoot));
+		fileService = store.add(new FileService(logService));
+		store.add(fileService.registerProvider(Schemas.inMemory, store.add(new InMemoryFileSystemProvider())));
+	});
+
+	function createService(): WorkspacePluginSettingsService {
+		return store.add(new WorkspacePluginSettingsService(
+			fileService,
+			workspaceContextService,
+			logService,
+		));
+	}
+
+	async function writeClaudeSettings(content: string): Promise<void> {
+		const uri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/settings.json' });
+		await fileService.writeFile(uri, VSBuffer.fromString(content));
+	}
+
+	async function writeClaudeLocalSettings(content: string): Promise<void> {
+		const uri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.claude/settings.local.json' });
+		await fileService.writeFile(uri, VSBuffer.fromString(content));
+	}
+
+	async function writeCopilotSettings(content: string): Promise<void> {
+		const uri = URI.from({ scheme: Schemas.inMemory, path: '/workspace/.github/copilot/settings.json' });
+		await fileService.writeFile(uri, VSBuffer.fromString(content));
+	}
+
+	// --- enabledPlugins parsing ---
+
+	test('parses enabledPlugins from Claude settings', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: {
+				'my-plugin@my-marketplace': true,
+				'disabled-plugin@my-marketplace': false,
+			}
+		}));
+
+		const service = createService();
+
+		// Allow async read to settle.
+		await new Promise(r => setTimeout(r, 50));
+
+		const enabled = service.enabledPlugins.get();
+		assert.strictEqual(enabled.get('my-plugin@my-marketplace'), true);
+		assert.strictEqual(enabled.get('disabled-plugin@my-marketplace'), false);
+		assert.strictEqual(enabled.size, 2);
+	});
+
+	test('settings.local.json overrides settings.json for enabledPlugins', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: {
+				'my-plugin@mp': true,
+				'other-plugin@mp': true,
+			}
+		}));
+		await writeClaudeLocalSettings(JSON.stringify({
+			enabledPlugins: {
+				'my-plugin@mp': false,
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const enabled = service.enabledPlugins.get();
+		assert.strictEqual(enabled.get('my-plugin@mp'), false, 'local should override shared');
+		assert.strictEqual(enabled.get('other-plugin@mp'), true, 'non-overridden key preserved');
+	});
+
+	test('merges enabledPlugins from Claude and Copilot settings', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: { 'from-claude@mp': true }
+		}));
+		await writeCopilotSettings(JSON.stringify({
+			enabledPlugins: { 'from-copilot@mp': true }
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const enabled = service.enabledPlugins.get();
+		assert.strictEqual(enabled.get('from-claude@mp'), true);
+		assert.strictEqual(enabled.get('from-copilot@mp'), true);
+	});
+
+	test('Claude enabledPlugins take precedence over Copilot for same key', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: { 'shared-plugin@mp': false }
+		}));
+		await writeCopilotSettings(JSON.stringify({
+			enabledPlugins: { 'shared-plugin@mp': true }
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const enabled = service.enabledPlugins.get();
+		assert.strictEqual(enabled.get('shared-plugin@mp'), false, 'Claude should win');
+	});
+
+	// --- extraKnownMarketplaces parsing ---
+
+	test('parses GitHub shorthand from extraKnownMarketplaces', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'my-marketplace': {
+					source: 'github',
+					repo: 'owner/repo',
+				}
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const marketplaces = service.extraMarketplaces.get();
+		assert.strictEqual(marketplaces.length, 1);
+		assert.strictEqual(marketplaces[0].name, 'my-marketplace');
+		assert.strictEqual(marketplaces[0].reference.displayLabel, 'my-marketplace');
+		assert.strictEqual(marketplaces[0].reference.githubRepo, 'owner/repo');
+	});
+
+	test('parses nested source object from extraKnownMarketplaces', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'nested-mp': {
+					source: {
+						source: 'github',
+						repo: 'nested-owner/nested-repo',
+					}
+				}
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const marketplaces = service.extraMarketplaces.get();
+		assert.strictEqual(marketplaces.length, 1);
+		assert.strictEqual(marketplaces[0].reference.githubRepo, 'nested-owner/nested-repo');
+		assert.strictEqual(marketplaces[0].reference.displayLabel, 'nested-mp');
+	});
+
+	test('deduplicates marketplaces across Claude and Copilot by canonical ID', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'claude-name': { source: 'github', repo: 'owner/repo' }
+			}
+		}));
+		await writeCopilotSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'copilot-name': { source: 'github', repo: 'owner/repo' }
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const marketplaces = service.extraMarketplaces.get();
+		assert.strictEqual(marketplaces.length, 1, 'should deduplicate by canonical ID');
+		assert.strictEqual(marketplaces[0].name, 'claude-name', 'Claude entry should win');
+	});
+
+	// --- Invalid input handling ---
+
+	test('ignores invalid enabledPlugins shapes', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: 'not-an-object'
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		assert.strictEqual(service.enabledPlugins.get().size, 0);
+	});
+
+	test('ignores non-boolean values in enabledPlugins', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			enabledPlugins: {
+				'valid@mp': true,
+				'number@mp': 42,
+				'string@mp': 'yes',
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const enabled = service.enabledPlugins.get();
+		assert.strictEqual(enabled.size, 1);
+		assert.strictEqual(enabled.get('valid@mp'), true);
+	});
+
+	test('ignores non-object marketplace entries', async () => {
+		await writeClaudeSettings(JSON.stringify({
+			extraKnownMarketplaces: {
+				'valid': { source: 'github', repo: 'owner/repo' },
+				'invalid-string': 'not-valid',
+				'invalid-number': 42,
+			}
+		}));
+
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		const marketplaces = service.extraMarketplaces.get();
+		assert.strictEqual(marketplaces.length, 1);
+		assert.strictEqual(marketplaces[0].name, 'valid');
+	});
+
+	test('returns empty observables when no settings files exist', async () => {
+		const service = createService();
+		await new Promise(r => setTimeout(r, 50));
+
+		assert.strictEqual(service.enabledPlugins.get().size, 0);
+		assert.strictEqual(service.extraMarketplaces.get().length, 0);
+	});
+});


### PR DESCRIPTION
- reads .claude/settings(.local).json and the Copilot equivalent
- currently this enables the `extraMarketplaces` and marks the extensions as 'recommended'. Users get a prompt on the first chat message and can find the extensions under `@agentPlugins @recommended`

todo: unify the enablement/disablement.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
