### PR TITLE
feat: respect XDG_CONFIG_HOME for argv.json on Linux

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -438,7 +438,28 @@ function getArgvConfigPath(): string {
 		dataFolderName = `${dataFolderName}-dev`;
 	}
 
-	return path.join(os.homedir(), dataFolderName!, 'argv.json');
+	// On Linux, respect XDG_CONFIG_HOME to align with how
+	// userDataPath is resolved (see userDataPath.ts)
+	const newArgvConfigPath = process.platform === 'linux'
+		? path.join(process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config'), dataFolderName!, 'argv.json')
+		: path.join(os.homedir(), dataFolderName!, 'argv.json');
+
+	// Migrate from the legacy path (~/.vscode/argv.json) if needed
+	if (process.platform === 'linux' && process.env['XDG_CONFIG_HOME']) {
+		const legacyArgvConfigPath = path.join(os.homedir(), dataFolderName!, 'argv.json');
+		if (legacyArgvConfigPath !== newArgvConfigPath) {
+			try {
+				if (fs.existsSync(legacyArgvConfigPath) && !fs.existsSync(newArgvConfigPath)) {
+					fs.mkdirSync(path.dirname(newArgvConfigPath), { recursive: true });
+					fs.renameSync(legacyArgvConfigPath, newArgvConfigPath);
+				}
+			} catch (error) {
+				console.error(`Unable to migrate argv.json from ${legacyArgvConfigPath} to ${newArgvConfigPath} (${error})`);
+			}
+		}
+	}
+
+	return newArgvConfigPath;
 }
 
 function configureCrashReporter(): void {

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -8,6 +8,7 @@ import { memoize } from '../../../base/common/decorators.js';
 import { FileAccess, Schemas } from '../../../base/common/network.js';
 import { dirname, join, normalize, resolve } from '../../../base/common/path.js';
 import { env } from '../../../base/common/process.js';
+import { isLinux } from '../../../base/common/platform.js';
 import { joinPath } from '../../../base/common/resources.js';
 import { URI } from '../../../base/common/uri.js';
 import { NativeParsedArgs } from './argv.js';
@@ -96,6 +97,11 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 		const vscodePortable = env['VSCODE_PORTABLE'];
 		if (vscodePortable) {
 			return URI.file(join(vscodePortable, 'argv.json'));
+		}
+
+		// On Linux, respect XDG_CONFIG_HOME to align with userDataPath resolution
+		if (env['XDG_CONFIG_HOME'] && isLinux) {
+			return URI.file(join(env['XDG_CONFIG_HOME'], this.productService.dataFolderName, 'argv.json'));
 		}
 
 		return joinPath(this.userHome, this.productService.dataFolderName, 'argv.json');


### PR DESCRIPTION
## Summary

Resolves the long-standing inconsistency where `argv.json` was placed under `~/.vscode/` even when `XDG_CONFIG_HOME` is set, while all other user data already respects it (via `userDataPath.ts`).

Fixes #162712

## Changes

### 2 files changed, 28 additions, 1 deletion

| File | Change |
|------|--------|
| `src/main.ts` | Update `getArgvConfigPath()` to use `XDG_CONFIG_HOME` on Linux (falling back to `~/.config`). Adds migration from legacy path. |
| `src/vs/platform/environment/common/environmentService.ts` | Update `argvResource` getter to resolve under `XDG_CONFIG_HOME` on Linux. |

## Behavior

| Platform | XDG_CONFIG_HOME set? | argv.json location |
|----------|---------------------|-------------------|
| Linux | Yes (`/custom/config`) | `/custom/config/.vscode/argv.json` |
| Linux | No | `~/.config/.vscode/argv.json` (same as userDataPath) |
| macOS/Windows | N/A | Unchanged (`~/.vscode/argv.json` / AppData) |

## Migration

When `XDG_CONFIG_HOME` is set on Linux:
1. Checks if legacy `~/.vscode/argv.json` exists
2. If new location doesn't exist yet → moves file to XDG-compliant path
3. Errors are caught and logged (no crash on permission issues)
4. If both exist → uses new location (no data loss)

## Prior Art

- Previous PR #170364 attempted this but was closed (CI issues, no error handling)
- This implementation adds proper error handling, `mkdirSync` for the target directory, and aligns with the existing XDG pattern in `userDataPath.ts` (line 90)
- Follows @bpasero's guidance: _"respect the XDG_CONFIG_HOME variable as we do [in userDataPath.ts]"_