### PR TITLE
fix: add BusyBox compatibility guard for bash shell integration (fixes #170868)

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -3,6 +3,12 @@
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
 
+# Bail out when /bin/bash is really BusyBox ash or another non-bash shell.
+# Keep this guard shell-agnostic: no [[ ]], no builtin, no arrays.
+if [ -z "${BASH_VERSION:-}" ]; then
+	return
+fi
+
 # Prevent the script recursing when setting up
 if [[ -n "${VSCODE_SHELL_INTEGRATION:-}" ]]; then
 	builtin return


### PR DESCRIPTION
## Description

Adds a shell-agnostic early return at the top of `shellIntegration-bash.sh` when `BASH_VERSION` is unset. This makes fake `bash` binaries backed by BusyBox ash skip VS Code's bash-specific shell integration instead of failing on `builtin`, arrays, and other bash-only syntax.

Fixes #170868

## Testing

- `npm run compile`
- `dash -c '. src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh'` returned cleanly without enabling shell integration
- `bash --noprofile --norc -c '. src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh; test "$VSCODE_SHELL_INTEGRATION" = 1'` succeeded
- `git diff --check main..HEAD`
- No `package.json` or `tsconfig.json` changes
