### PR TITLE
Rename isolation picker labels: Copilot CLI → Worktree, Local → Folder

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionTargetPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTargetPicker.ts
@@ -243,13 +243,13 @@ export class IsolationModePicker extends Disposable {
 		const items: IActionListItem<IsolationMode>[] = [
 			{
 				kind: ActionListItemKind.Action,
-				label: localize('isolationMode.worktree', "Copilot CLI"),
+				label: localize('isolationMode.worktree', "Worktree"),
 				group: { title: '', icon: Codicon.worktree },
 				item: 'worktree',
 			},
 			{
 				kind: ActionListItemKind.Action,
-				label: localize('isolationMode.folder', "Local"),
+				label: localize('isolationMode.folder', "Folder"),
 				group: { title: '', icon: Codicon.folder },
 				item: 'workspace',
 			},
@@ -296,8 +296,8 @@ export class IsolationModePicker extends Disposable {
 		const isDisabled = !this._repository;
 		const modeIcon = this._isolationMode === 'worktree' ? Codicon.worktree : Codicon.folder;
 		const modeLabel = this._isolationMode === 'worktree'
-			? localize('isolationMode.worktree', "Copilot CLI")
-			: localize('isolationMode.folder', "Local");
+			? localize('isolationMode.worktree', "Worktree")
+			: localize('isolationMode.folder', "Folder");
 
 		dom.append(this._triggerElement, renderIcon(modeIcon));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));


### PR DESCRIPTION
Renames the isolation mode picker labels in the Agent Sessions new chat view:

- **"Copilot CLI"** → **"Worktree"**
- **"Local"** → **"Folder"**

Updates both the picker dropdown items and the trigger button label in `sessionTargetPicker.ts`.