### PR TITLE
fix: improve vertical alignment of text and icons in status bar

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -95,6 +95,7 @@
 	cursor: pointer;
 	display: flex;
 	height: 100%;
+	line-height: 1; /* override inherited 22px so that align-items:center can vertically center text alongside codicons */
 	margin-right: 3px;
 	margin-left: 3px;
 	padding: 0 5px;


### PR DESCRIPTION
## Summary

Fixes the long-standing vertical misalignment between text and codicon icons in the status bar.

Fixes #162995

## Root Cause

The `.statusbar-item-label` container uses `display: flex` with `align-items: center`, which should vertically center its children. However, text inherited `line-height: 22px` from `.statusbar-item`, making anonymous text flex items the same height as the container (22px). This left `align-items: center` with nothing to adjust — text was already filling the full height and its position was determined solely by the font's baseline metrics.

Meanwhile, codicons declare `line-height: 1` in `codicon.css` (`font: normal normal normal 16px/1 codicon`), making them ~16px tall. Flexbox correctly centers these 16px items within the 22px bar, but text was stuck at its baseline-determined position.

On fonts like Segoe (Windows) and SF Pro (macOS), the baseline sits lower relative to the visual center, causing text to appear shifted downward compared to icons.

## Fix

```css
.statusbar-item-label {
    line-height: 1; /* was inheriting 22px */
}
```

**1 file changed, 1 insertion.**

This gives text an intrinsic height of ~12px (matching `font-size: 12px`), allowing `align-items: center` to genuinely center both text and icons at the same vertical midpoint within the 22px status bar.

## Why This Works

| Element | Before | After |
|---------|--------|-------|
| **Codicons** | `line-height: 1` → 16px tall → centered at 3px offset ✓ | No change |
| **Text** | `line-height: 22px` → 22px tall → 0px offset (baseline-dependent) ✗ | `line-height: 1` → 12px tall → centered at 5px offset ✓ |

Both now have their bounding-box centers at the 11px midpoint of the 22px bar.