### PR TITLE
feat: add markdown.preview.imageRoot setting

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -377,6 +377,12 @@
           "description": "%markdown.preview.scrollPreviewWithEditor.desc%",
           "scope": "resource"
         },
+        "markdown.preview.imageRoot": {
+          "type": "string",
+          "default": "",
+          "description": "%markdown.preview.imageRoot.desc%",
+          "scope": "resource"
+        },
         "markdown.preview.markEditorSelection": {
           "type": "boolean",
           "default": true,

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -13,6 +13,7 @@
 	"markdown.preview.markEditorSelection.desc": "Mark the current editor selection in the Markdown preview.",
 	"markdown.preview.scrollEditorWithPreview.desc": "When a Markdown preview is scrolled, update the view of the editor.",
 	"markdown.preview.scrollPreviewWithEditor.desc": "When a Markdown editor is scrolled, update the view of the preview.",
+	"markdown.preview.imageRoot.desc": "Path relative to the workspace root that absolute image paths (starting with `/`) are resolved against in the Markdown preview. For example, set to `static` for Hugo sites where images are in the `static` folder.",
 	"markdown.preview.title": "Open Preview",
 	"markdown.previewSide.title": "Open Preview to the Side",
 	"markdown.showLockedPreviewToSide.title": "Open Locked Preview to the Side",

--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -89,6 +89,7 @@ interface RenderEnv {
 	readonly currentDocument: vscode.Uri | undefined;
 	readonly resourceProvider: WebviewResourceProvider | undefined;
 	readonly slugifier: SlugBuilder;
+	readonly imageRoot: string | undefined;
 }
 
 export interface IMdParser {
@@ -215,6 +216,7 @@ export class MarkdownItEngine implements IMdParser {
 			currentDocument: typeof input === 'string' ? undefined : input.uri,
 			resourceProvider,
 			slugifier: this.slugifier.createBuilder(),
+			imageRoot: typeof input === 'string' ? undefined : this._getImageRoot(input.uri),
 		};
 
 		const html = engine.renderer.render(tokens, {
@@ -247,6 +249,12 @@ export class MarkdownItEngine implements IMdParser {
 		};
 	}
 
+	private _getImageRoot(resource: vscode.Uri): string | undefined {
+		const markdownConfig = vscode.workspace.getConfiguration('markdown', resource);
+		const imageRoot = markdownConfig.get<string>('preview.imageRoot', '');
+		return imageRoot || undefined;
+	}
+
 	private _addImageRenderer(md: MarkdownIt): void {
 		const original = md.renderer.rules.image;
 		md.renderer.rules.image = (tokens: Token[], idx: number, options, env: RenderEnv, self) => {
@@ -256,7 +264,7 @@ export class MarkdownItEngine implements IMdParser {
 				env.containingImages?.add(src);
 
 				if (!token.attrGet('data-src')) {
-					token.attrSet('src', this._toResourceUri(src, env.currentDocument, env.resourceProvider));
+					token.attrSet('src', this._toResourceUri(src, env.currentDocument, env.resourceProvider, env.imageRoot));
 					token.attrSet('data-src', src);
 				}
 			}
@@ -359,7 +367,7 @@ export class MarkdownItEngine implements IMdParser {
 		};
 	}
 
-	private _toResourceUri(href: string, currentDocument: vscode.Uri | undefined, resourceProvider: WebviewResourceProvider | undefined): string {
+	private _toResourceUri(href: string, currentDocument: vscode.Uri | undefined, resourceProvider: WebviewResourceProvider | undefined, imageRoot?: string): string {
 		try {
 			// Support file:// links
 			if (isOfScheme(Schemes.file, href)) {
@@ -381,7 +389,11 @@ export class MarkdownItEngine implements IMdParser {
 				if (uri.path[0] === '/' && currentDocument) {
 					const root = vscode.workspace.getWorkspaceFolder(currentDocument);
 					if (root) {
-						uri = vscode.Uri.joinPath(root.uri, uri.fsPath).with({
+						const baseUri = imageRoot
+							? vscode.Uri.joinPath(root.uri, imageRoot)
+							: root.uri;
+
+						uri = vscode.Uri.joinPath(baseUri, uri.fsPath).with({
 							fragment: uri.fragment,
 							query: uri.query,
 						});


### PR DESCRIPTION
## Summary

Add a `markdown.preview.imageRoot` setting that allows customizing how absolute image paths are resolved in the markdown preview.

Fixes #114319

## Problem

Static site generators (Hugo, Jekyll, Zenn.dev) store images in a dedicated folder (e.g., `static/`) but reference them with absolute paths like `/image.png`. The markdown preview resolves `/` to the workspace root, so images don't display correctly.

## Solution

New setting `markdown.preview.imageRoot` specifies a subdirectory within the workspace that absolute image paths resolve against.

### Example

```
# Project structure (Hugo)
blog/
├
└── static/photo.png
```

```json
// settings.json
{ "markdown.preview.imageRoot": "static" }
```

**Before:** `/photo.png` → `{workspace}/photo.png` ❌
**After:** `/photo.png` → `{workspace}/static/photo.png` ✅

## Changes

### 3 files changed, 22 additions, 3 deletions

| File | Change |
|------|--------|
| `package.json` | Register `markdown.preview.imageRoot` setting (string, default empty, resource scope) |
| `package.nls.json` | Add localized description |
| `markdownEngine.ts` | Pass `imageRoot` through `RenderEnv`, use in `_toResourceUri()` for absolute path resolution |

## Implementation

- Only affects absolute paths (starting with `/`) — relative paths are unchanged
- When `imageRoot` is set, `vscode.Uri.joinPath(root.uri, imageRoot)` becomes the base for resolution instead of `root.uri` directly
- Empty string (default) = current behavior (workspace root)
- Resource-scoped so different workspaces can have different roots

## Motivation

Requested since 2021 (#114319, 55 👍). Users of Hugo, Jekyll, Zenn.dev, and other static site generators need this for proper image preview.