### PR TITLE
Fix clipped items in AI Customization tree

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -254,7 +254,7 @@
 
 /* Spacing above non-first group headers */
 .ai-customization-group-header.has-previous-group {
-	margin-top: 4px;
+	padding-top: 12px;
 }
 
 .ai-customization-group-header:hover {
@@ -347,7 +347,6 @@
 	padding: 6px 8px 6px 24px;
 	cursor: pointer;
 	border-radius: 4px;
-	margin: 2px 0;
 	min-height: 32px;
 }
 
@@ -716,7 +715,6 @@
 	padding: 6px 8px;
 	cursor: pointer;
 	border-radius: 4px;
-	margin: 2px 0;
 	min-height: 32px;
 	gap: 10px;
 }


### PR DESCRIPTION
## Summary
- replace the extra group-header top margin with padding so spacing stays within the layout flow
- remove vertical margins from customization list items and MCP server items so the final row is no longer clipped

## Testing
- npm run compile-check-ts-native

Fixes #299049