### PR TITLE
Fix word wrap not accounting for variable font sizes

### DIFF
--- a/src/vs/editor/browser/view/domLineBreaksComputer.ts
+++ b/src/vs/editor/browser/view/domLineBreaksComputer.ts
@@ -11,7 +11,7 @@ import { applyFontInfo } from '../config/domFontInfo.js';
 import { WrappingIndent } from '../../common/config/editorOptions.js';
 import { StringBuilder } from '../../common/core/stringBuilder.js';
 import { InjectedTextOptions } from '../../common/model.js';
-import { ILineBreaksComputer, ILineBreaksComputerContext, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../common/modelLineProjectionData.js';
+import { ILineBreaksComputer, ILineBreaksComputerContext, ILineBreaksComputerFactory, LineFontSizeRange, ModelLineProjectionData } from '../../common/modelLineProjectionData.js';
 import { LineInjectedText } from '../../common/textModelEvents.js';
 import { FontInfo } from '../../common/config/fontInfo.js';
 
@@ -29,7 +29,7 @@ export class DOMLineBreaksComputerFactory implements ILineBreaksComputerFactory 
 	public createLineBreaksComputer(context: ILineBreaksComputerContext, fontInfo: FontInfo, tabSize: number, wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ILineBreaksComputer {
 		const lineNumbers: number[] = [];
 		return {
-			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null) => {
+			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null, _fontSizeRanges?: readonly LineFontSizeRange[] | null) => {
 				lineNumbers.push(lineNumber);
 			},
 			finalize: () => {

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -12,6 +12,8 @@ import { URI } from '../../base/common/uri.js';
 import { ISingleEditOperation } from './core/editOperation.js';
 import { IPosition, Position } from './core/position.js';
 import { IRange, Range } from './core/range.js';
+import type { LineFontSizeRange } from './modelLineProjectionData.js';
+export type { LineFontSizeRange };
 import { Selection } from './core/selection.js';
 import { TextChange } from './core/textChange.js';
 import { WordCharacterClassifier } from './core/wordCharacterClassifier.js';
@@ -1129,6 +1131,13 @@ export interface ITextModel {
 	 * @internal
 	 */
 	getFontDecorationsInRange(range: IRange, ownerId?: number): IModelDecoration[];
+
+	/**
+	 * Returns font size multiplier ranges for a given line from tokenization font decorations.
+	 * Used by the line breaks computer to account for variable font sizes during word wrap.
+	 * @internal
+	 */
+	getLineFontSizeRanges(lineNumber: number): readonly LineFontSizeRange[] | null;
 
 	/**
 	 * Gets all the decorations for the lines between `startLineNumber` and `endLineNumber` as an array.

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1866,6 +1866,10 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		return this._decorationsTree.getFontDecorationsInInterval(this, startOffset, endOffset, ownerId);
 	}
 
+	public getLineFontSizeRanges(lineNumber: number): readonly model.LineFontSizeRange[] | null {
+		return this._fontTokenDecorationsProvider.getLineFontSizeRanges(lineNumber);
+	}
+
 	public getAllDecorations(ownerId: number = 0, filterOutValidation: boolean = false, filterFontDecorations: boolean = false): model.IModelDecoration[] {
 		let result = this._decorationsTree.getAll(this, ownerId, filterOutValidation, filterFontDecorations, false, false);
 		result = result.concat(this._decorationProvider.getAllDecorations(ownerId, filterOutValidation));

--- a/src/vs/editor/common/model/tokens/annotations.ts
+++ b/src/vs/editor/common/model/tokens/annotations.ts
@@ -48,6 +48,10 @@ export class AnnotatedString<T> implements IAnnotatedString<T> {
 		this._annotations = annotations;
 	}
 
+	public get annotationCount(): number {
+		return this._annotations.length;
+	}
+
 	/**
 	 * Set annotations for a specific range.
 	 * Annotations should be sorted and non-overlapping.

--- a/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
+++ b/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
@@ -13,7 +13,7 @@ import { IFontTokenOption, IModelContentChangedEvent } from '../../textModelEven
 import { classNameForFontTokenDecorations } from '../../languages/supports/tokenization.js';
 import { LineFontSizeRange } from '../../modelLineProjectionData.js';
 import { Position } from '../../core/position.js';
-import { AnnotatedString, AnnotationsUpdate, IAnnotatedString, IAnnotationUpdate } from './annotations.js';
+import { AnnotatedString, AnnotationsUpdate, IAnnotationUpdate } from './annotations.js';
 import { OffsetRange } from '../../core/ranges/offsetRange.js';
 import { offsetEditFromContentChanges } from '../textModelStringEdit.js';
 
@@ -32,7 +32,7 @@ export class TokenizationFontDecorationProvider extends Disposable implements De
 	private readonly _onDidChangeFont = this._register(new Emitter<Set<LineFontChangingDecoration>>());
 	public readonly onDidChangeFont = this._onDidChangeFont.event;
 
-	private _fontAnnotatedString: IAnnotatedString<IFontTokenAnnotation> = new AnnotatedString<IFontTokenAnnotation>();
+	private _fontAnnotatedString = new AnnotatedString<IFontTokenAnnotation>();
 
 	constructor(
 		private readonly textModel: ITextModel,
@@ -157,6 +157,9 @@ export class TokenizationFontDecorationProvider extends Disposable implements De
 	 * Only returns ranges with a fontSizeMultiplier != 1.
 	 */
 	public getLineFontSizeRanges(lineNumber: number): readonly LineFontSizeRange[] | null {
+		if (this._fontAnnotatedString.annotationCount === 0) {
+			return null;
+		}
 		const lineStartOffset = this.textModel.getOffsetAt(new Position(lineNumber, 1));
 		const lineEndOffset = this.textModel.getOffsetAt(new Position(lineNumber, this.textModel.getLineMaxColumn(lineNumber)));
 		const annotations = this._fontAnnotatedString.getAnnotationsIntersecting(new OffsetRange(lineStartOffset, lineEndOffset));

--- a/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
+++ b/src/vs/editor/common/model/tokens/tokenizationFontDecorationsProvider.ts
@@ -11,6 +11,7 @@ import { DecorationProvider, LineFontChangingDecoration, LineHeightChangingDecor
 import { Emitter } from '../../../../base/common/event.js';
 import { IFontTokenOption, IModelContentChangedEvent } from '../../textModelEvents.js';
 import { classNameForFontTokenDecorations } from '../../languages/supports/tokenization.js';
+import { LineFontSizeRange } from '../../modelLineProjectionData.js';
 import { Position } from '../../core/position.js';
 import { AnnotatedString, AnnotationsUpdate, IAnnotatedString, IAnnotationUpdate } from './annotations.js';
 import { OffsetRange } from '../../core/ranges/offsetRange.js';
@@ -148,6 +149,33 @@ export class TokenizationFontDecorationProvider extends Disposable implements De
 			}
 		}
 		return decorations;
+	}
+
+	/**
+	 * Returns font size multiplier ranges for a given line.
+	 * Ranges are expressed as 0-based character offsets within the line.
+	 * Only returns ranges with a fontSizeMultiplier != 1.
+	 */
+	public getLineFontSizeRanges(lineNumber: number): readonly LineFontSizeRange[] | null {
+		const lineStartOffset = this.textModel.getOffsetAt(new Position(lineNumber, 1));
+		const lineEndOffset = this.textModel.getOffsetAt(new Position(lineNumber, this.textModel.getLineMaxColumn(lineNumber)));
+		const annotations = this._fontAnnotatedString.getAnnotationsIntersecting(new OffsetRange(lineStartOffset, lineEndOffset));
+
+		if (annotations.length === 0) {
+			return null;
+		}
+
+		const result: LineFontSizeRange[] = [];
+		for (const annotation of annotations) {
+			const multiplier = annotation.annotation.fontToken.fontSizeMultiplier;
+			if (multiplier && multiplier !== 1) {
+				// Clamp to the line boundaries and convert to 0-based line offsets
+				const startOffset = Math.max(0, annotation.range.start - lineStartOffset);
+				const endOffset = Math.min(lineEndOffset - lineStartOffset, annotation.range.endExclusive - lineStartOffset);
+				result.push({ startOffset, endOffset, fontSizeMultiplier: multiplier });
+			}
+		}
+		return result.length > 0 ? result : null;
 	}
 
 	public getAllDecorations(ownerId?: number, filterOutValidation?: boolean): IModelDecoration[] {

--- a/src/vs/editor/common/modelLineProjectionData.ts
+++ b/src/vs/editor/common/modelLineProjectionData.ts
@@ -328,6 +328,19 @@ export class OutputPosition {
 	}
 }
 
+/**
+ * Describes a range within a line that has a different font size multiplier.
+ * Used to account for variable font sizes during word wrap computation.
+ */
+export interface LineFontSizeRange {
+	/** 0-based start offset within the original line text (before injected text) */
+	readonly startOffset: number;
+	/** 0-based end offset (exclusive) within the original line text (before injected text) */
+	readonly endOffset: number;
+	/** Font size multiplier relative to the base font size (e.g., 3 means 3x the base size) */
+	readonly fontSizeMultiplier: number;
+}
+
 export interface ILineBreaksComputerContext {
 	getLineContent(lineNumber: number): string;
 	getLineInjectedText(lineNumber: number): LineInjectedText[] | null;
@@ -341,6 +354,6 @@ export interface ILineBreaksComputer {
 	/**
 	 * Pass in `previousLineBreakData` if the only difference is in breaking columns!!!
 	 */
-	addRequest(lineNumber: number, previousLineBreakData: ModelLineProjectionData | null): void;
+	addRequest(lineNumber: number, previousLineBreakData: ModelLineProjectionData | null, fontSizeRanges?: readonly LineFontSizeRange[] | null): void;
 	finalize(): (ModelLineProjectionData | null)[];
 }

--- a/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
+++ b/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
@@ -10,7 +10,7 @@ import { CharacterClassifier } from '../core/characterClassifier.js';
 import { FontInfo } from '../config/fontInfo.js';
 import { LineInjectedText } from '../textModelEvents.js';
 import { InjectedTextOptions } from '../model.js';
-import { ILineBreaksComputerFactory, ILineBreaksComputer, ModelLineProjectionData, ILineBreaksComputerContext } from '../modelLineProjectionData.js';
+import { ILineBreaksComputerFactory, ILineBreaksComputer, ModelLineProjectionData, ILineBreaksComputerContext, LineFontSizeRange } from '../modelLineProjectionData.js';
 
 export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFactory {
 	public static create(options: IComputedEditorOptions): MonospaceLineBreaksComputerFactory {
@@ -29,10 +29,12 @@ export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFa
 	public createLineBreaksComputer(context: ILineBreaksComputerContext, fontInfo: FontInfo, tabSize: number, wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ILineBreaksComputer {
 		const lineNumbers: number[] = [];
 		const previousBreakingData: (ModelLineProjectionData | null)[] = [];
+		const fontSizeRangesPerLine: (readonly LineFontSizeRange[] | null)[] = [];
 		return {
-			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null) => {
+			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null, fontSizeRanges?: readonly LineFontSizeRange[] | null) => {
 				lineNumbers.push(lineNumber);
 				previousBreakingData.push(previousLineBreakData);
+				fontSizeRangesPerLine.push(fontSizeRanges ?? null);
 			},
 			finalize: () => {
 				const columnsForFullWidthChar = fontInfo.typicalFullwidthCharacterWidth / fontInfo.typicalHalfwidthCharacterWidth;
@@ -42,11 +44,12 @@ export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFa
 					const injectedText = context.getLineInjectedText(lineNumber);
 					const lineText = context.getLineContent(lineNumber);
 					const previousLineBreakData = previousBreakingData[i];
+					const fontSizeRanges = fontSizeRangesPerLine[i];
 					const isLineFeedWrappingEnabled = wrapOnEscapedLineFeeds && lineText.includes('"') && lineText.includes('\\n');
-					if (previousLineBreakData && !previousLineBreakData.injectionOptions && !injectedText && !isLineFeedWrappingEnabled) {
+					if (previousLineBreakData && !previousLineBreakData.injectionOptions && !injectedText && !isLineFeedWrappingEnabled && !fontSizeRanges?.length) {
 						result[i] = createLineBreaksFromPreviousLineBreaks(this.classifier, previousLineBreakData, lineText, tabSize, wrappingColumn, columnsForFullWidthChar, wrappingIndent, wordBreak);
 					} else {
-						result[i] = createLineBreaks(this.classifier, lineText, injectedText, tabSize, wrappingColumn, columnsForFullWidthChar, wrappingIndent, wordBreak, isLineFeedWrappingEnabled);
+						result[i] = createLineBreaks(this.classifier, lineText, injectedText, tabSize, wrappingColumn, columnsForFullWidthChar, wrappingIndent, wordBreak, isLineFeedWrappingEnabled, fontSizeRanges);
 					}
 				}
 				arrPool1.length = 0;
@@ -356,8 +359,11 @@ function createLineBreaksFromPreviousLineBreaks(classifier: WrappingCharacterCla
 	return previousBreakingData;
 }
 
-function createLineBreaks(classifier: WrappingCharacterClassifier, _lineText: string, injectedTexts: LineInjectedText[] | null, tabSize: number, firstLineBreakColumn: number, columnsForFullWidthChar: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ModelLineProjectionData | null {
+function createLineBreaks(classifier: WrappingCharacterClassifier, _lineText: string, injectedTexts: LineInjectedText[] | null, tabSize: number, firstLineBreakColumn: number, columnsForFullWidthChar: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean, fontSizeRanges?: readonly LineFontSizeRange[] | null): ModelLineProjectionData | null {
 	const lineText = LineInjectedText.applyInjectedText(_lineText, injectedTexts);
+
+	// Adjust font size ranges for injected text offsets
+	const adjustedFontSizeRanges = adjustFontSizeRangesForInjectedText(fontSizeRanges, injectedTexts);
 
 	let injectionOptions: InjectedTextOptions[] | null;
 	let injectionOffsets: number[] | null;
@@ -399,14 +405,16 @@ function createLineBreaks(classifier: WrappingCharacterClassifier, _lineText: st
 	let breakOffsetVisibleColumn = 0;
 
 	let breakingColumn = firstLineBreakColumn;
+	const fontRangeIdx = { value: 0 };
 	let prevCharCode = lineText.charCodeAt(0);
 	let prevCharCodeClass = classifier.get(prevCharCode);
-	let visibleColumn = computeCharWidth(prevCharCode, 0, tabSize, columnsForFullWidthChar);
+	let fontMultiplier = getFontSizeMultiplier(adjustedFontSizeRanges, 0, fontRangeIdx);
+	let visibleColumn = computeCharWidth(prevCharCode, 0, tabSize, columnsForFullWidthChar) * fontMultiplier;
 
 	let startOffset = 1;
 	if (strings.isHighSurrogate(prevCharCode)) {
 		// A surrogate pair must always be considered as a single unit, so it is never to be broken
-		visibleColumn += 1;
+		visibleColumn += 1 * fontMultiplier;
 		prevCharCode = lineText.charCodeAt(1);
 		prevCharCodeClass = classifier.get(prevCharCode);
 		startOffset++;
@@ -419,14 +427,16 @@ function createLineBreaks(classifier: WrappingCharacterClassifier, _lineText: st
 		let charWidth: number;
 		let wrapEscapedLineFeed = false;
 
+		fontMultiplier = getFontSizeMultiplier(adjustedFontSizeRanges, charStartOffset, fontRangeIdx);
+
 		if (strings.isHighSurrogate(charCode)) {
 			// A surrogate pair must always be considered as a single unit, so it is never to be broken
 			i++;
 			charCodeClass = CharacterClass.NONE;
-			charWidth = 2;
+			charWidth = 2 * fontMultiplier;
 		} else {
 			charCodeClass = classifier.get(charCode);
-			charWidth = computeCharWidth(charCode, visibleColumn, tabSize, columnsForFullWidthChar);
+			charWidth = computeCharWidth(charCode, visibleColumn, tabSize, columnsForFullWidthChar) * fontMultiplier;
 		}
 
 		// literal \n shall trigger a softwrap
@@ -524,6 +534,64 @@ function canBreak(prevCharCode: number, prevCharCodeClass: CharacterClass, charC
 			|| (!isKeepAll && charCodeClass === CharacterClass.BREAK_IDEOGRAPHIC && prevCharCodeClass !== CharacterClass.BREAK_BEFORE)
 		)
 	);
+}
+
+/**
+ * Adjusts font size ranges from original model line offsets to post-injection offsets.
+ * Returns null if there are no font size ranges.
+ */
+function adjustFontSizeRangesForInjectedText(fontSizeRanges: readonly LineFontSizeRange[] | null | undefined, injectedTexts: LineInjectedText[] | null): readonly LineFontSizeRange[] | null {
+	if (!fontSizeRanges || fontSizeRanges.length === 0) {
+		return null;
+	}
+	if (!injectedTexts || injectedTexts.length === 0) {
+		return fontSizeRanges;
+	}
+
+	// Build sorted injection points with their content lengths
+	const injections: { offset: number; length: number }[] = [];
+	for (const t of injectedTexts) {
+		injections.push({ offset: t.column - 1, length: t.options.content.length });
+	}
+	injections.sort((a, b) => a.offset - b.offset);
+
+	const result: LineFontSizeRange[] = [];
+	for (const range of fontSizeRanges) {
+		let startShift = 0;
+		let endShift = 0;
+		for (const inj of injections) {
+			if (inj.offset <= range.startOffset) {
+				startShift += inj.length;
+				endShift += inj.length;
+			} else if (inj.offset < range.endOffset) {
+				endShift += inj.length;
+			}
+		}
+		result.push({
+			startOffset: range.startOffset + startShift,
+			endOffset: range.endOffset + endShift,
+			fontSizeMultiplier: range.fontSizeMultiplier
+		});
+	}
+	return result;
+}
+
+/**
+ * Returns the font size multiplier for a character at the given offset.
+ * Uses a running index to efficiently scan through sorted font size ranges.
+ */
+function getFontSizeMultiplier(fontSizeRanges: readonly LineFontSizeRange[] | null, offset: number, fontRangeIdx: { value: number }): number {
+	if (!fontSizeRanges) {
+		return 1;
+	}
+	// Advance past ranges that end before or at the current offset
+	while (fontRangeIdx.value < fontSizeRanges.length && fontSizeRanges[fontRangeIdx.value].endOffset <= offset) {
+		fontRangeIdx.value++;
+	}
+	if (fontRangeIdx.value < fontSizeRanges.length && fontSizeRanges[fontRangeIdx.value].startOffset <= offset) {
+		return fontSizeRanges[fontRangeIdx.value].fontSizeMultiplier;
+	}
+	return 1;
 }
 
 function computeWrappedTextIndentLength(lineText: string, tabSize: number, firstLineBreakColumn: number, columnsForFullWidthChar: number, wrappingIndent: WrappingIndent): number {

--- a/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
+++ b/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
@@ -548,23 +548,19 @@ function adjustFontSizeRangesForInjectedText(fontSizeRanges: readonly LineFontSi
 		return fontSizeRanges;
 	}
 
-	// Build sorted injection points with their content lengths
-	const injections: { offset: number; length: number }[] = [];
-	for (const t of injectedTexts) {
-		injections.push({ offset: t.column - 1, length: t.options.content.length });
-	}
-	injections.sort((a, b) => a.offset - b.offset);
-
+	// Injected texts are already sorted by (lineNumber, column, order) from fromDecorations()
 	const result: LineFontSizeRange[] = [];
 	for (const range of fontSizeRanges) {
 		let startShift = 0;
 		let endShift = 0;
-		for (const inj of injections) {
-			if (inj.offset <= range.startOffset) {
-				startShift += inj.length;
-				endShift += inj.length;
-			} else if (inj.offset < range.endOffset) {
-				endShift += inj.length;
+		for (const inj of injectedTexts) {
+			const injOffset = inj.column - 1;
+			const injLength = inj.options.content.length;
+			if (injOffset <= range.startOffset) {
+				startShift += injLength;
+				endShift += injLength;
+			} else if (injOffset < range.endOffset) {
+				endShift += injLength;
 			}
 		}
 		result.push({

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -542,6 +542,7 @@ export class ViewModel extends Disposable implements IViewModel {
 					accessor.insertOrChangeCustomLineHeight(data.decorationId, data.startLineNumber, data.endLineNumber, data.lineHeight);
 				}
 			});
+			this.viewLayout.onHeightMaybeChanged();
 		}
 	}
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -329,16 +329,20 @@ export class ViewModel extends Disposable implements IViewModel {
 
 			// Do a first pass to compute line mappings, and a second pass to actually interpret them
 			const lineBreaksComputer = this._lines.createLineBreaksComputer();
+			const modelLineCount = this.model.getLineCount();
 			for (const change of changes) {
 				switch (change.changeType) {
 					case textModelEvents.RawContentChangedType.LinesInserted: {
 						for (let i = 0; i < change.count; i++) {
-							lineBreaksComputer.addRequest(change.fromLineNumberPostEdit + i, null);
+							const lineNumber = change.fromLineNumberPostEdit + i;
+							const fontSizeRanges = lineNumber >= 1 && lineNumber <= modelLineCount ? this.model.getLineFontSizeRanges(lineNumber) : null;
+							lineBreaksComputer.addRequest(lineNumber, null, fontSizeRanges);
 						}
 						break;
 					}
 					case textModelEvents.RawContentChangedType.LineChanged: {
-						lineBreaksComputer.addRequest(change.lineNumberPostEdit, null);
+						const fontSizeRanges = change.lineNumberPostEdit >= 1 && change.lineNumberPostEdit <= modelLineCount ? this.model.getLineFontSizeRanges(change.lineNumberPostEdit) : null;
+						lineBreaksComputer.addRequest(change.lineNumberPostEdit, null, fontSizeRanges);
 						break;
 					}
 				}
@@ -468,6 +472,79 @@ export class ViewModel extends Disposable implements IViewModel {
 		});
 	}
 
+	private _recomputeLineBreaksForFontChanges(e: textModelEvents.ModelFontChangedEvent): void {
+		// Collect unique line numbers affected by font changes
+		const affectedLineNumbers = new Set<number>();
+		for (const change of e.changes) {
+			if (change.ownerId === this._editorId || change.ownerId === 0) {
+				if (change.lineNumber >= 1 && change.lineNumber <= this.model.getLineCount()) {
+					affectedLineNumbers.add(change.lineNumber);
+				}
+			}
+		}
+		if (affectedLineNumbers.size === 0) {
+			return;
+		}
+
+		const sortedLineNumbers = Array.from(affectedLineNumbers).sort((a, b) => a - b);
+
+		// Compute new line breaks for each affected line
+		const lineBreaksComputer = this._lines.createLineBreaksComputer();
+		for (const lineNumber of sortedLineNumbers) {
+			const fontSizeRanges = this.model.getLineFontSizeRanges(lineNumber);
+			lineBreaksComputer.addRequest(lineNumber, null, fontSizeRanges);
+		}
+		const lineBreaks = lineBreaksComputer.finalize();
+
+		// Apply the new line breaks
+		let hadLineMappingChange = false;
+		try {
+			const eventsCollector = this._eventDispatcher.beginEmitViewEvents();
+
+			for (let i = 0; i < sortedLineNumbers.length; i++) {
+				const [lineMappingChanged, linesChangedEvent, linesInsertedEvent, linesDeletedEvent] =
+					this._lines.onModelLineChanged(null, sortedLineNumbers[i], lineBreaks[i]);
+				if (lineMappingChanged) {
+					hadLineMappingChange = true;
+				}
+				if (linesChangedEvent) {
+					eventsCollector.emitViewEvent(linesChangedEvent);
+				}
+				if (linesInsertedEvent) {
+					eventsCollector.emitViewEvent(linesInsertedEvent);
+					this.viewLayout.onLinesInserted(linesInsertedEvent.fromLineNumber, linesInsertedEvent.toLineNumber);
+				}
+				if (linesDeletedEvent) {
+					eventsCollector.emitViewEvent(linesDeletedEvent);
+					this.viewLayout.onLinesDeleted(linesDeletedEvent.fromLineNumber, linesDeletedEvent.toLineNumber);
+				}
+			}
+
+			if (hadLineMappingChange) {
+				eventsCollector.emitViewEvent(new viewEvents.ViewLineMappingChangedEvent());
+				eventsCollector.emitViewEvent(new viewEvents.ViewDecorationsChangedEvent(null));
+				this._cursor.onLineMappingChanged(eventsCollector);
+				this._decorations.onLineMappingChanged();
+			}
+		} finally {
+			this._eventDispatcher.endEmitViewEvents();
+		}
+
+		// After line breaks changed, the view line numbers have shifted.
+		// Re-apply custom line heights using the updated view line mapping,
+		// since onDidChangeLineHeight fired before the line breaks were recomputed.
+		if (hadLineMappingChange) {
+			const minLine = sortedLineNumbers[0];
+			const maxLine = sortedLineNumbers[sortedLineNumbers.length - 1];
+			const customLineHeights = this._getCustomLineHeightsForLines(minLine, maxLine);
+			this.viewLayout.changeSpecialLineHeights((accessor) => {
+				for (const data of customLineHeights) {
+					accessor.insertOrChangeCustomLineHeight(data.decorationId, data.startLineNumber, data.endLineNumber, data.lineHeight);
+				}
+			});
+		}
+	}
+
 	private _registerModelEvents(): void {
 
 		const allowVariableLineHeights = this._configuration.options.get(EditorOption.allowVariableLineHeights);
@@ -504,6 +581,10 @@ export class ViewModel extends Disposable implements IViewModel {
 					const filteredEvent = new textModelEvents.ModelFontChangedEvent(filteredChanges);
 					this._eventDispatcher.emitOutgoingEvent(new ModelFontChangedEvent(filteredEvent));
 				}
+
+				// Recompute line breaks for affected lines since font size changes
+				// affect the visual width of characters used in word wrap computation
+				this._recomputeLineBreaksForFontChanges(e);
 			}));
 		}
 

--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -13,7 +13,7 @@ import { IActiveIndentGuideInfo, BracketGuideOptions, IndentGuide, IndentGuideHo
 import { ModelDecorationOptions } from '../model/textModel.js';
 import * as viewEvents from '../viewEvents.js';
 import { createModelLineProjection, IModelLineProjection } from './modelLineProjection.js';
-import { ILineBreaksComputer, ModelLineProjectionData, InjectedText, ILineBreaksComputerFactory, ILineBreaksComputerContext } from '../modelLineProjectionData.js';
+import { ILineBreaksComputer, ModelLineProjectionData, InjectedText, ILineBreaksComputerFactory, ILineBreaksComputerContext, LineFontSizeRange } from '../modelLineProjectionData.js';
 import { ConstantTimePrefixSumComputer } from '../model/prefixSumComputer.js';
 import { ViewLineData } from '../viewModel.js';
 import { ICoordinatesConverter, IdentityCoordinatesConverter } from '../coordinatesConverter.js';
@@ -131,7 +131,9 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 		const lineBreaksComputer = this.createLineBreaksComputer();
 
 		for (let i = 0; i < lineCount; i++) {
-			lineBreaksComputer.addRequest(i + 1, previousLineBreaks ? previousLineBreaks[i] : null);
+			const lineNumber = i + 1;
+			const fontSizeRanges = this.model.getLineFontSizeRanges(lineNumber);
+			lineBreaksComputer.addRequest(lineNumber, previousLineBreaks ? previousLineBreaks[i] : null, fontSizeRanges);
 		}
 		const linesBreaks = lineBreaksComputer.finalize();
 
@@ -1157,7 +1159,7 @@ export class ViewModelLinesFromModelAsIs implements IViewModelLines {
 	public createLineBreaksComputer(): ILineBreaksComputer {
 		const result: null[] = [];
 		return {
-			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null) => {
+			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null, _fontSizeRanges?: readonly LineFontSizeRange[] | null) => {
 				result.push(null);
 			},
 			finalize: () => {

--- a/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
+++ b/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
@@ -6,7 +6,7 @@ import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { EditorOptions, WrappingIndent } from '../../../common/config/editorOptions.js';
 import { FontInfo } from '../../../common/config/fontInfo.js';
-import { ILineBreaksComputerContext, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../../common/modelLineProjectionData.js';
+import { ILineBreaksComputerContext, type LineFontSizeRange, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../../common/modelLineProjectionData.js';
 import { MonospaceLineBreaksComputerFactory } from '../../../common/viewModel/monospaceLineBreaksComputer.js';
 
 function parseAnnotatedText(annotatedText: string): { text: string; indices: number[] } {
@@ -324,6 +324,63 @@ suite('Editor ViewModel - MonospaceLineBreaksComputer', () => {
 	test('Word break work well with Chinese/Japanese/Korean (CJK) text when setting keepAll', () => {
 		const factory = new MonospaceLineBreaksComputerFactory(EditorOptions.wordWrapBreakBeforeCharacters.defaultValue, EditorOptions.wordWrapBreakAfterCharacters.defaultValue);
 		assertLineBreaks(factory, 4, 8, '你好1111', WrappingIndent.Same, 'keepAll');
+	});
+
+	test('issue #288873: Line breaks incorrectly when variable font size', () => {
+		const factory = new MonospaceLineBreaksComputerFactory(EditorOptions.wordWrapBreakBeforeCharacters.defaultValue, EditorOptions.wordWrapBreakAfterCharacters.defaultValue);
+
+		function getLineBreakDataWithFontSizes(text: string, breakAfter: number, fontSizeRanges: readonly LineFontSizeRange[] | null): ModelLineProjectionData | null {
+			const fontInfo = new FontInfo({
+				pixelRatio: 1,
+				fontFamily: 'testFontFamily',
+				fontWeight: 'normal',
+				fontSize: 14,
+				fontFeatureSettings: '',
+				fontVariationSettings: '',
+				lineHeight: 19,
+				letterSpacing: 0,
+				isMonospace: true,
+				typicalHalfwidthCharacterWidth: 7,
+				typicalFullwidthCharacterWidth: 14,
+				canUseHalfwidthRightwardsArrow: true,
+				spaceWidth: 7,
+				middotWidth: 7,
+				wsmiddotWidth: 7,
+				maxDigitWidth: 7
+			}, false);
+			const context: ILineBreaksComputerContext = {
+				getLineContent(lineNumber: number) {
+					return text;
+				},
+				getLineInjectedText(lineNumber) {
+					return null;
+				}
+			};
+			const lineBreaksComputer = factory.createLineBreaksComputer(context, fontInfo, 4, breakAfter, WrappingIndent.None, 'normal', false);
+			lineBreaksComputer.addRequest(1, null, fontSizeRanges);
+			return lineBreaksComputer.finalize()[0];
+		}
+
+		// Without font size ranges, "class DebugProgressContribution" (30 chars) fits in 80 columns
+		const text = 'class DebugProgressContribution {';
+		const noFontSizeBreaks = getLineBreakDataWithFontSizes(text, 80, null);
+		assert.strictEqual(noFontSizeBreaks, null, 'Without font size ranges, the line should not wrap at 80 columns');
+
+		// With font size 3x on "DebugProgressContribution" (offset 6 to 31), each char takes 3 columns
+		// 6 chars at 1x = 6, then 25 chars at 3x = 75, then 2 chars at 1x = 2. Total = 83 > 80
+		const fontSizeRanges: LineFontSizeRange[] = [
+			{ startOffset: 6, endOffset: 31, fontSizeMultiplier: 3 }
+		];
+		const withFontSizeBreaks = getLineBreakDataWithFontSizes(text, 80, fontSizeRanges);
+		assert.ok(withFontSizeBreaks !== null, 'With 3x font size, the line should wrap before 80 columns');
+		assert.ok(withFontSizeBreaks!.breakOffsets[0] < text.length, 'Should break before end of line');
+
+		// With font size 2x, total = 6 + 25*2 + 2 = 58 <= 80, should not wrap
+		const fontSizeRanges2x: LineFontSizeRange[] = [
+			{ startOffset: 6, endOffset: 31, fontSizeMultiplier: 2 }
+		];
+		const with2xBreaks = getLineBreakDataWithFontSizes(text, 80, fontSizeRanges2x);
+		assert.strictEqual(with2xBreaks, null, 'With 2x font size, total width 58 should not wrap at 80 columns');
 	});
 
 	test('issue #258022: wrapOnEscapedLineFeeds: should work correctly after editor resize', () => {


### PR DESCRIPTION
## Summary

- Fixes the monospace line breaks computer (`wrappingStrategy: 'simple'`) to account for font size multipliers from `editor.tokenColorCustomizations` when computing word wrap positions
- Scales character widths by `fontSizeMultiplier` in the character-scanning loop, so lines with larger font tokens wrap at the correct column boundary instead of overflowing
- Recomputes line breaks when font decorations arrive asynchronously (after tokenization) and re-applies custom line heights to prevent visual overlap

Fixes #288873 (part 1 — monospace computer only; DOM computer for `wrappingStrategy: 'advanced'` is not yet addressed)

## Test plan

- [ ] Set `"editor.tokenColorCustomizations"` with a `fontSize` rule for a token scope (e.g. `entity.name.type.class` with `fontSize: 3`)
- [ ] Enable word wrap (`"editor.wordWrap": "wordWrapColumn"`, `"editor.wordWrapColumn": 80`)
- [ ] Verify that lines containing large-font tokens wrap before the column boundary, not after
- [ ] Verify that wrapped continuation lines don't visually overlap with subsequent lines
- [ ] Verify normal wrapping behavior is unchanged when no font size customizations are active
- [ ] Run monospace line breaks computer tests (`monospaceLineBreaksComputer.test.ts`)