### PR TITLE
support for chat customizations in parent repo folders

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -23,6 +23,7 @@ import { IPathService } from '../../../../workbench/services/path/common/pathSer
 import { ISearchService } from '../../../../workbench/services/search/common/search.js';
 import { IUserDataProfileService } from '../../../../workbench/services/userDataProfile/common/userDataProfile.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 
 /** URI root for built-in prompts bundled with the Sessions app. */
 export const BUILTIN_PROMPTS_URI = FileAccess.asFileUri('vs/sessions/prompts');
@@ -144,6 +145,7 @@ class AgenticPromptFilesLocator extends PromptFilesLocator {
 		@IUserDataProfileService userDataService: IUserDataProfileService,
 		@ILogService logService: ILogService,
 		@IPathService pathService: IPathService,
+		@IWorkspaceTrustManagementService workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IAICustomizationWorkspaceService private readonly customizationWorkspaceService: IAICustomizationWorkspaceService,
 	) {
 		super(
@@ -154,7 +156,8 @@ class AgenticPromptFilesLocator extends PromptFilesLocator {
 			searchService,
 			userDataService,
 			logService,
-			pathService
+			pathService,
+			workspaceTrustManagementService
 		);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -995,10 +995,10 @@ configurationRegistry.registerConfiguration({
 			disallowConfigurationDefault: true,
 			tags: ['prompts', 'reusable prompts', 'prompt snippets', 'instructions']
 		},
-		[PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS]: {
+		[PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS]: {
 			type: 'boolean',
-			title: nls.localize('chat.searchRootRepositoryCustomizations.title', "Search Root Repository Customizations",),
-			markdownDescription: nls.localize('chat.searchRootRepositoryCustomizations.description', "Controls whether configuration files should be searched in parent folders of the workspace folder if the parent folder are repositories.",),
+			title: nls.localize('chat.useCustomizationsInParentRepos.title', "Use Customizations in Parent Repositories",),
+			markdownDescription: nls.localize('chat.useCustomizationsInParentRepos.description', "Controls whether to use chat customization files in parent repositories.",),
 			default: false,
 			restricted: true,
 			disallowConfigurationDefault: true,

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/config.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/config.ts
@@ -136,9 +136,9 @@ export namespace PromptsConfig {
 	export const INCLUDE_REFERENCED_INSTRUCTIONS = 'chat.includeReferencedInstructions';
 
 	/**
-	 * Search for configuration files in parent folders of the workspace folder
+	 * Search for configuration files in parent repositories of the workspace folder
 	 */
-	export const SEARCH_ROOT_REPO_CUSTOMIZATIONS = 'chat.searchRootRepositoryCustomizations';
+	export const USE_CUSTOMIZATIONS_IN_PARENT_REPOS = 'chat.useCustomizationsInParentRepositories';
 
 	/**
 	 * Get value of the `reusable prompt locations` configuration setting.

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/config/promptFileLocations.ts
@@ -138,6 +138,8 @@ export interface IPromptSourceFolder {
  */
 export interface IResolvedPromptSourceFolder {
 	readonly uri: URI;
+	readonly parent: URI; // matches the URI when no glob pattern is used
+	readonly filePattern: string | undefined; // the part of the path with the glob pattern, or undefined if no glob pattern is used
 	readonly source: PromptFileSource;
 	readonly storage: PromptsStorage;
 	/**

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -906,7 +906,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 		const resolvedAgentFiles: IResolvedAgentFile[] = [];
 		const promises: Promise<IResolvedAgentFile[]>[] = [];
 
-		const includeParents = this.configurationService.getValue(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS) === true;
+		const includeParents = this.configurationService.getValue(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS) === true;
 		const rootFolders = await this.fileLocator.getWorkspaceFolderRoots(includeParents, logger);
 
 		const rootFiles: IWorkspaceInstructionFile[] = [];

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -907,7 +907,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 		const promises: Promise<IResolvedAgentFile[]>[] = [];
 
 		const includeParents = this.configurationService.getValue(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS) === true;
-		const rootFolders = await this.fileLocator.getWorkspaceFolderRoots(includeParents);
+		const rootFolders = await this.fileLocator.getWorkspaceFolderRoots(includeParents, logger);
 
 		const rootFiles: IWorkspaceInstructionFile[] = [];
 		const useAgentMD = this.configurationService.getValue(PromptsConfig.USE_AGENT_MD);

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -9,7 +9,7 @@ import { ResourceSet } from '../../../../../../base/common/map.js';
 import * as nls from '../../../../../../nls.js';
 import { FileOperationError, FileOperationResult, IFileService } from '../../../../../../platform/files/common/files.js';
 import { getPromptFileLocationsConfigKey, isTildePath, PromptsConfig } from '../config/config.js';
-import { basename, dirname, isEqual, isEqualOrParent, joinPath } from '../../../../../../base/common/resources.js';
+import { basename, dirname, isEqual, isEqualOrParent, joinPath, extname } from '../../../../../../base/common/resources.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { AGENTS_SOURCE_FOLDER, getPromptFileExtension, getPromptFileType, LEGACY_MODE_FILE_EXTENSION, getCleanPromptName, AGENT_FILE_EXTENSION, getPromptFileDefaultLocations, SKILL_FILENAME, IPromptSourceFolder, IResolvedPromptFile, IResolvedPromptSourceFolder, PromptFileSource } from '../config/promptFileLocations.js';
@@ -17,15 +17,16 @@ import { PromptsType } from '../promptTypes.js';
 import { IWorkbenchEnvironmentService } from '../../../../../services/environment/common/environmentService.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { getExcludes, IFileQuery, ISearchConfiguration, ISearchService, QueryType } from '../../../../../services/search/common/search.js';
-import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { isCancellationError } from '../../../../../../base/common/errors.js';
-import { AgentFileType, IResolvedAgentFile, PromptsStorage } from '../service/promptsService.js';
+import { AgentFileType, IResolvedAgentFile, Logger, PromptsStorage } from '../service/promptsService.js';
 import { IUserDataProfileService } from '../../../../../services/userDataProfile/common/userDataProfile.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../../../platform/log/common/log.js';
 import { IPathService } from '../../../../../services/path/common/pathService.js';
 import { equalsIgnoreCase } from '../../../../../../base/common/strings.js';
+import { IWorkspaceTrustManagementService } from '../../../../../../platform/workspace/common/workspaceTrust.js';
 
 /**
  * Maximum recursion depth when traversing subdirectories for instruction files.
@@ -42,6 +43,8 @@ export interface IWorkspaceInstructionFile {
  */
 export class PromptFilesLocator {
 
+	private readonly userDataFolder: IResolvedPromptSourceFolder;
+
 	constructor(
 		@IFileService private readonly fileService: IFileService,
 		@IConfigurationService private readonly configService: IConfigurationService,
@@ -51,7 +54,19 @@ export class PromptFilesLocator {
 		@IUserDataProfileService private readonly userDataService: IUserDataProfileService,
 		@ILogService private readonly logService: ILogService,
 		@IPathService private readonly pathService: IPathService,
+		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) {
+
+		const userDataPromptsHome = this.userDataService.currentProfile.promptsHome;
+		this.userDataFolder = {
+			uri: userDataPromptsHome,
+			parent: userDataPromptsHome,
+			filePattern: undefined,
+			source: PromptFileSource.CopilotPersonal,
+			storage: PromptsStorage.user,
+			displayPath: nls.localize('promptsUserDataFolder', "User Data"),
+			isDefault: true
+		};
 	}
 
 	protected getWorkspaceFolders(): readonly IWorkspaceFolder[] {
@@ -66,26 +81,85 @@ export class PromptFilesLocator {
 		return Event.map(this.workspaceService.onDidChangeWorkspaceFolders, () => undefined);
 	}
 
+	public async getWorkspaceFolderRoots(includeParents: boolean, logger?: Logger): Promise<URI[]> {
+		const workspaceFolders = this.getWorkspaceFolders();
+		if (includeParents) {
+			const roots = new ResourceSet();
+			const userHome = await this.pathService.userHome();
+			for (const workspaceFolder of workspaceFolders) {
+				roots.add(workspaceFolder.uri);
+				// Walk up from the workspace folder to find the repository root
+				// (.git folder). Only include parent folders if a repo root is
+				// actually found; otherwise keep only the workspace folder.
+				const parents = await this.findParentRepoFolders(workspaceFolder.uri, userHome, roots, logger);
+				for (const parent of parents) {
+					roots.add(parent);
+				}
+			}
+			return [...roots];
+		}
+		return workspaceFolders.map(f => f.uri);
+	}
+
+	/**
+	 * Walks up from {@link folderUri} collecting parent folders until a
+	 * repository root (a folder containing `.git`) is found.  Returns the
+	 * intermediate parent folders only when a repo root is found; returns
+	 * an empty array when the walk reaches the filesystem root, the user
+	 * home directory, or a folder already present in {@link seen}.
+	 */
+	private async findParentRepoFolders(folderUri: URI, userHome: URI, seen: ResourceSet, logger?: Logger): Promise<URI[]> {
+		const candidates: URI[] = [];
+		let current = folderUri;
+		let parent = dirname(current);
+		do {
+			try {
+				const isRepoRoot = await this.fileService.exists(joinPath(current, '.git'));
+				if (isRepoRoot) {
+					if ((await this.workspaceTrustManagementService.getUriTrustInfo(current)).trusted) {
+						candidates.push(current);
+						return candidates;
+					}
+					logger?.logInfo(`Repository root found at ${current.toString()}, but it is not trusted. Skipping parent folder inclusion for this workspace folder.`);
+					return []; // if the repo root isn't trusted, don't include it or any parents
+				}
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				logger?.logInfo(`No repository root found for folder ${folderUri.toString()}. Error accessing ${joinPath(current, '.git')}: ${msg}.`);
+				return []; // if we can't access the folder, return an empty list to avoid treating it as a non-repository when we might just have a permission issue
+			}
+			candidates.push(current);
+			current = parent;
+			parent = dirname(current);
+		} while (!seen.has(current) && current.path !== '/' && !isEqual(userHome, current));
+		// no repo found
+		logger?.logInfo(`No repository root found for folder ${folderUri.toString()}.`);
+		return [];
+	}
+
 	/**
 	 * List all prompt files from the filesystem.
 	 *
 	 * @returns List of prompt files found in the workspace.
 	 */
 	public async listFiles(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly URI[]> {
-		if (storage === PromptsStorage.local) {
-			return await this.listFilesInLocal(type, token);
-		} else if (storage === PromptsStorage.user) {
-			return await this.listFilesInUserData(type, token);
+		if (storage !== PromptsStorage.user && storage !== PromptsStorage.local) {
+			throw new Error(`Unsupported prompt file storage: ${storage}`);
 		}
-		throw new Error(`Unsupported prompt file storage: ${storage}`);
-	}
 
-	private async listFilesInUserData(type: PromptsType, token: CancellationToken): Promise<readonly URI[]> {
-		const userStorageFolders = await this.getUserStorageFolders(type);
+		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations.filter(loc => loc.storage === storage));
+
+		if (storage === PromptsStorage.user && (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt)) {
+			absoluteLocations.push(this.userDataFolder);
+		}
+
 		const paths = new ResourceSet();
 
-		for (const { uri } of userStorageFolders) {
-			const files = await this.resolveFilesAtLocation(uri, type, token);
+		for (const { parent, filePattern } of absoluteLocations) {
+			const files = (filePattern === undefined)
+				? await this.resolveFilesAtLocation(parent, type, token) // if the location does not contain a glob pattern, resolve the location directly
+				: await this.searchFilesInLocation(parent, filePattern, token);
 			for (const file of files) {
 				if (getPromptFileType(file) === type) {
 					paths.add(file);
@@ -95,123 +169,57 @@ export class PromptFilesLocator {
 				return [];
 			}
 		}
-
 		return [...paths];
-	}
-
-	/**
-	 * Gets all user storage folders for the given prompt type.
-	 * This includes configured tilde paths and the VS Code user data prompts folder.
-	 */
-	private async getUserStorageFolders(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
-		const userHome = await this.pathService.userHome();
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
-		const absoluteLocations = this.toAbsoluteLocations(type, configuredLocations, userHome);
-
-		// Filter to only user storage locations
-		const result = absoluteLocations.filter(loc => loc.storage === PromptsStorage.user);
-
-		// Also include the VS Code user data prompts folder for certain types
-		if (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt) {
-			const userDataPromptsHome = this.userDataService.currentProfile.promptsHome;
-			return [
-				...result,
-				{
-					uri: userDataPromptsHome,
-					source: PromptFileSource.CopilotPersonal,
-					storage: PromptsStorage.user,
-					displayPath: nls.localize('promptsUserDataFolder', "User Data"),
-					isDefault: true
-				}
-			];
-		}
-
-		return result;
-	}
-
-	/**
-	 * Gets all source folder URIs for a prompt type (both workspace and user home).
-	 * This is used for file watching to detect changes in all relevant locations.
-	 */
-	private getSourceFoldersSync(type: PromptsType, userHome: URI): readonly URI[] {
-		const result: URI[] = [];
-		const folders = this.getWorkspaceFolders();
-		const defaultFileOrFolders = getPromptFileDefaultLocations(type);
-
-		const getFolderUri = (type: PromptsType, fileOrFolderPath: URI): URI => {
-			// For hooks, the paths are sometimes file paths, so get the parent directory in that case
-			if (type === PromptsType.hook && fileOrFolderPath.path.toLowerCase().endsWith('.json')) {
-				return dirname(fileOrFolderPath);
-			}
-			return fileOrFolderPath;
-		};
-
-		for (const sourceFileOrFolder of defaultFileOrFolders) {
-			let fileOrFolderPath: URI;
-			if (sourceFileOrFolder.storage === PromptsStorage.local) {
-				for (const workspaceFolder of folders) {
-					fileOrFolderPath = joinPath(workspaceFolder.uri, sourceFileOrFolder.path);
-					result.push(getFolderUri(type, fileOrFolderPath));
-				}
-			} else if (sourceFileOrFolder.storage === PromptsStorage.user) {
-				// For tilde paths, strip the ~/ prefix before joining with userHome
-				const relativePath = isTildePath(sourceFileOrFolder.path) ? sourceFileOrFolder.path.substring(2) : sourceFileOrFolder.path;
-				fileOrFolderPath = joinPath(userHome, relativePath);
-				result.push(getFolderUri(type, fileOrFolderPath));
-			}
-		}
-
-		return result;
 	}
 
 	public createFilesUpdatedEvent(type: PromptsType): { readonly event: Event<void>; dispose: () => void } {
 		const disposables = new DisposableStore();
 		const eventEmitter = disposables.add(new Emitter<void>());
-
-		const userDataFolder = this.userDataService.currentProfile.promptsHome;
-
-		const key = getPromptFileLocationsConfigKey(type);
-		let parentFolders = this.getLocalParentFolders(type);
-		let allSourceFolders: URI[] = [];
+		const token = disposables.add(new CancellationTokenSource()).token; // track the disposal of the event listeners so we can cancel any in-flight async operations when the event is disposed
 
 		const externalFolderWatchers = disposables.add(new DisposableStore());
+		const key = getPromptFileLocationsConfigKey(type);
+		const userDataFolder = this.userDataService.currentProfile.promptsHome;
+
+		let parentFolders: readonly IResolvedPromptSourceFolder[] = [];
+
 		const updateExternalFolderWatchers = () => {
 			externalFolderWatchers.clear();
 			for (const folder of parentFolders) {
 				if (!this.getWorkspaceFolder(folder.parent)) {
 					// if the folder is not part of the workspace, we need to watch it
-					const recursive = folder.filePattern !== undefined;
+					const recursive = folder.filePattern !== undefined || type === PromptsType.instructions; // instructions can be in subfolders, so watch recursively
 					externalFolderWatchers.add(this.fileService.watch(folder.parent, { recursive, excludes: [] }));
-				}
-			}
-			// Watch all source folders (including user home if applicable)
-			for (const folder of allSourceFolders) {
-				if (!this.getWorkspaceFolder(folder)) {
-					externalFolderWatchers.add(this.fileService.watch(folder, { recursive: true, excludes: [] }));
 				}
 			}
 		};
 
-		// Initialize source folders (async if type has userHome locations)
-		this.pathService.userHome().then(userHome => {
-			allSourceFolders = [...this.getSourceFoldersSync(type, userHome)];
-			updateExternalFolderWatchers();
-		});
+		const update = async (emitEvent: boolean) => {
+			try {
+				const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
+				parentFolders = await this.toAbsoluteLocations(type, configuredLocations, undefined);
 
+				if (token.isCancellationRequested) {
+					return;
+				}
+				updateExternalFolderWatchers();
+				if (emitEvent) {
+					eventEmitter.fire();
+				}
+			} catch (err) {
+				this.logService.error(`Error updating prompt file watchers after config change:`, err);
+			}
+		};
 		disposables.add(this.configService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(key)) {
-				parentFolders = this.getLocalParentFolders(type);
-				updateExternalFolderWatchers();
-				eventEmitter.fire();
+				void update(true);
 			}
 		}));
 		disposables.add(this.onDidChangeWorkspaceFolders()(() => {
-			parentFolders = this.getLocalParentFolders(type);
-			this.pathService.userHome().then(userHome => {
-				allSourceFolders = [...this.getSourceFoldersSync(type, userHome)];
-				updateExternalFolderWatchers();
-			});
-			eventEmitter.fire();
+			void update(true);
+		}));
+		disposables.add(this.workspaceTrustManagementService.onDidChangeTrustedFolders(() => {
+			void update(true);
 		}));
 		disposables.add(this.fileService.onDidFilesChange(e => {
 			if (e.affects(userDataFolder)) {
@@ -222,12 +230,10 @@ export class PromptFilesLocator {
 				eventEmitter.fire();
 				return;
 			}
-			if (allSourceFolders.some(folder => e.affects(folder))) {
-				eventEmitter.fire();
-				return;
-			}
 		}));
 		disposables.add(this.fileService.watch(userDataFolder));
+
+		void update(false);
 
 		return { event: eventEmitter.event, dispose: () => disposables.dispose() };
 	}
@@ -237,7 +243,6 @@ export class PromptFilesLocator {
 	 * Returns folders from config, excluding user storage and Claude paths (which are read-only).
 	 */
 	public async getHookSourceFolders(): Promise<readonly URI[]> {
-		const userHome = await this.pathService.userHome();
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, PromptsType.hook);
 
 		// Ignore claude folders since they aren't first-class supported, so we don't want to create invalid formats
@@ -248,19 +253,13 @@ export class PromptFilesLocator {
 
 		// Convert to absolute URIs
 		const result = new ResourceSet();
-		const absoluteLocations = this.toAbsoluteLocations(PromptsType.hook, allowedHookFolders, userHome);
+		const absoluteLocations = await this.toAbsoluteLocations(PromptsType.hook, allowedHookFolders);
 
 		for (const location of absoluteLocations) {
 			// For hook configs, entries are directories unless the path ends with .json (specific file)
 			// Default entries have filePattern, user entries don't but are still directories
-			const isSpecificFile = location.uri.path.endsWith('.json');
-			if (isSpecificFile) {
-				// It's a specific file path (like .github/hooks/hooks.json), use parent directory
-				result.add(dirname(location.uri));
-			} else {
-				// It's a directory path (like .github/hooks or .github/books)
-				result.add(location.uri);
-			}
+			// location.parent points to the directory in both cases, so we can just use that
+			result.add(location.parent);
 		}
 
 		return [...result];
@@ -279,28 +278,28 @@ export class PromptFilesLocator {
 	 * @returns List of possible unambiguous prompt file folders.
 	 */
 	public async getConfigBasedSourceFolders(type: PromptsType): Promise<readonly URI[]> {
-		const userHome = await this.pathService.userHome();
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
-		const absoluteLocations = this.toAbsoluteLocations(type, configuredLocations, userHome).map(l => l.uri);
+		const absoluteLocations = await this.toAbsoluteLocations(type, configuredLocations);
 
 		// For anything that doesn't support glob patterns, we can return
 		if (type !== PromptsType.prompt && type !== PromptsType.instructions) {
-			return absoluteLocations;
+			return absoluteLocations.map(l => l.uri);
 		}
 
 		// locations in the settings can contain glob patterns so we need
 		// to process them to get "clean" paths; the goal here is to have
 		// a list of unambiguous folder paths where prompt files are stored
 		const result = new ResourceSet();
-		for (let absoluteLocation of absoluteLocations) {
-			const baseName = basename(absoluteLocation);
+		for (const absoluteLocation of absoluteLocations) {
+			let location = absoluteLocation.uri;
+			const baseName = basename(location);
 
 			// if a path ends with a well-known "any file" pattern, remove
 			// it so we can get the dirname path of that setting value
 			const filePatterns = ['*.md', `*${getPromptFileExtension(type)}`];
 			for (const filePattern of filePatterns) {
 				if (baseName === filePattern) {
-					absoluteLocation = dirname(absoluteLocation);
+					location = dirname(location);
 					continue;
 				}
 			}
@@ -308,16 +307,16 @@ export class PromptFilesLocator {
 			// likewise, if the pattern ends with single `*` (any file name)
 			// remove it to get the dirname path of the setting value
 			if (baseName === '*') {
-				absoluteLocation = dirname(absoluteLocation);
+				location = dirname(location);
 			}
 
 			// if after replacing the "file name" glob pattern, the path
 			// still contains a glob pattern, then ignore the path
-			if (isValidGlob(absoluteLocation.path) === true) {
+			if (isValidGlob(location.path) === true) {
 				continue;
 			}
 
-			result.add(absoluteLocation);
+			result.add(location);
 		}
 
 		return [...result];
@@ -335,8 +334,10 @@ export class PromptFilesLocator {
 	 * @returns List of resolved source folders with metadata.
 	 */
 	public async getResolvedSourceFolders(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
-		const localFolders = await this.getLocalStorageFolders(type);
-		const userFolders = await this.getUserStorageFolders(type);
+		const absoluteLocations = await this.getLocalStorageFolders(type);
+
+		const localFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.local);
+		const userFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.user);
 		return this.dedupeSourceFolders([...localFolders, ...userFolders]);
 	}
 
@@ -347,8 +348,9 @@ export class PromptFilesLocator {
 	 * for debug/diagnostic output so the displayed order is accurate.
 	 */
 	public async getSourceFoldersInDiscoveryOrder(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
-		const userFolders = await this.getUserStorageFolders(type);
-		const localFolders = await this.getLocalStorageFolders(type);
+		const absoluteLocations = await this.getLocalStorageFolders(type);
+		const userFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.user);
+		const localFolders = absoluteLocations.filter(loc => loc.storage === PromptsStorage.local);
 		return this.dedupeSourceFolders([...userFolders, ...localFolders]);
 	}
 
@@ -357,7 +359,6 @@ export class PromptFilesLocator {
 	 * This merges default folders with configured locations.
 	 */
 	private async getLocalStorageFolders(type: PromptsType): Promise<readonly IResolvedPromptSourceFolder[]> {
-		const userHome = await this.pathService.userHome();
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
 		const defaultFolders = getPromptFileDefaultLocations(type);
 
@@ -367,7 +368,11 @@ export class PromptFilesLocator {
 			...configuredLocations.filter(loc => !defaultFolders.some(df => df.path === loc.path))
 		];
 
-		return this.toAbsoluteLocations(type, allFolders, userHome, defaultFolders);
+		const absoluteLocations = await this.toAbsoluteLocations(type, allFolders, defaultFolders);
+		if (type === PromptsType.agent || type === PromptsType.instructions || type === PromptsType.prompt) {
+			absoluteLocations.push(this.userDataFolder);
+		}
+		return absoluteLocations;
 	}
 
 	/**
@@ -386,49 +391,18 @@ export class PromptFilesLocator {
 	}
 
 	/**
-	 * Finds all existent prompt files in the configured local source folders.
-	 *
-	 * @returns List of prompt files found in the local source folders.
-	 */
-	private async listFilesInLocal(type: PromptsType, token: CancellationToken): Promise<readonly URI[]> {
-		// find all prompt files in the provided locations, then match
-		// the found file paths against (possible) glob patterns
-		const paths = new ResourceSet();
-
-		for (const { parent, filePattern } of this.getLocalParentFolders(type)) {
-			const files = (filePattern === undefined)
-				? await this.resolveFilesAtLocation(parent, type, token) // if the location does not contain a glob pattern, resolve the location directly
-				: await this.searchFilesInLocation(parent, filePattern, token);
-			for (const file of files) {
-				if (getPromptFileType(file) === type) {
-					paths.add(file);
-				}
-			}
-			if (token.isCancellationRequested) {
-				return [];
-			}
-		}
-
-		return [...paths];
-	}
-
-	private getLocalParentFolders(type: PromptsType): readonly { parent: URI; filePattern?: string }[] {
-		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, type);
-		const absoluteLocations = this.toAbsoluteLocations(type, configuredLocations, undefined);
-		return absoluteLocations.map((location) => firstNonGlobParentAndPattern(location.uri));
-	}
-
-	/**
 	 * Converts locations defined in `settings` to absolute filesystem path URIs with metadata.
 	 * This conversion is needed because locations in settings can be relative,
 	 * hence we need to resolve them based on the current workspace folders.
 	 * If userHome is provided, paths starting with `~` will be expanded. Otherwise these paths are ignored.
 	 * Preserves the type and location properties from the source folder definitions.
 	 */
-	private toAbsoluteLocations(type: PromptsType, configuredLocations: readonly IPromptSourceFolder[], userHome: URI | undefined, defaultLocations?: readonly IPromptSourceFolder[]): readonly IResolvedPromptSourceFolder[] {
+	private async toAbsoluteLocations(type: PromptsType, configuredLocations: readonly IPromptSourceFolder[], defaultLocations?: readonly IPromptSourceFolder[]): Promise<IResolvedPromptSourceFolder[]> {
 		const result: IResolvedPromptSourceFolder[] = [];
 		const seen = new ResourceSet();
-		const folders = this.getWorkspaceFolders();
+
+		const userHome = await this.pathService.userHome();
+		const rootFolders = await this.getWorkspaceFolderRoots(this.configService.getValue(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS) === true);
 
 		// Create a set of default paths for quick lookup
 		const defaultPaths = new Set(defaultLocations?.map(loc => loc.path));
@@ -461,13 +435,11 @@ export class PromptFilesLocator {
 			try {
 				// Handle tilde paths when userHome is provided
 				if (isTildePath(configuredLocation)) {
-					// If userHome is not provided, we cannot resolve tilde paths so we skip this entry
-					if (userHome) {
-						const uri = joinPath(userHome, configuredLocation.substring(2));
-						if (!seen.has(uri)) {
-							seen.add(uri);
-							result.push({ uri, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
-						}
+					const uri = joinPath(userHome, configuredLocation.substring(2));
+					if (!seen.has(uri)) {
+						seen.add(uri);
+						const { parent, filePattern } = getParentFolder(type, uri);
+						result.push({ uri, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 					}
 					continue;
 				}
@@ -482,14 +454,16 @@ export class PromptFilesLocator {
 					}
 					if (!seen.has(uri)) {
 						seen.add(uri);
-						result.push({ uri, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
+						const { parent, filePattern } = getParentFolder(type, uri);
+						result.push({ uri, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 					}
 				} else {
-					for (const workspaceFolder of folders) {
-						const absolutePath = joinPath(workspaceFolder.uri, configuredLocation);
+					for (const folder of rootFolders) {
+						const absolutePath = joinPath(folder, configuredLocation);
 						if (!seen.has(absolutePath)) {
 							seen.add(absolutePath);
-							result.push({ uri: absolutePath, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
+							const { parent, filePattern } = getParentFolder(type, absolutePath);
+							result.push({ uri: absolutePath, parent, filePattern, source: sourceFolder.source, storage: sourceFolder.storage, displayPath: configuredLocation, isDefault });
 						}
 					}
 				}
@@ -671,23 +645,7 @@ export class PromptFilesLocator {
 		return result;
 	}
 
-	public async getWorkspaceFolderRoots(includeParents: boolean): Promise<URI[]> {
-		const workspaceFolders = this.getWorkspaceFolders();
-		if (includeParents) {
-			const folders: URI[] = [];
-			const userHome = await this.pathService.userHome();
-			for (const workspaceFolder of workspaceFolders) {
-				folders.push(workspaceFolder.uri);
-				let parent = dirname(workspaceFolder.uri);
-				while (parent.path !== '/' && !isEqual(userHome, parent) && !folders.some(f => isEqual(f, parent))) {
-					folders.push(parent);
-					parent = dirname(parent);
-				}
-			}
-			return folders;
-		}
-		return workspaceFolders.map(f => f.uri);
-	}
+
 
 	public async findFilesInRoots(roots: URI[], folder: string | undefined, paths: IWorkspaceInstructionFile[], token: CancellationToken, result: IResolvedAgentFile[] = []): Promise<IResolvedAgentFile[]> {
 		const toResolve = roots.map(root => ({ resource: folder !== undefined ? joinPath(root, folder) : root }));
@@ -761,9 +719,8 @@ export class PromptFilesLocator {
 	 * Searches for skills in all configured locations.
 	 */
 	public async findAgentSkills(token: CancellationToken): Promise<IResolvedPromptFile[]> {
-		const userHome = await this.pathService.userHome();
 		const configuredLocations = PromptsConfig.promptSourceFolders(this.configService, PromptsType.skill);
-		const absoluteLocations = this.toAbsoluteLocations(PromptsType.skill, configuredLocations, userHome);
+		const absoluteLocations = await this.toAbsoluteLocations(PromptsType.skill, configuredLocations);
 		const allResults: IResolvedPromptFile[] = [];
 
 		for (const { uri, source, storage } of absoluteLocations) {
@@ -861,6 +818,11 @@ export function isValidGlob(pattern: string): boolean {
 	return false;
 }
 
+interface IParentFolderResult {
+	readonly parent: URI;
+	readonly filePattern?: string;
+}
+
 /**
  * Finds the first parent of the provided location that does not contain a `glob pattern`.
  *
@@ -870,13 +832,21 @@ export function isValidGlob(pattern: string): boolean {
  *
  * ```typescript
  * assert.strictDeepEqual(
- *     firstNonGlobParentAndPattern(URI.file('/home/user/{folder1,folder2}/file.md')).path,
+ *     getParentFolder(PromptsType.prompt, URI.file('/home/user/{folder1,folder2}/file.md')),
  *     { parent: URI.file('/home/user'), filePattern: '{folder1,folder2}/file.md' },
  *     'Must find correct non-glob parent dirname.',
  * );
  * ```
  */
-function firstNonGlobParentAndPattern(location: URI): { parent: URI; filePattern?: string } {
+function getParentFolder(type: PromptsType, location: URI): IParentFolderResult {
+	if (type === PromptsType.hook && extname(location) === '.json') {
+		location = dirname(location);
+	}
+	if (type !== PromptsType.instructions && type !== PromptsType.prompt) {
+		// only instructions and prompts support glob patterns, so we can return the location as is
+		return { parent: location };
+	}
+
 	const segments = location.path.split('/');
 	let i = 0;
 	while (i < segments.length && isValidGlob(segments[i]) === false) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/utils/promptFilesLocator.ts
@@ -402,7 +402,7 @@ export class PromptFilesLocator {
 		const seen = new ResourceSet();
 
 		const userHome = await this.pathService.userHome();
-		const rootFolders = await this.getWorkspaceFolderRoots(this.configService.getValue(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS) === true);
+		const rootFolders = await this.getWorkspaceFolderRoots(this.configService.getValue(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS) === true);
 
 		// Create a set of default paths for quick lookup
 		const defaultPaths = new Set(defaultLocations?.map(loc => loc.path));

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -77,7 +77,7 @@ suite('ComputeAutomaticInstructions', () => {
 		testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_SKILLS, true);
 		testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
 		testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_REFERENCED_INSTRUCTIONS, true);
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, false);
 		testConfigService.setUserConfiguration(PromptsConfig.INSTRUCTIONS_LOCATION_KEY, { [INSTRUCTIONS_DEFAULT_SOURCE_FOLDER]: true, [CLAUDE_RULES_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.PROMPT_LOCATIONS_KEY, { [PROMPT_DEFAULT_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.MODE_LOCATION_KEY, { [LEGACY_MODE_DEFAULT_SOURCE_FOLDER]: true });
@@ -1659,7 +1659,7 @@ suite('ComputeAutomaticInstructions', () => {
 		]);
 
 		testConfigService.setUserConfiguration(PromptsConfig.USE_CLAUDE_MD, true);
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, false);
 
 		await workspaceTrustService.setTrustedUris([URI.file(parentFolder)]);
 
@@ -1676,7 +1676,7 @@ suite('ComputeAutomaticInstructions', () => {
 		assert.ok(!paths.includes(`${parentFolder}/.claude/CLAUDE.md`), 'Should not include parent .claude/CLAUDE.md when parent search is disabled');
 
 		// Parent folder settings should allow finding both root and .claude CLAUDE files above the workspace folder.
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, true);
 
 		const enabledParentContextComputer = instaService.createInstance(ComputeAutomaticInstructions, ChatModeKind.Agent, undefined, undefined, undefined);
 		const enabledParentVariables = new ChatRequestVariableSet();
@@ -1720,7 +1720,7 @@ suite('ComputeAutomaticInstructions', () => {
 
 		testConfigService.setUserConfiguration(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES, true);
 		testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_MD, true);
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, false);
 
 		await workspaceTrustService.setTrustedUris([URI.file(parentFolder)]);
 
@@ -1736,7 +1736,7 @@ suite('ComputeAutomaticInstructions', () => {
 		assert.ok(!paths.includes(`${parentFolder}/.github/copilot-instructions.md`), 'Should not include parent copilot-instructions.md when parent search is disabled');
 		assert.ok(!paths.includes(`${parentFolder}/AGENTS.md`), 'Should not include parent AGENTS.md when parent search is disabled');
 
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, true);
 
 		const enabledParentContextComputer = instaService.createInstance(ComputeAutomaticInstructions, ChatModeKind.Agent, undefined, undefined, undefined);
 		const enabledParentVariables = new ChatRequestVariableSet();

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -60,6 +60,7 @@ suite('ComputeAutomaticInstructions', () => {
 	let fileService: IFileService;
 	let toolsService: ILanguageModelToolsService;
 	let fileSystemProvider: TestInMemoryFileSystemProviderWithRealPath;
+	let workspaceTrustService: TestWorkspaceTrustManagementService;
 
 	setup(async () => {
 		instaService = disposables.add(new TestInstantiationService());
@@ -91,6 +92,9 @@ suite('ComputeAutomaticInstructions', () => {
 			whenInstalledExtensionsRegistered: () => Promise.resolve(true),
 			activateByEvent: () => Promise.resolve()
 		});
+
+		workspaceTrustService = disposables.add(new TestWorkspaceTrustManagementService());
+		instaService.stub(IWorkspaceTrustManagementService, workspaceTrustService);
 
 		fileService = disposables.add(instaService.createInstance(FileService));
 		instaService.stub(IFileService, fileService);
@@ -182,8 +186,6 @@ suite('ComputeAutomaticInstructions', () => {
 		});
 
 		instaService.stub(IContextKeyService, new MockContextKeyService());
-
-		instaService.stub(IWorkspaceTrustManagementService, disposables.add(new TestWorkspaceTrustManagementService()));
 
 		instaService.stub(IAgentPluginService, {
 			plugins: observableValue('testPlugins', []),
@@ -1639,6 +1641,10 @@ suite('ComputeAutomaticInstructions', () => {
 
 		await mockFiles(fileService, [
 			{
+				path: `${parentFolder}/.git/HEAD`,
+				contents: ['ref: refs/heads/main'],
+			},
+			{
 				path: `${parentFolder}/CLAUDE.md`,
 				contents: ['Parent Claude guidelines'],
 			},
@@ -1654,6 +1660,8 @@ suite('ComputeAutomaticInstructions', () => {
 
 		testConfigService.setUserConfiguration(PromptsConfig.USE_CLAUDE_MD, true);
 		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+
+		await workspaceTrustService.setTrustedUris([URI.file(parentFolder)]);
 
 		const disabledParentContextComputer = instaService.createInstance(ComputeAutomaticInstructions, ChatModeKind.Agent, undefined, undefined, undefined);
 		const disabledParentVariables = new ChatRequestVariableSet();
@@ -1693,6 +1701,10 @@ suite('ComputeAutomaticInstructions', () => {
 
 		await mockFiles(fileService, [
 			{
+				path: `${parentFolder}/.git/HEAD`,
+				contents: ['ref: refs/heads/main'],
+			},
+			{
 				path: `${parentFolder}/.github/copilot-instructions.md`,
 				contents: ['Parent copilot instructions'],
 			},
@@ -1709,6 +1721,8 @@ suite('ComputeAutomaticInstructions', () => {
 		testConfigService.setUserConfiguration(PromptsConfig.USE_COPILOT_INSTRUCTION_FILES, true);
 		testConfigService.setUserConfiguration(PromptsConfig.USE_AGENT_MD, true);
 		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+
+		await workspaceTrustService.setTrustedUris([URI.file(parentFolder)]);
 
 		const disabledParentContextComputer = instaService.createInstance(ComputeAutomaticInstructions, ChatModeKind.Agent, undefined, undefined, undefined);
 		const disabledParentVariables = new ChatRequestVariableSet();

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -80,7 +80,7 @@ suite('PromptsService', () => {
 		testConfigService.setUserConfiguration(PromptsConfig.USE_NESTED_AGENT_MD, false);
 		testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_REFERENCED_INSTRUCTIONS, true);
 		testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
-		testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+		testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, false);
 		testConfigService.setUserConfiguration(PromptsConfig.INSTRUCTIONS_LOCATION_KEY, { [INSTRUCTIONS_DEFAULT_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.PROMPT_LOCATIONS_KEY, { [PROMPT_DEFAULT_SOURCE_FOLDER]: true });
 		testConfigService.setUserConfiguration(PromptsConfig.MODE_LOCATION_KEY, { [LEGACY_MODE_DEFAULT_SOURCE_FOLDER]: true });
@@ -2102,7 +2102,7 @@ suite('PromptsService', () => {
 			]);
 
 			testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
-			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, false);
 
 			// With parent search disabled, should not find parent files
 			let promptFiles = await service.listPromptFiles(PromptsType.prompt, CancellationToken.None);
@@ -2114,7 +2114,7 @@ suite('PromptsService', () => {
 			assert.ok(!instructionFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent instruction files when parent search is disabled');
 
 			// With parent search enabled, should find parent files
-			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, true);
 
 			promptFiles = await service.listPromptFiles(PromptsType.prompt, CancellationToken.None);
 			agentFiles = await service.listPromptFiles(PromptsType.agent, CancellationToken.None);
@@ -2180,7 +2180,7 @@ suite('PromptsService', () => {
 			]);
 
 			testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
-			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS, true);
 
 			// Mark the parent repo root as untrusted
 			workspaceTrustService.getUriTrustInfo = (uri: URI) => {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -169,6 +169,7 @@ suite('PromptsService', () => {
 		instaService.stub(IContextKeyService, new MockContextKeyService());
 
 		workspaceTrustService = disposables.add(new TestWorkspaceTrustManagementService());
+		workspaceTrustService.getUriTrustInfo = (uri: URI) => Promise.resolve({ trusted: true, uri });
 		instaService.stub(IWorkspaceTrustManagementService, workspaceTrustService);
 
 		testPluginsObservable = observableValue<readonly IAgentPlugin[]>('testPlugins', []);
@@ -2046,6 +2047,156 @@ suite('PromptsService', () => {
 
 			// Restore original stub
 			instaService.stub(IContextKeyService, new MockContextKeyService());
+		});
+	});
+
+	suite('listPromptFiles - parent repo folder', () => {
+		test('should find prompts, instructions, and agents in a parent repo folder', async () => {
+			const parentFolder = '/repos/collect-prompt-parent-test';
+			const rootFolder = `${parentFolder}/repo`;
+			const rootFolderUri = URI.file(rootFolder);
+
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+
+			await mockFiles(fileService, [
+				// .git in parent marks it as a repo root
+				{
+					path: `${parentFolder}/.git/HEAD`,
+					contents: ['ref: refs/heads/main'],
+				},
+				// Applying instruction in parent
+				{
+					path: `${parentFolder}/.github/instructions/typescript.instructions.md`,
+					contents: [
+						'---',
+						'description: \'Parent TypeScript instructions\'',
+						'applyTo: "**/*.ts"',
+						'---',
+						'Parent TypeScript coding standards',
+					]
+				},
+				// Prompt file in parent
+				{
+					path: `${parentFolder}/.github/prompts/help.prompt.md`,
+					contents: [
+						'---',
+						'description: \'Parent help prompt\'',
+						'---',
+						'Help the user with their question',
+					]
+				},
+				// Agent file in parent
+				{
+					path: `${parentFolder}/.github/agents/reviewer.agent.md`,
+					contents: [
+						'---',
+						'description: \'Parent code reviewer agent\'',
+						'---',
+						'You are a code reviewer',
+					]
+				},
+				{
+					path: `${rootFolder}/src/file.ts`,
+					contents: ['console.log("test");'],
+				},
+			]);
+
+			testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, false);
+
+			// With parent search disabled, should not find parent files
+			let promptFiles = await service.listPromptFiles(PromptsType.prompt, CancellationToken.None);
+			let agentFiles = await service.listPromptFiles(PromptsType.agent, CancellationToken.None);
+			let instructionFiles = await service.listPromptFiles(PromptsType.instructions, CancellationToken.None);
+
+			assert.ok(!promptFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent prompt files when parent search is disabled');
+			assert.ok(!agentFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent agent files when parent search is disabled');
+			assert.ok(!instructionFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent instruction files when parent search is disabled');
+
+			// With parent search enabled, should find parent files
+			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+
+			promptFiles = await service.listPromptFiles(PromptsType.prompt, CancellationToken.None);
+			agentFiles = await service.listPromptFiles(PromptsType.agent, CancellationToken.None);
+			instructionFiles = await service.listPromptFiles(PromptsType.instructions, CancellationToken.None);
+
+			const promptPaths = promptFiles.map(f => f.uri.path);
+			const agentPaths = agentFiles.map(f => f.uri.path);
+			const instructionPaths = instructionFiles.map(f => f.uri.path);
+
+			assert.ok(promptPaths.includes(`${parentFolder}/.github/prompts/help.prompt.md`), 'Should find parent prompt file when parent search is enabled');
+			assert.ok(agentPaths.includes(`${parentFolder}/.github/agents/reviewer.agent.md`), 'Should find parent agent file when parent search is enabled');
+			assert.ok(instructionPaths.includes(`${parentFolder}/.github/instructions/typescript.instructions.md`), 'Should find parent instruction file when parent search is enabled');
+		});
+
+		test('should not find files in an untrusted parent repo folder', async () => {
+			const parentFolder = '/repos/untrusted-parent-test';
+			const rootFolder = `${parentFolder}/repo`;
+			const rootFolderUri = URI.file(rootFolder);
+
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+
+			await mockFiles(fileService, [
+				// .git in parent marks it as a repo root
+				{
+					path: `${parentFolder}/.git/HEAD`,
+					contents: ['ref: refs/heads/main'],
+				},
+				// Applying instruction in parent
+				{
+					path: `${parentFolder}/.github/instructions/typescript.instructions.md`,
+					contents: [
+						'---',
+						'description: \'Parent TypeScript instructions\'',
+						'applyTo: "**/*.ts"',
+						'---',
+						'Parent TypeScript coding standards',
+					]
+				},
+				// Prompt file in parent
+				{
+					path: `${parentFolder}/.github/prompts/help.prompt.md`,
+					contents: [
+						'---',
+						'description: \'Parent help prompt\'',
+						'---',
+						'Help the user with their question',
+					]
+				},
+				// Agent file in parent
+				{
+					path: `${parentFolder}/.github/agents/reviewer.agent.md`,
+					contents: [
+						'---',
+						'description: \'Parent code reviewer agent\'',
+						'---',
+						'You are a code reviewer',
+					]
+				},
+				{
+					path: `${rootFolder}/src/file.ts`,
+					contents: ['console.log("test");'],
+				},
+			]);
+
+			testConfigService.setUserConfiguration(PromptsConfig.INCLUDE_APPLYING_INSTRUCTIONS, true);
+			testConfigService.setUserConfiguration(PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS, true);
+
+			// Mark the parent repo root as untrusted
+			workspaceTrustService.getUriTrustInfo = (uri: URI) => {
+				if (uri.path === parentFolder) {
+					return Promise.resolve({ trusted: false, uri });
+				}
+				return Promise.resolve({ trusted: true, uri });
+			};
+
+			const promptFiles = await service.listPromptFiles(PromptsType.prompt, CancellationToken.None);
+			const agentFiles = await service.listPromptFiles(PromptsType.agent, CancellationToken.None);
+			const instructionFiles = await service.listPromptFiles(PromptsType.instructions, CancellationToken.None);
+
+			assert.ok(!promptFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent prompt files when parent repo is untrusted');
+			assert.ok(!agentFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent agent files when parent repo is untrusted');
+			assert.ok(!instructionFiles.some(f => f.uri.path.includes(parentFolder)), 'Should not find parent instruction files when parent repo is untrusted');
 		});
 	});
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -25,11 +25,12 @@ import { IPathService } from '../../../../../../services/path/common/pathService
 import { PromptsConfig } from '../../../../common/promptSyntax/config/config.js';
 import { PromptsType } from '../../../../common/promptSyntax/promptTypes.js';
 import { hasGlobPattern, isValidGlob, isValidPromptFolderPath, PromptFilesLocator } from '../../../../common/promptSyntax/utils/promptFilesLocator.js';
-import { IMockFileEntry, IMockFolder, MockFilesystem } from '../testUtils/mockFilesystem.js';
+import { mockFiles } from '../testUtils/mockFilesystem.js';
 import { mockService } from './mock.js';
-import { TestUserDataProfileService } from '../../../../../../test/common/workbenchTestServices.js';
+import { TestUserDataProfileService, TestWorkspaceTrustManagementService } from '../../../../../../test/common/workbenchTestServices.js';
 import { PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
 import { runWithFakedTimers } from '../../../../../../../base/test/common/timeTravelScheduler.js';
+import { IWorkspaceTrustManagementService } from '../../../../../../../platform/workspace/common/workspaceTrust.js';
 
 /**
  * Mocked instance of {@link IConfigurationService}.
@@ -77,40 +78,22 @@ suite('PromptFilesLocator', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let instantiationService: TestInstantiationService;
-	setup(async () => {
-		instantiationService = disposables.add(new TestInstantiationService());
-		instantiationService.stub(ILogService, new NullLogService());
+	let fileService: IFileService;
+	const configValues: Record<string, unknown> = {};
+	let workspaceTrustService: TestWorkspaceTrustManagementService;
 
-		const fileService = disposables.add(instantiationService.createInstance(FileService));
-		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
-		disposables.add(fileService.registerProvider(Schemas.file, fileSystemProvider));
+	// Sets all prompt file location config keys to the same value
+	const setLocations = (value: unknown) => {
+		configValues[PromptsConfig.PROMPT_LOCATIONS_KEY] = value;
+		configValues[PromptsConfig.INSTRUCTIONS_LOCATION_KEY] = value;
+		configValues[PromptsConfig.MODE_LOCATION_KEY] = value;
+		configValues[PromptsConfig.SKILLS_LOCATION_KEY] = value;
+	};
 
-		instantiationService.stub(IFileService, fileService);
-	});
-
-	/**
-	 * Create a new instance of {@link PromptFilesLocator} with provided mocked
-	 * values for configuration and workspace services.
-	 */
-	const createPromptsLocator = async (configValue: unknown, workspaceFolderPaths: string[], filesystem: IMockFolder[]) => {
-
-		const mockFs = instantiationService.createInstance(MockFilesystem, filesystem);
-		await mockFs.mock();
-
-		instantiationService.stub(IConfigurationService, mockConfigService({
-			'explorer.excludeGitIgnore': false,
-			'files.exclude': {},
-			'search.exclude': {},
-			[PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS]: false,
-			[PromptsConfig.PROMPT_LOCATIONS_KEY]: configValue,
-			[PromptsConfig.INSTRUCTIONS_LOCATION_KEY]: configValue,
-			[PromptsConfig.MODE_LOCATION_KEY]: configValue,
-			[PromptsConfig.SKILLS_LOCATION_KEY]: configValue,
-		}));
-
-		const workspaceFolders = workspaceFolderPaths.map((path, index) => {
+	// Stubs workspace context service with the given folder paths
+	const setWorkspaceFolders = (paths: string[]) => {
+		const workspaceFolders = paths.map((path, index) => {
 			const uri = URI.file(path);
-
 			return new class extends mock<IWorkspaceFolder>() {
 				override uri = uri;
 				override name = basename(uri);
@@ -118,6 +101,34 @@ suite('PromptFilesLocator', () => {
 			};
 		});
 		instantiationService.stub(IWorkspaceContextService, mockWorkspaceService(workspaceFolders));
+	};
+
+	setup(async () => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogService());
+
+		fileService = disposables.add(instantiationService.createInstance(FileService));
+		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
+		disposables.add(fileService.registerProvider(Schemas.file, fileSystemProvider));
+		instantiationService.stub(IFileService, fileService);
+
+		workspaceTrustService = disposables.add(new TestWorkspaceTrustManagementService());
+		instantiationService.stub(IWorkspaceTrustManagementService, workspaceTrustService);
+
+		// Reset config values to defaults
+		for (const key of Object.keys(configValues)) {
+			delete configValues[key];
+		}
+		Object.assign(configValues, {
+			'explorer.excludeGitIgnore': false,
+			'files.exclude': {},
+			'search.exclude': {},
+			[PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS]: false,
+		});
+		instantiationService.stub(IConfigurationService, mockConfigService(configValues));
+
+		setWorkspaceFolders([]);
+
 		instantiationService.stub(IWorkbenchEnvironmentService, {} as IWorkbenchEnvironmentService);
 		instantiationService.stub(IUserDataProfileService, new TestUserDataProfileService());
 		instantiationService.stub(ISearchService, {
@@ -125,11 +136,9 @@ suite('PromptFilesLocator', () => {
 				return true;
 			},
 			async fileSearch(query: IFileQuery) {
-				// mock the search service
-				const fs = instantiationService.get(IFileService);
 				const findFilesInLocation = async (location: URI, results: URI[] = []) => {
 					try {
-						const resolve = await fs.resolve(location);
+						const resolve = await fileService.resolve(location);
 						if (resolve.isFile) {
 							results.push(resolve.resource);
 						} else if (resolve.isDirectory && resolve.children) {
@@ -150,7 +159,6 @@ suite('PromptFilesLocator', () => {
 							results.push({ resource });
 						}
 					}
-
 				}
 				return { results, messages: [] };
 			}
@@ -164,134 +172,112 @@ suite('PromptFilesLocator', () => {
 				return Promise.resolve(uri);
 			}
 		} as IPathService);
-
-		const locator = instantiationService.createInstance(PromptFilesLocator);
-
-		return {
-			async listFiles(type: PromptsType, storage: PromptsStorage, token: CancellationToken): Promise<readonly URI[]> {
-				return locator.listFiles(type, storage, token);
-			},
-			async getConfigBasedSourceFolders(type: PromptsType): Promise<readonly URI[]> {
-				return await locator.getConfigBasedSourceFolders(type);
-			},
-			async findAgentSkills(token: CancellationToken) {
-				return await locator.findAgentSkills(token);
-			},
-			async disposeAsync(): Promise<void> {
-				await mockFs.delete();
-			}
-		};
-	};
+	});
 
 	suite('empty workspace', () => {
 		const EMPTY_WORKSPACE: string[] = [];
 
 		suite('empty filesystem', () => {
 			testT('no config value', async () => {
-				const locator = await createPromptsLocator(undefined, EMPTY_WORKSPACE, []);
+				setLocations(undefined);
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
 					[],
 					'No prompts must be found.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('object config value', async () => {
-				const locator = await createPromptsLocator({
+				setLocations({
 					'/Users/legomushroom/repos/prompts/': true,
 					'/tmp/prompts/': false,
-				}, EMPTY_WORKSPACE, []);
+				});
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
 					[],
 					'No prompts must be found.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('array config value', async () => {
-				const locator = await createPromptsLocator([
+				setLocations([
 					'relative/path/to/prompts/',
 					'/abs/path',
-				], EMPTY_WORKSPACE, []);
+				]);
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
 					[],
 					'No prompts must be found.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('null config value', async () => {
-				const locator = await createPromptsLocator(null, EMPTY_WORKSPACE, []);
+				setLocations(null);
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
 					[],
 					'No prompts must be found.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('string config value', async () => {
-				const locator = await createPromptsLocator('/etc/hosts/prompts', EMPTY_WORKSPACE, []);
+				setLocations('/etc/hosts/prompts');
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
 					[],
 					'No prompts must be found.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 
 		suite('non-empty filesystem', () => {
 			testT('core logic', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': true,
+				});
+				setWorkspaceFolders(EMPTY_WORKSPACE);
+				await mockFiles(fileService, [
 					{
-						'/Users/legomushroom/repos/prompts': true,
-						'/tmp/prompts/': true,
-						'/absolute/path/prompts': false,
-						'.copilot/prompts': true,
+						path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+						contents: ['Hello, World!'],
 					},
-					EMPTY_WORKSPACE,
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-					]);
+					{
+						path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+						contents: ['some file content goes here'],
+					},
+					{
+						path: '/tmp/prompts/translate.to-rust.prompt.md',
+						contents: ['some more random file contents'],
+					},
+					{
+						path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+						contents: ['hey hey hey'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -302,7 +288,6 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
-				await locator.disposeAsync();
 			});
 
 			suite('absolute', () => {
@@ -327,47 +312,31 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of settings) {
-						const locator = await createPromptsLocator(
-							{ [setting]: true },
-							EMPTY_WORKSPACE,
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations({ [setting]: true });
+						setWorkspaceFolders(EMPTY_WORKSPACE);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -379,7 +348,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 					}
 				});
 
@@ -481,51 +449,35 @@ suite('PromptFilesLocator', () => {
 							vscodeSettings[setting] = true;
 						}
 
-						const locator = await createPromptsLocator(
-							vscodeSettings,
-							EMPTY_WORKSPACE,
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'default.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rawbot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations(vscodeSettings);
+						setWorkspaceFolders(EMPTY_WORKSPACE);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/default.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rawbot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -536,7 +488,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 					}
 				});
 			});
@@ -567,47 +518,31 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of testSettings) {
-						const locator = await createPromptsLocator(
-							{ [setting]: true },
-							['/Users/legomushroom/repos/vscode'],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations({ [setting]: true });
+						setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -619,7 +554,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -722,51 +656,35 @@ suite('PromptFilesLocator', () => {
 							vscodeSettings[setting] = true;
 						}
 
-						const locator = await createPromptsLocator(
-							vscodeSettings,
-							['/Users/legomushroom/repos/vscode'],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'default.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rawbot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations(vscodeSettings);
+						setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/default.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rawbot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -777,7 +695,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 					}
 				});
 			});
@@ -805,47 +722,31 @@ suite('PromptFilesLocator', () => {
 
 					for (const setting of settings) {
 
-						const locator = await createPromptsLocator(
-							{ [setting]: true },
-							['/Users/legomushroom/repos/vscode'],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations({ [setting]: true });
+						setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -857,7 +758,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -960,51 +860,35 @@ suite('PromptFilesLocator', () => {
 							vscodeSettings[setting] = true;
 						}
 
-						const locator = await createPromptsLocator(
-							vscodeSettings,
-							['/Users/legomushroom/repos/vscode'],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'deps/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'default.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rawbot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-							],
-						);
+						setLocations(vscodeSettings);
+						setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/default.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rawbot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/deps/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1015,7 +899,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -1024,72 +907,42 @@ suite('PromptFilesLocator', () => {
 	});
 
 	testT('core logic', async () => {
-		const locator = await createPromptsLocator(
+		setLocations({
+			'/Users/legomushroom/repos/prompts': true,
+			'/tmp/prompts/': true,
+			'/absolute/path/prompts': false,
+			'.copilot/prompts': true,
+		});
+		setWorkspaceFolders([
+			'/Users/legomushroom/repos/vscode',
+		]);
+		await mockFiles(fileService, [
 			{
-				'/Users/legomushroom/repos/prompts': true,
-				'/tmp/prompts/': true,
-				'/absolute/path/prompts': false,
-				'.copilot/prompts': true,
+				path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+				contents: ['Hello, World!'],
 			},
-			[
-				'/Users/legomushroom/repos/vscode',
-			],
-			[
-				{
-					name: '/Users/legomushroom/repos/prompts',
-					children: [
-						{
-							name: 'test.prompt.md',
-							contents: 'Hello, World!',
-						},
-						{
-							name: 'refactor-tests.prompt.md',
-							contents: 'some file content goes here',
-						},
-					],
-				},
-				{
-					name: '/tmp/prompts',
-					children: [
-						{
-							name: 'translate.to-rust.prompt.md',
-							contents: 'some more random file contents',
-						},
-					],
-				},
-				{
-					name: '/absolute/path/prompts',
-					children: [
-						{
-							name: 'some-prompt-file.prompt.md',
-							contents: 'hey hey hey',
-						},
-					],
-				},
-				{
-					name: '/Users/legomushroom/repos/vscode',
-					children: [
-						{
-							name: '.copilot/prompts',
-							children: [
-								{
-									name: 'default.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-							],
-						},
-						{
-							name: '.github/prompts',
-							children: [
-								{
-									name: 'my.prompt.md',
-									contents: 'oh hi, bot!',
-								},
-							],
-						},
-					],
-				},
-			]);
+			{
+				path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+				contents: ['some file content goes here'],
+			},
+			{
+				path: '/tmp/prompts/translate.to-rust.prompt.md',
+				contents: ['some more random file contents'],
+			},
+			{
+				path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+				contents: ['hey hey hey'],
+			},
+			{
+				path: '/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md',
+				contents: ['oh hi, robot!'],
+			},
+			{
+				path: '/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md',
+				contents: ['oh hi, bot!'],
+			},
+		]);
+		const locator = instantiationService.createInstance(PromptFilesLocator);
 
 		assertOutcome(
 			await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1102,81 +955,50 @@ suite('PromptFilesLocator', () => {
 			],
 			'Must find correct prompts.',
 		);
-		await locator.disposeAsync();
 	});
 
 	testT('with disabled `.github/prompts` location', async () => {
-		const locator = await createPromptsLocator(
+		setLocations({
+			'/Users/legomushroom/repos/prompts': true,
+			'/tmp/prompts/': true,
+			'/absolute/path/prompts': false,
+			'.copilot/prompts': true,
+			'.github/prompts': false,
+		});
+		setWorkspaceFolders([
+			'/Users/legomushroom/repos/vscode',
+		]);
+		await mockFiles(fileService, [
 			{
-				'/Users/legomushroom/repos/prompts': true,
-				'/tmp/prompts/': true,
-				'/absolute/path/prompts': false,
-				'.copilot/prompts': true,
-				'.github/prompts': false,
+				path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+				contents: ['Hello, World!'],
 			},
-			[
-				'/Users/legomushroom/repos/vscode',
-			],
-			[
-				{
-					name: '/Users/legomushroom/repos/prompts',
-					children: [
-						{
-							name: 'test.prompt.md',
-							contents: 'Hello, World!',
-						},
-						{
-							name: 'refactor-tests.prompt.md',
-							contents: 'some file content goes here',
-						},
-					],
-				},
-				{
-					name: '/tmp/prompts',
-					children: [
-						{
-							name: 'translate.to-rust.prompt.md',
-							contents: 'some more random file contents',
-						},
-					],
-				},
-				{
-					name: '/absolute/path/prompts',
-					children: [
-						{
-							name: 'some-prompt-file.prompt.md',
-							contents: 'hey hey hey',
-						},
-					],
-				},
-				{
-					name: '/Users/legomushroom/repos/vscode',
-					children: [
-						{
-							name: '.copilot/prompts',
-							children: [
-								{
-									name: 'default.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-							],
-						},
-						{
-							name: '.github/prompts',
-							children: [
-								{
-									name: 'my.prompt.md',
-									contents: 'oh hi, bot!',
-								},
-								{
-									name: 'your.prompt.md',
-									contents: 'oh hi, bot!',
-								},
-							],
-						},
-					],
-				},
-			]);
+			{
+				path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+				contents: ['some file content goes here'],
+			},
+			{
+				path: '/tmp/prompts/translate.to-rust.prompt.md',
+				contents: ['some more random file contents'],
+			},
+			{
+				path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+				contents: ['hey hey hey'],
+			},
+			{
+				path: '/Users/legomushroom/repos/vscode/.copilot/prompts/default.prompt.md',
+				contents: ['oh hi, robot!'],
+			},
+			{
+				path: '/Users/legomushroom/repos/vscode/.github/prompts/my.prompt.md',
+				contents: ['oh hi, bot!'],
+			},
+			{
+				path: '/Users/legomushroom/repos/vscode/.github/prompts/your.prompt.md',
+				contents: ['oh hi, bot!'],
+			},
+		]);
+		const locator = instantiationService.createInstance(PromptFilesLocator);
 
 		assertOutcome(
 			await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1188,116 +1010,64 @@ suite('PromptFilesLocator', () => {
 			],
 			'Must find correct prompts.',
 		);
-		await locator.disposeAsync();
 	});
 
 	suite('multi-root workspace', () => {
 		suite('core logic', () => {
 			testT('without top-level `.github` folder', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': false,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+				]);
+				await mockFiles(fileService, [
 					{
-						'/Users/legomushroom/repos/prompts': true,
-						'/tmp/prompts/': true,
-						'/absolute/path/prompts': false,
-						'.copilot/prompts': false,
+						path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+						contents: ['Hello, World!'],
 					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt1.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/node',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt5.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'refactor-static-classes.prompt.md',
-											contents: 'file contents',
-										},
-									],
-								},
-							],
-						},
-						// note! this folder is not part of the workspace, so prompt files are `ignored`
-						{
-							name: '/Users/legomushroom/repos/.github/prompts',
-							children: [
-								{
-									name: 'prompt-name.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-								{
-									name: 'name-of-the-prompt.prompt.md',
-									contents: 'oh hi, raw bot!',
-								},
-							],
-						},
-					]);
+					{
+						path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+						contents: ['some file content goes here'],
+					},
+					{
+						path: '/tmp/prompts/translate.to-rust.prompt.md',
+						contents: ['some more random file contents'],
+					},
+					{
+						path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+						contents: ['hey hey hey'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.copilot/prompts/prompt1.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md',
+						contents: ['oh hi, bot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.copilot/prompts/prompt5.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md',
+						contents: ['file contents'],
+					},
+					{
+						path: '/Users/legomushroom/repos/.github/prompts/prompt-name.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/.github/prompts/name-of-the-prompt.prompt.md',
+						contents: ['oh hi, raw bot!'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1310,115 +1080,63 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('with top-level `.github` folder', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': false,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+					'/var/shared/prompts',
+				]);
+				await mockFiles(fileService, [
 					{
-						'/Users/legomushroom/repos/prompts': true,
-						'/tmp/prompts/': true,
-						'/absolute/path/prompts': false,
-						'.copilot/prompts': false,
+						path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+						contents: ['Hello, World!'],
 					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-						'/var/shared/prompts',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt1.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/node',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt5.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'refactor-static-classes.prompt.md',
-											contents: 'file contents',
-										},
-									],
-								},
-							],
-						},
-						// note! this folder is part of the workspace, so prompt files are `included`
-						{
-							name: '/var/shared/prompts/.github/prompts',
-							children: [
-								{
-									name: 'prompt-name.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-								{
-									name: 'name-of-the-prompt.prompt.md',
-									contents: 'oh hi, raw bot!',
-								},
-							],
-						},
-					]);
+					{
+						path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+						contents: ['some file content goes here'],
+					},
+					{
+						path: '/tmp/prompts/translate.to-rust.prompt.md',
+						contents: ['some more random file contents'],
+					},
+					{
+						path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+						contents: ['hey hey hey'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.copilot/prompts/prompt1.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md',
+						contents: ['oh hi, bot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.copilot/prompts/prompt5.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md',
+						contents: ['file contents'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/prompt-name.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md',
+						contents: ['oh hi, raw bot!'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1433,116 +1151,64 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('with disabled `.github/prompts` location', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'/Users/legomushroom/repos/prompts': true,
+					'/tmp/prompts/': true,
+					'/absolute/path/prompts': false,
+					'.copilot/prompts': false,
+					'.github/prompts': false,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+					'/var/shared/prompts',
+				]);
+				await mockFiles(fileService, [
 					{
-						'/Users/legomushroom/repos/prompts': true,
-						'/tmp/prompts/': true,
-						'/absolute/path/prompts': false,
-						'.copilot/prompts': false,
-						'.github/prompts': false,
+						path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+						contents: ['Hello, World!'],
 					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-						'/var/shared/prompts',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt1.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/node',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt5.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'refactor-static-classes.prompt.md',
-											contents: 'file contents',
-										},
-									],
-								},
-							],
-						},
-						// note! this folder is part of the workspace, so prompt files are `included`
-						{
-							name: '/var/shared/prompts/.github/prompts',
-							children: [
-								{
-									name: 'prompt-name.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-								{
-									name: 'name-of-the-prompt.prompt.md',
-									contents: 'oh hi, raw bot!',
-								},
-							],
-						},
-					]);
+					{
+						path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+						contents: ['some file content goes here'],
+					},
+					{
+						path: '/tmp/prompts/translate.to-rust.prompt.md',
+						contents: ['some more random file contents'],
+					},
+					{
+						path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+						contents: ['hey hey hey'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.copilot/prompts/prompt1.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md',
+						contents: ['oh hi, bot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.copilot/prompts/prompt5.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md',
+						contents: ['file contents'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/prompt-name.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md',
+						contents: ['oh hi, raw bot!'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1553,119 +1219,67 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('mixed', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'/Users/legomushroom/repos/**/*test*': true,
+					'.copilot/prompts': false,
+					'.github/prompts': true,
+					'/absolute/path/prompts/some-prompt-file.prompt.md': true,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+					'/var/shared/prompts',
+				]);
+				await mockFiles(fileService, [
 					{
-						'/Users/legomushroom/repos/**/*test*': true,
-						'.copilot/prompts': false,
-						'.github/prompts': true,
-						'/absolute/path/prompts/some-prompt-file.prompt.md': true,
+						path: '/Users/legomushroom/repos/prompts/test.prompt.md',
+						contents: ['Hello, World!'],
 					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-						'/var/shared/prompts',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/prompts',
-							children: [
-								{
-									name: 'test.prompt.md',
-									contents: 'Hello, World!',
-								},
-								{
-									name: 'refactor-tests.prompt.md',
-									contents: 'some file content goes here',
-								},
-								{
-									name: 'elf.prompt.md',
-									contents: 'haalo!',
-								},
-							],
-						},
-						{
-							name: '/tmp/prompts',
-							children: [
-								{
-									name: 'translate.to-rust.prompt.md',
-									contents: 'some more random file contents',
-								},
-							],
-						},
-						{
-							name: '/absolute/path/prompts',
-							children: [
-								{
-									name: 'some-prompt-file.prompt.md',
-									contents: 'hey hey hey',
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/vscode',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt1.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'default.prompt.md',
-											contents: 'oh hi, bot!',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/node',
-							children: [
-								{
-									name: '.copilot/prompts',
-									children: [
-										{
-											name: 'prompt5.prompt.md',
-											contents: 'oh hi, robot!',
-										},
-									],
-								},
-								{
-									name: '.github/prompts',
-									children: [
-										{
-											name: 'refactor-static-classes.prompt.md',
-											contents: 'file contents',
-										},
-									],
-								},
-							],
-						},
-						// note! this folder is part of the workspace, so prompt files are `included`
-						{
-							name: '/var/shared/prompts/.github/prompts',
-							children: [
-								{
-									name: 'prompt-name.prompt.md',
-									contents: 'oh hi, robot!',
-								},
-								{
-									name: 'name-of-the-prompt.prompt.md',
-									contents: 'oh hi, raw bot!',
-								},
-							],
-						},
-					]);
+					{
+						path: '/Users/legomushroom/repos/prompts/refactor-tests.prompt.md',
+						contents: ['some file content goes here'],
+					},
+					{
+						path: '/Users/legomushroom/repos/prompts/elf.prompt.md',
+						contents: ['haalo!'],
+					},
+					{
+						path: '/tmp/prompts/translate.to-rust.prompt.md',
+						contents: ['some more random file contents'],
+					},
+					{
+						path: '/absolute/path/prompts/some-prompt-file.prompt.md',
+						contents: ['hey hey hey'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.copilot/prompts/prompt1.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.github/prompts/default.prompt.md',
+						contents: ['oh hi, bot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.copilot/prompts/prompt5.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/Users/legomushroom/repos/node/.github/prompts/refactor-static-classes.prompt.md',
+						contents: ['file contents'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/prompt-name.prompt.md',
+						contents: ['oh hi, robot!'],
+					},
+					{
+						path: '/var/shared/prompts/.github/prompts/name-of-the-prompt.prompt.md',
+						contents: ['oh hi, raw bot!'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				assertOutcome(
 					await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1683,7 +1297,6 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find correct prompts.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 
@@ -1715,72 +1328,46 @@ suite('PromptFilesLocator', () => {
 
 					for (const setting of testSettings) {
 
-						const locator = await createPromptsLocator(
-							{ [setting]: true },
-							[
-								'/Users/legomushroom/repos/vscode',
-								'/Users/legomushroom/repos/prompts',
-							],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'gen/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-								{
-									name: '/Users/legomushroom/repos/prompts',
-									children: [
-										{
-											name: 'general',
-											children: [
-												{
-													name: 'common.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'uncommon-10.prompt.md',
-													contents: 'oh hi, robot!',
-												},
-												{
-													name: 'license.md',
-													contents: 'non prompt file',
-												},
-											],
-										}
-									],
-								},
-							],
-						);
+						setLocations({ [setting]: true });
+						setWorkspaceFolders([
+							'/Users/legomushroom/repos/vscode',
+							'/Users/legomushroom/repos/prompts',
+						]);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/common.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/license.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -1795,7 +1382,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -1920,72 +1506,46 @@ suite('PromptFilesLocator', () => {
 							vscodeSettings[setting] = true;
 						}
 
-						const locator = await createPromptsLocator(
-							vscodeSettings,
-							[
-								'/Users/legomushroom/repos/vscode',
-								'/Users/legomushroom/repos/prompts',
-							],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'gen/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-								{
-									name: '/Users/legomushroom/repos/prompts',
-									children: [
-										{
-											name: 'general',
-											children: [
-												{
-													name: 'common.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'uncommon-10.prompt.md',
-													contents: 'oh hi, robot!',
-												},
-												{
-													name: 'license.md',
-													contents: 'non prompt file',
-												},
-											],
-										}
-									],
-								},
-							],
-						);
+						setLocations(vscodeSettings);
+						setWorkspaceFolders([
+							'/Users/legomushroom/repos/vscode',
+							'/Users/legomushroom/repos/prompts',
+						]);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/common.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/license.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -2000,7 +1560,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -2044,72 +1603,46 @@ suite('PromptFilesLocator', () => {
 					];
 
 					for (const setting of testSettings) {
-						const locator = await createPromptsLocator(
-							{ [setting]: true },
-							[
-								'/Users/legomushroom/repos/vscode',
-								'/Users/legomushroom/repos/prompts',
-							],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'gen/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-								{
-									name: '/Users/legomushroom/repos/prompts',
-									children: [
-										{
-											name: 'general',
-											children: [
-												{
-													name: 'common.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'uncommon-10.prompt.md',
-													contents: 'oh hi, robot!',
-												},
-												{
-													name: 'license.md',
-													contents: 'non prompt file',
-												},
-											],
-										}
-									],
-								},
-							],
-						);
+						setLocations({ [setting]: true });
+						setWorkspaceFolders([
+							'/Users/legomushroom/repos/vscode',
+							'/Users/legomushroom/repos/prompts',
+						]);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/common.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/license.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -2124,7 +1657,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -2279,72 +1811,46 @@ suite('PromptFilesLocator', () => {
 							vscodeSettings[setting] = true;
 						}
 
-						const locator = await createPromptsLocator(
-							vscodeSettings,
-							[
-								'/Users/legomushroom/repos/vscode',
-								'/Users/legomushroom/repos/prompts',
-							],
-							[
-								{
-									name: '/Users/legomushroom/repos/vscode',
-									children: [
-										{
-											name: 'gen/text',
-											children: [
-												{
-													name: 'my.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'nested',
-													children: [
-														{
-															name: 'specific.prompt.md',
-															contents: 'oh hi, bot!',
-														},
-														{
-															name: 'unspecific1.prompt.md',
-															contents: 'oh hi, robot!',
-														},
-														{
-															name: 'unspecific2.prompt.md',
-															contents: 'oh hi, rabot!',
-														},
-														{
-															name: 'readme.md',
-															contents: 'non prompt file',
-														},
-													],
-												}
-											],
-										},
-									],
-								},
-								{
-									name: '/Users/legomushroom/repos/prompts',
-									children: [
-										{
-											name: 'general',
-											children: [
-												{
-													name: 'common.prompt.md',
-													contents: 'oh hi, bot!',
-												},
-												{
-													name: 'uncommon-10.prompt.md',
-													contents: 'oh hi, robot!',
-												},
-												{
-													name: 'license.md',
-													contents: 'non prompt file',
-												},
-											],
-										}
-									],
-								},
-							],
-						);
+						setLocations(vscodeSettings);
+						setWorkspaceFolders([
+							'/Users/legomushroom/repos/vscode',
+							'/Users/legomushroom/repos/prompts',
+						]);
+						await mockFiles(fileService, [
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/my.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/specific.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific1.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/unspecific2.prompt.md',
+								contents: ['oh hi, rabot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/vscode/gen/text/nested/readme.md',
+								contents: ['non prompt file'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/common.prompt.md',
+								contents: ['oh hi, bot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/uncommon-10.prompt.md',
+								contents: ['oh hi, robot!'],
+							},
+							{
+								path: '/Users/legomushroom/repos/prompts/general/license.md',
+								contents: ['non prompt file'],
+							},
+						]);
+						const locator = instantiationService.createInstance(PromptFilesLocator);
 
 						assertOutcome(
 							await locator.listFiles(PromptsType.prompt, PromptsStorage.local, CancellationToken.None),
@@ -2359,7 +1865,6 @@ suite('PromptFilesLocator', () => {
 							],
 							'Must find correct prompts.',
 						);
-						await locator.disposeAsync();
 
 					}
 				});
@@ -2369,52 +1874,31 @@ suite('PromptFilesLocator', () => {
 
 	suite('instructions', () => {
 		testT('finds instructions files in subdirectories of .github/instructions', async () => {
-			const locator = await createPromptsLocator(
+			setLocations({
+				'.github/instructions': true,
+				'.claude/rules': false,
+				'~/.copilot/instructions': false,
+			});
+			setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+			await mockFiles(fileService, [
 				{
-					'.github/instructions': true,
-					'.claude/rules': false,
-					'~/.copilot/instructions': false,
+					path: '/Users/legomushroom/repos/vscode/.github/instructions/root.instructions.md',
+					contents: ['root instructions'],
 				},
-				['/Users/legomushroom/repos/vscode'],
-				[
-					{
-						name: '/Users/legomushroom/repos/vscode',
-						children: [
-							{
-								name: '.github/instructions',
-								children: [
-									{
-										name: 'root.instructions.md',
-										contents: 'root instructions',
-									},
-									{
-										name: 'frontend',
-										children: [
-											{
-												name: 'react.instructions.md',
-												contents: 'react instructions',
-											},
-											{
-												name: 'css.instructions.md',
-												contents: 'css instructions',
-											},
-										],
-									},
-									{
-										name: 'backend',
-										children: [
-											{
-												name: 'api.instructions.md',
-												contents: 'api instructions',
-											},
-										],
-									},
-								],
-							},
-						],
-					},
-				],
-			);
+				{
+					path: '/Users/legomushroom/repos/vscode/.github/instructions/frontend/react.instructions.md',
+					contents: ['react instructions'],
+				},
+				{
+					path: '/Users/legomushroom/repos/vscode/.github/instructions/frontend/css.instructions.md',
+					contents: ['css instructions'],
+				},
+				{
+					path: '/Users/legomushroom/repos/vscode/.github/instructions/backend/api.instructions.md',
+					contents: ['api instructions'],
+				},
+			]);
+			const locator = instantiationService.createInstance(PromptFilesLocator);
 
 			assertOutcome(
 				await locator.listFiles(PromptsType.instructions, PromptsStorage.local, CancellationToken.None),
@@ -2426,48 +1910,31 @@ suite('PromptFilesLocator', () => {
 				],
 				'Must find instructions files recursively in subdirectories of .github/instructions.',
 			);
-			await locator.disposeAsync();
 		});
 	});
 
 	suite('skills', () => {
 		suite('findAgentSkills', () => {
 			testT('finds skill files in configured locations', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'.claude/skills': true,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, [
 					{
-						'.claude/skills': true,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/pptx/SKILL.md',
+						contents: ['# PPTX Skill'],
 					},
-					['/Users/legomushroom/repos/vscode'],
-					[
-						{
-							name: '/Users/legomushroom/repos/vscode/.claude/skills',
-							children: [
-								{
-									name: 'pptx',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# PPTX Skill',
-										},
-									],
-								},
-								{
-									name: 'excel',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# Excel Skill',
-										},
-									],
-								},
-							],
-						},
-					],
-				);
+					{
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/excel/SKILL.md',
+						contents: ['# Excel Skill'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const skills = await locator.findAgentSkills(CancellationToken.None);
 				assertOutcome(
@@ -2478,54 +1945,32 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find skill files.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('ignores folders without SKILL.md', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'.claude/skills': true,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, [
 					{
-						'.claude/skills': true,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/valid-skill/SKILL.md',
+						contents: ['# Valid Skill'],
 					},
-					['/Users/legomushroom/repos/vscode'],
-					[
-						{
-							name: '/Users/legomushroom/repos/vscode/.claude/skills',
-							children: [
-								{
-									name: 'valid-skill',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# Valid Skill',
-										},
-									],
-								},
-								{
-									name: 'invalid-skill',
-									children: [
-										{
-											name: 'readme.md',
-											contents: 'Not a skill file',
-										},
-									],
-								},
-								{
-									name: 'another-invalid',
-									children: [
-										{
-											name: 'index.js',
-											contents: 'console.log("not a skill")',
-										},
-									],
-								},
-							],
-						},
-					],
-				);
+					{
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/invalid-skill/readme.md',
+						contents: ['Not a skill file'],
+					},
+					{
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/another-invalid/index.js',
+						contents: ['console.log("not a skill")'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const skills = await locator.findAgentSkills(CancellationToken.None);
 				assertOutcome(
@@ -2535,26 +1980,19 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must only find folders with SKILL.md.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('returns empty array when no skills exist', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'.claude/skills': true,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[
-						{
-							name: '/Users/legomushroom/repos/vscode/.claude/skills',
-							children: [],
-						},
-					],
-				);
+				setLocations({
+					'.claude/skills': true,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const skills = await locator.findAgentSkills(CancellationToken.None);
 				assertOutcome(
@@ -2562,21 +2000,19 @@ suite('PromptFilesLocator', () => {
 					[],
 					'Must return empty array when no skills exist.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('returns empty array when skill folder does not exist', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'.claude/skills': true,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[], // empty filesystem
-				);
+				setLocations({
+					'.claude/skills': true,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const skills = await locator.findAgentSkills(CancellationToken.None);
 				assertOutcome(
@@ -2584,53 +2020,31 @@ suite('PromptFilesLocator', () => {
 					[],
 					'Must return empty array when folder does not exist.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('finds skills across multiple workspace folders', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'.claude/skills': true,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+				]);
+				await mockFiles(fileService, [
 					{
-						'.claude/skills': true,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/skill-a/SKILL.md',
+						contents: ['# Skill A'],
 					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-					],
-					[
-						{
-							name: '/Users/legomushroom/repos/vscode/.claude/skills',
-							children: [
-								{
-									name: 'skill-a',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# Skill A',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: '/Users/legomushroom/repos/node/.claude/skills',
-							children: [
-								{
-									name: 'skill-b',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# Skill B',
-										},
-									],
-								},
-							],
-						},
-					],
-				);
+					{
+						path: '/Users/legomushroom/repos/node/.claude/skills/skill-b/SKILL.md',
+						contents: ['# Skill B'],
+					},
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const skills = await locator.findAgentSkills(CancellationToken.None);
 				assertOutcome(
@@ -2641,38 +2055,26 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must find skills across all workspace folders.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 
 		suite('listFiles with PromptsType.skill', () => {
 			testT('does not list skills when location is disabled', async () => {
-				const locator = await createPromptsLocator(
+				setLocations({
+					'.claude/skills': false,
+					// disable other defaults
+					'.github/skills': false,
+					'~/.copilot/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, [
 					{
-						'.claude/skills': false,
-						// disable other defaults
-						'.github/skills': false,
-						'~/.copilot/skills': false,
-						'~/.claude/skills': false,
+						path: '/Users/legomushroom/repos/vscode/.claude/skills/pptx/SKILL.md',
+						contents: ['# PPTX Skill'],
 					},
-					['/Users/legomushroom/repos/vscode'],
-					[
-						{
-							name: '/Users/legomushroom/repos/vscode/.claude/skills',
-							children: [
-								{
-									name: 'pptx',
-									children: [
-										{
-											name: 'SKILL.md',
-											contents: '# PPTX Skill',
-										},
-									],
-								},
-							],
-						},
-					],
-				);
+				]);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const files = await locator.listFiles(PromptsType.skill, PromptsStorage.local, CancellationToken.None);
 				assertOutcome(
@@ -2680,28 +2082,26 @@ suite('PromptFilesLocator', () => {
 					[],
 					'Must not list skills when location is disabled.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 
 		suite('toAbsoluteLocationsForSkills path validation', () => {
 			testT('rejects glob patterns in skill paths via getConfigBasedSourceFolders', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'skills/**': true,
-						'skills/*': true,
-						'**/skills': true,
-						// disable defaults
-						'.github/skills': false,
-						'.agents/skills': false,
-						'.claude/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'skills/**': true,
+					'skills/*': true,
+					'**/skills': true,
+					// disable defaults
+					'.github/skills': false,
+					'.agents/skills': false,
+					'.claude/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2709,24 +2109,22 @@ suite('PromptFilesLocator', () => {
 					[],
 					'Must reject glob patterns in skill paths.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('rejects absolute paths in skill paths via getConfigBasedSourceFolders', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'/absolute/path/skills': true,
-						// disable defaults
-						'.github/skills': false,
-						'.agents/skills': false,
-						'.claude/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'/absolute/path/skills': true,
+					// disable defaults
+					'.github/skills': false,
+					'.agents/skills': false,
+					'.claude/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2734,25 +2132,23 @@ suite('PromptFilesLocator', () => {
 					[],
 					'Must reject absolute paths in skill paths.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('accepts relative paths in skill paths via getConfigBasedSourceFolders', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'./my-skills': true,
-						'custom/skills': true,
-						// disable defaults
-						'.github/skills': false,
-						'.agents/skills': false,
-						'.claude/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'./my-skills': true,
+					'custom/skills': true,
+					// disable defaults
+					'.github/skills': false,
+					'.agents/skills': false,
+					'.claude/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2763,24 +2159,22 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must accept relative paths in skill paths.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('accepts parent relative paths for monorepos via getConfigBasedSourceFolders', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'../shared-skills': true,
-						// disable defaults
-						'.github/skills': false,
-						'.agents/skills': false,
-						'.claude/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'../shared-skills': true,
+					// disable defaults
+					'.github/skills': false,
+					'.agents/skills': false,
+					'.claude/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2790,24 +2184,22 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must accept parent relative paths for monorepos.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('accepts tilde paths for user home skills', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'~/my-skills': true,
-						// disable defaults
-						'.github/skills': false,
-						'.agents/skills': false,
-						'.claude/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'~/my-skills': true,
+					// disable defaults
+					'.github/skills': false,
+					'.agents/skills': false,
+					'.claude/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2817,29 +2209,27 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must accept tilde paths for user home skills.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 
 		suite('getConfigBasedSourceFolders for skills', () => {
 			testT('returns source folders without glob processing', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'.claude/skills': true,
-						'custom-skills': true,
-						// explicitly disable other defaults we don't want for this test
-						'.github/skills': false,
-						'.agents/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					[
-						'/Users/legomushroom/repos/vscode',
-						'/Users/legomushroom/repos/node',
-					],
-					[],
-				);
+				setLocations({
+					'.claude/skills': true,
+					'custom-skills': true,
+					// explicitly disable other defaults we don't want for this test
+					'.github/skills': false,
+					'.agents/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders([
+					'/Users/legomushroom/repos/vscode',
+					'/Users/legomushroom/repos/node',
+				]);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2852,25 +2242,23 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must return skill source folders without glob processing.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('filters out invalid skill paths from source folders', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'.claude/skills': true,
-						'skills/**': true, // glob - should be filtered out
-						'/absolute/skills': true, // absolute - should be filtered out
-						// explicitly disable other defaults we don't want for this test
-						'.github/skills': false,
-						'.agents/skills': false,
-						'~/.copilot/skills': false,
-						'~/.agents/skills': false,
-						'~/.claude/skills': false,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'.claude/skills': true,
+					'skills/**': true, // glob - should be filtered out
+					'/absolute/skills': true, // absolute - should be filtered out
+					// explicitly disable other defaults we don't want for this test
+					'.github/skills': false,
+					'.agents/skills': false,
+					'~/.copilot/skills': false,
+					'~/.agents/skills': false,
+					'~/.claude/skills': false,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2880,17 +2268,15 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must filter out invalid skill paths.',
 				);
-				await locator.disposeAsync();
 			});
 
 			testT('includes default skill source folders from defaults', async () => {
-				const locator = await createPromptsLocator(
-					{
-						'custom-skills': true,
-					},
-					['/Users/legomushroom/repos/vscode'],
-					[],
-				);
+				setLocations({
+					'custom-skills': true,
+				});
+				setWorkspaceFolders(['/Users/legomushroom/repos/vscode']);
+				await mockFiles(fileService, []);
+				const locator = instantiationService.createInstance(PromptFilesLocator);
 
 				const folders = await locator.getConfigBasedSourceFolders(PromptsType.skill);
 				assertOutcome(
@@ -2908,7 +2294,6 @@ suite('PromptFilesLocator', () => {
 					],
 					'Must include default skill source folders.',
 				);
-				await locator.disposeAsync();
 			});
 		});
 	});
@@ -3213,23 +2598,22 @@ suite('PromptFilesLocator', () => {
 
 	suite('getConfigBasedSourceFolders', () => {
 		testT('gets unambiguous list of folders', async () => {
-			const locator = await createPromptsLocator(
-				{
-					'.github/prompts': true,
-					'/Users/**/repos/**': true,
-					'gen/text/**': true,
-					'gen/text/nested/*.prompt.md': true,
-					'general/*': true,
-					'/Users/legomushroom/repos/vscode/my-prompts': true,
-					'/Users/legomushroom/repos/vscode/your-prompts/*.md': true,
-					'/Users/legomushroom/repos/prompts/shared-prompts/*': true,
-				},
-				[
-					'/Users/legomushroom/repos/vscode',
-					'/Users/legomushroom/repos/prompts',
-				],
-				[],
-			);
+			setLocations({
+				'.github/prompts': true,
+				'/Users/**/repos/**': true,
+				'gen/text/**': true,
+				'gen/text/nested/*.prompt.md': true,
+				'general/*': true,
+				'/Users/legomushroom/repos/vscode/my-prompts': true,
+				'/Users/legomushroom/repos/vscode/your-prompts/*.md': true,
+				'/Users/legomushroom/repos/prompts/shared-prompts/*': true,
+			});
+			setWorkspaceFolders([
+				'/Users/legomushroom/repos/vscode',
+				'/Users/legomushroom/repos/prompts',
+			]);
+			await mockFiles(fileService, []);
+			const locator = instantiationService.createInstance(PromptFilesLocator);
 
 			assertOutcome(
 				await locator.getConfigBasedSourceFolders(PromptsType.prompt),
@@ -3246,29 +2630,25 @@ suite('PromptFilesLocator', () => {
 				],
 				'Must find correct prompts.',
 			);
-			await locator.disposeAsync();
 		});
 	});
 
 	suite('findAgentMDsInWorkspace', () => {
 		testT('finds AGENTS.md files using FileSearchProvider', async () => {
-			const locator = await createPromptsLocatorForAgentMD(
-				{},
-				['/Users/legomushroom/repos/workspace'],
-				[
-					{
-						path: '/Users/legomushroom/repos/workspace/AGENTS.md',
-						contents: ['# Root agents']
-					},
-					{
-						path: '/Users/legomushroom/repos/workspace/src/AGENTS.md',
-						contents: ['# Src agents']
-					}
-				],
-				true // has FileSearchProvider
-			);
+			setWorkspaceFolders(['/Users/legomushroom/repos/workspace']);
+			await mockFiles(fileService, [
+				{
+					path: '/Users/legomushroom/repos/workspace/AGENTS.md',
+					contents: ['# Root agents']
+				},
+				{
+					path: '/Users/legomushroom/repos/workspace/src/AGENTS.md',
+					contents: ['# Src agents']
+				}
+			]);
+			const locator = instantiationService.createInstance(PromptFilesLocator);
 
-			const result = await locator.findAgentMDsInWorkspace(CancellationToken.None);
+			const result = (await locator.findAgentMDsInWorkspace(CancellationToken.None)).map(f => f.uri);
 			assertOutcome(
 				result,
 				[
@@ -3277,31 +2657,31 @@ suite('PromptFilesLocator', () => {
 				],
 				'Must find all AGENTS.md files using search service.'
 			);
-			await locator.disposeAsync();
 		});
 
 		testT('finds AGENTS.md files using file service fallback', async () => {
-			const locator = await createPromptsLocatorForAgentMD(
-				{},
-				['/Users/legomushroom/repos/workspace'],
-				[
-					{
-						path: '/Users/legomushroom/repos/workspace/AGENTS.md',
-						contents: ['# Root agents']
-					},
-					{
-						path: '/Users/legomushroom/repos/workspace/src/AGENTS.md',
-						contents: ['# Src agents']
-					},
-					{
-						path: '/Users/legomushroom/repos/workspace/src/nested/AGENTS.md',
-						contents: ['# Nested agents']
-					}
-				],
-				false // no FileSearchProvider - should use file service fallback
-			);
+			setWorkspaceFolders(['/Users/legomushroom/repos/workspace']);
+			await mockFiles(fileService, [
+				{
+					path: '/Users/legomushroom/repos/workspace/AGENTS.md',
+					contents: ['# Root agents']
+				},
+				{
+					path: '/Users/legomushroom/repos/workspace/src/AGENTS.md',
+					contents: ['# Src agents']
+				},
+				{
+					path: '/Users/legomushroom/repos/workspace/src/nested/AGENTS.md',
+					contents: ['# Nested agents']
+				}
+			]);
+			instantiationService.stub(ISearchService, {
+				schemeHasFileSearchProvider: () => false,
+				async fileSearch() { throw new Error('FileSearchProvider not available'); }
+			});
+			const locator = instantiationService.createInstance(PromptFilesLocator);
 
-			const result = await locator.findAgentMDsInWorkspace(CancellationToken.None);
+			const result = (await locator.findAgentMDsInWorkspace(CancellationToken.None)).map(f => f.uri);
 			assertOutcome(
 				result,
 				[
@@ -3311,120 +2691,110 @@ suite('PromptFilesLocator', () => {
 				],
 				'Must find all AGENTS.md files using file service fallback.'
 			);
-			await locator.disposeAsync();
 		});
 
 		testT('handles cancellation token in file service fallback', async () => {
-			const locator = await createPromptsLocatorForAgentMD(
-				{},
-				['/Users/legomushroom/repos/workspace'],
-				[
-					{
-						path: '/Users/legomushroom/repos/workspace/AGENTS.md',
-						contents: ['# Root agents']
-					}
-				],
-				false // no FileSearchProvider
-			);
+			setWorkspaceFolders(['/Users/legomushroom/repos/workspace']);
+			await mockFiles(fileService, [
+				{
+					path: '/Users/legomushroom/repos/workspace/AGENTS.md',
+					contents: ['# Root agents']
+				}
+			]);
+			instantiationService.stub(ISearchService, {
+				schemeHasFileSearchProvider: () => false,
+				async fileSearch() { throw new Error('FileSearchProvider not available'); }
+			});
+			const locator = instantiationService.createInstance(PromptFilesLocator);
 
 			const source = new CancellationTokenSource();
 			// Cancel immediately
 			source.cancel();
-			const result = await locator.findAgentMDsInWorkspace(source.token);
+			const result = (await locator.findAgentMDsInWorkspace(source.token)).map(f => f.uri);
 			assertOutcome(
 				result,
 				[],
 				'Must return empty array when cancelled.'
 			);
-			await locator.disposeAsync();
 		});
 
-		const createPromptsLocatorForAgentMD = async (
-			configValue: unknown,
-			workspaceFolderPaths: string[],
-			filesystem: IMockFileEntry[],
-			hasFileSearchProvider: boolean
-		) => {
-			const mockFs = instantiationService.createInstance(MockFilesystem, filesystem);
-			await mockFs.mock();
+	});
 
-			instantiationService.stub(IConfigurationService, mockConfigService({
-				'explorer.excludeGitIgnore': false,
-				'files.exclude': {},
-				'search.exclude': {}
-			}));
+	suite('getWorkspaceFolderRoots', () => {
+		let locator: PromptFilesLocator;
 
-			const workspaceFolders = workspaceFolderPaths.map((path, index) => {
-				const uri = URI.file(path);
-
-				return new class extends mock<IWorkspaceFolder>() {
-					override uri = uri;
-					override name = basename(uri);
-					override index = index;
-				};
-			});
-			instantiationService.stub(IWorkspaceContextService, mockWorkspaceService(workspaceFolders));
-			instantiationService.stub(IWorkbenchEnvironmentService, {} as IWorkbenchEnvironmentService);
-			instantiationService.stub(IUserDataProfileService, new TestUserDataProfileService());
-			instantiationService.stub(ISearchService, {
-				schemeHasFileSearchProvider(scheme: string): boolean {
-					return hasFileSearchProvider;
-				},
-				async fileSearch(query: IFileQuery) {
-					if (!hasFileSearchProvider) {
-						throw new Error('FileSearchProvider not available');
-					}
-					// mock the search service
-					const fs = instantiationService.get(IFileService);
-					const findFilesInLocation = async (location: URI, results: URI[] = []) => {
-						try {
-							const resolve = await fs.resolve(location);
-							if (resolve.isFile) {
-								results.push(resolve.resource);
-							} else if (resolve.isDirectory && resolve.children) {
-								for (const child of resolve.children) {
-									await findFilesInLocation(child.resource, results);
-								}
-							}
-						} catch (error) {
-						}
-						return results;
-					};
-					const results: IFileMatch[] = [];
-					for (const folderQuery of query.folderQueries) {
-						const allFiles = await findFilesInLocation(folderQuery.folder);
-						for (const resource of allFiles) {
-							const pathInFolder = relativePath(folderQuery.folder, resource) ?? '';
-							if (query.filePattern === undefined || match(query.filePattern, pathInFolder)) {
-								results.push({ resource });
-							}
-						}
-
-					}
-					return { results, messages: [] };
-				}
-			});
-			instantiationService.stub(IPathService, {
-				userHome(options?: { preferLocal: boolean }): URI | Promise<URI> {
-					const uri = URI.file('/Users/legomushroom');
-					if (options?.preferLocal) {
-						return uri;
-					}
-					return Promise.resolve(uri);
-				}
-			} as IPathService);
-
-			const locator = instantiationService.createInstance(PromptFilesLocator);
-
-			return {
-				async findAgentMDsInWorkspace(token: CancellationToken): Promise<URI[]> {
-					return (await locator.findAgentMDsInWorkspace(token)).map(f => f.uri);
-				},
-				async disposeAsync(): Promise<void> {
-					await mockFs.delete();
-				}
-			};
+		// Override setWorkspaceFolders to also create the locator
+		const setWorkspaceFoldersForRoots = (paths: string[]) => {
+			setWorkspaceFolders(paths);
+			locator = instantiationService.createInstance(PromptFilesLocator);
 		};
+
+		testT('returns only workspace folder when it has .git', async () => {
+			setWorkspaceFoldersForRoots(['/repos/my-project']);
+			await mockFiles(fileService, [
+				{ path: '/repos/my-project/.git/HEAD', contents: ['ref: refs/heads/main'] },
+				{ path: '/repos/my-project/src/index.ts', contents: ['export {};'] },
+			]);
+
+			const roots = await locator.getWorkspaceFolderRoots(true);
+			assert.deepStrictEqual(
+				roots.map(r => r.path),
+				['/repos/my-project'],
+				'Should only return the workspace folder itself when it has .git',
+			);
+		});
+
+		testT('walks up to parent with .git when workspace folder has no .git', async () => {
+			setWorkspaceFoldersForRoots(['/repos/monorepo/packages/my-app']);
+			await mockFiles(fileService, [
+				{ path: '/repos/monorepo/.git/HEAD', contents: ['ref: refs/heads/main'] },
+				{ path: '/repos/monorepo/packages/my-app/src/index.ts', contents: ['export {};'] },
+			]);
+
+			workspaceTrustService.setTrustedUris([URI.file('/repos/monorepo')]);
+
+			const roots = await locator.getWorkspaceFolderRoots(true);
+			assert.deepStrictEqual(
+				roots.map(r => r.path).sort(),
+				[
+					'/repos/monorepo',
+					'/repos/monorepo/packages',
+					'/repos/monorepo/packages/my-app',
+				].sort(),
+				'Should include workspace folder and all parents up to the one with .git',
+			);
+		});
+
+		testT('does not walk up when includeParents is false', async () => {
+			setWorkspaceFoldersForRoots(['/repos/monorepo/packages/my-app']);
+			await mockFiles(fileService, [
+				{ path: '/repos/monorepo/.git/HEAD', contents: ['ref: refs/heads/main'] },
+				{ path: '/repos/monorepo/packages/my-app/src/index.ts', contents: ['export {};'] },
+			]);
+
+			workspaceTrustService.setTrustedUris([URI.file('/repos/monorepo')]);
+
+			const roots = await locator.getWorkspaceFolderRoots(false);
+			assert.deepStrictEqual(
+				roots.map(r => r.path),
+				['/repos/monorepo/packages/my-app'],
+				'Should only return workspace folders when includeParents is false',
+			);
+		});
+
+		testT('returns only workspace folder when no .git is found', async () => {
+			setWorkspaceFoldersForRoots(['/Users/legomushroom/my-project']);
+			await mockFiles(fileService, [
+				{ path: '/Users/legomushroom/my-project/src/index.ts', contents: ['export {};'] },
+			]);
+
+			const roots = await locator.getWorkspaceFolderRoots(true);
+			assert.deepStrictEqual(
+				roots.map(r => r.path),
+				['/Users/legomushroom/my-project'],
+				'Should only return the workspace folder when no .git is found in any parent',
+			);
+		});
 	});
 });
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/promptFilesLocator.test.ts
@@ -123,7 +123,7 @@ suite('PromptFilesLocator', () => {
 			'explorer.excludeGitIgnore': false,
 			'files.exclude': {},
 			'search.exclude': {},
-			[PromptsConfig.SEARCH_ROOT_REPO_CUSTOMIZATIONS]: false,
+			[PromptsConfig.USE_CUSTOMIZATIONS_IN_PARENT_REPOS]: false,
 		});
 		instantiationService.stub(IConfigurationService, mockConfigService(configValues));
 

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -9,7 +9,7 @@ import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { Iterable } from '../../../base/common/iterator.js';
 import { Disposable, IDisposable, toDisposable } from '../../../base/common/lifecycle.js';
-import { ResourceMap } from '../../../base/common/map.js';
+import { ResourceMap, ResourceSet } from '../../../base/common/map.js';
 import { Schemas } from '../../../base/common/network.js';
 import { observableValue } from '../../../base/common/observable.js';
 import { join } from '../../../base/common/path.js';
@@ -380,7 +380,8 @@ export class TestWorkspaceTrustManagementService extends Disposable implements I
 
 
 	constructor(
-		private trusted: boolean = true
+		private trusted: boolean = true,
+		private trustedUris: ResourceSet = new ResourceSet()
 	) {
 		super();
 	}
@@ -406,11 +407,11 @@ export class TestWorkspaceTrustManagementService extends Disposable implements I
 	}
 
 	getUriTrustInfo(uri: URI): Promise<IWorkspaceTrustUriInfo> {
-		throw new Error('Method not implemented.');
+		return Promise.resolve({ trusted: this.trustedUris.has(uri), uri });
 	}
 
 	async setTrustedUris(folders: URI[]): Promise<void> {
-		throw new Error('Method not implemented.');
+		this.trustedUris = new ResourceSet(folders);
 	}
 
 	async setUrisTrust(uris: URI[], trusted: boolean): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/293277

Support for finding chat customizations (instructions/prompts/agents/skills/..) in parent repositories. 
This was requested by users of monorepos where users only open subfolders in VS Code.

- new setting `chat.useCustomizationsInParentRepositories`, default false (for now)
- when enabled: if a workspaceFolder is not a repository (does not have a `.git` folder), walk up until we find repository folder. If found, and the folder is trusted, use chat customizations of that folder and all folders in between.
- incudes agent instructions (AGENT.md, CLAUDE.md...), instructions, skills, prompts, agents and hooks using the locations configured in the corresponding settings.