### PR TITLE
Add onDidReceiveChatDebugEvent API to send chat customization events

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../base/common/lifecycle.js';
 import { URI } from '../../../base/common/uri.js';
 import { VSBuffer } from '../../../base/common/buffer.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugService } from '../../contrib/chat/common/chatDebugService.js';
@@ -17,6 +17,7 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 	private readonly _proxy: Proxied<ExtHostChatDebugShape>;
 	private readonly _providerDisposables = new Map<number, DisposableStore>();
 	private readonly _activeSessionResources = new Map<number, URI>();
+	private readonly _coreEventForwarder = this._register(new MutableDisposable());
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -25,13 +26,18 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatDebug);
+	}
 
-		// Forward core-originated events to the extension host in real-time
-		this._register(this._chatDebugService.onDidAddEvent(event => {
+	$subscribeToCoreDebugEvents(): void {
+		this._coreEventForwarder.value = this._chatDebugService.onDidAddEvent(event => {
 			if (this._chatDebugService.isCoreEvent(event)) {
 				this._proxy.$onCoreDebugEvent(this._serializeEvent(event));
 			}
-		}));
+		});
+	}
+
+	$unsubscribeFromCoreDebugEvents(): void {
+		this._coreEventForwarder.clear();
 	}
 
 	$registerChatDebugLogProvider(handle: number): void {

--- a/src/vs/workbench/api/browser/mainThreadChatDebug.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatDebug.ts
@@ -25,6 +25,13 @@ export class MainThreadChatDebug extends Disposable implements MainThreadChatDeb
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatDebug);
+
+		// Forward core-originated events to the extension host in real-time
+		this._register(this._chatDebugService.onDidAddEvent(event => {
+			if (this._chatDebugService.isCoreEvent(event)) {
+				this._proxy.$onCoreDebugEvent(this._serializeEvent(event));
+			}
+		}));
 	}
 
 	$registerChatDebugLogProvider(handle: number): void {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1679,6 +1679,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'chatDebug');
 				return extHostChatDebug.registerChatDebugLogProvider(provider);
 			},
+			onDidReceiveChatDebugEvent: (listener, thisArgs?, disposables?) => {
+				checkProposedApiEnabled(extension, 'chatDebug');
+				return extHostChatDebug.onDidAddCoreEvent(listener, thisArgs, disposables);
+			},
 			get customAgents() {
 				checkProposedApiEnabled(extension, 'chatPromptFiles');
 				return extHostChatAgents2.customAgents as readonly vscode.ChatResource[];

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1511,6 +1511,8 @@ export interface MainThreadChatDebugShape extends IDisposable {
 	$registerChatDebugLogProvider(handle: number): void;
 	$unregisterChatDebugLogProvider(handle: number): void;
 	$acceptChatDebugEvent(handle: number, event: IChatDebugEventDto): void;
+	$subscribeToCoreDebugEvents(): void;
+	$unsubscribeFromCoreDebugEvents(): void;
 }
 
 export interface MainThreadEmbeddingsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1504,6 +1504,7 @@ export interface ExtHostChatDebugShape {
 	$resolveChatDebugLogEvent(handle: number, eventId: string, token: CancellationToken): Promise<IChatDebugResolvedEventContentDto | undefined>;
 	$exportChatDebugLog(handle: number, sessionResource: UriComponents, coreEvents: IChatDebugEventDto[], sessionTitle: string | undefined, token: CancellationToken): Promise<VSBuffer | undefined>;
 	$importChatDebugLog(handle: number, data: VSBuffer, token: CancellationToken): Promise<{ uri: UriComponents; sessionTitle?: string } | undefined>;
+	$onCoreDebugEvent(event: IChatDebugEventDto): void;
 }
 
 export interface MainThreadChatDebugShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -22,7 +22,10 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 	/** Progress pipelines keyed by `${handle}:${sessionResource}` so multiple sessions can stream concurrently. */
 	private readonly _activeProgress = new Map<string, DisposableStore>();
 
-	private readonly _onDidAddCoreEvent = this._register(new Emitter<vscode.ChatDebugEvent>());
+	private readonly _onDidAddCoreEvent = this._register(new Emitter<vscode.ChatDebugEvent>({
+		onWillAddFirstListener: () => this._proxy.$subscribeToCoreDebugEvents(),
+		onDidRemoveLastListener: () => this._proxy.$unsubscribeFromCoreDebugEvents(),
+	}));
 	readonly onDidAddCoreEvent = this._onDidAddCoreEvent.event;
 
 	constructor(

--- a/src/vs/workbench/api/common/extHostChatDebug.ts
+++ b/src/vs/workbench/api/common/extHostChatDebug.ts
@@ -22,6 +22,9 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 	/** Progress pipelines keyed by `${handle}:${sessionResource}` so multiple sessions can stream concurrently. */
 	private readonly _activeProgress = new Map<string, DisposableStore>();
 
+	private readonly _onDidAddCoreEvent = this._register(new Emitter<vscode.ChatDebugEvent>());
+	readonly onDidAddCoreEvent = this._onDidAddCoreEvent.event;
+
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
 	) {
@@ -364,6 +367,13 @@ export class ExtHostChatDebug extends Disposable implements ExtHostChatDebugShap
 			}
 			default:
 				return undefined;
+		}
+	}
+
+	$onCoreDebugEvent(dto: IChatDebugEventDto): void {
+		const event = this._deserializeEvent(dto);
+		if (event) {
+			this._onDidAddCoreEvent.fire(event);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
@@ -60,11 +60,12 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 				const loaded = info.files.filter(f => f.status === 'loaded').map(f => f.name ?? f.uri.path.split('/').pop() ?? f.uri.toString());
 				const skipped = info.files.filter(f => f.status === 'skipped').map(f => f.name ?? f.uri.path.split('/').pop() ?? f.uri.toString());
 				const folders = info.sourceFolders?.map(sf => sf.uri.path) ?? [];
-				const parts = [details];
-				if (loaded.length > 0) { parts.push(`loaded: [${loaded.join(', ')}]`); }
-				if (skipped.length > 0) { parts.push(`skipped: [${skipped.join(', ')}]`); }
-				if (folders.length > 0) { parts.push(`folders: [${folders.join(', ')}]`); }
-				details = parts.join(' | ');
+				const parts: string[] = [];
+				if (details) { parts.push(details); }
+				if (loaded.length > 0) { parts.push(`loaded: [${truncateList(loaded)}]`); }
+				if (skipped.length > 0) { parts.push(`skipped: [${truncateList(skipped)}]`); }
+				if (folders.length > 0) { parts.push(`folders: [${truncateList(folders)}]`); }
+				details = parts.join(' | ') || undefined;
 			}
 
 			chatDebugService.log(
@@ -111,4 +112,17 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 			})),
 		};
 	}
+}
+
+const MAX_LIST_ITEMS = 20;
+
+/**
+ * Join a list of strings, truncating after {@link MAX_LIST_ITEMS} entries.
+ * Full details are available via {@link IChatDebugService.resolveEvent}.
+ */
+function truncateList(items: string[]): string {
+	if (items.length <= MAX_LIST_ITEMS) {
+		return items.join(', ');
+	}
+	return items.slice(0, MAX_LIST_ITEMS).join(', ') + ` (+${items.length - MAX_LIST_ITEMS} more)`;
 }

--- a/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
@@ -51,10 +51,26 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 				}
 			}
 
+			// Enrich details with file paths so they appear in the event
+			// payload (e.g. forwarded via onDidReceiveChatDebugEvent to the
+			// extension's JSONL file logger).
+			let details = entry.details;
+			if (entry.discoveryInfo) {
+				const info = entry.discoveryInfo;
+				const loaded = info.files.filter(f => f.status === 'loaded').map(f => f.name ?? f.uri.path.split('/').pop() ?? f.uri.toString());
+				const skipped = info.files.filter(f => f.status === 'skipped').map(f => f.name ?? f.uri.path.split('/').pop() ?? f.uri.toString());
+				const folders = info.sourceFolders?.map(sf => sf.uri.path) ?? [];
+				const parts = [details];
+				if (loaded.length > 0) { parts.push(`loaded: [${loaded.join(', ')}]`); }
+				if (skipped.length > 0) { parts.push(`skipped: [${skipped.join(', ')}]`); }
+				if (folders.length > 0) { parts.push(`folders: [${folders.join(', ')}]`); }
+				details = parts.join(' | ');
+			}
+
 			chatDebugService.log(
 				entry.sessionResource,
 				entry.name,
-				entry.details,
+				details,
 				undefined,
 				{ id: eventId, category: entry.category },
 			);

--- a/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
@@ -114,7 +114,7 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 	}
 }
 
-const MAX_LIST_ITEMS = 20;
+const MAX_LIST_ITEMS = 100;
 
 /**
  * Join a list of strings, truncating after {@link MAX_LIST_ITEMS} entries.

--- a/src/vscode-dts/vscode.proposed.chatDebug.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatDebug.d.ts
@@ -684,6 +684,13 @@ declare module 'vscode' {
 		 * @returns A disposable that unregisters the provider.
 		 */
 		export function registerChatDebugLogProvider(provider: ChatDebugLogProvider): Disposable;
+
+		/**
+		 * Fired when a core-originated debug event is received (e.g., prompt discovery,
+		 * skill loading). Extensions can use this to capture events that originate
+		 * inside Code rather than from the extension's own telemetry pipeline.
+		 */
+		export const onDidReceiveChatDebugEvent: Event<ChatDebugEvent>;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.chatDebug.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatDebug.d.ts
@@ -688,7 +688,7 @@ declare module 'vscode' {
 		/**
 		 * Fired when a core-originated debug event is received (e.g., prompt discovery,
 		 * skill loading). Extensions can use this to capture events that originate
-		 * inside Code rather than from the extension's own telemetry pipeline.
+		 * inside Core.
 		 */
 		export const onDidReceiveChatDebugEvent: Event<ChatDebugEvent>;
 	}


### PR DESCRIPTION
Add a new proposed API event onDidReceiveChatDebugEvent on vscode.chat that fires when VS Code core logs a debug event (e.g., prompt discovery, skill/instruction loading). This enables extensions to capture core-originated events in real-time.
