### PR TITLE
feat: add USER_NAME and USER_HOME snippet variables

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetSession.ts
@@ -22,7 +22,7 @@ import { OvertypingCapturer } from '../../suggest/browser/suggestOvertypingCaptu
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { Choice, Marker, Placeholder, SnippetParser, Text, TextmateSnippet } from './snippetParser.js';
-import { ClipboardBasedVariableResolver, CommentBasedVariableResolver, CompositeSnippetVariableResolver, ModelBasedVariableResolver, RandomBasedVariableResolver, SelectionBasedVariableResolver, TimeBasedVariableResolver, WorkspaceBasedVariableResolver } from './snippetVariables.js';
+import { ClipboardBasedVariableResolver, CommentBasedVariableResolver, CompositeSnippetVariableResolver, ModelBasedVariableResolver, RandomBasedVariableResolver, SelectionBasedVariableResolver, TimeBasedVariableResolver, UserBasedVariableResolver, WorkspaceBasedVariableResolver } from './snippetVariables.js';
 import { EditSources, TextModelEditSource } from '../../../common/textModelEditSource.js';
 
 export class OneSnippet {
@@ -529,6 +529,7 @@ export class SnippetSession {
 				new TimeBasedVariableResolver,
 				new WorkspaceBasedVariableResolver(workspaceService),
 				new RandomBasedVariableResolver,
+				new UserBasedVariableResolver,
 			]));
 
 			// store snippets with the index of their originating selection.
@@ -564,6 +565,7 @@ export class SnippetSession {
 			new TimeBasedVariableResolver,
 			new WorkspaceBasedVariableResolver(editor.invokeWithinContext(accessor => accessor.get(IWorkspaceContextService))),
 			new RandomBasedVariableResolver,
+			new UserBasedVariableResolver,
 		]);
 
 		//

--- a/src/vs/editor/contrib/snippet/browser/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetVariables.ts
@@ -5,6 +5,7 @@
 
 import { normalizeDriveLetter } from '../../../../base/common/labels.js';
 import * as path from '../../../../base/common/path.js';
+import { env } from '../../../../base/common/process.js';
 import { dirname } from '../../../../base/common/resources.js';
 import { commonPrefixLength, getLeadingWhitespace, isFalsyOrWhitespace, splitLines } from '../../../../base/common/strings.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -53,7 +54,9 @@ export const KnownSnippetVariableNames = Object.freeze<{ [key: string]: true }>(
 	'WORKSPACE_FOLDER': true,
 	'RANDOM': true,
 	'RANDOM_HEX': true,
-	'UUID': true
+	'UUID': true,
+	'USER_NAME': true,
+	'USER_HOME': true,
 });
 
 export class CompositeSnippetVariableResolver implements VariableResolver {
@@ -374,6 +377,20 @@ export class RandomBasedVariableResolver implements VariableResolver {
 			return Math.random().toString(16).slice(-6);
 		} else if (name === 'UUID') {
 			return generateUuid();
+		}
+
+		return undefined;
+	}
+}
+
+export class UserBasedVariableResolver implements VariableResolver {
+	resolve(variable: Variable): string | undefined {
+		const { name } = variable;
+
+		if (name === 'USER_NAME') {
+			return env['USER'] || env['USERNAME'] || undefined;
+		} else if (name === 'USER_HOME') {
+			return env['HOME'] || env['USERPROFILE'] || undefined;
 		}
 
 		return undefined;

--- a/src/vs/editor/contrib/snippet/test/browser/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetVariables.test.ts
@@ -14,7 +14,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { Selection } from '../../../../common/core/selection.js';
 import { TextModel } from '../../../../common/model/textModel.js';
 import { SnippetParser, Variable, VariableResolver } from '../../browser/snippetParser.js';
-import { ClipboardBasedVariableResolver, CompositeSnippetVariableResolver, ModelBasedVariableResolver, SelectionBasedVariableResolver, TimeBasedVariableResolver, WorkspaceBasedVariableResolver } from '../../browser/snippetVariables.js';
+import { ClipboardBasedVariableResolver, CompositeSnippetVariableResolver, ModelBasedVariableResolver, SelectionBasedVariableResolver, TimeBasedVariableResolver, UserBasedVariableResolver, WorkspaceBasedVariableResolver } from '../../browser/snippetVariables.js';
 import { createTextModel } from '../../../../test/common/testTextModel.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IWorkspace, IWorkspaceContextService, toWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
@@ -444,5 +444,19 @@ suite('Snippet Variables Resolver', function () {
 		}
 
 		model.dispose();
+	});
+
+	test('User variables for snippets #64599', function () {
+
+		const resolver = new UserBasedVariableResolver;
+
+		// USER_NAME resolves to a non-empty string on all platforms
+		const snippetUserName = new SnippetParser().parse('$USER_NAME');
+		const variableUserName = <Variable>snippetUserName.children[0];
+		assert.strictEqual(variableUserName.resolve(resolver), true, 'USER_NAME failed to resolve');
+
+		const snippetUserHome = new SnippetParser().parse('$USER_HOME');
+		const variableUserHome = <Variable>snippetUserHome.children[0];
+		assert.strictEqual(variableUserHome.resolve(resolver), true, 'USER_HOME failed to resolve');
 	});
 });


### PR DESCRIPTION
## Summary

Adds two new built-in snippet variables for inserting the OS username and home directory into snippets.

Fixes #64599

## New Variables

| Variable | Description | Linux/macOS | Windows |
|----------|-------------|-------------|---------|
| `$USER_NAME` | Current OS username | `$USER` | `$USERNAME` |
| `$USER_HOME` | User home directory | `$HOME` | `$USERPROFILE` |

## Example Usage

```json
{
  "Author Header": {
    "prefix": "author",
    "body": [
      "// Author: $USER_NAME",
      "// Created: $CURRENT_DATE/$CURRENT_MONTH/$CURRENT_YEAR"
    ]
  }
}
```

## Changes

### 3 files changed, 36 additions, 3 deletions

| File | Change |
|------|--------|
| `src/vs/editor/contrib/snippet/browser/snippetVariables.ts` | Add `UserBasedVariableResolver` class, register `USER_NAME` and `USER_HOME` in `KnownSnippetVariableNames` |
| `src/vs/editor/contrib/snippet/browser/snippetSession.ts` | Wire resolver into both `CompositeSnippetVariableResolver` compositions |
| `src/vs/editor/contrib/snippet/test/browser/snippetVariables.test.ts` | Add test for variable resolution |

## Implementation

Follows the established pattern (same as `TimeBasedVariableResolver` / `RandomBasedVariableResolver`):
- No external dependencies — uses `env` from `base/common/process.js` (VS Code's cross-platform process abstraction)
- Falls back across platform-specific env vars (`USER` → `USERNAME`, `HOME` → `USERPROFILE`)
- Returns `undefined` when no env var is available (snippet shows placeholder instead)

## Motivation

This has been requested since 2018 (#64599) — developers want to insert their username in copyright headers, author tags, and documentation snippets without having to type it every time. Currently requires manual input or custom extensions.