### PR TITLE
Add `min-release-age` in npmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,3 +6,4 @@ ignore-scripts=false
 build_from_source="true"
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/build/.npmrc
+++ b/build/.npmrc
@@ -4,3 +4,4 @@ build_from_source="true"
 legacy-peer-deps="true"
 force_process_config="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/.npmrc
+++ b/extensions/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/configuration-editing/.npmrc
+++ b/extensions/configuration-editing/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/css-language-features/.npmrc
+++ b/extensions/css-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/css-language-features/server/.npmrc
+++ b/extensions/css-language-features/server/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/debug-auto-launch/.npmrc
+++ b/extensions/debug-auto-launch/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/debug-server-ready/.npmrc
+++ b/extensions/debug-server-ready/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/emmet/.npmrc
+++ b/extensions/emmet/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/extension-editing/.npmrc
+++ b/extensions/extension-editing/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/git-base/.npmrc
+++ b/extensions/git-base/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/git/.npmrc
+++ b/extensions/git/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/github-authentication/.npmrc
+++ b/extensions/github-authentication/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/github/.npmrc
+++ b/extensions/github/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/grunt/.npmrc
+++ b/extensions/grunt/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/gulp/.npmrc
+++ b/extensions/gulp/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/html-language-features/.npmrc
+++ b/extensions/html-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/html-language-features/server/.npmrc
+++ b/extensions/html-language-features/server/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/ipynb/.npmrc
+++ b/extensions/ipynb/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/jake/.npmrc
+++ b/extensions/jake/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/json-language-features/.npmrc
+++ b/extensions/json-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/json-language-features/server/.npmrc
+++ b/extensions/json-language-features/server/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/markdown-language-features/.npmrc
+++ b/extensions/markdown-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/markdown-math/.npmrc
+++ b/extensions/markdown-math/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/media-preview/.npmrc
+++ b/extensions/media-preview/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/merge-conflict/.npmrc
+++ b/extensions/merge-conflict/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/mermaid-chat-features/.npmrc
+++ b/extensions/mermaid-chat-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/microsoft-authentication/.npmrc
+++ b/extensions/microsoft-authentication/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/notebook-renderers/.npmrc
+++ b/extensions/notebook-renderers/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/npm/.npmrc
+++ b/extensions/npm/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/php-language-features/.npmrc
+++ b/extensions/php-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/references-view/.npmrc
+++ b/extensions/references-view/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/simple-browser/.npmrc
+++ b/extensions/simple-browser/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/terminal-suggest/.npmrc
+++ b/extensions/terminal-suggest/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/tunnel-forwarding/.npmrc
+++ b/extensions/tunnel-forwarding/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/typescript-language-features/.npmrc
+++ b/extensions/typescript-language-features/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/vscode-api-tests/.npmrc
+++ b/extensions/vscode-api-tests/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/vscode-colorize-perf-tests/.npmrc
+++ b/extensions/vscode-colorize-perf-tests/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/vscode-colorize-tests/.npmrc
+++ b/extensions/vscode-colorize-tests/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/extensions/vscode-test-resolver/.npmrc
+++ b/extensions/vscode-test-resolver/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/remote/.npmrc
+++ b/remote/.npmrc
@@ -5,3 +5,4 @@ runtime="node"
 build_from_source="true"
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/remote/web/.npmrc
+++ b/remote/web/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"

--- a/test/monaco/.npmrc
+++ b/test/monaco/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps="true"
 timeout=180000
+min-release-age="1"


### PR DESCRIPTION
For #299632

Not fully enabled unless you're using a recent npm. Next step will be to bump the min node/npm versions for the workspace too
