### PR TITLE
Fix options being overridden by view options update in abstract tree

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -2729,7 +2729,7 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 			renderer.updateOptions(optionsUpdate);
 		}
 
-		this.view.updateOptions(this._options);
+		this.view.updateOptions(optionsUpdate);
 		this.findController?.updateOptions(optionsUpdate);
 		this.updateStickyScroll(optionsUpdate);
 


### PR DESCRIPTION
```Copilot Generated Description:``` Update the view options to use the provided options update instead of the existing options, preventing unintended overrides.

