### PR TITLE
feat: show number of folded lines in collapsed regions

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.css
+++ b/src/vs/editor/contrib/folding/browser/folding.css
@@ -30,12 +30,9 @@
 	opacity: 1;
 }
 
-.monaco-editor .inline-folded:after {
+.monaco-editor .inline-folded {
 	color: var(--vscode-editor-foldPlaceholderForeground);
 	margin: 0.1em 0.2em 0 0.2em;
-	content: "\22EF"; /* ellipses unicode character */
-	display: inline;
-	line-height: 1em;
 	cursor: pointer;
 }
 

--- a/src/vs/editor/contrib/folding/browser/foldingDecorations.ts
+++ b/src/vs/editor/contrib/folding/browser/foldingDecorations.ts
@@ -5,7 +5,7 @@
 
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
-import { IModelDecorationOptions, IModelDecorationsChangeAccessor, MinimapPosition, TrackedRangeStickiness } from '../../../common/model.js';
+import { IModelDecorationOptions, IModelDecorationsChangeAccessor, InjectedTextCursorStops, MinimapPosition, TrackedRangeStickiness } from '../../../common/model.js';
 import { ModelDecorationOptions } from '../../../common/model/textModel.js';
 import { IDecorationProvider } from './foldingModel.js';
 import { localize } from '../../../../nls.js';
@@ -138,25 +138,50 @@ export class FoldingDecorationProvider implements IDecorationProvider {
 	constructor(private readonly editor: ICodeEditor) {
 	}
 
-	getDecorationOption(isCollapsed: boolean, isHidden: boolean, isManual: boolean): IModelDecorationOptions {
+	getDecorationOption(isCollapsed: boolean, isHidden: boolean, isManual: boolean, lineCount?: number): IModelDecorationOptions {
 		if (isHidden) { // is inside another collapsed region
 			return FoldingDecorationProvider.HIDDEN_RANGE_DECORATION;
 		}
-		if (this.showFoldingControls === 'never') {
-			if (isCollapsed) {
-				return this.showFoldingHighlights ? FoldingDecorationProvider.NO_CONTROLS_COLLAPSED_HIGHLIGHTED_RANGE_DECORATION : FoldingDecorationProvider.NO_CONTROLS_COLLAPSED_RANGE_DECORATION;
-			}
-			return FoldingDecorationProvider.NO_CONTROLS_EXPANDED_RANGE_DECORATION;
-		}
 		if (isCollapsed) {
-			return isManual ?
-				(this.showFoldingHighlights ? FoldingDecorationProvider.MANUALLY_COLLAPSED_HIGHLIGHTED_VISUAL_DECORATION : FoldingDecorationProvider.MANUALLY_COLLAPSED_VISUAL_DECORATION)
-				: (this.showFoldingHighlights ? FoldingDecorationProvider.COLLAPSED_HIGHLIGHTED_VISUAL_DECORATION : FoldingDecorationProvider.COLLAPSED_VISUAL_DECORATION);
+			return this._createCollapsedDecoration(lineCount ?? 0, this.showFoldingHighlights, isManual);
+		}
+		if (this.showFoldingControls === 'never') {
+			return FoldingDecorationProvider.NO_CONTROLS_EXPANDED_RANGE_DECORATION;
 		} else if (this.showFoldingControls === 'mouseover') {
 			return isManual ? FoldingDecorationProvider.MANUALLY_EXPANDED_AUTO_HIDE_VISUAL_DECORATION : FoldingDecorationProvider.EXPANDED_AUTO_HIDE_VISUAL_DECORATION;
 		} else {
 			return isManual ? FoldingDecorationProvider.MANUALLY_EXPANDED_VISUAL_DECORATION : FoldingDecorationProvider.EXPANDED_VISUAL_DECORATION;
 		}
+	}
+
+	private _createCollapsedDecoration(lineCount: number, showHighlight: boolean, isManual: boolean): IModelDecorationOptions {
+		const text = lineCount === 1
+			? `\u22EF ${localize('1LineCollapsed', "(1 line)")}`
+			: `\u22EF ${localize('nLinesCollapsed', "({0} lines)", lineCount)}`;
+
+		const options: IModelDecorationOptions = {
+			description: 'folding-collapsed-visual-decoration',
+			stickiness: TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
+			after: {
+				content: text,
+				inlineClassName: 'inline-folded',
+				cursorStops: InjectedTextCursorStops.None,
+			},
+			isWholeLine: true,
+			linesDecorationsTooltip: collapsed,
+		};
+
+		if (this.showFoldingControls !== 'never') {
+			const icon = isManual ? foldingManualCollapsedIcon : foldingCollapsedIcon;
+			options.firstLineDecorationClassName = ThemeIcon.asClassName(icon);
+		}
+
+		if (showHighlight) {
+			options.className = 'folded-background';
+			options.minimap = foldedBackgroundMinimap;
+		}
+
+		return options;
 	}
 
 	changeDecorations<T>(callback: (changeAccessor: IModelDecorationsChangeAccessor) => T): T | null {

--- a/src/vs/editor/contrib/folding/browser/foldingModel.ts
+++ b/src/vs/editor/contrib/folding/browser/foldingModel.ts
@@ -10,7 +10,7 @@ import { hash } from '../../../../base/common/hash.js';
 import { SelectedLines } from './folding.js';
 
 export interface IDecorationProvider {
-	getDecorationOption(isCollapsed: boolean, isHidden: boolean, isManual: boolean): IModelDecorationOptions;
+	getDecorationOption(isCollapsed: boolean, isHidden: boolean, isManual: boolean, lineCount?: number): IModelDecorationOptions;
 	changeDecorations<T>(callback: (changeAccessor: IModelDecorationsChangeAccessor) => T): T | null;
 	removeDecorations(decorationIds: string[]): void;
 }
@@ -62,11 +62,13 @@ export class FoldingModel {
 			let lastHiddenLine = -1; // the end of the last hidden lines
 			const updateDecorationsUntil = (index: number) => {
 				while (k < index) {
+					const startLineNumber = this._regions.getStartLineNumber(k);
 					const endLineNumber = this._regions.getEndLineNumber(k);
 					const isCollapsed = this._regions.isCollapsed(k);
 					if (endLineNumber <= dirtyRegionEndLine) {
 						const isManual = this.regions.getSource(k) !== FoldSource.provider;
-						accessor.changeDecorationOptions(this._editorDecorationIds[k], this._decorationProvider.getDecorationOption(isCollapsed, endLineNumber <= lastHiddenLine, isManual));
+						const lineCount = endLineNumber - startLineNumber;
+						accessor.changeDecorationOptions(this._editorDecorationIds[k], this._decorationProvider.getDecorationOption(isCollapsed, endLineNumber <= lastHiddenLine, isManual, lineCount));
 					}
 					if (isCollapsed && endLineNumber > lastHiddenLine) {
 						lastHiddenLine = endLineNumber;
@@ -132,7 +134,7 @@ export class FoldingModel {
 				endLineNumber: endLineNumber,
 				endColumn: this._textModel.getLineMaxColumn(endLineNumber) + 1
 			};
-			newEditorDecorations.push({ range: decorationRange, options: this._decorationProvider.getDecorationOption(isCollapsed, endLineNumber <= lastHiddenLine, isManual) });
+			newEditorDecorations.push({ range: decorationRange, options: this._decorationProvider.getDecorationOption(isCollapsed, endLineNumber <= lastHiddenLine, isManual, endLineNumber - startLineNumber) });
 			if (isCollapsed && endLineNumber > lastHiddenLine) {
 				lastHiddenLine = endLineNumber;
 			}

--- a/src/vs/editor/contrib/folding/test/browser/foldingModel.test.ts
+++ b/src/vs/editor/contrib/folding/test/browser/foldingModel.test.ts
@@ -52,7 +52,7 @@ export class TestDecorationProvider {
 	constructor(private model: ITextModel) {
 	}
 
-	getDecorationOption(isCollapsed: boolean, isHidden: boolean): ModelDecorationOptions {
+	getDecorationOption(isCollapsed: boolean, isHidden: boolean, _isManual?: boolean, _lineCount?: number): ModelDecorationOptions {
 		if (isHidden) {
 			return TestDecorationProvider.hiddenDecoration;
 		}


### PR DESCRIPTION
## Summary

Display the line count in folded region placeholders, changing the static `⋯` to a dynamic `⋯ (N lines)` text.

Fixes #130250

## Before / After

| Before | After |
|--------|-------|
| `def foo(): ⋯` | `def foo(): ⋯ (12 lines)` |
| `if (condition) { ⋯` | `if (condition) { ⋯ (3 lines)` |

## Changes

### 4 files changed, 42 additions, 18 deletions

| File | Change |
|------|--------|
| `foldingDecorations.ts` | Switch from static `afterContentClassName` to dynamic `InjectedTextOptions.after` with localized line count |
| `foldingModel.ts` | Compute `lineCount = endLine - startLine` and pass to decoration provider |
| `folding.css` | Change `.inline-folded:after` to `.inline-folded` (style injected text directly) |
| `foldingModel.test.ts` | Update test decoration provider interface signature |

## Implementation

Uses the existing `IModelDecorationOptions.after` (`InjectedTextOptions`) API — the same mechanism used by ghost text and inline progress decorations — to inject dynamic content per folded region.

Key design decisions:
- **Localized text**: Uses `localize()` for proper i18n — `(1 line)` singular, `(N lines)` plural
- **Cursor behavior**: `InjectedTextCursorStops.None` prevents cursor from entering the placeholder
- **Click to expand**: Still works — injected text triggers `CONTENT_TEXT` mouse target at end-of-line position
- **Performance**: Dynamic object creation only for collapsed regions (same pattern as ghost text)

## Motivation

This has been requested since 2021 (#130250, 64 👍). For large folded blocks, counting lines by looking at line numbers in the gutter is tedious. Showing the count directly makes code navigation much faster.