### PR TITLE
Add slight clairification to ChatParticipant in content provider API

### DIFF
--- a/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatSessionsProvider.d.ts
@@ -483,10 +483,11 @@ declare module 'vscode' {
 		 *
 		 * @param scheme The uri-scheme to register for. This must be unique.
 		 * @param provider The provider to register.
+		 * @param defaultChatParticipant The default {@link ChatParticipant chat participant} used in sessions provided by this provider.
 		 *
 		 * @returns A disposable that unregisters the provider when disposed.
 		 */
-		export function registerChatSessionContentProvider(scheme: string, provider: ChatSessionContentProvider, chatParticipant: ChatParticipant, capabilities?: ChatSessionCapabilities): Disposable;
+		export function registerChatSessionContentProvider(scheme: string, provider: ChatSessionContentProvider, defaultChatParticipant: ChatParticipant, capabilities?: ChatSessionCapabilities): Disposable;
 	}
 
 	export interface ChatContext {


### PR DESCRIPTION
Just clarifying the expected behavior since there was some confusion

@TylerLeonhardt @rebornix @DonJayamanne:  longer term I think the story we want is:

- The extension defines a top level chat participant (called something like `@claude`). This is what is used for delegating from an existing chat to a new session. 
   
    It would be expected to stream out a response, ending with a link to the new session

- The default chat participant for sessions of a given type. This is the participant passed into `registerChatSessionContentProvider`. It's not something you could directly `@` mention