### PR TITLE
Revert macOS multiline PTY chunking workaround and simplify shell matrix tests

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -77,6 +77,31 @@ const generalShellTypeMap = new Map<string, GeneralShellType>([
 	['node', GeneralShellType.Node],
 	['xonsh', GeneralShellType.Xonsh],
 ]);
+
+const MacMultilineWriteChunkByteLength = 512;
+const MacMultilineWritePauseDuration = 5;
+
+function getUtf8ChunkEnd(buffer: Buffer, start: number, chunkByteLength: number): number {
+	let end = Math.min(start + chunkByteLength, buffer.length);
+	if (end >= buffer.length) {
+		return buffer.length;
+	}
+	while (end > start && (buffer[end] & 0b11000000) === 0b10000000) {
+		end--;
+	}
+	return end > start ? end : Math.min(start + chunkByteLength, buffer.length);
+}
+
+function splitUtf8Chunks(data: string, chunkByteLength: number): string[] {
+	const buffer = Buffer.from(data, 'utf8');
+	const chunks: string[] = [];
+	for (let start = 0; start < buffer.length;) {
+		const end = getUtf8ChunkEnd(buffer, start, chunkByteLength);
+		chunks.push(buffer.subarray(start, end).toString('utf8'));
+		start = end;
+	}
+	return chunks;
+}
 export class TerminalProcess extends Disposable implements ITerminalChildProcess {
 	readonly id = 0;
 	readonly shouldPersist = false;
@@ -469,7 +494,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._logService.trace('node-pty.IPty#write', data, isBinary);
 		if (isBinary) {
 			this._ptyProcess!.write(Buffer.from(data, 'binary'));
-		} else if (isMacintosh && data.length > 512 && data.includes('\r')) {
+		} else if (isMacintosh && Buffer.byteLength(data, 'utf8') > MacMultilineWriteChunkByteLength && data.includes('\r')) {
 			// macOS PTY has a ~1024-byte canonical-mode input buffer. Multiline
 			// input exceeding this causes writes to block or corrupt due to
 			// backpressure from the shell's line editor echoing characters.
@@ -483,13 +508,14 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 
 	private _writeChunked(data: string): void {
 		this._writeQueue = this._writeQueue.then(async () => {
-			for (let i = 0; i < data.length; i += 512) {
+			const chunks = splitUtf8Chunks(data, MacMultilineWriteChunkByteLength);
+			for (let i = 0; i < chunks.length; i++) {
 				if (this._store.isDisposed) {
 					return;
 				}
-				this._ptyProcess!.write(data.slice(i, i + 512));
-				if (i + 512 < data.length) {
-					await timeout(5);
+				this._ptyProcess!.write(chunks[i]);
+				if (i + 1 < chunks.length) {
+					await timeout(MacMultilineWritePauseDuration);
 				}
 			}
 		});

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -78,30 +78,6 @@ const generalShellTypeMap = new Map<string, GeneralShellType>([
 	['xonsh', GeneralShellType.Xonsh],
 ]);
 
-const MacMultilineWriteChunkByteLength = 512;
-const MacMultilineWritePauseDuration = 5;
-
-function getUtf8ChunkEnd(buffer: Buffer, start: number, chunkByteLength: number): number {
-	let end = Math.min(start + chunkByteLength, buffer.length);
-	if (end >= buffer.length) {
-		return buffer.length;
-	}
-	while (end > start && (buffer[end] & 0b11000000) === 0b10000000) {
-		end--;
-	}
-	return end > start ? end : Math.min(start + chunkByteLength, buffer.length);
-}
-
-function splitUtf8Chunks(data: string, chunkByteLength: number): string[] {
-	const buffer = Buffer.from(data, 'utf8');
-	const chunks: string[] = [];
-	for (let start = 0; start < buffer.length;) {
-		const end = getUtf8ChunkEnd(buffer, start, chunkByteLength);
-		chunks.push(buffer.subarray(start, end).toString('utf8'));
-		start = end;
-	}
-	return chunks;
-}
 export class TerminalProcess extends Disposable implements ITerminalChildProcess {
 	readonly id = 0;
 	readonly shouldPersist = false;
@@ -135,7 +111,6 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 
 	private _isPtyPaused: boolean = false;
 	private _unacknowledgedCharCount: number = 0;
-	private _writeQueue: Promise<void> = Promise.resolve();
 	get exitMessage(): string | undefined { return this._exitMessage; }
 
 	get currentTitle(): string { return this._windowsShellHelper?.shellTitle || this._currentTitle; }
@@ -494,31 +469,10 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._logService.trace('node-pty.IPty#write', data, isBinary);
 		if (isBinary) {
 			this._ptyProcess!.write(Buffer.from(data, 'binary'));
-		} else if (isMacintosh && Buffer.byteLength(data, 'utf8') > MacMultilineWriteChunkByteLength && data.includes('\r')) {
-			// macOS PTY has a ~1024-byte canonical-mode input buffer. Multiline
-			// input exceeding this causes writes to block or corrupt due to
-			// backpressure from the shell's line editor echoing characters.
-			// https://github.com/microsoft/vscode/issues/296955
-			this._writeChunked(data);
 		} else {
 			this._ptyProcess!.write(data);
 		}
 		this._childProcessMonitor?.handleInput();
-	}
-
-	private _writeChunked(data: string): void {
-		this._writeQueue = this._writeQueue.then(async () => {
-			const chunks = splitUtf8Chunks(data, MacMultilineWriteChunkByteLength);
-			for (let i = 0; i < chunks.length; i++) {
-				if (this._store.isDisposed) {
-					return;
-				}
-				this._ptyProcess!.write(chunks[i]);
-				if (i + 1 < chunks.length) {
-					await timeout(MacMultilineWritePauseDuration);
-				}
-			}
-		});
 	}
 
 	sendSignal(signal: string): void {

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { deepStrictEqual, ok } from 'assert';
+import { deepStrictEqual } from 'assert';
+import * as fs from 'fs';
 import { tmpdir } from 'os';
 import * as path from '../../../../base/common/path.js';
-import * as fs from 'fs';
+import { isWindows } from '../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { NullLogService } from '../../../log/common/log.js';
 import { IProductService } from '../../../product/common/productService.js';
-import { ITerminalProcessOptions, ITerminalLaunchError } from '../../common/terminal.js';
+import { IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions } from '../../common/terminal.js';
 import { TerminalProcess } from '../../node/terminalProcess.js';
-import { isWindows } from '../../../../base/common/platform.js';
 
 const processOptions: ITerminalProcessOptions = {
 	shellIntegration: { enabled: false, suggestEnabled: false, nonce: '' },
@@ -22,52 +22,34 @@ const processOptions: ITerminalProcessOptions = {
 	isScreenReaderOptimized: false
 };
 
-/**
- * Build a multiline shell command that writes its content to a file.
- * The command writes numbered lines to a temp file so we can verify
- * the entire payload was received intact by the shell.
- */
-function buildMultilineCommand(lines: string[], outputFile: string): { command: string; expectedLines: string[] } {
-	// Use cat heredoc to write content to a file - this exercises multiline PTY input
-	const command = `cat > ${escapeForSingleQuotedShellString(outputFile)} << 'TESTEOF'\n${lines.join('\n')}\nTESTEOF\n`;
-	return { command, expectedLines: lines };
+const shellMatrix: IShellLaunchConfig[] = [
+	{ executable: '/bin/bash', args: ['--norc', '--noprofile', '-i'] },
+	{ executable: '/bin/zsh', args: ['-f', '-i'] },
+	{ executable: '/bin/sh', args: ['-i'] },
+	{ executable: '/bin/ksh', args: ['-i'] },
+	{ executable: '/bin/dash', args: ['-i'] },
+	{ executable: '/bin/csh', args: ['-i'] },
+	{ executable: '/bin/tcsh', args: ['-i'] },
+];
+
+const lineCount = 20;
+const waitDuration = 4000;
+
+function shellExists(executable: string): boolean {
+	return fs.existsSync(executable);
 }
 
-function buildAsciiMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
-	const lines: string[] = [];
+function buildMultilineCommand(outputFile: string): { command: string; expectedLines: string[] } {
+	const expectedLines: string[] = [];
 	for (let i = 1; i <= lineCount; i++) {
-		// Pad line number, add filler to make each line ~55 chars
-		const line = `L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`;
-		lines.push(line);
+		expectedLines.push(`L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`);
 	}
-	return buildMultilineCommand(lines, outputFile);
+	const escapedOutputFile = `'${outputFile.replace(/'/g, `'\\''`)}'`;
+	const command = [`: > ${escapedOutputFile}`, ...expectedLines.map(line => `echo '${line}' >> ${escapedOutputFile}`)].join('\n') + '\n';
+	return { command, expectedLines };
 }
 
-function buildMultibyteMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
-	for (let repeatCount = 1; repeatCount <= 256; repeatCount++) {
-		const lines: string[] = [];
-		for (let i = 1; i <= lineCount; i++) {
-			lines.push(`L${String(i).padStart(2, '0')} ${'中'.repeat(repeatCount)}`);
-		}
-		const result = buildMultilineCommand(lines, outputFile);
-		if (result.command.length <= 512 && Buffer.byteLength(result.command, 'utf8') > 1024) {
-			return result;
-		}
-	}
-	throw new Error('Failed to generate a multibyte command within the UTF-16 and UTF-8 thresholds');
-}
-
-interface IRunMultilineTestOptions {
-	outputFile: string;
-	buildCommand: (outputFile: string) => { command: string; expectedLines: string[] };
-	maxWait?: number;
-}
-
-function escapeForSingleQuotedShellString(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-// These tests spawn real PTY processes and are macOS/Linux only
+// These tests spawn real PTY processes and are macOS/Linux only.
 (isWindows ? suite.skip : suite)('TerminalProcess - multiline write', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let outputDir: string;
@@ -80,12 +62,12 @@ function escapeForSingleQuotedShellString(value: string): string {
 		fs.rmSync(outputDir, { recursive: true, force: true });
 	});
 
-	async function runMultilineTest(options: IRunMultilineTestOptions): Promise<void> {
-		const { outputFile, buildCommand, maxWait = 10000 } = options;
-		const { command, expectedLines } = buildCommand(outputFile);
-
+	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig): Promise<void> {
+		const shellName = path.posix.basename(shellLaunchConfig.executable!);
+		const outputFile = path.join(outputDir, `output-${shellName}.txt`);
+		const { command, expectedLines } = buildMultilineCommand(outputFile);
 		const terminalProcess = store.add(new TerminalProcess(
-			{ executable: '/bin/bash', args: ['--norc', '--noprofile', '-i'] },
+			shellLaunchConfig,
 			outputDir,
 			80,
 			24,
@@ -102,35 +84,29 @@ function escapeForSingleQuotedShellString(value: string): string {
 			throw new Error(`Failed to start terminal: ${error.message}`);
 		}
 
-		// Wait for shell to produce output (prompt), indicating it's ready for input
 		await new Promise<void>(resolve => {
-			const timeout = setTimeout(() => {
+			const timer = setTimeout(() => {
 				listener.dispose();
 				resolve();
 			}, 10000);
 			const listener = terminalProcess.onProcessData(() => {
-				clearTimeout(timeout);
+				clearTimeout(timer);
 				listener.dispose();
 				resolve();
 			});
 		});
 
-		// Send the multiline command — newlines are converted to \r for PTY
-		const ptyData = command.replace(/\n/g, '\r');
-		terminalProcess.input(ptyData);
+		terminalProcess.input(command.replace(/\n/g, '\r'));
 
-		// Wait for the command to execute and write the file
 		const start = Date.now();
-		while (Date.now() - start < maxWait) {
+		while (Date.now() - start < waitDuration) {
 			await new Promise(resolve => setTimeout(resolve, 200));
 			if (fs.existsSync(outputFile)) {
-				// Give a moment for the write to flush
 				await new Promise(resolve => setTimeout(resolve, 200));
 				break;
 			}
 		}
 
-		// Shut down and wait for the process to exit
 		const exitPromise = new Promise<void>(resolve => {
 			const listener = terminalProcess.onProcessExit(() => {
 				listener.dispose();
@@ -141,53 +117,22 @@ function escapeForSingleQuotedShellString(value: string): string {
 		await exitPromise;
 
 		if (!fs.existsSync(outputFile)) {
-			throw new Error(`Output file was not created — terminal likely got stuck (command was ${command.length} UTF-16 code units / ${Buffer.byteLength(command, 'utf8')} UTF-8 bytes)`);
+			throw new Error('Output file was not created');
 		}
 
-		const actualContent = fs.readFileSync(outputFile, 'utf-8');
-		const actualLines = actualContent.trimEnd().split('\n');
+		const actualLines = fs.readFileSync(outputFile, 'utf-8').trimEnd().split('\n');
 		deepStrictEqual(actualLines, expectedLines);
 	}
 
-	async function runAsciiMultilineTest(lineCount: number): Promise<void> {
-		await runMultilineTest({
-			outputFile: path.join(outputDir, `output-${lineCount}.txt`),
-			buildCommand: outputFile => buildAsciiMultilineCommand(lineCount, outputFile)
+	for (const shell of shellMatrix) {
+		const shellName = path.posix.basename(shell.executable!);
+		test(`${shellName} medium multiline write`, async function () {
+			if (!shellExists(shell.executable!)) {
+				this.skip();
+			}
+
+			this.timeout(10000);
+			await runShellMultilineTest(shell);
 		});
 	}
-
-	test('small multiline command (10 lines, ~700 bytes)', async function () {
-		this.timeout(15000);
-		await runAsciiMultilineTest(10);
-	});
-
-	test('medium multiline command (20 lines, ~1300 bytes)', async function () {
-		this.timeout(15000);
-		await runAsciiMultilineTest(20);
-	});
-
-	test.skip('large multiline command (500 lines, ~32KB)', async function () {
-		this.timeout(30000);
-		await runAsciiMultilineTest(500);
-	});
-
-	test('multibyte multiline command can exceed the UTF-8 threshold while staying under the current UTF-16 gate', async function () {
-		const outputFile = path.join(outputDir, 'output-u8.txt');
-		const { command } = buildMultibyteMultilineCommand(10, outputFile);
-		const utf16Length = command.length;
-		const utf8Length = Buffer.byteLength(command, 'utf8');
-
-		// This payload documents the predicate mismatch directly: the current
-		// macOS chunking gate uses JS string length, but the PTY buffer limit is
-		// relevant in UTF-8 bytes.
-		ok(utf16Length <= 512, `Expected payload to stay under the current UTF-16 chunking gate, got ${utf16Length}`);
-		ok(utf8Length > 1024, `Expected payload to exceed the macOS canonical-mode buffer in UTF-8 bytes, got ${utf8Length}`);
-
-		this.timeout(15000);
-		await runMultilineTest({
-			outputFile,
-			buildCommand: currentOutputFile => buildMultibyteMultilineCommand(10, currentOutputFile)
-		});
-	});
-
 });

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { deepStrictEqual } from 'assert';
+import { deepStrictEqual, ok } from 'assert';
 import { tmpdir } from 'os';
 import * as path from '../../../../base/common/path.js';
 import * as fs from 'fs';
@@ -27,16 +27,35 @@ const processOptions: ITerminalProcessOptions = {
  * The command writes numbered lines to a temp file so we can verify
  * the entire payload was received intact by the shell.
  */
-function buildMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
+function buildMultilineCommand(lines: string[], outputFile: string): { command: string; expectedLines: string[] } {
+	// Use cat heredoc to write content to a file - this exercises multiline PTY input
+	const command = `cat > ${outputFile} << 'TESTEOF'\n${lines.join('\n')}\nTESTEOF\n`;
+	return { command, expectedLines: lines };
+}
+
+function buildAsciiMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
 	const lines: string[] = [];
 	for (let i = 1; i <= lineCount; i++) {
 		// Pad line number, add filler to make each line ~55 chars
 		const line = `L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`;
 		lines.push(line);
 	}
-	// Use cat heredoc to write content to a file — this exercises multiline PTY input
-	const command = `cat > ${outputFile} << 'TESTEOF'\n${lines.join('\n')}\nTESTEOF\n`;
-	return { command, expectedLines: lines };
+	return buildMultilineCommand(lines, outputFile);
+
+}
+
+function buildMultibyteMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
+	const lines: string[] = [];
+	for (let i = 1; i <= lineCount; i++) {
+		lines.push(`L${String(i).padStart(2, '0')} ${'中'.repeat(40)}`);
+	}
+	return buildMultilineCommand(lines, outputFile);
+}
+
+interface IRunMultilineTestOptions {
+	outputFile: string;
+	buildCommand: (outputFile: string) => { command: string; expectedLines: string[] };
+	maxWait?: number;
 }
 
 // These tests spawn real PTY processes and are macOS/Linux only
@@ -52,9 +71,9 @@ function buildMultilineCommand(lineCount: number, outputFile: string): { command
 		fs.rmSync(outputDir, { recursive: true, force: true });
 	});
 
-	async function runMultilineTest(lineCount: number): Promise<void> {
-		const outputFile = path.join(outputDir, `output-${lineCount}.txt`);
-		const { command, expectedLines } = buildMultilineCommand(lineCount, outputFile);
+	async function runMultilineTest(options: IRunMultilineTestOptions): Promise<void> {
+		const { outputFile, buildCommand, maxWait = 3000 } = options;
+		const { command, expectedLines } = buildCommand(outputFile);
 
 		const terminalProcess = store.add(new TerminalProcess(
 			{ executable: '/bin/bash', args: ['--norc', '--noprofile', '-i'] },
@@ -92,7 +111,6 @@ function buildMultilineCommand(lineCount: number, outputFile: string): { command
 		terminalProcess.input(ptyData);
 
 		// Wait for the command to execute and write the file
-		const maxWait = 10000;
 		const start = Date.now();
 		while (Date.now() - start < maxWait) {
 			await new Promise(resolve => setTimeout(resolve, 200));
@@ -122,18 +140,47 @@ function buildMultilineCommand(lineCount: number, outputFile: string): { command
 		deepStrictEqual(actualLines, expectedLines);
 	}
 
+	async function runAsciiMultilineTest(lineCount: number): Promise<void> {
+		await runMultilineTest({
+			outputFile: path.join(outputDir, `output-${lineCount}.txt`),
+			buildCommand: outputFile => buildAsciiMultilineCommand(lineCount, outputFile)
+		});
+	}
+
 	test('small multiline command (10 lines, ~700 bytes)', async function () {
 		this.timeout(15000);
-		await runMultilineTest(10);
+		await runAsciiMultilineTest(10);
 	});
 
 	test('medium multiline command (20 lines, ~1300 bytes)', async function () {
 		this.timeout(15000);
-		await runMultilineTest(20);
+		await runAsciiMultilineTest(20);
 	});
 
 	test.skip('large multiline command (500 lines, ~32KB)', async function () {
 		this.timeout(30000);
-		await runMultilineTest(500);
+		await runAsciiMultilineTest(500);
 	});
+
+	test('multibyte multiline command can exceed the UTF-8 threshold while staying under the current UTF-16 gate', async function () {
+		const outputFile = '/tmp/vscode-pty-u8.txt';
+		fs.rmSync(outputFile, { force: true });
+		const { command } = buildMultibyteMultilineCommand(10, outputFile);
+		const utf16Length = command.length;
+		const utf8Length = Buffer.byteLength(command, 'utf8');
+
+		// This payload documents the predicate mismatch directly: the current
+		// macOS chunking gate uses JS string length, but the PTY buffer limit is
+		// relevant in UTF-8 bytes.
+		ok(utf16Length <= 512, `Expected payload to stay under the current UTF-16 chunking gate, got ${utf16Length}`);
+		ok(utf8Length > 1024, `Expected payload to exceed the macOS canonical-mode buffer in UTF-8 bytes, got ${utf8Length}`);
+
+		this.timeout(15000);
+		await runMultilineTest({
+			outputFile,
+			buildCommand: currentOutputFile => buildMultibyteMultilineCommand(10, currentOutputFile)
+		});
+		fs.rmSync(outputFile, { force: true });
+	});
+
 });

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -32,20 +32,24 @@ const shellMatrix: IShellLaunchConfig[] = [
 	{ executable: '/bin/tcsh', args: ['-i'] },
 ];
 
-const lineCount = 20;
+const lineCounts = [10, 20];
 const waitDuration = 4000;
 
 function shellExists(executable: string): boolean {
 	return fs.existsSync(executable);
 }
 
-function buildMultilineCommand(outputFile: string): { command: string; expectedLines: string[] } {
+function escapeForDoubleQuotedShellString(value: string): string {
+	return `"${value.replace(/[\\"$`]/g, '\\$&')}"`;
+}
+
+function buildMultilineCommand(outputFile: string, lineCount: number): { command: string; expectedLines: string[] } {
 	const expectedLines: string[] = [];
 	for (let i = 1; i <= lineCount; i++) {
 		expectedLines.push(`L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`);
 	}
-	const escapedOutputFile = `'${outputFile.replace(/'/g, `'\\''`)}'`;
-	const command = [`: > ${escapedOutputFile}`, ...expectedLines.map(line => `echo '${line}' >> ${escapedOutputFile}`)].join('\n') + '\n';
+	const escapedOutputFile = escapeForDoubleQuotedShellString(outputFile);
+	const command = `printf "%s\\n" \\\n${expectedLines.map(line => escapeForDoubleQuotedShellString(line)).join(' \\\n')} > ${escapedOutputFile}\n`;
 	return { command, expectedLines };
 }
 
@@ -62,10 +66,10 @@ function buildMultilineCommand(outputFile: string): { command: string; expectedL
 		fs.rmSync(outputDir, { recursive: true, force: true });
 	});
 
-	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig): Promise<void> {
+	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
 		const shellName = path.posix.basename(shellLaunchConfig.executable!);
-		const outputFile = path.join(outputDir, `output-${shellName}.txt`);
-		const { command, expectedLines } = buildMultilineCommand(outputFile);
+		const outputFile = path.join(outputDir, `output-${shellName}-${lineCount}.txt`);
+		const { command, expectedLines } = buildMultilineCommand(outputFile, lineCount);
 		const terminalProcess = store.add(new TerminalProcess(
 			shellLaunchConfig,
 			outputDir,
@@ -124,15 +128,18 @@ function buildMultilineCommand(outputFile: string): { command: string; expectedL
 		deepStrictEqual(actualLines, expectedLines);
 	}
 
-	for (const shell of shellMatrix) {
-		const shellName = path.posix.basename(shell.executable!);
-		test(`${shellName} medium multiline write`, async function () {
-			if (!shellExists(shell.executable!)) {
-				this.skip();
-			}
+	for (const lineCount of lineCounts) {
+		const sizeName = lineCount === 10 ? 'small' : lineCount === 20 ? 'medium' : 'large';
+		for (const shell of shellMatrix) {
+			const shellName = path.posix.basename(shell.executable!);
+			test(`${shellName} ${sizeName} multiline write`, async function () {
+				if (!shellExists(shell.executable!)) {
+					this.skip();
+				}
 
-			this.timeout(10000);
-			await runShellMultilineTest(shell);
-		});
+				this.timeout(10000);
+				await runShellMultilineTest(shell, lineCount);
+			});
+		}
 	}
 });

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -29,7 +29,7 @@ const processOptions: ITerminalProcessOptions = {
  */
 function buildMultilineCommand(lines: string[], outputFile: string): { command: string; expectedLines: string[] } {
 	// Use cat heredoc to write content to a file - this exercises multiline PTY input
-	const command = `cat > ${outputFile} << 'TESTEOF'\n${lines.join('\n')}\nTESTEOF\n`;
+	const command = `cat > ${escapeForSingleQuotedShellString(outputFile)} << 'TESTEOF'\n${lines.join('\n')}\nTESTEOF\n`;
 	return { command, expectedLines: lines };
 }
 
@@ -41,21 +41,30 @@ function buildAsciiMultilineCommand(lineCount: number, outputFile: string): { co
 		lines.push(line);
 	}
 	return buildMultilineCommand(lines, outputFile);
-
 }
 
 function buildMultibyteMultilineCommand(lineCount: number, outputFile: string): { command: string; expectedLines: string[] } {
-	const lines: string[] = [];
-	for (let i = 1; i <= lineCount; i++) {
-		lines.push(`L${String(i).padStart(2, '0')} ${'中'.repeat(40)}`);
+	for (let repeatCount = 1; repeatCount <= 256; repeatCount++) {
+		const lines: string[] = [];
+		for (let i = 1; i <= lineCount; i++) {
+			lines.push(`L${String(i).padStart(2, '0')} ${'中'.repeat(repeatCount)}`);
+		}
+		const result = buildMultilineCommand(lines, outputFile);
+		if (result.command.length <= 512 && Buffer.byteLength(result.command, 'utf8') > 1024) {
+			return result;
+		}
 	}
-	return buildMultilineCommand(lines, outputFile);
+	throw new Error('Failed to generate a multibyte command within the UTF-16 and UTF-8 thresholds');
 }
 
 interface IRunMultilineTestOptions {
 	outputFile: string;
 	buildCommand: (outputFile: string) => { command: string; expectedLines: string[] };
 	maxWait?: number;
+}
+
+function escapeForSingleQuotedShellString(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 // These tests spawn real PTY processes and are macOS/Linux only
@@ -72,7 +81,7 @@ interface IRunMultilineTestOptions {
 	});
 
 	async function runMultilineTest(options: IRunMultilineTestOptions): Promise<void> {
-		const { outputFile, buildCommand, maxWait = 3000 } = options;
+		const { outputFile, buildCommand, maxWait = 10000 } = options;
 		const { command, expectedLines } = buildCommand(outputFile);
 
 		const terminalProcess = store.add(new TerminalProcess(
@@ -132,7 +141,7 @@ interface IRunMultilineTestOptions {
 		await exitPromise;
 
 		if (!fs.existsSync(outputFile)) {
-			throw new Error(`Output file was not created — terminal likely got stuck (command was ${command.length} bytes)`);
+			throw new Error(`Output file was not created — terminal likely got stuck (command was ${command.length} UTF-16 code units / ${Buffer.byteLength(command, 'utf8')} UTF-8 bytes)`);
 		}
 
 		const actualContent = fs.readFileSync(outputFile, 'utf-8');
@@ -163,8 +172,7 @@ interface IRunMultilineTestOptions {
 	});
 
 	test('multibyte multiline command can exceed the UTF-8 threshold while staying under the current UTF-16 gate', async function () {
-		const outputFile = '/tmp/vscode-pty-u8.txt';
-		fs.rmSync(outputFile, { force: true });
+		const outputFile = path.join(outputDir, 'output-u8.txt');
 		const { command } = buildMultibyteMultilineCommand(10, outputFile);
 		const utf16Length = command.length;
 		const utf8Length = Buffer.byteLength(command, 'utf8');
@@ -180,7 +188,6 @@ interface IRunMultilineTestOptions {
 			outputFile,
 			buildCommand: currentOutputFile => buildMultibyteMultilineCommand(10, currentOutputFile)
 		});
-		fs.rmSync(outputFile, { force: true });
 	});
 
 });


### PR DESCRIPTION
## Summary
- revert the macOS multiline PTY chunking workaround from #298993
- keep a simplified shell matrix test for `bash`, `zsh`, `sh`, `ksh`, `dash`, `csh`, and `tcsh`
- use a shell-neutral multiline `printf` payload so the same command shape works across all tested shells

## Current Test State
| Shell | 10 lines | 20 lines |
| --- | --- | --- |
| bash | ✅ | ❌ |
| zsh | ✅ | ✅ |
| sh | ✅ | ❌ |
| ksh | ✅ | ❌ |
| dash | ✅ | ✅ |
| csh | ✅ | ❌ |
| tcsh | ✅ | ❌ |

The 10-line case passes on all tested shells. The 20-line case fails on bash, sh, ksh, csh, and tcsh with no output file, while zsh and dash continue to pass.
