### PR TITLE
add denial details for auto-approval rules in command line tools

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
@@ -19,7 +19,7 @@ export class RunInTerminalToolTelemetry {
 		subCommands: string[];
 		autoApproveAllowed: 'allowed' | 'needsOptIn' | 'off';
 		autoApproveResult: 'approved' | 'denied' | 'manual';
-		autoApproveReason: 'subCommand' | 'commandLine' | undefined;
+		autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined;
 		autoApproveDefault: boolean | undefined;
 	}) {
 		const subCommandsSanitized = state.subCommands.map(e => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
@@ -65,4 +65,13 @@ export interface ICommandLineAnalyzerResult {
 	readonly customActions?: ToolConfirmationAction[];
 	// Indicates that auto approval should be forced (e.g. sandboxed commands).
 	readonly forceAutoApproval?: boolean;
+	/**
+	 * Optional denial details when this analyzer explicitly denied auto-execution.
+	 */
+	readonly denialDetails?: {
+		readonly scope: 'subCommand' | 'commandLine';
+		readonly deniedCommand: string;
+		readonly reason: string;
+		readonly ruleSourceText?: string;
+	};
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -51,20 +51,9 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 	}
 
 	async analyze(options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
-		if (options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource)) {
-			this._log('Session has auto approval enabled, auto approving command');
-			const disableUri = createCommandUri(TerminalChatCommandId.DisableSessionAutoApproval, options.chatSessionResource);
-			const mdTrustSettings = {
-				isTrusted: {
-					enabledCommands: [TerminalChatCommandId.DisableSessionAutoApproval]
-				}
-			};
-			return {
-				isAutoApproved: true,
-				isAutoApproveAllowed: true,
-				disclaimers: [],
-				autoApproveInfo: new MarkdownString(`${localize('autoApprove.session', 'Auto approved for this session')} ([${localize('autoApprove.session.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings),
-			};
+		const hasSessionAutoApproval = options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource);
+		if (hasSessionAutoApproval) {
+			this._log('Session has auto approval enabled');
 		}
 
 		const trimmedCommandLine = options.commandLine.trimStart();
@@ -131,6 +120,10 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 				isAutoApproved = true;
 				autoApproveReason = 'subCommand';
 				autoApproveDefault = subCommandResults.every(e => isAutoApproveRule(e.rule) && e.rule.isDefaultRule);
+			} else if (hasSessionAutoApproval) {
+				this._log('Session auto approval - approving non-denied command');
+				isAutoApproved = true;
+				autoApproveReason = 'subCommand';
 			} else {
 				this._log('All sub-commands NOT auto-approved');
 				if (commandLineResult.result === 'approved') {
@@ -152,7 +145,15 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		// Apply auto approval or force it off depending on enablement/opt-in state
 		const isAutoApproveEnabled = this._configurationService.getValue(TerminalChatAgentToolsSettingId.EnableAutoApprove) === true;
 		const isAutoApproveWarningAccepted = this._storageService.getBoolean(TerminalToolConfirmationStorageKeys.TerminalAutoApproveWarningAccepted, StorageScope.APPLICATION, false);
-		if (isAutoApproveEnabled && isAutoApproved) {
+		if (hasSessionAutoApproval && isAutoApproved) {
+			const disableUri = createCommandUri(TerminalChatCommandId.DisableSessionAutoApproval, options.chatSessionResource!);
+			const mdTrustSettings = {
+				isTrusted: {
+					enabledCommands: [TerminalChatCommandId.DisableSessionAutoApproval]
+				}
+			};
+			autoApproveInfo = new MarkdownString(`${localize('autoApprove.session', 'Auto approved for this session')} ([${localize('autoApprove.session.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings);
+		} else if (isAutoApproveEnabled && isAutoApproved) {
 			autoApproveInfo = this._createAutoApproveInfo(
 				isAutoApproved,
 				isDenied,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -99,18 +99,32 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		let isDenied = false;
 		let autoApproveReason: 'subCommand' | 'commandLine' | undefined;
 		let autoApproveDefault: boolean | undefined;
+		let denialDetails: ICommandLineAnalyzerResult['denialDetails'];
 
-		const deniedSubCommandResult = subCommandResults.find(e => e.result === 'denied');
+		const deniedSubCommandResultIndex = subCommandResults.findIndex(e => e.result === 'denied');
+		const deniedSubCommandResult = deniedSubCommandResultIndex !== -1 ? subCommandResults[deniedSubCommandResultIndex] : undefined;
 		if (deniedSubCommandResult) {
 			this._log('Sub-command DENIED auto approval');
 			isDenied = true;
 			autoApproveDefault = isAutoApproveRule(deniedSubCommandResult.rule) ? deniedSubCommandResult.rule.isDefaultRule : undefined;
 			autoApproveReason = 'subCommand';
+			denialDetails = {
+				scope: 'subCommand',
+				deniedCommand: subCommands[deniedSubCommandResultIndex] ?? trimmedCommandLine,
+				reason: deniedSubCommandResult.reason,
+				ruleSourceText: isAutoApproveRule(deniedSubCommandResult.rule) ? deniedSubCommandResult.rule.sourceText : undefined,
+			};
 		} else if (commandLineResult.result === 'denied') {
 			this._log('Command line DENIED auto approval');
 			isDenied = true;
 			autoApproveDefault = isAutoApproveRule(commandLineResult.rule) ? commandLineResult.rule.isDefaultRule : undefined;
 			autoApproveReason = 'commandLine';
+			denialDetails = {
+				scope: 'commandLine',
+				deniedCommand: trimmedCommandLine,
+				reason: commandLineResult.reason,
+				ruleSourceText: isAutoApproveRule(commandLineResult.rule) ? commandLineResult.rule.sourceText : undefined,
+			};
 		} else {
 			if (subCommandResults.every(e => e.result === 'approved')) {
 				this._log('All sub-commands auto-approved');
@@ -195,6 +209,7 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 			disclaimers,
 			autoApproveInfo,
 			customActions,
+			denialDetails,
 		};
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -86,7 +86,7 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		];
 
 		let isDenied = false;
-		let autoApproveReason: 'subCommand' | 'commandLine' | undefined;
+		let autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined;
 		let autoApproveDefault: boolean | undefined;
 		let denialDetails: ICommandLineAnalyzerResult['denialDetails'];
 
@@ -123,7 +123,7 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 			} else if (hasSessionAutoApproval) {
 				this._log('Session auto approval - approving non-denied command');
 				isAutoApproved = true;
-				autoApproveReason = 'subCommand';
+				autoApproveReason = 'session';
 			} else {
 				this._log('All sub-commands NOT auto-approved');
 				if (commandLineResult.result === 'approved') {
@@ -217,7 +217,7 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 	private _createAutoApproveInfo(
 		isAutoApproved: boolean,
 		isDenied: boolean,
-		autoApproveReason: 'subCommand' | 'commandLine' | undefined,
+		autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined,
 		subCommandResults: ICommandApprovalResultWithReason[],
 		commandLineResult: ICommandApprovalResultWithReason,
 	): IMarkdownString | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -9,7 +9,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { basename, posix, win32 } from '../../../../../../base/common/path.js';
@@ -659,13 +659,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (isSessionAutoApproved && deniedAnalyzerResult?.denialDetails && context.forceConfirmationReason === undefined) {
 			const denial = deniedAnalyzerResult.denialDetails;
 			const deniedRule = denial.ruleSourceText
-				? ` Rule: \`${denial.ruleSourceText}\`.`
+				? ` Rule: \`${escapeMarkdownSyntaxTokens(denial.ruleSourceText)}\`.`
 				: '';
 			const deniedAttempts = this._recordDeniedCommandAttempt(chatSessionResource!, denial);
 			const shouldCircuitBreak = deniedAttempts >= deniedCommandCircuitBreakerThreshold;
 			toolSpecificData.alternativeRecommendation = shouldCircuitBreak
-				? `POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked ${deniedAttempts} times in this session and will not be retried. Scope: ${denial.scope}. Command: \`${denial.deniedCommand}\`. Reason: ${denial.reason}.${deniedRule}`
-				: `POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: ${denial.scope}. Command: \`${denial.deniedCommand}\`. Reason: ${denial.reason}.${deniedRule}`;
+				? `POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked ${deniedAttempts} times in this session and will not be retried. Scope: ${denial.scope}. Command: \`${escapeMarkdownSyntaxTokens(denial.deniedCommand)}\`. Reason: ${denial.reason}.${deniedRule}`
+				: `POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: ${denial.scope}. Command: \`${escapeMarkdownSyntaxTokens(denial.deniedCommand)}\`. Reason: ${denial.reason}.${deniedRule}`;
 			return {
 				confirmationMessages: undefined,
 				toolSpecificData,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -1298,7 +1298,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			sessionCounts = new Map<string, number>();
 			this._sessionDeniedCommandCounts.set(chatSessionResource, sessionCounts);
 		}
-		const signature = `${denial.scope}|${denial.deniedCommand}|${denial.ruleSourceText ?? denial.reason}`;
+		const signature = JSON.stringify([denial.scope, denial.deniedCommand, denial.ruleSourceText ?? denial.reason]);
 		const attempts = (sessionCounts.get(signature) ?? 0) + 1;
 		sessionCounts.set(signature, attempts);
 		return attempts;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -659,28 +659,13 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (isSessionAutoApproved && deniedAnalyzerResult?.denialDetails && context.forceConfirmationReason === undefined) {
 			const denial = deniedAnalyzerResult.denialDetails;
 			const deniedRule = denial.ruleSourceText
-				? localize('runInTerminal.policyDeniedRule', ' Rule: `{0}`.', denial.ruleSourceText)
+				? ` Rule: \`${denial.ruleSourceText}\`.`
 				: '';
 			const deniedAttempts = this._recordDeniedCommandAttempt(chatSessionResource!, denial);
 			const shouldCircuitBreak = deniedAttempts >= deniedCommandCircuitBreakerThreshold;
 			toolSpecificData.alternativeRecommendation = shouldCircuitBreak
-				? localize(
-					'runInTerminal.policyDeniedCircuitBreaker',
-					'POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked {0} times in this session and will not be retried. Scope: {1}. Command: `{2}`. Reason: {3}.{4}',
-					deniedAttempts,
-					denial.scope,
-					denial.deniedCommand,
-					denial.reason,
-					deniedRule
-				)
-				: localize(
-					'runInTerminal.policyDeniedSessionAutoApprove',
-					'POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: {0}. Command: `{1}`. Reason: {2}.{3}',
-					denial.scope,
-					denial.deniedCommand,
-					denial.reason,
-					deniedRule
-				);
+				? `POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked ${deniedAttempts} times in this session and will not be retried. Scope: ${denial.scope}. Command: \`${denial.deniedCommand}\`. Reason: ${denial.reason}.${deniedRule}`
+				: `POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: ${denial.scope}. Command: \`${denial.deniedCommand}\`. Reason: ${denial.reason}.${deniedRule}`;
 			return {
 				confirmationMessages: undefined,
 				toolSpecificData,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -715,6 +715,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (inspected.policyValue === false) {
 			return false;
 		}
+		// Check the terminal chat service's session auto-approval state
+		if (this._terminalChatService.hasChatSessionAutoApproval(chatSessionResource)) {
+			return true;
+		}
 		// Check the live widget picker level (handles mid-session switches).
 		// Fall back to lastFocusedWidget if the session-specific widget isn't found
 		// (e.g., widget was backgrounded or URI mismatch).

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -658,7 +658,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// a confirmation that may block unattended runs.
 		if (isSessionAutoApproved && deniedAnalyzerResult?.denialDetails && context.forceConfirmationReason === undefined) {
 			const denial = deniedAnalyzerResult.denialDetails;
-			const deniedRule = denial.ruleSourceText ? ` Rule: \`${denial.ruleSourceText}\`.` : '';
+			const deniedRule = denial.ruleSourceText
+				? localize('runInTerminal.policyDeniedRule', ' Rule: `{0}`.', denial.ruleSourceText)
+				: '';
 			const deniedAttempts = this._recordDeniedCommandAttempt(chatSessionResource!, denial);
 			const shouldCircuitBreak = deniedAttempts >= deniedCommandCircuitBreakerThreshold;
 			toolSpecificData.alternativeRecommendation = shouldCircuitBreak

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -45,7 +45,7 @@ import { SandboxedCommandLinePresenter } from './commandLinePresenter/sandboxedC
 import { RunInTerminalToolTelemetry } from '../runInTerminalToolTelemetry.js';
 import { ShellIntegrationQuality, ToolTerminalCreator, type IToolTerminal } from '../toolTerminalCreator.js';
 import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../treeSitterCommandParser.js';
-import { type ICommandLineAnalyzer, type ICommandLineAnalyzerOptions } from './commandLineAnalyzer/commandLineAnalyzer.js';
+import { type ICommandLineAnalyzer, type ICommandLineAnalyzerOptions, type ICommandLineAnalyzerResult } from './commandLineAnalyzer/commandLineAnalyzer.js';
 import { CommandLineAutoApproveAnalyzer } from './commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
 import { CommandLineFileWriteAnalyzer } from './commandLineAnalyzer/commandLineFileWriteAnalyzer.js';
 import { CommandLineSandboxAnalyzer } from './commandLineAnalyzer/commandLineSandboxAnalyzer.js';
@@ -309,6 +309,8 @@ const telemetryIgnoredSequences = [
 ];
 
 const altBufferMessage = '\n' + localize('runInTerminalTool.altBufferMessage', "The command opened the alternate buffer.");
+const deniedCommandCircuitBreakerThreshold = 3;
+type DenialDetails = NonNullable<ICommandLineAnalyzerResult['denialDetails']>;
 
 
 export class RunInTerminalTool extends Disposable implements IToolImpl {
@@ -327,6 +329,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	protected readonly _sessionTerminalAssociations = new ResourceMap<IToolTerminal>();
 	protected readonly _sessionTerminalInstances = new ResourceMap<Set<ITerminalInstance>>();
+	private readonly _sessionDeniedCommandCounts = new ResourceMap<Map<string, number>>();
 	private readonly _terminalsBeingDisposedBySessionCleanup = new Set<ITerminalInstance>();
 
 	// Immutable window state
@@ -649,6 +652,41 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// Check if the session's permission level (Autopilot/Bypass Approvals) auto-approves all tools.
 		// When active, skip terminal confirmation entirely since the user has opted into full auto-approval.
 		const isSessionAutoApproved = chatSessionResource && this._isSessionAutoApproveLevel(chatSessionResource);
+		const deniedAnalyzerResult = commandLineAnalyzerResults.find(e => e.isAutoApproved === false && e.denialDetails);
+
+		// In auto-approval session mode, fail closed for policy-denied commands instead of showing
+		// a confirmation that may block unattended runs.
+		if (isSessionAutoApproved && deniedAnalyzerResult?.denialDetails && context.forceConfirmationReason === undefined) {
+			const denial = deniedAnalyzerResult.denialDetails;
+			const deniedRule = denial.ruleSourceText ? ` Rule: \`${denial.ruleSourceText}\`.` : '';
+			const deniedAttempts = this._recordDeniedCommandAttempt(chatSessionResource!, denial);
+			const shouldCircuitBreak = deniedAttempts >= deniedCommandCircuitBreakerThreshold;
+			toolSpecificData.alternativeRecommendation = shouldCircuitBreak
+				? localize(
+					'runInTerminal.policyDeniedCircuitBreaker',
+					'POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked {0} times in this session and will not be retried. Scope: {1}. Command: `{2}`. Reason: {3}.{4}',
+					deniedAttempts,
+					denial.scope,
+					denial.deniedCommand,
+					denial.reason,
+					deniedRule
+				)
+				: localize(
+					'runInTerminal.policyDeniedSessionAutoApprove',
+					'POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: {0}. Command: `{1}`. Reason: {2}.{3}',
+					denial.scope,
+					denial.deniedCommand,
+					denial.reason,
+					deniedRule
+				);
+			return {
+				confirmationMessages: undefined,
+				toolSpecificData,
+			};
+		}
+		if (isSessionAutoApproved && chatSessionResource) {
+			this._sessionDeniedCommandCounts.delete(chatSessionResource);
+		}
 
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
 		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
@@ -1233,6 +1271,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		this._sessionTerminalAssociations.delete(chatSessionResource);
 		this._sessionTerminalInstances.delete(chatSessionResource);
+		this._sessionDeniedCommandCounts.delete(chatSessionResource);
 
 		for (const terminal of terminalsToDispose) {
 			// Skip redundant map walks in onDidDispose since this session has already been removed.
@@ -1251,6 +1290,18 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		for (const termId of terminalToRemove) {
 			RunInTerminalTool._activeExecutions.delete(termId);
 		}
+	}
+
+	private _recordDeniedCommandAttempt(chatSessionResource: URI, denial: DenialDetails): number {
+		let sessionCounts = this._sessionDeniedCommandCounts.get(chatSessionResource);
+		if (!sessionCounts) {
+			sessionCounts = new Map<string, number>();
+			this._sessionDeniedCommandCounts.set(chatSessionResource, sessionCounts);
+		}
+		const signature = `${denial.scope}|${denial.deniedCommand}|${denial.ruleSourceText ?? denial.reason}`;
+		const attempts = (sessionCounts.get(signature) ?? 0) + 1;
+		sessionCounts.set(signature, attempts);
+		return attempts;
 	}
 
 	private _addSessionTerminalAssociation(chatSessionResource: URI, toolTerminal: IToolTerminal): void {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1416,7 +1416,7 @@ suite('RunInTerminalTool', () => {
 	});
 
 	suite('session auto approval', () => {
-		test('should auto approve all commands when session has auto approval enabled', async () => {
+		test('should return policy denial details for denied commands when session has auto approval enabled', async () => {
 			const sessionId = 'test-session-123';
 			const sessionResource = LocalChatSessionUri.forSession(sessionId);
 			const terminalChatService = instantiationService.get(ITerminalChatService);
@@ -1440,8 +1440,61 @@ suite('RunInTerminalTool', () => {
 			assertAutoApproved(result);
 
 			const terminalData = result!.toolSpecificData as IChatTerminalToolInvocationData;
-			ok(terminalData.autoApproveInfo, 'Expected autoApproveInfo to be defined');
-			ok(terminalData.autoApproveInfo.value.includes('Auto approved for this session'), 'Expected session approval message');
+			ok(terminalData.alternativeRecommendation, 'Expected policy denial alternative recommendation');
+			ok(terminalData.alternativeRecommendation.includes('POLICY_DENIED'), 'Expected policy denial marker');
+			ok(terminalData.alternativeRecommendation.includes('rm dangerous-file.txt'), 'Expected denied command details');
+		});
+
+		test('should still show confirmation when forceConfirmationReason is provided', async () => {
+			const sessionId = 'test-session-123-force';
+			const sessionResource = LocalChatSessionUri.forSession(sessionId);
+			const terminalChatService = instantiationService.get(ITerminalChatService);
+
+			terminalChatService.setChatSessionAutoApproval(sessionResource, true);
+
+			const context: IToolInvocationPreparationContext = {
+				parameters: {
+					command: 'rm dangerous-file.txt',
+					explanation: 'Remove a file',
+					goal: 'Remove a file',
+					isBackground: false
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource,
+				forceConfirmationReason: 'test'
+			} as IToolInvocationPreparationContext;
+
+			const result = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
+			assertConfirmationRequired(result);
+		});
+
+		test('should circuit break repeated denied command attempts in auto approval sessions', async () => {
+			const sessionId = 'test-session-123-circuit-break';
+			const sessionResource = LocalChatSessionUri.forSession(sessionId);
+			const terminalChatService = instantiationService.get(ITerminalChatService);
+
+			terminalChatService.setChatSessionAutoApproval(sessionResource, true);
+
+			const context: IToolInvocationPreparationContext = {
+				parameters: {
+					command: 'rm dangerous-file.txt',
+					explanation: 'Remove a file',
+					goal: 'Remove a file',
+					isBackground: false
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource
+			} as IToolInvocationPreparationContext;
+
+			const first = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
+			const second = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
+			const third = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
+
+			const firstData = first!.toolSpecificData as IChatTerminalToolInvocationData;
+			const secondData = second!.toolSpecificData as IChatTerminalToolInvocationData;
+			const thirdData = third!.toolSpecificData as IChatTerminalToolInvocationData;
+
+			ok(firstData.alternativeRecommendation?.includes('POLICY_DENIED'), 'Expected initial policy denial message');
+			ok(secondData.alternativeRecommendation?.includes('POLICY_DENIED'), 'Expected second policy denial message');
+			ok(thirdData.alternativeRecommendation?.includes('POLICY_DENIED_CIRCUIT_BREAKER'), 'Expected circuit breaker policy denial message');
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1416,6 +1416,10 @@ suite('RunInTerminalTool', () => {
 	});
 
 	suite('session auto approval', () => {
+		setup(() => {
+			setAutoApprove({ rm: false });
+		});
+
 		test('should return policy denial details for denied commands when session has auto approval enabled', async () => {
 			const sessionId = 'test-session-123';
 			const sessionResource = LocalChatSessionUri.forSession(sessionId);


### PR DESCRIPTION
Fix `runInTerminal` policy-denial handling in auto-approve sessions (issue [#7036](https://github.com/microsoft/vscode-internalbacklog/issues/7036)).

## Problem
In auto-approve sessions, commands denied by terminal policy could still enter confirmation flow. In unattended/eval runs, this showed up as `X_BLOCKING_UI_ERROR` and deny/wait loops rather than a clean policy failure, wasting time and not producing the right artifacts.

## What changed
- Added structured denial metadata from command analysis:
  - `scope`, `deniedCommand`, `reason`, `ruleSourceText`.
- In `prepareToolInvocation`, if session auto-approve is enabled and command is denied:
  - short-circuit before execution/confirmation,
  - return immediate `POLICY_DENIED`.
- Added per-session deny circuit breaker:
  - repeated identical denial (threshold: 3) returns `POLICY_DENIED_CIRCUIT_BREAKER` (“will not be retried”).
- Preserved explicit override behavior:
  - `forceConfirmationReason` still forces confirmation UI.

## Why
Fast-first fail-closed behavior: deny early, avoid UI stalls, and provide actionable policy feedback so the model can pivot instead of retrying blocked commands.

## Failure comparisons this targets (CLI pass -> VS Code fail)
- `compile-compcert`
  - Example blocked commands:
    - `curl -L --fail -s https://compcert.org/download.html`
    - `rm -rf /tmp/CompCert /tmp/compcert-3.13.1 /tmp/compcert-3.13.1.tar.gz`
- `nginx-request-logging`
  - Example blocked command:
    - `rm -f /etc/nginx/sites-enabled/default`
- `qemu-startup`
  - Example blocked commands:
    - `ps -ef`
    - `kill 22278`
    - `dd if=/app/alpine.iso bs=1 skip=32768 count=8`

## All tests in this VS Code run that hit `X_BLOCKING_UI_ERROR`
- `compile-compcert`
- `crack-7z-hash`
- `mcmc-sampling-stan`
- `mteb-leaderboard`
- `nginx-request-logging`
- `qemu-alpine-ssh`
- `qemu-startup`
- `raman-fitting`

## Expected impact
- Fewer hidden confirmation deadlocks/deny loops in unattended runs.
- Clearer model-visible policy failures.
- Better observability for policy-blocked failures.

---

This fixes the *failure mode*, not the underlying policy.

Before:
- The tool attempted denied commands, entered confirm/wait behavior, and the model kept probing variations.
- Result: long loops, unclear signal, time burned.

After early block:
- Denied command is rejected immediately in `prepareToolInvocation` with structured `POLICY_DENIED` details.
- No terminal execution attempt, no confirmation path, no hidden stall.
- Repeated identical denials trip a circuit breaker (`POLICY_DENIED_CIRCUIT_BREAKER`) so the model is told to stop retrying that path.

Practical effect:
- Better UX: fast, explicit error instead of hanging.
- Better agent behavior: clearer chance to pivot to a truly different approach.
- Better pass rate only when an alternate allowed path exists.
- If policy blocks all viable paths (like needing `curl`/`rm` for setup), tests still fail, but faster and more diagnosably.