### PR TITLE
fix: remove persistent focus outline on walkthrough step checkbox click

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -897,6 +897,16 @@
 	margin-right: 9px;
 }
 
+/* Don't show focus outline on mouse click. Instead only show outline on keyboard focus. */
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon:focus {
+	outline: none;
+}
+
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 0;
+}
+
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox.codicon:not(.checked)::before {
 	opacity: 0;


### PR DESCRIPTION
Fixes #300862

## Problem
When clicking a walkthrough step checkbox (codicon) in an **expanded** step on the Getting Started page, a blue focus border appears and persists until clicking elsewhere. Collapsed steps are unaffected.

## Root Cause
When `selectStep()` expands a step, it sets `tabindex="0"` on the codicon element, making it focusable. A mouse click gives it focus, and since there were no `:focus` / `:focus-visible` CSS rules for the codicon, the browser's default focus ring appeared.

## Fix
Added `:focus` and `:focus-visible` rules for `.getting-started-step .codicon`, mirroring the existing pattern already used for `<button>` elements in the same stylesheet:

- `:focus` → `outline: none` (suppresses outline on mouse click)
- `:focus-visible` → `outline: 1px solid var(--vscode-focusBorder)` (preserves outline for keyboard navigation)

## Testing
Verified both interactions work correctly after the fix:
- **Mouse click** on the checkbox in an expanded step — no blue focus border appears
- **Keyboard navigation** (Tab + Enter/Space) — focus outline correctly appears via `:focus-visible`, maintaining accessibility

## Demo

<!-- Drag and drop your .mp4 or .webm video file here while editing on GitHub. 
     GitHub will upload it and replace the URL automatically. -->

https://github.com/user-attachments/assets/6d971d13-b029-47cf-bc10-4521be1c0adc

