### PR TITLE
docs: correct disjunction JSDoc from intersection to union

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1202,7 +1202,7 @@ function getContiguousRangeContaining(range: number[], value: number): number[] 
 }
 
 /**
- * Given two sorted collections of numbers, returns the intersection
+ * Given two sorted collections of numbers, returns the union
  * between them (OR).
  */
 function disjunction(one: number[], other: number[]): number[] {


### PR DESCRIPTION
This PR fixes a minor factual error in the JSDoc comment for the `disjunction` function in `src/vs/base/browser/ui/list/listWidget.ts`. 

The underlying implementation merges both sorted arrays (acting as a union / logical OR), but the comment previously stated it returned the 'intersection'. I have updated the word 'intersection' to 'union' to accurately reflect the function's behavior.