### PR TITLE
sessions: Improve built-in prompt override saving in AI Customization

### DIFF
--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a draft pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
+<!-- Customize this built-in prompt by editing it in AI Customization, then click the Save icon to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,6 +1,7 @@
 ---
 description: Create a draft pull request for the current session
 ---
+<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,7 +1,6 @@
 ---
 description: Create a draft pull request for the current session
 ---
-<!-- Tip: Create a workspace or user prompt named 'create-draft-pr' to override this built-in prompt -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a draft pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. -->
+<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a draft pull request for the current session
 ---
-<!-- Edit in AI Customization and click the Save icon to create an override. Delete that copy to restore the built-in behavior. -->
+<!-- Customize this prompt and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-draft-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-draft-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a draft pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click the Save icon to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
+<!-- Edit in AI Customization and click the Save icon to create an override. Delete that copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a draft pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click the Save icon to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
+<!-- Edit in AI Customization and click the Save icon to create an override. Delete that copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,6 +1,7 @@
 ---
 description: Create a pull request for the current session
 ---
+<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,7 +1,6 @@
 ---
 description: Create a pull request for the current session
 ---
-<!-- Tip: Create a workspace or user prompt named 'create-pr' to override this built-in prompt -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull request for the current session
 ---
-<!-- Edit in AI Customization and click the Save icon to create an override. Delete that copy to restore the built-in behavior. -->
+<!-- Customize this prompt and select save to override its behavior. Delete that copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
+<!-- Customize this built-in prompt by editing it in AI Customization, then click the Save icon to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/sessions/prompts/create-pr.prompt.md
+++ b/src/vs/sessions/prompts/create-pr.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: Create a pull request for the current session
 ---
-<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. -->
+<!-- Customize this built-in prompt by editing it in AI Customization, then click Save to create a workspace or user override. Delete your saved copy to restore the built-in behavior. -->
 
 Use the GitHub MCP server to create a pull request — do NOT use the `gh` CLI.
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -843,7 +843,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.editorItemPathElement = DOM.append(itemInfo, $('.editor-item-path'));
 
 		this.editorSaveButton = DOM.append(editorHeader, $('button.editor-save-button'));
-		this.editorSaveButton.textContent = localize('savePromptCopy', "Save");
+		const saveIcon = DOM.append(this.editorSaveButton, $(`.codicon.codicon-${Codicon.save.id}.editor-save-button-icon`));
+		saveIcon.setAttribute('aria-hidden', 'true');
+		const saveLabel = DOM.append(this.editorSaveButton, $('span.editor-save-button-label'));
+		saveLabel.textContent = localize('savePromptCopy', "Save");
 		this.editorSaveButton.setAttribute('aria-label', localize('savePromptCopyAriaLabel', "Save prompt copy"));
 		this.editorDisposables.add(DOM.addDisposableListener(this.editorSaveButton, 'click', () => {
 			void this.saveBuiltinPromptCopy().catch(error => {
@@ -1107,7 +1110,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 
 		const isBuiltinPrompt = this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt;
-		this.editorSaveButton.style.display = isBuiltinPrompt ? '' : 'none';
+		this.editorSaveButton.style.display = isBuiltinPrompt ? 'inline-flex' : 'none';
 		this.editorSaveButton.disabled = !this._editorContentChanged;
 		this.editorSaveButton.title = isBuiltinPrompt
 			? this._editorContentChanged

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -167,9 +167,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 	// Embedded editor state
 	private editorContentContainer: HTMLElement | undefined;
 	private embeddedEditor: CodeEditorWidget | undefined;
+	private editorActionButton!: HTMLButtonElement;
+	private editorActionButtonIcon!: HTMLElement;
 	private editorItemNameElement!: HTMLElement;
 	private editorItemPathElement!: HTMLElement;
-	private editorSaveButton!: HTMLButtonElement;
 	private editorSaveIndicator!: HTMLElement;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
@@ -830,30 +831,17 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		const editorHeader = DOM.append(this.editorContentContainer, $('.editor-header'));
 
-		const backButton = DOM.append(editorHeader, $('button.editor-back-button'));
-		backButton.setAttribute('aria-label', localize('backToList', "Back to list"));
-		const backIcon = DOM.append(backButton, $(`.codicon.codicon-${Codicon.arrowLeft.id}`));
-		backIcon.setAttribute('aria-hidden', 'true');
-		this.editorDisposables.add(DOM.addDisposableListener(backButton, 'click', () => {
-			this.goBackToList();
+		this.editorActionButton = DOM.append(editorHeader, $('button.editor-back-button'));
+		this.editorActionButton.setAttribute('aria-label', localize('backToList', "Back to list"));
+		this.editorActionButtonIcon = DOM.append(this.editorActionButton, $(`.codicon.codicon-${Codicon.arrowLeft.id}.editor-action-button-icon`));
+		this.editorActionButtonIcon.setAttribute('aria-hidden', 'true');
+		this.editorDisposables.add(DOM.addDisposableListener(this.editorActionButton, 'click', () => {
+			void this.handleEditorActionButton();
 		}));
 
 		const itemInfo = DOM.append(editorHeader, $('.editor-item-info'));
 		this.editorItemNameElement = DOM.append(itemInfo, $('.editor-item-name'));
 		this.editorItemPathElement = DOM.append(itemInfo, $('.editor-item-path'));
-
-		this.editorSaveButton = DOM.append(editorHeader, $('button.editor-save-button'));
-		const saveIcon = DOM.append(this.editorSaveButton, $(`.codicon.codicon-${Codicon.save.id}.editor-save-button-icon`));
-		saveIcon.setAttribute('aria-hidden', 'true');
-		const saveLabel = DOM.append(this.editorSaveButton, $('span.editor-save-button-label'));
-		saveLabel.textContent = localize('savePromptCopy', "Save");
-		this.editorSaveButton.setAttribute('aria-label', localize('savePromptCopyAriaLabel', "Save prompt copy"));
-		this.editorDisposables.add(DOM.addDisposableListener(this.editorSaveButton, 'click', () => {
-			void this.saveBuiltinPromptCopy().catch(error => {
-				console.error('Failed to save built-in prompt copy:', error);
-				this.notificationService.error(localize('saveBuiltinPromptCopyFailed', "Failed to save the prompt copy."));
-			});
-		}));
 
 		this.editorSaveIndicator = DOM.append(editorHeader, $('.editor-save-indicator'));
 
@@ -895,7 +883,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.editorItemPathElement.textContent = basename(uri);
 		this._editorContentChanged = false;
 		this.resetEditorSaveIndicator();
-		this.updateBuiltinSaveButton();
+		this.updateEditorActionButton();
 		this.updateContentVisibility();
 
 		try {
@@ -909,7 +897,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 				this.embeddedEditor!.setModel(session.model);
 				this.embeddedEditor!.updateOptions({ readOnly: false });
 				this._editorContentChanged = session.model.getValue() !== session.originalContent;
-				this.updateBuiltinSaveButton();
+				this.updateEditorActionButton();
 
 				if (this.dimension) {
 					this.layout(this.dimension);
@@ -918,7 +906,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 				this.editorModelChangeDisposables.add(session.model.onDidChangeContent(() => {
 					this._editorContentChanged = session.model.getValue() !== session.originalContent;
-					this.updateBuiltinSaveButton();
+					this.updateEditorActionButton();
 				}));
 				return;
 			}
@@ -940,7 +928,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.embeddedEditor!.focus();
 
 			this._editorContentChanged = false;
-			this.updateBuiltinSaveButton();
+			this.updateEditorActionButton();
 			const saveDelayer = this.editorModelChangeDisposables.add(new Delayer<void>(500));
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
 				this._editorContentChanged = true;
@@ -989,7 +977,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.currentEditingPromptType = undefined;
 		this.editorModelChangeDisposables.clear();
 		this.resetEditorSaveIndicator();
-		this.updateBuiltinSaveButton();
+		this.updateEditorActionButton();
 		this.embeddedEditor?.setModel(null);
 		this.viewMode = 'list';
 		this.updateContentVisibility();
@@ -1055,7 +1043,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.builtinEditingSessions.delete(sourceUri.toString());
 		session.model.dispose();
 		this._editorContentChanged = false;
-		this.updateBuiltinSaveButton();
+		this.updateEditorActionButton();
 		status(target.target === 'workspace'
 			? localize('saveBuiltinPromptCopySuccessWorkspace', "Saved the prompt override to the workspace prompts.")
 			: localize('saveBuiltinPromptCopySuccessUser', "Saved the prompt override to your user prompts."));
@@ -1104,19 +1092,37 @@ export class AICustomizationManagementEditor extends EditorPane {
 		});
 	}
 
-	private updateBuiltinSaveButton(): void {
-		if (!this.editorSaveButton) {
+	private async handleEditorActionButton(): Promise<void> {
+		if (this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt) {
+			try {
+				await this.saveBuiltinPromptCopy();
+			} catch (error) {
+				console.error('Failed to save built-in prompt copy:', error);
+				this.notificationService.error(localize('saveBuiltinPromptCopyFailed', "Failed to save the prompt copy."));
+			}
+			return;
+		}
+
+		this.goBackToList();
+	}
+
+	private updateEditorActionButton(): void {
+		if (!this.editorActionButton || !this.editorActionButtonIcon) {
 			return;
 		}
 
 		const isBuiltinPrompt = this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt;
-		this.editorSaveButton.style.display = isBuiltinPrompt ? 'inline-flex' : 'none';
-		this.editorSaveButton.disabled = !this._editorContentChanged;
-		this.editorSaveButton.title = isBuiltinPrompt
+		this.editorActionButtonIcon.className = `codicon codicon-${isBuiltinPrompt ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
+		this.editorActionButton.classList.toggle('editor-save-mode', isBuiltinPrompt);
+		this.editorActionButton.disabled = isBuiltinPrompt && !this._editorContentChanged;
+		this.editorActionButton.setAttribute('aria-label', isBuiltinPrompt
+			? localize('savePromptCopyAriaLabel', "Save prompt copy")
+			: localize('backToList', "Back to list"));
+		this.editorActionButton.title = isBuiltinPrompt
 			? this._editorContentChanged
 				? localize('saveBuiltinPromptCopyTooltip', "Save an edited copy as a workspace or user prompt")
 				: localize('saveBuiltinPromptCopyDisabledTooltip', "Edit the prompt to save a workspace or user copy")
-			: '';
+			: localize('backToList', "Back to list");
 	}
 
 	private resetEditorSaveIndicator(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1081,9 +1081,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private async handleEditorActionButton(): Promise<void> {
-		const shouldPromptToSave = this.currentEditingStorage === BUILTIN_STORAGE &&
-			this.currentEditingPromptType === PromptsType.prompt &&
-			this._editorContentChanged;
+		const hasDirtyChanges = this._editorContentChanged;
+		const shouldPromptToSave = hasDirtyChanges &&
+			this.currentEditingStorage === BUILTIN_STORAGE &&
+			this.currentEditingPromptType === PromptsType.prompt;
+		const shouldSaveAndGoBack = hasDirtyChanges && !shouldPromptToSave;
+
+		if (shouldSaveAndGoBack && this.currentEditingUri) {
+			await this.textFileService.save(this.currentEditingUri);
+		}
 
 		if (shouldPromptToSave) {
 			const selection = await this.pickBuiltinPromptSaveTarget();
@@ -1104,16 +1110,21 @@ export class AICustomizationManagementEditor extends EditorPane {
 			return;
 		}
 
-		const shouldPromptToSave = this.currentEditingStorage === BUILTIN_STORAGE &&
-			this.currentEditingPromptType === PromptsType.prompt &&
-			this._editorContentChanged;
-		this.editorActionButtonIcon.className = `codicon codicon-${shouldPromptToSave ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
+		const hasDirtyChanges = this._editorContentChanged;
+		const shouldPromptToSave = hasDirtyChanges &&
+			this.currentEditingStorage === BUILTIN_STORAGE &&
+			this.currentEditingPromptType === PromptsType.prompt;
+		this.editorActionButtonIcon.className = `codicon codicon-${hasDirtyChanges ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
 		this.editorActionButton.disabled = false;
-		this.editorActionButton.setAttribute('aria-label', shouldPromptToSave
-			? localize('savePromptCopyAndChooseLocation', "Save prompt override")
+		this.editorActionButton.setAttribute('aria-label', hasDirtyChanges
+			? shouldPromptToSave
+				? localize('savePromptCopyAndChooseLocation', "Save prompt override")
+				: localize('saveChangesAndGoBack', "Save changes and go back")
 			: localize('backToList', "Back to list"));
-		this.editorActionButton.title = shouldPromptToSave
-			? localize('savePromptCopyAndChooseLocationTooltip', "Save prompt override (choose Workspace, User, or Cancel)")
+		this.editorActionButton.title = hasDirtyChanges
+			? shouldPromptToSave
+				? localize('savePromptCopyAndChooseLocationTooltip', "Save prompt override (choose Workspace, User, or Cancel)")
+				: localize('saveChangesAndGoBackTooltip', "Save changes and go back")
 			: localize('backToList', "Back to list");
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1107,13 +1107,13 @@ export class AICustomizationManagementEditor extends EditorPane {
 		const shouldPromptToSave = this.currentEditingStorage === BUILTIN_STORAGE &&
 			this.currentEditingPromptType === PromptsType.prompt &&
 			this._editorContentChanged;
-		this.editorActionButtonIcon.className = `codicon codicon-${Codicon.arrowLeft.id} editor-action-button-icon`;
+		this.editorActionButtonIcon.className = `codicon codicon-${shouldPromptToSave ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
 		this.editorActionButton.disabled = false;
 		this.editorActionButton.setAttribute('aria-label', shouldPromptToSave
-			? localize('backToListAndSavePromptCopy', "Back to list and choose where to save the prompt override")
+			? localize('savePromptCopyAndChooseLocation', "Save prompt override")
 			: localize('backToList', "Back to list"));
 		this.editorActionButton.title = shouldPromptToSave
-			? localize('backToListAndSavePromptCopyTooltip', "Go back and choose Workspace, User, or Cancel")
+			? localize('savePromptCopyAndChooseLocationTooltip', "Save prompt override (choose Workspace, User, or Cancel)")
 			: localize('backToList', "Back to list");
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -8,7 +8,7 @@ import * as DOM from '../../../../../base/browser/dom.js';
 import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
-import { DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { Orientation, Sizing, SplitView } from '../../../../../base/browser/ui/splitview/splitview.js';
@@ -66,8 +66,6 @@ import { IResolvedTextEditorModel, ITextModelService } from '../../../../../edit
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
-import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
-import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -173,7 +171,6 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private editorItemPathElement!: HTMLElement;
 	private editorSaveIndicator!: HTMLElement;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
-	private readonly currentAutoSaveDisabled = this._register(new MutableDisposable<IDisposable>());
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
 	private currentEditingProjectRoot: URI | undefined;
@@ -221,14 +218,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@ITextModelService private readonly textModelService: ITextModelService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IWorkingCopyService private readonly workingCopyService: IWorkingCopyService,
-		@ITextFileService private readonly textFileService: ITextFileService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@IModelService private readonly modelService: IModelService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@IFileService private readonly fileService: IFileService,
 		@INotificationService private readonly notificationService: INotificationService,
-		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
 	) {
 		super(AICustomizationManagementEditor.ID, group, telemetryService, themeService, storageService);
 
@@ -877,7 +872,6 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private async showEmbeddedEditor(uri: URI, displayName: string, promptType: PromptsType, storage: PromptsStorage, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
-		this.currentAutoSaveDisabled.clear();
 		this.editorModelChangeDisposables.clear();
 		this.currentEditingUri = uri;
 		this.currentEditingProjectRoot = isWorkspaceFile ? this.workspaceService.getActiveProjectRoot() : undefined;
@@ -927,7 +921,6 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.currentModelRef = ref;
 			this.embeddedEditor!.setModel(ref.object.textEditorModel);
 			this.embeddedEditor!.updateOptions({ readOnly: isReadOnly });
-			this.currentAutoSaveDisabled.value = this.filesConfigurationService.disableAutoSave(uri);
 
 			if (this.dimension) {
 				this.layout(this.dimension);
@@ -935,17 +928,9 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.embeddedEditor!.focus();
 
 			this._editorContentChanged = this.workingCopyService.isDirty(uri);
-			this.updateEditorActionButton();
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
 				this._editorContentChanged = true;
-				this.updateEditorActionButton();
 				this.resetEditorSaveIndicator();
-			}));
-			this.editorModelChangeDisposables.add(this.workingCopyService.onDidChangeDirty(workingCopy => {
-				if (isEqual(workingCopy.resource, uri)) {
-					this._editorContentChanged = workingCopy.isDirty();
-					this.updateEditorActionButton();
-				}
 			}));
 			this.editorModelChangeDisposables.add(this.workingCopyService.onDidSave(e => {
 				if (isEqual(e.workingCopy.resource, uri)) {
@@ -953,7 +938,6 @@ export class AICustomizationManagementEditor extends EditorPane {
 					this.editorSaveIndicator.className = 'editor-save-indicator visible saved';
 					this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
 					this.editorSaveIndicator.title = localize('saved', "Saved");
-					this.updateEditorActionButton();
 				}
 			}));
 		} catch (error) {
@@ -974,7 +958,6 @@ export class AICustomizationManagementEditor extends EditorPane {
 		if (fileUri && this.currentEditingStorage === BUILTIN_STORAGE) {
 			this.disposeBuiltinEditingSession(fileUri);
 		}
-		this.currentAutoSaveDisabled.clear();
 
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
@@ -982,6 +965,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.currentEditingProjectRoot = undefined;
 		this.currentEditingStorage = undefined;
 		this.currentEditingPromptType = undefined;
+		this._editorContentChanged = false;
 		this.editorModelChangeDisposables.clear();
 		this.resetEditorSaveIndicator();
 		this.updateEditorActionButton();
@@ -1088,21 +1072,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private async handleEditorActionButton(): Promise<void> {
-		const hasDirtyChanges = this._editorContentChanged;
-		const shouldPromptToSave = hasDirtyChanges &&
-			this.currentEditingStorage === BUILTIN_STORAGE &&
-			this.currentEditingPromptType === PromptsType.prompt;
-		const shouldSaveAndGoBack = hasDirtyChanges && !shouldPromptToSave;
-
-		if (shouldSaveAndGoBack && this.currentEditingUri) {
-			await this.textFileService.save(this.currentEditingUri);
-			if (this.currentEditingProjectRoot) {
-				await this.workspaceService.commitFiles(this.currentEditingProjectRoot, [this.currentEditingUri]);
-			}
-			this._editorContentChanged = false;
-		}
-
-		if (shouldPromptToSave) {
+		if (this.shouldShowBuiltinSaveAction()) {
 			const selection = await this.pickBuiltinPromptSaveTarget();
 			if (!selection) {
 				return;
@@ -1121,22 +1091,21 @@ export class AICustomizationManagementEditor extends EditorPane {
 			return;
 		}
 
-		const hasDirtyChanges = this._editorContentChanged;
-		const shouldPromptToSave = hasDirtyChanges &&
-			this.currentEditingStorage === BUILTIN_STORAGE &&
-			this.currentEditingPromptType === PromptsType.prompt;
-		this.editorActionButtonIcon.className = `codicon codicon-${hasDirtyChanges ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
+		const shouldShowBuiltinSaveAction = this.shouldShowBuiltinSaveAction();
+		this.editorActionButtonIcon.className = `codicon codicon-${shouldShowBuiltinSaveAction ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
 		this.editorActionButton.disabled = false;
-		this.editorActionButton.setAttribute('aria-label', hasDirtyChanges
-			? shouldPromptToSave
-				? localize('savePromptCopyAndChooseLocation', "Save prompt override")
-				: localize('saveChangesAndGoBack', "Save changes and go back")
+		this.editorActionButton.setAttribute('aria-label', shouldShowBuiltinSaveAction
+			? localize('savePromptCopyAndChooseLocation', "Save prompt override")
 			: localize('backToList', "Back to list"));
-		this.editorActionButton.title = hasDirtyChanges
-			? shouldPromptToSave
-				? localize('savePromptCopyAndChooseLocationTooltip', "Save prompt override (choose Workspace, User, or Cancel)")
-				: localize('saveChangesAndGoBackTooltip', "Save changes and go back")
+		this.editorActionButton.title = shouldShowBuiltinSaveAction
+			? localize('savePromptCopyAndChooseLocationTooltip', "Save prompt override (choose Workspace, User, or Cancel)")
 			: localize('backToList', "Back to list");
+	}
+
+	private shouldShowBuiltinSaveAction(): boolean {
+		return this._editorContentChanged
+			&& this.currentEditingStorage === BUILTIN_STORAGE
+			&& this.currentEditingPromptType === PromptsType.prompt;
 	}
 
 	private resetEditorSaveIndicator(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -8,7 +8,7 @@ import * as DOM from '../../../../../base/browser/dom.js';
 import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
-import { DisposableStore, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { Orientation, Sizing, SplitView } from '../../../../../base/browser/ui/splitview/splitview.js';
@@ -66,6 +66,7 @@ import { IResolvedTextEditorModel, ITextModelService } from '../../../../../edit
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
+import { IFilesConfigurationService } from '../../../../services/filesConfiguration/common/filesConfigurationService.js';
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
@@ -172,6 +173,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private editorItemPathElement!: HTMLElement;
 	private editorSaveIndicator!: HTMLElement;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
+	private readonly currentAutoSaveDisabled = this._register(new MutableDisposable<IDisposable>());
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
 	private currentEditingProjectRoot: URI | undefined;
@@ -226,6 +228,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@IFileService private readonly fileService: IFileService,
 		@INotificationService private readonly notificationService: INotificationService,
+		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
 	) {
 		super(AICustomizationManagementEditor.ID, group, telemetryService, themeService, storageService);
 
@@ -874,6 +877,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private async showEmbeddedEditor(uri: URI, displayName: string, promptType: PromptsType, storage: PromptsStorage, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
+		this.currentAutoSaveDisabled.clear();
 		this.editorModelChangeDisposables.clear();
 		this.currentEditingUri = uri;
 		this.currentEditingProjectRoot = isWorkspaceFile ? this.workspaceService.getActiveProjectRoot() : undefined;
@@ -923,6 +927,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.currentModelRef = ref;
 			this.embeddedEditor!.setModel(ref.object.textEditorModel);
 			this.embeddedEditor!.updateOptions({ readOnly: isReadOnly });
+			this.currentAutoSaveDisabled.value = this.filesConfigurationService.disableAutoSave(uri);
 
 			if (this.dimension) {
 				this.layout(this.dimension);
@@ -932,9 +937,15 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this._editorContentChanged = this.workingCopyService.isDirty(uri);
 			this.updateEditorActionButton();
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
-				this._editorContentChanged = this.workingCopyService.isDirty(uri);
+				this._editorContentChanged = true;
 				this.updateEditorActionButton();
 				this.resetEditorSaveIndicator();
+			}));
+			this.editorModelChangeDisposables.add(this.workingCopyService.onDidChangeDirty(workingCopy => {
+				if (isEqual(workingCopy.resource, uri)) {
+					this._editorContentChanged = workingCopy.isDirty();
+					this.updateEditorActionButton();
+				}
 			}));
 			this.editorModelChangeDisposables.add(this.workingCopyService.onDidSave(e => {
 				if (isEqual(e.workingCopy.resource, uri)) {
@@ -963,6 +974,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		if (fileUri && this.currentEditingStorage === BUILTIN_STORAGE) {
 			this.disposeBuiltinEditingSession(fileUri);
 		}
+		this.currentAutoSaveDisabled.clear();
 
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
@@ -1028,6 +1040,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 		const targetUri = URI.joinPath(target.folder, basename(sourceUri));
 		await this.fileService.createFolder(target.folder);
 		await this.fileService.writeFile(targetUri, VSBuffer.fromString(session.model.getValue()));
+		if (target.target === 'workspace') {
+			const projectRoot = this.workspaceService.getActiveProjectRoot();
+			if (projectRoot) {
+				await this.workspaceService.commitFiles(projectRoot, [targetUri]);
+			}
+		}
 
 		status(target.target === 'workspace'
 			? localize('saveBuiltinPromptCopySuccessWorkspace', "Saved the prompt override to the workspace prompts.")
@@ -1078,6 +1096,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		if (shouldSaveAndGoBack && this.currentEditingUri) {
 			await this.textFileService.save(this.currentEditingUri);
+			if (this.currentEditingProjectRoot) {
+				await this.workspaceService.commitFiles(this.currentEditingProjectRoot, [this.currentEditingUri]);
+			}
+			this._editorContentChanged = false;
 		}
 
 		if (shouldPromptToSave) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -5,7 +5,6 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
@@ -98,6 +97,14 @@ interface ISectionItem {
 interface ISaveTargetQuickPickItem extends IQuickPickItem {
 	readonly target: 'workspace' | 'user' | 'cancel';
 	readonly folder?: URI;
+}
+
+interface IBuiltinPromptSaveRequest {
+	readonly target: 'workspace' | 'user';
+	readonly folder: URI;
+	readonly sourceUri: URI;
+	readonly content: string;
+	readonly projectRoot?: URI;
 }
 
 class SectionItemDelegate implements IListVirtualDelegate<ISectionItem> {
@@ -1009,10 +1016,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 	}
 
-	private async saveBuiltinPromptCopy(target: ISaveTargetQuickPickItem): Promise<void> {
+	private createBuiltinPromptSaveRequest(target: ISaveTargetQuickPickItem): IBuiltinPromptSaveRequest | undefined {
 		const sourceUri = this.currentEditingUri;
 		const promptType = this.currentEditingPromptType;
-		if (!sourceUri || this.currentEditingStorage !== BUILTIN_STORAGE || promptType !== PromptsType.prompt || !target.folder) {
+		if (!sourceUri || this.currentEditingStorage !== BUILTIN_STORAGE || promptType !== PromptsType.prompt || !target.folder || target.target === 'cancel') {
 			return;
 		}
 
@@ -1021,19 +1028,22 @@ export class AICustomizationManagementEditor extends EditorPane {
 			return;
 		}
 
-		const targetUri = URI.joinPath(target.folder, basename(sourceUri));
-		await this.fileService.createFolder(target.folder);
-		await this.fileService.writeFile(targetUri, VSBuffer.fromString(session.model.getValue()));
-		if (target.target === 'workspace') {
-			const projectRoot = this.workspaceService.getActiveProjectRoot();
-			if (projectRoot) {
-				await this.workspaceService.commitFiles(projectRoot, [targetUri]);
-			}
-		}
+		return {
+			target: target.target,
+			folder: target.folder,
+			sourceUri,
+			content: session.model.getValue(),
+			projectRoot: target.target === 'workspace' ? this.workspaceService.getActiveProjectRoot() : undefined,
+		};
+	}
 
-		status(target.target === 'workspace'
-			? localize('saveBuiltinPromptCopySuccessWorkspace', "Saved the prompt override to the workspace prompts.")
-			: localize('saveBuiltinPromptCopySuccessUser', "Saved the prompt override to your user prompts."));
+	private async saveBuiltinPromptCopy(request: IBuiltinPromptSaveRequest): Promise<void> {
+		const targetUri = URI.joinPath(request.folder, basename(request.sourceUri));
+		await this.fileService.createFolder(request.folder);
+		await this.fileService.writeFile(targetUri, VSBuffer.fromString(request.content));
+		if (request.target === 'workspace' && request.projectRoot) {
+			await this.workspaceService.commitFiles(request.projectRoot, [targetUri]);
+		}
 	}
 
 	private async pickBuiltinPromptSaveTarget(): Promise<ISaveTargetQuickPickItem | undefined> {
@@ -1072,6 +1082,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private async handleEditorActionButton(): Promise<void> {
+		let backgroundSaveRequest: IBuiltinPromptSaveRequest | undefined;
 		if (this.shouldShowBuiltinSaveAction()) {
 			const selection = await this.pickBuiltinPromptSaveTarget();
 			if (!selection) {
@@ -1079,11 +1090,22 @@ export class AICustomizationManagementEditor extends EditorPane {
 			}
 
 			if (selection.target !== 'cancel') {
-				await this.saveBuiltinPromptCopy(selection);
+				backgroundSaveRequest = this.createBuiltinPromptSaveRequest(selection);
 			}
 		}
 
 		this.goBackToList();
+		if (backgroundSaveRequest) {
+			const saveRequest = backgroundSaveRequest;
+			void this.saveBuiltinPromptCopy(saveRequest).then(() => {
+				void this.listWidget?.refresh();
+			}, error => {
+				console.error('Failed to save built-in prompt override:', error);
+				this.notificationService.warn(saveRequest.target === 'workspace'
+					? localize('saveBuiltinPromptCopyFailedWorkspace', "Could not save the prompt override to the workspace prompts.")
+					: localize('saveBuiltinPromptCopyFailedUser', "Could not save the prompt override to your user prompts."));
+			});
+		}
 	}
 
 	private updateEditorActionButton(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -98,8 +98,8 @@ interface ISectionItem {
 }
 
 interface ISaveTargetQuickPickItem extends IQuickPickItem {
-	readonly target: 'workspace' | 'user';
-	readonly folder: URI;
+	readonly target: 'workspace' | 'user' | 'cancel';
+	readonly folder?: URI;
 }
 
 class SectionItemDelegate implements IListVirtualDelegate<ISectionItem> {
@@ -836,7 +836,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.editorActionButtonIcon = DOM.append(this.editorActionButton, $(`.codicon.codicon-${Codicon.arrowLeft.id}.editor-action-button-icon`));
 		this.editorActionButtonIcon.setAttribute('aria-hidden', 'true');
 		this.editorDisposables.add(DOM.addDisposableListener(this.editorActionButton, 'click', () => {
-			void this.handleEditorActionButton();
+			void this.handleEditorActionButton().catch(error => {
+				console.error('Failed to handle editor back action:', error);
+				this.notificationService.error(localize('editorActionButtonFailed', "Failed to finish the prompt action."));
+			});
 		}));
 
 		const itemInfo = DOM.append(editorHeader, $('.editor-item-info'));
@@ -968,6 +971,9 @@ export class AICustomizationManagementEditor extends EditorPane {
 		if (fileUri && projectRoot && this._editorContentChanged) {
 			this.workspaceService.commitFiles(projectRoot, [fileUri]);
 		}
+		if (fileUri && this.currentEditingStorage === BUILTIN_STORAGE) {
+			this.disposeBuiltinEditingSession(fileUri);
+		}
 
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
@@ -1018,10 +1024,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 	}
 
-	private async saveBuiltinPromptCopy(): Promise<void> {
+	private async saveBuiltinPromptCopy(target: ISaveTargetQuickPickItem): Promise<void> {
 		const sourceUri = this.currentEditingUri;
 		const promptType = this.currentEditingPromptType;
-		if (!sourceUri || this.currentEditingStorage !== BUILTIN_STORAGE || promptType !== PromptsType.prompt) {
+		if (!sourceUri || this.currentEditingStorage !== BUILTIN_STORAGE || promptType !== PromptsType.prompt || !target.folder) {
 			return;
 		}
 
@@ -1030,31 +1036,13 @@ export class AICustomizationManagementEditor extends EditorPane {
 			return;
 		}
 
-		const target = await this.pickBuiltinPromptSaveTarget();
-		if (!target) {
-			return;
-		}
-
 		const targetUri = URI.joinPath(target.folder, basename(sourceUri));
 		await this.fileService.createFolder(target.folder);
 		await this.fileService.writeFile(targetUri, VSBuffer.fromString(session.model.getValue()));
 
-		session.originalContent = session.model.getValue();
-		this.builtinEditingSessions.delete(sourceUri.toString());
-		session.model.dispose();
-		this._editorContentChanged = false;
-		this.updateEditorActionButton();
 		status(target.target === 'workspace'
 			? localize('saveBuiltinPromptCopySuccessWorkspace', "Saved the prompt override to the workspace prompts.")
 			: localize('saveBuiltinPromptCopySuccessUser', "Saved the prompt override to your user prompts."));
-
-		await this.showEmbeddedEditor(
-			targetUri,
-			this.editorItemNameElement.textContent || basename(targetUri),
-			PromptsType.prompt,
-			target.target === 'workspace' ? PromptsStorage.local : PromptsStorage.user,
-			target.target === 'workspace',
-		);
 	}
 
 	private async pickBuiltinPromptSaveTarget(): Promise<ISaveTargetQuickPickItem | undefined> {
@@ -1080,27 +1068,32 @@ export class AICustomizationManagementEditor extends EditorPane {
 			});
 		}
 
-		if (items.length === 0) {
-			this.notificationService.error(localize('saveBuiltinPromptCopyNoTargets', "No prompt locations are available for saving this prompt."));
-			return undefined;
-		}
+		items.push({
+			label: localize('cancelSaveTarget', "Cancel"),
+			target: 'cancel',
+		});
 
 		return this.quickInputService.pick(items, {
 			canPickMany: false,
-			placeHolder: localize('saveBuiltinPromptCopyPlaceholder', "Select where to save the edited prompt"),
+			placeHolder: localize('saveBuiltinPromptCopyPlaceholder', "Select Workspace, User, or Cancel"),
 			matchOnDescription: true,
 		});
 	}
 
 	private async handleEditorActionButton(): Promise<void> {
-		if (this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt) {
-			try {
-				await this.saveBuiltinPromptCopy();
-			} catch (error) {
-				console.error('Failed to save built-in prompt copy:', error);
-				this.notificationService.error(localize('saveBuiltinPromptCopyFailed', "Failed to save the prompt copy."));
+		const shouldPromptToSave = this.currentEditingStorage === BUILTIN_STORAGE &&
+			this.currentEditingPromptType === PromptsType.prompt &&
+			this._editorContentChanged;
+
+		if (shouldPromptToSave) {
+			const selection = await this.pickBuiltinPromptSaveTarget();
+			if (!selection) {
+				return;
 			}
-			return;
+
+			if (selection.target !== 'cancel') {
+				await this.saveBuiltinPromptCopy(selection);
+			}
 		}
 
 		this.goBackToList();
@@ -1111,17 +1104,16 @@ export class AICustomizationManagementEditor extends EditorPane {
 			return;
 		}
 
-		const isBuiltinPrompt = this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt;
-		this.editorActionButtonIcon.className = `codicon codicon-${isBuiltinPrompt ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
-		this.editorActionButton.classList.toggle('editor-save-mode', isBuiltinPrompt);
-		this.editorActionButton.disabled = isBuiltinPrompt && !this._editorContentChanged;
-		this.editorActionButton.setAttribute('aria-label', isBuiltinPrompt
-			? localize('savePromptCopyAriaLabel', "Save prompt copy")
+		const shouldPromptToSave = this.currentEditingStorage === BUILTIN_STORAGE &&
+			this.currentEditingPromptType === PromptsType.prompt &&
+			this._editorContentChanged;
+		this.editorActionButtonIcon.className = `codicon codicon-${Codicon.arrowLeft.id} editor-action-button-icon`;
+		this.editorActionButton.disabled = false;
+		this.editorActionButton.setAttribute('aria-label', shouldPromptToSave
+			? localize('backToListAndSavePromptCopy', "Back to list and choose where to save the prompt override")
 			: localize('backToList', "Back to list"));
-		this.editorActionButton.title = isBuiltinPrompt
-			? this._editorContentChanged
-				? localize('saveBuiltinPromptCopyTooltip', "Save an edited copy as a workspace or user prompt")
-				: localize('saveBuiltinPromptCopyDisabledTooltip', "Edit the prompt to save a workspace or user copy")
+		this.editorActionButton.title = shouldPromptToSave
+			? localize('backToListAndSavePromptCopyTooltip', "Go back and choose Workspace, User, or Cancel")
 			: localize('backToList', "Back to list");
 	}
 
@@ -1135,6 +1127,17 @@ export class AICustomizationManagementEditor extends EditorPane {
 			session.model.dispose();
 		}
 		this.builtinEditingSessions.clear();
+	}
+
+	private disposeBuiltinEditingSession(uri: URI): void {
+		const key = uri.toString();
+		const session = this.builtinEditingSessions.get(key);
+		if (!session) {
+			return;
+		}
+
+		session.model.dispose();
+		this.builtinEditingSessions.delete(key);
 	}
 
 	//#region Embedded MCP Server Detail

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -935,6 +935,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			const saveDelayer = this.editorModelChangeDisposables.add(new Delayer<void>(500));
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
 				this._editorContentChanged = true;
+				this.updateEditorActionButton();
 				this.editorSaveIndicator.className = 'editor-save-indicator visible';
 				this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
 				this.editorSaveIndicator.title = localize('saving', "Saving...");
@@ -954,6 +955,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 					this.editorSaveIndicator.className = 'editor-save-indicator visible saved';
 					this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
 					this.editorSaveIndicator.title = localize('saved', "Saved");
+					this.updateEditorActionButton();
 				}
 			}));
 		} catch (error) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -9,7 +9,6 @@ import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
-import { Delayer } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { Orientation, Sizing, SplitView } from '../../../../../base/browser/ui/splitview/splitview.js';
@@ -930,28 +929,16 @@ export class AICustomizationManagementEditor extends EditorPane {
 			}
 			this.embeddedEditor!.focus();
 
-			this._editorContentChanged = false;
+			this._editorContentChanged = this.workingCopyService.isDirty(uri);
 			this.updateEditorActionButton();
-			const saveDelayer = this.editorModelChangeDisposables.add(new Delayer<void>(500));
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
-				this._editorContentChanged = true;
+				this._editorContentChanged = this.workingCopyService.isDirty(uri);
 				this.updateEditorActionButton();
-				this.editorSaveIndicator.className = 'editor-save-indicator visible';
-				this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
-				this.editorSaveIndicator.title = localize('saving', "Saving...");
-				saveDelayer.trigger(async () => {
-					try {
-						await this.textFileService.save(uri);
-					} catch (error) {
-						console.error('Failed to save AI customization file:', error);
-						this.editorSaveIndicator.className = 'editor-save-indicator visible error';
-						this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.error));
-						this.editorSaveIndicator.title = localize('saveFailed', "Save Failed");
-					}
-				});
+				this.resetEditorSaveIndicator();
 			}));
 			this.editorModelChangeDisposables.add(this.workingCopyService.onDidSave(e => {
 				if (isEqual(e.workingCopy.resource, uri)) {
+					this._editorContentChanged = this.workingCopyService.isDirty(uri);
 					this.editorSaveIndicator.className = 'editor-save-indicator visible saved';
 					this.editorSaveIndicator.classList.add(...ThemeIcon.asClassNameArray(Codicon.check));
 					this.editorSaveIndicator.title = localize('saved', "Saved");

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -40,6 +40,7 @@ import {
 	AI_CUSTOMIZATION_MANAGEMENT_SIDEBAR_WIDTH_KEY,
 	AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY,
 	AICustomizationManagementSection,
+	AICustomizationPromptsStorage,
 	BUILTIN_STORAGE,
 	CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_EDITOR,
 	CONTEXT_AI_CUSTOMIZATION_MANAGEMENT_SECTION,
@@ -103,6 +104,12 @@ interface IBuiltinPromptSaveRequest {
 	readonly target: 'workspace' | 'user';
 	readonly folder: URI;
 	readonly sourceUri: URI;
+	readonly content: string;
+	readonly projectRoot?: URI;
+}
+
+interface IExistingCustomizationSaveRequest {
+	readonly fileUri: URI;
 	readonly content: string;
 	readonly projectRoot?: URI;
 }
@@ -174,6 +181,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private embeddedEditor: CodeEditorWidget | undefined;
 	private editorActionButton!: HTMLButtonElement;
 	private editorActionButtonIcon!: HTMLElement;
+	private editorActionButtonInProgress = false;
 	private editorItemNameElement!: HTMLElement;
 	private editorItemPathElement!: HTMLElement;
 	private editorSaveIndicator!: HTMLElement;
@@ -181,7 +189,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
 	private currentEditingProjectRoot: URI | undefined;
-	private currentEditingStorage: PromptsStorage | undefined;
+	private currentEditingStorage: AICustomizationPromptsStorage | undefined;
 	private currentEditingPromptType: PromptsType | undefined;
 	private currentModelRef: IReference<IResolvedTextEditorModel> | undefined;
 	private viewMode: 'list' | 'editor' | 'mcpDetail' | 'pluginDetail' = 'list';
@@ -876,7 +884,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		));
 	}
 
-	private async showEmbeddedEditor(uri: URI, displayName: string, promptType: PromptsType, storage: PromptsStorage, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
+	private async showEmbeddedEditor(uri: URI, displayName: string, promptType: PromptsType, storage: AICustomizationPromptsStorage, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
 		this.editorModelChangeDisposables.clear();
@@ -956,12 +964,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private goBackToList(): void {
-		// Auto-commit workspace files when leaving the embedded editor (only if modified)
 		const fileUri = this.currentEditingUri;
-		const projectRoot = this.currentEditingProjectRoot;
-		if (fileUri && projectRoot && this._editorContentChanged) {
-			this.workspaceService.commitFiles(projectRoot, [fileUri]);
-		}
+		const backgroundSaveRequest = this.createExistingCustomizationSaveRequest();
 		if (fileUri && this.currentEditingStorage === BUILTIN_STORAGE) {
 			this.disposeBuiltinEditingSession(fileUri);
 		}
@@ -987,6 +991,14 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.layout(this.dimension);
 		}
 		this.listWidget?.focusSearch();
+
+		if (backgroundSaveRequest) {
+			const saveRequest = backgroundSaveRequest;
+			void this.saveExistingCustomization(saveRequest).catch(error => {
+				console.error('Failed to save customization changes on exit:', error);
+				this.notificationService.warn(localize('saveCustomizationOnExitFailed', "Could not save changes to {0}.", basename(saveRequest.fileUri)));
+			});
+		}
 	}
 
 	//#endregion
@@ -1037,12 +1049,36 @@ export class AICustomizationManagementEditor extends EditorPane {
 		};
 	}
 
+	private createExistingCustomizationSaveRequest(): IExistingCustomizationSaveRequest | undefined {
+		if (!this._editorContentChanged || this.currentEditingStorage === BUILTIN_STORAGE || !this.currentEditingUri) {
+			return undefined;
+		}
+
+		const model = this.currentModelRef?.object.textEditorModel;
+		if (!model) {
+			return undefined;
+		}
+
+		return {
+			fileUri: this.currentEditingUri,
+			content: model.getValue(),
+			projectRoot: this.currentEditingProjectRoot,
+		};
+	}
+
 	private async saveBuiltinPromptCopy(request: IBuiltinPromptSaveRequest): Promise<void> {
 		const targetUri = URI.joinPath(request.folder, basename(request.sourceUri));
 		await this.fileService.createFolder(request.folder);
 		await this.fileService.writeFile(targetUri, VSBuffer.fromString(request.content));
 		if (request.target === 'workspace' && request.projectRoot) {
 			await this.workspaceService.commitFiles(request.projectRoot, [targetUri]);
+		}
+	}
+
+	private async saveExistingCustomization(request: IExistingCustomizationSaveRequest): Promise<void> {
+		await this.fileService.writeFile(request.fileUri, VSBuffer.fromString(request.content));
+		if (request.projectRoot) {
+			await this.workspaceService.commitFiles(request.projectRoot, [request.fileUri]);
 		}
 	}
 
@@ -1082,29 +1118,39 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private async handleEditorActionButton(): Promise<void> {
-		let backgroundSaveRequest: IBuiltinPromptSaveRequest | undefined;
-		if (this.shouldShowBuiltinSaveAction()) {
-			const selection = await this.pickBuiltinPromptSaveTarget();
-			if (!selection) {
-				return;
-			}
-
-			if (selection.target !== 'cancel') {
-				backgroundSaveRequest = this.createBuiltinPromptSaveRequest(selection);
-			}
+		if (this.editorActionButtonInProgress) {
+			return;
 		}
 
-		this.goBackToList();
-		if (backgroundSaveRequest) {
-			const saveRequest = backgroundSaveRequest;
-			void this.saveBuiltinPromptCopy(saveRequest).then(() => {
-				void this.listWidget?.refresh();
-			}, error => {
-				console.error('Failed to save built-in prompt override:', error);
-				this.notificationService.warn(saveRequest.target === 'workspace'
-					? localize('saveBuiltinPromptCopyFailedWorkspace', "Could not save the prompt override to the workspace prompts.")
-					: localize('saveBuiltinPromptCopyFailedUser', "Could not save the prompt override to your user prompts."));
-			});
+		this.editorActionButtonInProgress = true;
+		this.updateEditorActionButton();
+
+		let backgroundSaveRequest: IBuiltinPromptSaveRequest | undefined;
+		try {
+			if (this.shouldShowBuiltinSaveAction()) {
+				const selection = await this.pickBuiltinPromptSaveTarget();
+				if (!selection || selection.target === 'cancel') {
+					return;
+				}
+
+				backgroundSaveRequest = this.createBuiltinPromptSaveRequest(selection);
+			}
+
+			this.goBackToList();
+			if (backgroundSaveRequest) {
+				const saveRequest = backgroundSaveRequest;
+				void this.saveBuiltinPromptCopy(saveRequest).then(() => {
+					void this.listWidget?.refresh();
+				}, error => {
+					console.error('Failed to save built-in prompt override:', error);
+					this.notificationService.warn(saveRequest.target === 'workspace'
+						? localize('saveBuiltinPromptCopyFailedWorkspace', "Could not save the prompt override to the workspace prompts.")
+						: localize('saveBuiltinPromptCopyFailedUser', "Could not save the prompt override to your user prompts."));
+				});
+			}
+		} finally {
+			this.editorActionButtonInProgress = false;
+			this.updateEditorActionButton();
 		}
 	}
 
@@ -1115,7 +1161,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 		const shouldShowBuiltinSaveAction = this.shouldShowBuiltinSaveAction();
 		this.editorActionButtonIcon.className = `codicon codicon-${shouldShowBuiltinSaveAction ? Codicon.save.id : Codicon.arrowLeft.id} editor-action-button-icon`;
-		this.editorActionButton.disabled = false;
+		this.editorActionButton.disabled = this.editorActionButtonInProgress;
 		this.editorActionButton.setAttribute('aria-label', shouldShowBuiltinSaveAction
 			? localize('savePromptCopyAndChooseLocation', "Save prompt override")
 			: localize('backToList', "Back to list"));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -5,13 +5,16 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { status } from '../../../../../base/browser/ui/aria/aria.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { DisposableStore, IReference, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { Delayer } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
 import { Orientation, Sizing, SplitView } from '../../../../../base/browser/ui/splitview/splitview.js';
 import { localize } from '../../../../../nls.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
@@ -57,6 +60,9 @@ import { resolveWorkspaceTargetDirectory, resolveUserTargetDirectory } from './c
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { createTextBufferFactoryFromSnapshot } from '../../../../../editor/common/model/textModel.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
 import { IResolvedTextEditorModel, ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
@@ -64,6 +70,9 @@ import { IWorkingCopyService } from '../../../../services/workingCopy/common/wor
 import { ITextFileService } from '../../../../services/textfile/common/textfiles.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { McpServerEditorInput } from '../../../mcp/browser/mcpServerEditorInput.js';
 import { McpServerEditor } from '../../../mcp/browser/mcpServerEditor.js';
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
@@ -86,6 +95,11 @@ interface ISectionItem {
 	readonly id: AICustomizationManagementSection;
 	readonly label: string;
 	readonly icon: ThemeIcon;
+}
+
+interface ISaveTargetQuickPickItem extends IQuickPickItem {
+	readonly target: 'workspace' | 'user';
+	readonly folder: URI;
 }
 
 class SectionItemDelegate implements IListVirtualDelegate<ISectionItem> {
@@ -155,10 +169,14 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private embeddedEditor: CodeEditorWidget | undefined;
 	private editorItemNameElement!: HTMLElement;
 	private editorItemPathElement!: HTMLElement;
+	private editorSaveButton!: HTMLButtonElement;
 	private editorSaveIndicator!: HTMLElement;
 	private readonly editorModelChangeDisposables = this._register(new DisposableStore());
+	private readonly builtinEditingSessions = new Map<string, { model: ITextModel; originalContent: string }>();
 	private currentEditingUri: URI | undefined;
 	private currentEditingProjectRoot: URI | undefined;
+	private currentEditingStorage: PromptsStorage | undefined;
+	private currentEditingPromptType: PromptsType | undefined;
 	private currentModelRef: IReference<IResolvedTextEditorModel> | undefined;
 	private viewMode: 'list' | 'editor' | 'mcpDetail' | 'pluginDetail' = 'list';
 
@@ -204,6 +222,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@ITextFileService private readonly textFileService: ITextFileService,
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IModelService private readonly modelService: IModelService,
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@IFileService private readonly fileService: IFileService,
+		@INotificationService private readonly notificationService: INotificationService,
 	) {
 		super(AICustomizationManagementEditor.ID, group, telemetryService, themeService, storageService);
 
@@ -221,6 +243,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.currentModelRef?.dispose();
 			this.currentModelRef = undefined;
 		}));
+		this._register(toDisposable(() => this.disposeBuiltinEditingSessions()));
 
 		// Build sections from the workspace service configuration
 		const sectionInfo: Record<string, { label: string; icon: ThemeIcon }> = {
@@ -451,7 +474,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.editorDisposables.add(this.listWidget.onDidSelectItem(item => {
 			const isWorkspaceFile = item.storage === PromptsStorage.local;
 			const isReadOnly = item.storage === PromptsStorage.extension || item.storage === PromptsStorage.plugin || item.storage === BUILTIN_STORAGE;
-			this.showEmbeddedEditor(item.uri, item.name, isWorkspaceFile, isReadOnly);
+			this.showEmbeddedEditor(item.uri, item.name, item.promptType, item.storage, isWorkspaceFile, isReadOnly);
 		}));
 
 		// Handle create actions - AI-guided creation
@@ -647,7 +670,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 				// Sessions: show hooks filtered to Copilot CLI (GitHub Copilot) hook types
 				await this.instantiationService.invokeFunction(showConfigureHooksQuickPick, {
 					openEditor: async (resource) => {
-						await this.showEmbeddedEditor(resource, basename(resource), true);
+						await this.showEmbeddedEditor(resource, basename(resource), PromptsType.hook, PromptsStorage.local, true);
 						return;
 					},
 					target: Target.GitHubCopilot,
@@ -656,7 +679,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 				// Core: use the default core behaviour
 				await this.instantiationService.invokeFunction(showConfigureHooksQuickPick, {
 					openEditor: async (resource) => {
-						await this.showEmbeddedEditor(resource, basename(resource), true);
+						await this.showEmbeddedEditor(resource, basename(resource), PromptsType.hook, PromptsStorage.local, true);
 						return;
 					}
 				});
@@ -673,7 +696,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 			targetStorage: target === 'user' ? PromptsStorage.user : PromptsStorage.local,
 			openFile: async (uri) => {
 				const isWorkspace = target === 'workspace';
-				await this.showEmbeddedEditor(uri, basename(uri), isWorkspace);
+				await this.showEmbeddedEditor(uri, basename(uri), type, target === 'user' ? PromptsStorage.user : PromptsStorage.local, isWorkspace);
 				return this.embeddedEditor;
 			},
 		};
@@ -725,6 +748,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 		// Clear transient folder override on close
 		this.workspaceService.clearOverrideProjectRoot();
+		this.disposeBuiltinEditingSessions();
 		super.clearInput();
 	}
 
@@ -817,6 +841,17 @@ export class AICustomizationManagementEditor extends EditorPane {
 		const itemInfo = DOM.append(editorHeader, $('.editor-item-info'));
 		this.editorItemNameElement = DOM.append(itemInfo, $('.editor-item-name'));
 		this.editorItemPathElement = DOM.append(itemInfo, $('.editor-item-path'));
+
+		this.editorSaveButton = DOM.append(editorHeader, $('button.editor-save-button'));
+		this.editorSaveButton.textContent = localize('savePromptCopy', "Save");
+		this.editorSaveButton.setAttribute('aria-label', localize('savePromptCopyAriaLabel', "Save prompt copy"));
+		this.editorDisposables.add(DOM.addDisposableListener(this.editorSaveButton, 'click', () => {
+			void this.saveBuiltinPromptCopy().catch(error => {
+				console.error('Failed to save built-in prompt copy:', error);
+				this.notificationService.error(localize('saveBuiltinPromptCopyFailed', "Failed to save the prompt copy."));
+			});
+		}));
+
 		this.editorSaveIndicator = DOM.append(editorHeader, $('.editor-save-indicator'));
 
 		const embeddedEditorContainer = DOM.append(this.editorContentContainer, $('.embedded-editor-container'));
@@ -843,18 +878,48 @@ export class AICustomizationManagementEditor extends EditorPane {
 		));
 	}
 
-	private async showEmbeddedEditor(uri: URI, displayName: string, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
+	private async showEmbeddedEditor(uri: URI, displayName: string, promptType: PromptsType, storage: PromptsStorage, isWorkspaceFile = false, isReadOnly = false): Promise<void> {
 		this.currentModelRef?.dispose();
 		this.currentModelRef = undefined;
+		this.editorModelChangeDisposables.clear();
 		this.currentEditingUri = uri;
 		this.currentEditingProjectRoot = isWorkspaceFile ? this.workspaceService.getActiveProjectRoot() : undefined;
+		this.currentEditingStorage = storage;
+		this.currentEditingPromptType = promptType;
 		this.viewMode = 'editor';
 
 		this.editorItemNameElement.textContent = displayName;
 		this.editorItemPathElement.textContent = basename(uri);
+		this._editorContentChanged = false;
+		this.resetEditorSaveIndicator();
+		this.updateBuiltinSaveButton();
 		this.updateContentVisibility();
 
 		try {
+			if (storage === BUILTIN_STORAGE && promptType === PromptsType.prompt) {
+				const session = await this.getOrCreateBuiltinEditingSession(uri);
+
+				if (!isEqual(this.currentEditingUri, uri)) {
+					return;
+				}
+
+				this.embeddedEditor!.setModel(session.model);
+				this.embeddedEditor!.updateOptions({ readOnly: false });
+				this._editorContentChanged = session.model.getValue() !== session.originalContent;
+				this.updateBuiltinSaveButton();
+
+				if (this.dimension) {
+					this.layout(this.dimension);
+				}
+				this.embeddedEditor!.focus();
+
+				this.editorModelChangeDisposables.add(session.model.onDidChangeContent(() => {
+					this._editorContentChanged = session.model.getValue() !== session.originalContent;
+					this.updateBuiltinSaveButton();
+				}));
+				return;
+			}
+
 			const ref = await this.textModelService.createModelReference(uri);
 
 			if (!isEqual(this.currentEditingUri, uri)) {
@@ -871,8 +936,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 			}
 			this.embeddedEditor!.focus();
 
-			this.editorModelChangeDisposables.clear();
 			this._editorContentChanged = false;
+			this.updateBuiltinSaveButton();
 			const saveDelayer = this.editorModelChangeDisposables.add(new Delayer<void>(500));
 			this.editorModelChangeDisposables.add(ref.object.textEditorModel.onDidChangeContent(() => {
 				this._editorContentChanged = true;
@@ -917,9 +982,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.currentModelRef = undefined;
 		this.currentEditingUri = undefined;
 		this.currentEditingProjectRoot = undefined;
+		this.currentEditingStorage = undefined;
+		this.currentEditingPromptType = undefined;
 		this.editorModelChangeDisposables.clear();
-		this.editorSaveIndicator.className = 'editor-save-indicator';
-		this.editorSaveIndicator.title = '';
+		this.resetEditorSaveIndicator();
+		this.updateBuiltinSaveButton();
 		this.embeddedEditor?.setModel(null);
 		this.viewMode = 'list';
 		this.updateContentVisibility();
@@ -934,6 +1001,132 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	//#endregion
+
+	private async getOrCreateBuiltinEditingSession(uri: URI): Promise<{ model: ITextModel; originalContent: string }> {
+		const key = uri.toString();
+		const existing = this.builtinEditingSessions.get(key);
+		if (existing && !existing.model.isDisposed()) {
+			return existing;
+		}
+
+		const ref = await this.textModelService.createModelReference(uri);
+		try {
+			const session = {
+				model: this.modelService.createModel(
+					createTextBufferFactoryFromSnapshot(ref.object.textEditorModel.createSnapshot()),
+					{ languageId: ref.object.textEditorModel.getLanguageId(), onDidChange: Event.None },
+					URI.from({ scheme: 'ai-customization-builtin', path: uri.path, query: generateUuid() }),
+					false
+				),
+				originalContent: ref.object.textEditorModel.getValue(),
+			};
+			this.builtinEditingSessions.set(key, session);
+			return session;
+		} finally {
+			ref.dispose();
+		}
+	}
+
+	private async saveBuiltinPromptCopy(): Promise<void> {
+		const sourceUri = this.currentEditingUri;
+		const promptType = this.currentEditingPromptType;
+		if (!sourceUri || this.currentEditingStorage !== BUILTIN_STORAGE || promptType !== PromptsType.prompt) {
+			return;
+		}
+
+		const session = this.builtinEditingSessions.get(sourceUri.toString());
+		if (!session || !this._editorContentChanged) {
+			return;
+		}
+
+		const target = await this.pickBuiltinPromptSaveTarget();
+		if (!target) {
+			return;
+		}
+
+		const targetUri = URI.joinPath(target.folder, basename(sourceUri));
+		await this.fileService.createFolder(target.folder);
+		await this.fileService.writeFile(targetUri, VSBuffer.fromString(session.model.getValue()));
+
+		session.originalContent = session.model.getValue();
+		this.builtinEditingSessions.delete(sourceUri.toString());
+		session.model.dispose();
+		this._editorContentChanged = false;
+		this.updateBuiltinSaveButton();
+		status(target.target === 'workspace'
+			? localize('saveBuiltinPromptCopySuccessWorkspace', "Saved the prompt override to the workspace prompts.")
+			: localize('saveBuiltinPromptCopySuccessUser', "Saved the prompt override to your user prompts."));
+
+		await this.showEmbeddedEditor(
+			targetUri,
+			this.editorItemNameElement.textContent || basename(targetUri),
+			PromptsType.prompt,
+			target.target === 'workspace' ? PromptsStorage.local : PromptsStorage.user,
+			target.target === 'workspace',
+		);
+	}
+
+	private async pickBuiltinPromptSaveTarget(): Promise<ISaveTargetQuickPickItem | undefined> {
+		const items: ISaveTargetQuickPickItem[] = [];
+
+		const workspaceFolder = resolveWorkspaceTargetDirectory(this.workspaceService, PromptsType.prompt);
+		if (workspaceFolder) {
+			items.push({
+				label: localize('workspaceSaveTarget', "Workspace"),
+				description: workspaceFolder.fsPath,
+				target: 'workspace',
+				folder: workspaceFolder,
+			});
+		}
+
+		const userFolder = await resolveUserTargetDirectory(this.promptsService, PromptsType.prompt);
+		if (userFolder) {
+			items.push({
+				label: localize('userSaveTarget', "User"),
+				description: userFolder.fsPath,
+				target: 'user',
+				folder: userFolder,
+			});
+		}
+
+		if (items.length === 0) {
+			this.notificationService.error(localize('saveBuiltinPromptCopyNoTargets', "No prompt locations are available for saving this prompt."));
+			return undefined;
+		}
+
+		return this.quickInputService.pick(items, {
+			canPickMany: false,
+			placeHolder: localize('saveBuiltinPromptCopyPlaceholder', "Select where to save the edited prompt"),
+			matchOnDescription: true,
+		});
+	}
+
+	private updateBuiltinSaveButton(): void {
+		if (!this.editorSaveButton) {
+			return;
+		}
+
+		const isBuiltinPrompt = this.currentEditingStorage === BUILTIN_STORAGE && this.currentEditingPromptType === PromptsType.prompt;
+		this.editorSaveButton.style.display = isBuiltinPrompt ? '' : 'none';
+		this.editorSaveButton.disabled = !this._editorContentChanged;
+		this.editorSaveButton.title = isBuiltinPrompt
+			? this._editorContentChanged
+				? localize('saveBuiltinPromptCopyTooltip', "Save an edited copy as a workspace or user prompt")
+				: localize('saveBuiltinPromptCopyDisabledTooltip', "Edit the prompt to save a workspace or user copy")
+			: '';
+	}
+
+	private resetEditorSaveIndicator(): void {
+		this.editorSaveIndicator.className = 'editor-save-indicator';
+		this.editorSaveIndicator.title = '';
+	}
+
+	private disposeBuiltinEditingSessions(): void {
+		for (const session of this.builtinEditingSessions.values()) {
+			session.model.dispose();
+		}
+		this.builtinEditingSessions.clear();
+	}
 
 	//#region Embedded MCP Server Detail
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -933,6 +933,28 @@
 	font-family: var(--monaco-monospace-font);
 }
 
+.ai-customization-management-editor .editor-save-button {
+	display: none;
+	flex-shrink: 0;
+	padding: 4px 10px;
+	border: 1px solid var(--vscode-button-border, transparent);
+	border-radius: 4px;
+	background: var(--vscode-button-secondaryBackground);
+	color: var(--vscode-button-secondaryForeground);
+	cursor: pointer;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.ai-customization-management-editor .editor-save-button:hover:not(:disabled) {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.ai-customization-management-editor .editor-save-button:disabled {
+	cursor: default;
+	opacity: 0.6;
+}
+
 .ai-customization-management-editor .editor-save-indicator {
 	flex-shrink: 0;
 	width: 16px;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -898,13 +898,23 @@
 	transition: background-color 0.1s ease, opacity 0.1s ease;
 }
 
-.ai-customization-management-editor .editor-back-button:hover {
+.ai-customization-management-editor .editor-back-button:hover:not(:disabled) {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	opacity: 1;
 }
 
-.ai-customization-management-editor .editor-back-button:active {
+.ai-customization-management-editor .editor-back-button:active:not(:disabled) {
 	background-color: var(--vscode-toolbar-activeBackground);
+}
+
+.ai-customization-management-editor .editor-back-button:disabled {
+	cursor: default;
+	opacity: 0.45;
+}
+
+.ai-customization-management-editor .editor-action-button-icon {
+	font-size: 14px;
+	line-height: 14px;
 }
 
 .ai-customization-management-editor .editor-item-info {
@@ -931,35 +941,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-family: var(--monaco-monospace-font);
-}
-
-.ai-customization-management-editor .editor-save-button {
-	display: none;
-	align-items: center;
-	gap: 6px;
-	flex-shrink: 0;
-	padding: 4px 10px;
-	border: 1px solid var(--vscode-button-border, transparent);
-	border-radius: 4px;
-	background: var(--vscode-button-secondaryBackground);
-	color: var(--vscode-button-secondaryForeground);
-	cursor: pointer;
-	font-size: 12px;
-	line-height: 18px;
-}
-
-.ai-customization-management-editor .editor-save-button-icon {
-	font-size: 14px;
-	line-height: 14px;
-}
-
-.ai-customization-management-editor .editor-save-button:hover:not(:disabled) {
-	background: var(--vscode-button-secondaryHoverBackground);
-}
-
-.ai-customization-management-editor .editor-save-button:disabled {
-	cursor: default;
-	opacity: 0.6;
 }
 
 .ai-customization-management-editor .editor-save-indicator {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -935,6 +935,8 @@
 
 .ai-customization-management-editor .editor-save-button {
 	display: none;
+	align-items: center;
+	gap: 6px;
 	flex-shrink: 0;
 	padding: 4px 10px;
 	border: 1px solid var(--vscode-button-border, transparent);
@@ -944,6 +946,11 @@
 	cursor: pointer;
 	font-size: 12px;
 	line-height: 18px;
+}
+
+.ai-customization-management-editor .editor-save-button-icon {
+	font-size: 14px;
+	line-height: 14px;
 }
 
 .ai-customization-management-editor .editor-save-button:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- make built-in prompts editable in AI Customization without modifying the bundled prompt files directly
- replace the old static override hint with a built-in-only save flow that offers Workspace or User destinations
- keep the exit flow snappy by saving built-in prompt overrides in the background and only warning on failure

## Testing
- npm run compile-check-ts-native
- node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts