### PR TITLE
Fix view name when SCM Graph is moved to panel

### DIFF
--- a/src/vs/workbench/services/views/common/viewContainerModel.ts
+++ b/src/vs/workbench/services/views/common/viewContainerModel.ts
@@ -346,7 +346,14 @@ export class ViewContainerModel extends Disposable implements IViewContainerMode
 	private updateContainerInfo(): void {
 		/* Use default container info if one of the visible view descriptors belongs to the current container by default */
 		const useDefaultContainerInfo = this.viewContainer.alwaysUseContainerInfo || this.visibleViewDescriptors.length === 0 || this.visibleViewDescriptors.some(v => Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).getViewContainer(v.id) === this.viewContainer);
-		const title = useDefaultContainerInfo ? (typeof this.viewContainer.title === 'string' ? this.viewContainer.title : this.viewContainer.title.value) : this.visibleViewDescriptors[0]?.containerTitle || this.visibleViewDescriptors[0]?.name?.value || '';
+		let title: string;
+		if (useDefaultContainerInfo) {
+			title = typeof this.viewContainer.title === 'string' ? this.viewContainer.title : this.viewContainer.title.value;
+		} else {
+			const firstDescriptor = this.visibleViewDescriptors[0];
+			const fallbackTitle = firstDescriptor?.containerTitle || firstDescriptor?.name?.value || '';
+			title = (this.visibleViewDescriptors.length === 1 && firstDescriptor?.singleViewPaneContainerTitle) || fallbackTitle;
+		}
 		let titleChanged: boolean = false;
 		if (this._title !== title) {
 			this._title = title;


### PR DESCRIPTION
## Summary
- When a single view is placed in a non-default container (e.g., SCM Graph moved to the panel or secondary sidebar), the container title showed "Source Control" instead of "Source Control Graph"
- The fix uses `singleViewPaneContainerTitle` in `ViewContainerModel.updateContainerInfo()` when there is exactly one visible view in a non-default container

<img width="1312" height="911" alt="Screenshot 2026-03-11 at 16 20 29" src="https://github.com/user-attachments/assets/5453aa19-c366-4d1d-a67b-b6d7a944e5b5" />

Fixes #250196