### PR TITLE
fix: detect ARM64 Windows and prevent x64 auto-update errors (fixes #141031)

### DIFF
--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -783,7 +783,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	}
 
 	async isRunningUnderARM64Translation(): Promise<boolean> {
-		if (isLinux || isWindows) {
+		if (isLinux) {
 			return false;
 		}
 

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -63,6 +63,7 @@ export const enum DisablementReason {
 	MissingConfiguration,
 	InvalidConfiguration,
 	RunningAsAdmin,
+	RunningX64OnArm64,
 }
 
 export type Uninitialized = { type: StateType.Uninitialized };

--- a/src/vs/platform/update/common/updateWindows.ts
+++ b/src/vs/platform/update/common/updateWindows.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IProductConfiguration } from '../../../base/common/product.js';
+
+export function shouldDisableUpdatesForWindowsX64OnArm64(processArch: string, isRunningUnderARM64Translation: boolean): boolean {
+	return processArch === 'x64' && isRunningUnderARM64Translation;
+}
+
+export function getWindowsArm64DownloadPlatform(target: string | undefined): string {
+	return target === 'user' ? 'win32-arm64-user' : 'win32-arm64';
+}
+
+export function getWindowsArm64DownloadUrl(productService: Pick<IProductConfiguration, 'downloadUrl' | 'quality' | 'target' | 'updateUrl' | 'version'>): string | undefined {
+	const platform = getWindowsArm64DownloadPlatform(productService.target);
+
+	if (productService.updateUrl && productService.version && productService.quality) {
+		const updateUrl = new URL(productService.updateUrl);
+		return new URL(`/${encodeURIComponent(productService.version)}/${platform}/${encodeURIComponent(productService.quality)}`, updateUrl.origin).toString();
+	}
+
+	if (!productService.downloadUrl) {
+		return undefined;
+	}
+
+	try {
+		const downloadUrl = new URL(productService.downloadUrl);
+
+		if (downloadUrl.searchParams.has('os')) {
+			downloadUrl.searchParams.set('os', platform);
+
+			if (productService.quality && downloadUrl.searchParams.has('build')) {
+				downloadUrl.searchParams.set('build', productService.quality);
+			}
+
+			return downloadUrl.toString();
+		}
+	} catch {
+		// Fall back to the configured download URL below.
+	}
+
+	return productService.downloadUrl;
+}

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -131,7 +131,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 
 		const runningX64OnArm64 = shouldDisableUpdatesForWindowsX64OnArm64(
 			process.arch,
-			process.arch === 'x64' && await this.nativeHostMainService.isRunningUnderARM64Translation()
+			process.arch === 'x64' && await this.nativeHostMainService.isRunningUnderARM64Translation(undefined)
 		);
 
 		if (runningX64OnArm64) {

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -32,6 +32,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { asJson, IRequestService } from '../../request/common/request.js';
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { AvailableForDownload, DisablementReason, IUpdate, State, StateType, UpdateType } from '../common/update.js';
+import { shouldDisableUpdatesForWindowsX64OnArm64 } from '../common/updateWindows.js';
 import { AbstractUpdateService, createUpdateURL, getUpdateRequestHeaders, IUpdateURLOptions, UpdateErrorClassification } from './abstractUpdateService.js';
 import { INodeProcess } from '../../../base/common/platform.js';
 
@@ -127,6 +128,17 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		const osRelease = await getWindowsRelease();
 		const osNodeRelease = release();
 		this.telemetryService.publicLog2<WindowsUpdateInitEvent, WindowsUpdateInitClassification>('windowsUpdateInit', { osRelease, osNodeRelease });
+
+		const runningX64OnArm64 = shouldDisableUpdatesForWindowsX64OnArm64(
+			process.arch,
+			process.arch === 'x64' && await this.nativeHostMainService.isRunningUnderARM64Translation()
+		);
+
+		if (runningX64OnArm64) {
+			this.setState(State.Disabled(DisablementReason.RunningX64OnArm64));
+			this.logService.info('update#ctor - updates are disabled because the x64 build is running under ARM64 translation on Windows');
+			return;
+		}
 
 		if (this.productService.target === 'user' && await this.nativeHostMainService.isAdmin(undefined)) {
 			this.setState(State.Disabled(DisablementReason.RunningAsAdmin));

--- a/src/vs/platform/update/test/common/updateWindows.test.ts
+++ b/src/vs/platform/update/test/common/updateWindows.test.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { getWindowsArm64DownloadPlatform, getWindowsArm64DownloadUrl, shouldDisableUpdatesForWindowsX64OnArm64 } from '../../common/updateWindows.js';
 
 suite('UpdateWindows', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('detects x64 builds running under ARM64 translation', () => {
 		assert.strictEqual(shouldDisableUpdatesForWindowsX64OnArm64('x64', true), true);
 		assert.strictEqual(shouldDisableUpdatesForWindowsX64OnArm64('x64', false), false);
@@ -32,7 +35,9 @@ suite('UpdateWindows', () => {
 		assert.strictEqual(getWindowsArm64DownloadUrl({
 			downloadUrl: 'https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user',
 			quality: 'insider',
-			target: 'user'
+			target: 'user',
+			updateUrl: '',
+			version: ''
 		}), 'https://code.visualstudio.com/sha/download?build=insider&os=win32-arm64-user');
 	});
 });

--- a/src/vs/platform/update/test/common/updateWindows.test.ts
+++ b/src/vs/platform/update/test/common/updateWindows.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { getWindowsArm64DownloadPlatform, getWindowsArm64DownloadUrl, shouldDisableUpdatesForWindowsX64OnArm64 } from '../../common/updateWindows.js';
+
+suite('UpdateWindows', () => {
+	test('detects x64 builds running under ARM64 translation', () => {
+		assert.strictEqual(shouldDisableUpdatesForWindowsX64OnArm64('x64', true), true);
+		assert.strictEqual(shouldDisableUpdatesForWindowsX64OnArm64('x64', false), false);
+		assert.strictEqual(shouldDisableUpdatesForWindowsX64OnArm64('arm64', true), false);
+	});
+
+	test('maps download targets to the ARM64 installer platform', () => {
+		assert.strictEqual(getWindowsArm64DownloadPlatform('user'), 'win32-arm64-user');
+		assert.strictEqual(getWindowsArm64DownloadPlatform('system'), 'win32-arm64');
+		assert.strictEqual(getWindowsArm64DownloadPlatform(undefined), 'win32-arm64');
+	});
+
+	test('builds a versioned ARM64 download URL from the update service host', () => {
+		assert.strictEqual(getWindowsArm64DownloadUrl({
+			updateUrl: 'https://update.code.visualstudio.com/api/update',
+			quality: 'stable',
+			target: 'user',
+			version: '1.99.0'
+		}), 'https://update.code.visualstudio.com/1.99.0/win32-arm64-user/stable');
+	});
+
+	test('falls back to rewriting a configured download URL', () => {
+		assert.strictEqual(getWindowsArm64DownloadUrl({
+			downloadUrl: 'https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user',
+			quality: 'insider',
+			target: 'user'
+		}), 'https://code.visualstudio.com/sha/download?build=insider&os=win32-arm64-user');
+	});
+});

--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../../nls.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 import severity from '../../../../base/common/severity.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -32,10 +33,13 @@ import { Event } from '../../../../base/common/event.js';
 import { toAction } from '../../../../base/common/actions.js';
 import { IDefaultAccountService } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { getInternalOrg } from '../../../../platform/assignment/common/assignment.js';
+import { IBannerService } from '../../../services/banner/browser/bannerService.js';
 import { IVersion, preprocessError, tryParseVersion } from '../common/updateUtils.js';
+import { getWindowsArm64DownloadUrl } from '../../../../platform/update/common/updateWindows.js';
 
 export const CONTEXT_UPDATE_STATE = new RawContextKey<string>('updateState', StateType.Uninitialized);
 export const MAJOR_MINOR_UPDATE_AVAILABLE = new RawContextKey<boolean>('majorMinorUpdateAvailable', false);
+const WINDOWS_ARM64_ARCHITECTURE_MISMATCH_BANNER_ID = 'update.architectureMismatch';
 
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
@@ -223,6 +227,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		@IDialogService private readonly dialogService: IDialogService,
 		@IUpdateService private readonly updateService: IUpdateService,
 		@IActivityService private readonly activityService: IActivityService,
+		@IBannerService private readonly bannerService: IBannerService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IProductService private readonly productService: IProductService,
 		@IOpenerService private readonly openerService: IOpenerService,
@@ -267,6 +272,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 
 	private async onUpdateStateChange(state: UpdateState): Promise<void> {
 		this.updateStateContextKey.set(state.type);
+		this.updateArchitectureMismatchBanner(state);
 
 		switch (state.type) {
 			case StateType.Disabled:
@@ -341,6 +347,29 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 		}
 
 		this.state = state;
+	}
+
+	private updateArchitectureMismatchBanner(state: UpdateState): void {
+		if (state.type !== StateType.Disabled || state.reason !== DisablementReason.RunningX64OnArm64) {
+			this.bannerService.hide(WINDOWS_ARM64_ARCHITECTURE_MISMATCH_BANNER_ID);
+			return;
+		}
+
+		const downloadUrl = getWindowsArm64DownloadUrl(this.productService);
+
+		this.bannerService.show({
+			id: WINDOWS_ARM64_ARCHITECTURE_MISMATCH_BANNER_ID,
+			icon: Codicon.warning,
+			message: nls.localize(
+				'update.architectureMismatch.banner',
+				"You are running the x64 build of {0} on ARM64 Windows. Updates are disabled for this installation. Install the ARM64 build to receive updates again.",
+				this.productService.nameLong
+			),
+			actions: downloadUrl ? [{
+				label: nls.localize('update.architectureMismatch.banner.action', "Download ARM64 Build"),
+				href: downloadUrl
+			}] : undefined
+		});
 	}
 
 	private onError(error: string): void {

--- a/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTitleBarEntry.ts
@@ -113,7 +113,7 @@ export class UpdateTitleBarContribution extends Disposable implements IWorkbench
 	private shouldShowTooltip(state: State): boolean {
 		switch (state.type) {
 			case StateType.Disabled:
-				return state.reason === DisablementReason.InvalidConfiguration || state.reason === DisablementReason.RunningAsAdmin;
+				return state.reason === DisablementReason.InvalidConfiguration || state.reason === DisablementReason.RunningAsAdmin || state.reason === DisablementReason.RunningX64OnArm64;
 			case StateType.Idle:
 				return !!state.error || state.notAvailable || this.isMajorMinorVersionChange();
 			case StateType.AvailableForDownload:

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -225,6 +225,14 @@ export class UpdateTooltip extends Disposable {
 						this.productService.nameShort),
 					Codicon.warning);
 				break;
+			case DisablementReason.RunningX64OnArm64:
+				this.showMessage(
+					localize(
+						'updateTooltip.disabledRunningX64OnArm64',
+						"Updates are not available when running the x64 build of {0} on ARM64 Windows. Install the ARM64 build to receive updates again.",
+						this.productService.nameShort),
+					Codicon.warning);
+				break;
 			default:
 				this.showMessage(localize('updateTooltip.disabledGeneric', "Updates are disabled."), Codicon.warning);
 				break;

--- a/src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts
@@ -1,0 +1,148 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/configurationServiceMock.js';
+import { IMeteredConnectionService } from '../../../../../platform/meteredConnection/common/meteredConnection.js';
+import { NullOpenerService } from '../../../../../platform/opener/test/common/nullOpenerService.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { DisablementReason, IUpdateService, State, StateType, UpdateType, type State as UpdateState } from '../../../../../platform/update/common/update.js';
+import { IBannerItem, IBannerService } from '../../../../services/banner/browser/bannerService.js';
+import { IActivityService } from '../../../../services/activity/common/activity.js';
+import { TestActivityService, TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { type ITestInstantiationService, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { UpdateContribution } from '../../browser/update.js';
+import { UpdateTooltip } from '../../browser/updateTooltip.js';
+
+class TestUpdateService implements IUpdateService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onStateChange = new Emitter<UpdateState>();
+	readonly onStateChange = this._onStateChange.event;
+
+	constructor(public state: UpdateState) { }
+
+	setState(state: UpdateState): void {
+		this.state = state;
+		this._onStateChange.fire(state);
+	}
+
+	async checkForUpdates(_explicit: boolean): Promise<void> { }
+	async downloadUpdate(_explicit: boolean): Promise<void> { }
+	async applyUpdate(): Promise<void> { }
+	async quitAndInstall(): Promise<void> { }
+	async isLatestVersion(): Promise<boolean | undefined> { return undefined; }
+	async _applySpecificUpdate(_packagePath: string): Promise<void> { }
+	async setInternalOrg(_internalOrg: string | undefined): Promise<void> { }
+}
+
+class TestBannerService implements IBannerService {
+	declare readonly _serviceBrand: undefined;
+
+	lastItem: IBannerItem | undefined;
+	hiddenIds: string[] = [];
+
+	focus(): void { }
+	focusNextAction(): void { }
+	focusPreviousAction(): void { }
+
+	hide(id: string): void {
+		this.hiddenIds.push(id);
+
+		if (this.lastItem?.id === id) {
+			this.lastItem = undefined;
+		}
+	}
+
+	show(item: IBannerItem): void {
+		this.lastItem = item;
+	}
+}
+
+suite('UpdateContribution', () => {
+	const suiteDisposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let disposables: DisposableStore;
+	let instantiationService: ITestInstantiationService;
+	let updateService: TestUpdateService;
+	let bannerService: TestBannerService;
+	let registerGlobalActivityActionsStub: sinon.SinonStub;
+
+	setup(() => {
+		disposables = suiteDisposables.add(new DisposableStore());
+		instantiationService = workbenchInstantiationService({
+			configurationService: () => new TestConfigurationService({
+				update: {
+					titleBar: 'none'
+				}
+			})
+		}, disposables);
+
+		updateService = new TestUpdateService(State.Disabled(DisablementReason.RunningX64OnArm64));
+		bannerService = new TestBannerService();
+		registerGlobalActivityActionsStub = sinon.stub(UpdateContribution.prototype as object as { registerGlobalActivityActions(): void }, 'registerGlobalActivityActions').callsFake(() => { });
+
+		instantiationService.stub(IActivityService, new TestActivityService());
+		instantiationService.stub(IBannerService, bannerService);
+		instantiationService.stub(ICommandService, {
+			_serviceBrand: undefined,
+			onWillExecuteCommand: Event.None,
+			onDidExecuteCommand: Event.None,
+			executeCommand: async () => undefined
+		});
+		instantiationService.stub(IMeteredConnectionService, {
+			_serviceBrand: undefined,
+			isConnectionMetered: false,
+			onDidChangeIsConnectionMetered: Event.None
+		});
+		instantiationService.stub(IOpenerService, NullOpenerService);
+		instantiationService.stub(IProductService, {
+			...TestProductService,
+			_serviceBrand: undefined,
+			nameLong: 'Visual Studio Code',
+			nameShort: 'VS Code',
+			quality: 'stable',
+			target: 'user',
+			updateUrl: 'https://update.code.visualstudio.com/api/update',
+			version: '1.99.0'
+		});
+		instantiationService.stub(IUpdateService, updateService);
+	});
+
+	teardown(() => {
+		registerGlobalActivityActionsStub.restore();
+		disposables.clear();
+	});
+
+	test('shows an ARM64 guidance banner when updates are disabled for x64-on-ARM64', () => {
+		disposables.add(instantiationService.createInstance(UpdateContribution));
+
+		assert.strictEqual(bannerService.lastItem?.id, 'update.architectureMismatch');
+		assert.strictEqual(bannerService.lastItem?.actions?.[0].href, 'https://update.code.visualstudio.com/1.99.0/win32-arm64-user/stable');
+		assert.match(String(bannerService.lastItem?.message), /ARM64 Windows/);
+	});
+
+	test('hides the guidance banner when the update state changes away from the architecture mismatch', () => {
+		disposables.add(instantiationService.createInstance(UpdateContribution));
+
+		updateService.setState(State.Idle(UpdateType.Setup));
+
+		assert.strictEqual(bannerService.lastItem, undefined);
+		assert.ok(bannerService.hiddenIds.includes('update.architectureMismatch'));
+	});
+
+	test('renders a disabled tooltip message for the architecture mismatch reason', () => {
+		const tooltip = disposables.add(instantiationService.createInstance(UpdateTooltip));
+
+		assert.strictEqual(updateService.state.type, StateType.Disabled);
+		assert.match(tooltip.domNode.textContent ?? '', /Install the ARM64 build to receive updates again\./);
+	});
+});

--- a/src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from '../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { TestConfigurationService } from '../../../../../platform/configuration/test/common/configurationServiceMock.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IMeteredConnectionService } from '../../../../../platform/meteredConnection/common/meteredConnection.js';
 import { NullOpenerService } from '../../../../../platform/opener/test/common/nullOpenerService.js';
 import { IOpenerService } from '../../../../../platform/opener/common/opener.js';


### PR DESCRIPTION
## Description

Detects when VS Code is running as an x64 build under ARM64 translation on Windows, disables updates for that incompatible architecture, and shows banner/tooltip guidance directing users to install the ARM64 build.

Fixes #141031

## Testing

- `npm run compile-check-ts-native`
- `cd build && npm run typecheck`
- changed-file ESLint with the repo flat config passed
- `npm run hygiene`
- `npm run test-node -- --run src/vs/platform/update/test/common/updateWindows.test.ts`
- Added `src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts` for the banner path
- `node test/unit/browser/index.js --run src/vs/workbench/contrib/update/test/browser/updateContribution.test.ts --browser chromium` currently fails in test setup with `TypeError: Cannot add property sinonOptions, object is not extensible`; banner behavior was verified by code inspection while fixing the follow-up test coverage
- No `package.json` or `tsconfig.json` changes
