### PR TITLE
Add showUnavailableFeatured and showFeatured options to model picker delegate

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -699,7 +699,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			getModels: () => this._getAvailableModels(),
 			useGroupedModelPicker: () => true,
 			showManageModelsAction: () => false,
-			showUnavailableFeatured: () => true,
+			showUnavailableFeatured: () => false,
 			showFeatured: () => true,
 		};
 

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -699,6 +699,8 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			getModels: () => this._getAvailableModels(),
 			useGroupedModelPicker: () => true,
 			showManageModelsAction: () => false,
+			showRecentlyUsed: () => true,
+			showFeatured: () => true,
 		};
 
 		const pickerOptions: IChatInputPickerOptions = {

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -699,7 +699,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			getModels: () => this._getAvailableModels(),
 			useGroupedModelPicker: () => true,
 			showManageModelsAction: () => false,
-			showRecentlyUsed: () => true,
+			showUnavailableFeatured: () => true,
 			showFeatured: () => true,
 		};
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2230,11 +2230,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
 						},
-						showRecentlyUsed: () => true,
-						showFeatured: () => {
+						showUnavailableFeatured: () => {
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
 						},
+						showFeatured: () => true,
 					};
 					return this.modelWidget = this.instantiationService.createInstance(EnhancedModelPickerActionItem, action, itemDelegate, pickerOptions);
 				} else if (action.id === OpenModePickerAction.ID && action instanceof MenuItemAction) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2230,10 +2230,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
 						},
-						showRecentlyUsed: () => {
-							const sessionType = this.getCurrentSessionType();
-							return !sessionType || sessionType === localChatSessionType;
-						},
+						showRecentlyUsed: () => true,
 						showFeatured: () => {
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2230,8 +2230,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
 						},
-						showRecentlyUsed: () => true,
-						showFeatured: () => true,
+						showRecentlyUsed: () => {
+							const sessionType = this.getCurrentSessionType();
+							return !sessionType || sessionType === localChatSessionType;
+						},
+						showFeatured: () => {
+							const sessionType = this.getCurrentSessionType();
+							return !sessionType || sessionType === localChatSessionType;
+						},
 					};
 					return this.modelWidget = this.instantiationService.createInstance(EnhancedModelPickerActionItem, action, itemDelegate, pickerOptions);
 				} else if (action.id === OpenModePickerAction.ID && action instanceof MenuItemAction) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -2229,7 +2229,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						showManageModelsAction: () => {
 							const sessionType = this.getCurrentSessionType();
 							return !sessionType || sessionType === localChatSessionType;
-						}
+						},
+						showRecentlyUsed: () => true,
+						showFeatured: () => true,
 					};
 					return this.modelWidget = this.instantiationService.createInstance(EnhancedModelPickerActionItem, action, itemDelegate, pickerOptions);
 				} else if (action.id === OpenModePickerAction.ID && action instanceof MenuItemAction) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -264,12 +264,13 @@ export function buildModelPickerItems(
 					}
 					const model = resolveModel(entryId);
 					if (model && !placed.has(model.identifier)) {
-						markPlaced(model.identifier, model.metadata.id);
 						if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
 							if (showUnavailableFeatured) {
+								markPlaced(model.identifier, model.metadata.id);
 								promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
 							}
 						} else {
+							markPlaced(model.identifier, model.metadata.id);
 							promotedItems.push({ kind: 'available', model });
 						}
 					} else if (!model && !entry.exists) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -155,7 +155,7 @@ export function buildModelPickerItems(
 	useGroupedModelPicker: boolean,
 	manageModelsAction: IActionWidgetDropdownAction | undefined,
 	chatEntitlementService: IChatEntitlementService,
-	showRecentlyUsed: boolean,
+	showUnavailableFeatured: boolean,
 	showFeatured: boolean,
 	hoverPosition?: IHoverPositionOptions,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
@@ -252,10 +252,8 @@ export function buildModelPickerItems(
 			}
 
 			// Recently used models
-			if (showRecentlyUsed) {
-				for (const id of recentModelIds) {
-					tryPlaceModel(id);
-				}
+			for (const id of recentModelIds) {
+				tryPlaceModel(id);
 			}
 
 			// Featured models from control manifest
@@ -268,13 +266,17 @@ export function buildModelPickerItems(
 					if (model && !placed.has(model.identifier)) {
 						markPlaced(model.identifier, model.metadata.id);
 						if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-							promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
+							if (showUnavailableFeatured) {
+								promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
+							}
 						} else {
 							promotedItems.push({ kind: 'available', model });
 						}
 					} else if (!model && !entry.exists) {
-						markPlaced(entryId);
-						promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
+						if (showUnavailableFeatured) {
+							markPlaced(entryId);
+							promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
+						}
 					}
 				}
 			}
@@ -596,7 +598,7 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.useGroupedModelPicker(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
-			this._delegate.showRecentlyUsed(),
+			this._delegate.showUnavailableFeatured(),
 			this._delegate.showFeatured(),
 			this._hoverPosition,
 		);

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -155,6 +155,8 @@ export function buildModelPickerItems(
 	useGroupedModelPicker: boolean,
 	manageModelsAction: IActionWidgetDropdownAction | undefined,
 	chatEntitlementService: IChatEntitlementService,
+	showRecentlyUsed: boolean,
+	showFeatured: boolean,
 	hoverPosition?: IHoverPositionOptions,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
@@ -250,26 +252,30 @@ export function buildModelPickerItems(
 			}
 
 			// Recently used models
-			for (const id of recentModelIds) {
-				tryPlaceModel(id);
+			if (showRecentlyUsed) {
+				for (const id of recentModelIds) {
+					tryPlaceModel(id);
+				}
 			}
 
 			// Featured models from control manifest
-			for (const [entryId, entry] of Object.entries(controlModels)) {
-				if (!entry.featured || placed.has(entryId)) {
-					continue;
-				}
-				const model = resolveModel(entryId);
-				if (model && !placed.has(model.identifier)) {
-					markPlaced(model.identifier, model.metadata.id);
-					if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-						promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
-					} else {
-						promotedItems.push({ kind: 'available', model });
+			if (showFeatured) {
+				for (const [entryId, entry] of Object.entries(controlModels)) {
+					if (!entry.featured || placed.has(entryId)) {
+						continue;
 					}
-				} else if (!model && !entry.exists) {
-					markPlaced(entryId);
-					promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
+					const model = resolveModel(entryId);
+					if (model && !placed.has(model.identifier)) {
+						markPlaced(model.identifier, model.metadata.id);
+						if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
+							promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
+						} else {
+							promotedItems.push({ kind: 'available', model });
+						}
+					} else if (!model && !entry.exists) {
+						markPlaced(entryId);
+						promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
+					}
 				}
 			}
 
@@ -590,6 +596,8 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.useGroupedModelPicker(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
+			this._delegate.showRecentlyUsed(),
+			this._delegate.showFeatured(),
 			this._hoverPosition,
 		);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -31,6 +31,8 @@ export interface IModelPickerDelegate {
 	getModels(): ILanguageModelChatMetadataAndIdentifier[];
 	useGroupedModelPicker(): boolean;
 	showManageModelsAction(): boolean;
+	showRecentlyUsed(): boolean;
+	showFeatured(): boolean;
 }
 
 type ChatModelChangeClassification = {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -31,7 +31,7 @@ export interface IModelPickerDelegate {
 	getModels(): ILanguageModelChatMetadataAndIdentifier[];
 	useGroupedModelPicker(): boolean;
 	showManageModelsAction(): boolean;
-	showRecentlyUsed(): boolean;
+	showUnavailableFeatured(): boolean;
 	showFeatured(): boolean;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -80,7 +80,7 @@ function callBuild(
 		updateStateType?: StateType;
 		manageSettingsUrl?: string;
 		anonymous?: boolean;
-		showRecentlyUsed?: boolean;
+		showUnavailableFeatured?: boolean;
 		showFeatured?: boolean;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
@@ -101,7 +101,7 @@ function callBuild(
 		true,
 		stubManageModelsAction,
 		entitlementService,
-		opts.showRecentlyUsed ?? true,
+		opts.showUnavailableFeatured ?? true,
 		opts.showFeatured ?? true,
 	);
 }

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -655,4 +655,68 @@ suite('buildModelPickerItems', () => {
 		gptItem.item.run();
 		assert.strictEqual(selectedModel?.identifier, modelA.identifier);
 	});
+
+	test('showFeatured=false omits featured models from promoted section', () => {
+		const auto = createAutoModel();
+		const modelA = createModel('gpt-4o', 'GPT-4o');
+		const modelB = createModel('claude', 'Claude');
+		const items = callBuild([auto, modelA, modelB], {
+			controlModels: {
+				'gpt-4o': { label: 'GPT-4o', featured: true, exists: true },
+			},
+			showFeatured: false,
+		});
+		const actions = getActionItems(items);
+		// Auto first, then Other Models toggle, then models in other section
+		assert.strictEqual(actions[0].label, 'Auto');
+		// GPT-4o should NOT be promoted — it should be in Other Models
+		const promotedLabels = actions.filter(a => !a.isSectionToggle && a.section !== 'other' && a.item?.id !== 'manageModels').map(a => a.label);
+		assert.ok(!promotedLabels.includes('GPT-4o'), 'GPT-4o should not be in promoted section when showFeatured=false');
+	});
+
+	test('showUnavailableFeatured=false omits unavailable featured models from promoted section', () => {
+		const auto = createAutoModel();
+		const items = callBuild([auto], {
+			controlModels: {
+				'premium-model': { label: 'Premium Model', featured: true, exists: false },
+			},
+			entitlement: ChatEntitlement.Free,
+			showUnavailableFeatured: false,
+		});
+		const actions = getActionItems(items);
+		// Premium Model should not appear at all
+		const premiumItem = actions.find(a => a.label === 'Premium Model');
+		assert.strictEqual(premiumItem, undefined, 'Unavailable featured model should not appear when showUnavailableFeatured=false');
+	});
+
+	test('showUnavailableFeatured=false still shows available featured models', () => {
+		const auto = createAutoModel();
+		const modelA = createModel('gpt-4o', 'GPT-4o');
+		const items = callBuild([auto, modelA], {
+			controlModels: {
+				'gpt-4o': { label: 'GPT-4o', featured: true, exists: true },
+			},
+			showUnavailableFeatured: false,
+		});
+		const actions = getActionItems(items);
+		// GPT-4o is available and featured, so it should still appear in promoted
+		const gptItem = actions.find(a => a.label === 'GPT-4o');
+		assert.ok(gptItem, 'Available featured model should appear even when showUnavailableFeatured=false');
+	});
+
+	test('showUnavailableFeatured=false with version-gated model does not place it in promoted', () => {
+		const auto = createAutoModel();
+		const modelA = createModel('gpt-4o', 'GPT-4o');
+		const items = callBuild([auto, modelA], {
+			controlModels: {
+				'gpt-4o': { label: 'GPT-4o', featured: true, minVSCodeVersion: '2.0.0', exists: true },
+			},
+			showUnavailableFeatured: false,
+		});
+		const actions = getActionItems(items);
+		// Version-gated model should not be in promoted section as unavailable
+		const promotedLabels = actions.filter(a => !a.isSectionToggle && a.section !== 'other' && a.item?.id !== 'manageModels').map(a => a.label);
+		assert.ok(!promotedLabels.includes('GPT-4o') || !actions.find(a => a.label === 'GPT-4o')?.disabled,
+			'Version-gated featured model should not appear as unavailable in promoted when showUnavailableFeatured=false');
+	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -80,6 +80,8 @@ function callBuild(
 		updateStateType?: StateType;
 		manageSettingsUrl?: string;
 		anonymous?: boolean;
+		showRecentlyUsed?: boolean;
+		showFeatured?: boolean;
 	} = {},
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const onSelect = () => { };
@@ -99,6 +101,8 @@ function callBuild(
 		true,
 		stubManageModelsAction,
 		entitlementService,
+		opts.showRecentlyUsed ?? true,
+		opts.showFeatured ?? true,
 	);
 }
 
@@ -474,6 +478,8 @@ suite('buildModelPickerItems', () => {
 			true,
 			undefined,
 			stubChatEntitlementService,
+			true,
+			true,
 		);
 		const gptItem = getActionItems(items).find(a => a.label === 'GPT-4o');
 		assert.ok(gptItem?.item);
@@ -556,6 +562,8 @@ suite('buildModelPickerItems', () => {
 			true,
 			undefined,
 			stubChatEntitlementService,
+			true,
+			true,
 		);
 
 		const adminItem = getActionItems(items).find(a => a.label === 'Missing Model');
@@ -639,6 +647,8 @@ suite('buildModelPickerItems', () => {
 			true,
 			undefined,
 			anonymousEntitlementService,
+			true,
+			true,
 		);
 		const gptItem = getActionItems(items).find(a => a.label === 'GPT-4o');
 		assert.ok(gptItem?.item);

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -704,7 +704,7 @@ suite('buildModelPickerItems', () => {
 		assert.ok(gptItem, 'Available featured model should appear even when showUnavailableFeatured=false');
 	});
 
-	test('showUnavailableFeatured=false with version-gated model does not place it in promoted', () => {
+	test('showUnavailableFeatured=false with version-gated model allows it in Other Models', () => {
 		const auto = createAutoModel();
 		const modelA = createModel('gpt-4o', 'GPT-4o');
 		const items = callBuild([auto, modelA], {
@@ -715,8 +715,10 @@ suite('buildModelPickerItems', () => {
 		});
 		const actions = getActionItems(items);
 		// Version-gated model should not be in promoted section as unavailable
-		const promotedLabels = actions.filter(a => !a.isSectionToggle && a.section !== 'other' && a.item?.id !== 'manageModels').map(a => a.label);
-		assert.ok(!promotedLabels.includes('GPT-4o') || !actions.find(a => a.label === 'GPT-4o')?.disabled,
-			'Version-gated featured model should not appear as unavailable in promoted when showUnavailableFeatured=false');
+		const promotedGpt = actions.find(a => a.label === 'GPT-4o' && a.section !== 'other');
+		assert.strictEqual(promotedGpt?.disabled, undefined, 'Version-gated featured model should not appear as unavailable in promoted when showUnavailableFeatured=false');
+		// It should still appear in Other Models since it was not placed
+		const otherGpt = actions.find(a => a.label === 'GPT-4o' && a.section === 'other');
+		assert.ok(otherGpt, 'Version-gated featured model should appear in Other Models when showUnavailableFeatured=false');
 	});
 });


### PR DESCRIPTION
## Summary

Adds `showUnavailableFeatured` and `showFeatured` options to `IModelPickerDelegate` so callers can control whether unavailable featured models and featured models appear in the model picker's promoted section.

## Changes

- **`IModelPickerDelegate`** — Added `showUnavailableFeatured(): boolean` and `showFeatured(): boolean`
- **`buildModelPickerItems`** — Accepts the two new boolean params:
  - `showFeatured` gates whether featured models from the control manifest appear at all
  - `showUnavailableFeatured` gates whether *unavailable* featured models (upgrade/update/admin) are shown; available featured models always appear when `showFeatured` is true
  - Recently used models always show (no gate)
- **`chatInputPart.ts`** — `showUnavailableFeatured` enabled only for no session type or local sessions; `showFeatured` always true
- **`newChatViewPane.ts`** — `showUnavailableFeatured` is `false`; `showFeatured` is `true`
- **Tests** — Updated `callBuild` helper with new params (default `true`)