### PR TITLE
feat: move line up/down skips collapsed folding regions

### DIFF
--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -16,7 +16,7 @@ import { TrimTrailingWhitespaceCommand } from '../../../common/commands/trimTrai
 import { EditorOption } from '../../../common/config/editorOptions.js';
 import { EditOperation, ISingleEditOperation } from '../../../common/core/editOperation.js';
 import { Position } from '../../../common/core/position.js';
-import { Range } from '../../../common/core/range.js';
+import { IRange, Range } from '../../../common/core/range.js';
 import { Selection } from '../../../common/core/selection.js';
 import { EnterOperation } from '../../../common/cursor/cursorTypeEditOperations.js';
 import { TypeOperations } from '../../../common/cursor/cursorTypeOperations.js';
@@ -25,7 +25,7 @@ import { EditorContextKeys } from '../../../common/editorContextKeys.js';
 import { ILanguageConfigurationService } from '../../../common/languages/languageConfigurationRegistry.js';
 import { ITextModel } from '../../../common/model.js';
 import { CopyLinesCommand } from './copyLinesCommand.js';
-import { MoveLinesCommand } from './moveLinesCommand.js';
+import { MoveLinesCommand, MoveLinesOverFoldCommand } from './moveLinesCommand.js';
 import { SortLinesCommand } from './sortLinesCommand.js';
 
 // copy lines
@@ -180,13 +180,54 @@ abstract class AbstractMoveLinesAction extends EditorAction {
 		const selections = editor.getSelections() || [];
 		const autoIndent = editor.getOption(EditorOption.autoIndent);
 
+		const hiddenAreas = editor._getViewModel()?.getHiddenAreas() ?? [];
+
 		for (const selection of selections) {
-			commands.push(new MoveLinesCommand(selection, this.down, autoIndent, languageConfigurationService));
+			const foldRange = this._getAdjacentFold(selection, this.down, hiddenAreas);
+			if (foldRange) {
+				commands.push(new MoveLinesOverFoldCommand(selection, this.down, foldRange.startLineNumber, foldRange.endLineNumber));
+			} else {
+				commands.push(new MoveLinesCommand(selection, this.down, autoIndent, languageConfigurationService));
+			}
 		}
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, commands);
 		editor.pushUndoStop();
+	}
+
+	/**
+	 * Check if the line adjacent to the selection is the start/end of a collapsed fold.
+	 * Hidden areas represent the hidden lines of a fold: for a fold at lines 10-20,
+	 * line 10 is the visible header and lines 11-20 are hidden → hiddenArea = Range(11, 1, 20, 1).
+	 * The full fold block is (hiddenArea.startLineNumber - 1) to hiddenArea.endLineNumber.
+	 */
+	private _getAdjacentFold(selection: Selection, isMovingDown: boolean, hiddenAreas: IRange[]): { startLineNumber: number; endLineNumber: number } | null {
+		if (isMovingDown) {
+			// Match MoveLinesCommand behavior: if selection ends at col 1 of a line,
+			// the effective end is the previous line
+			let effectiveEndLine = selection.endLineNumber;
+			if (selection.startLineNumber < selection.endLineNumber && selection.endColumn === 1) {
+				effectiveEndLine = selection.endLineNumber - 1;
+			}
+
+			const nextLine = effectiveEndLine + 1;
+			for (const area of hiddenAreas) {
+				if (area.startLineNumber === nextLine + 1) {
+					// nextLine is the fold header, hidden area starts right after it
+					return { startLineNumber: nextLine, endLineNumber: area.endLineNumber };
+				}
+			}
+		} else {
+			const prevLine = selection.startLineNumber - 1;
+			for (const area of hiddenAreas) {
+				if (area.endLineNumber === prevLine) {
+					// The fold header is area.startLineNumber - 1, fold ends at prevLine
+					return { startLineNumber: area.startLineNumber - 1, endLineNumber: prevLine };
+				}
+			}
+		}
+		return null;
 	}
 }
 

--- a/src/vs/editor/contrib/linesOperations/browser/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/moveLinesCommand.ts
@@ -421,3 +421,79 @@ export class MoveLinesCommand implements ICommand {
 		return result;
 	}
 }
+
+/**
+ * Moves a selection over a collapsed folding region, keeping the fold intact.
+ */
+export class MoveLinesOverFoldCommand implements ICommand {
+
+	private readonly _selection: Selection;
+	private readonly _isMovingDown: boolean;
+	private readonly _foldStartLine: number;
+	private readonly _foldEndLine: number;
+	private _selectionId: string | null;
+
+	constructor(selection: Selection, isMovingDown: boolean, foldStartLine: number, foldEndLine: number) {
+		this._selection = selection;
+		this._isMovingDown = isMovingDown;
+		this._foldStartLine = foldStartLine;
+		this._foldEndLine = foldEndLine;
+		this._selectionId = null;
+	}
+
+	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
+		const s = this._selection;
+		const foldSize = this._foldEndLine - this._foldStartLine + 1;
+
+		if (this._isMovingDown) {
+			// Moving selection down past a fold:
+			// [selection lines] [fold lines] → [fold lines] [selection lines]
+			const selectionText = model.getValueInRange(
+				new Range(s.startLineNumber, 1, s.endLineNumber, model.getLineMaxColumn(s.endLineNumber))
+			);
+			const foldText = model.getValueInRange(
+				new Range(this._foldStartLine, 1, this._foldEndLine, model.getLineMaxColumn(this._foldEndLine))
+			);
+
+			builder.addEditOperation(
+				new Range(s.startLineNumber, 1, this._foldEndLine, model.getLineMaxColumn(this._foldEndLine)),
+				foldText + '\n' + selectionText
+			);
+
+			const newSelection = new Selection(
+				s.startLineNumber + foldSize,
+				s.startColumn,
+				s.endLineNumber + foldSize,
+				s.endColumn
+			);
+			this._selectionId = builder.trackSelection(newSelection);
+
+		} else {
+			// Moving selection up past a fold:
+			// [fold lines] [selection lines] → [selection lines] [fold lines]
+			const selectionText = model.getValueInRange(
+				new Range(s.startLineNumber, 1, s.endLineNumber, model.getLineMaxColumn(s.endLineNumber))
+			);
+			const foldText = model.getValueInRange(
+				new Range(this._foldStartLine, 1, this._foldEndLine, model.getLineMaxColumn(this._foldEndLine))
+			);
+
+			builder.addEditOperation(
+				new Range(this._foldStartLine, 1, s.endLineNumber, model.getLineMaxColumn(s.endLineNumber)),
+				selectionText + '\n' + foldText
+			);
+
+			const newSelection = new Selection(
+				s.startLineNumber - foldSize,
+				s.startColumn,
+				s.endLineNumber - foldSize,
+				s.endColumn
+			);
+			this._selectionId = builder.trackSelection(newSelection);
+		}
+	}
+
+	public computeCursorState(model: ITextModel, helper: ICursorStateComputerData): Selection {
+		return helper.getTrackedSelection(this._selectionId!);
+	}
+}

--- a/src/vs/editor/contrib/linesOperations/test/browser/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/browser/moveLinesCommand.test.ts
@@ -10,7 +10,7 @@ import { ILanguageService } from '../../../../common/languages/language.js';
 import { IndentationRule } from '../../../../common/languages/languageConfiguration.js';
 import { ILanguageConfigurationService } from '../../../../common/languages/languageConfigurationRegistry.js';
 import { LanguageService } from '../../../../common/services/languageService.js';
-import { MoveLinesCommand } from '../../browser/moveLinesCommand.js';
+import { MoveLinesCommand, MoveLinesOverFoldCommand } from '../../browser/moveLinesCommand.js';
 import { testCommand } from '../../../../test/browser/testCommand.js';
 import { TestLanguageConfigurationService } from '../../../../test/common/modes/testLanguageConfigurationService.js';
 
@@ -459,5 +459,118 @@ suite('Editor - contrib - Move Lines Command honors onEnter Rules', () => {
 		mode.dispose();
 		languageService.dispose();
 		languageConfigurationService.dispose();
+	});
+});
+
+suite('Editor Contrib - Move Lines Over Fold Command', () => {
+
+	const disposables = new DisposableStore();
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	function testMoveLinesOverFoldDown(lines: string[], selection: Selection, foldStartLine: number, foldEndLine: number, expectedLines: string[], expectedSelection: Selection): void {
+		const languageConfigurationService = disposables.add(new TestLanguageConfigurationService());
+		testCommand(lines, null, selection, (accessor, sel) => new MoveLinesOverFoldCommand(sel, true, foldStartLine, foldEndLine), expectedLines, expectedSelection);
+	}
+
+	function testMoveLinesOverFoldUp(lines: string[], selection: Selection, foldStartLine: number, foldEndLine: number, expectedLines: string[], expectedSelection: Selection): void {
+		const languageConfigurationService = disposables.add(new TestLanguageConfigurationService());
+		testCommand(lines, null, selection, (accessor, sel) => new MoveLinesOverFoldCommand(sel, false, foldStartLine, foldEndLine), expectedLines, expectedSelection);
+	}
+
+	test('move single line down over fold', function () {
+		testMoveLinesOverFoldDown(
+			[
+				'line 1',
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line 5',
+			],
+			new Selection(1, 1, 1, 7),
+			2, 4, // fold covers lines 2-4
+			[
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line 1',
+				'line 5',
+			],
+			new Selection(4, 1, 4, 7)
+		);
+	});
+
+	test('move single line up over fold', function () {
+		testMoveLinesOverFoldUp(
+			[
+				'line 1',
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line 5',
+			],
+			new Selection(5, 1, 5, 7),
+			2, 4, // fold covers lines 2-4
+			[
+				'line 1',
+				'line 5',
+				'function foo() {',
+				'    return 1;',
+				'}',
+			],
+			new Selection(2, 1, 2, 7)
+		);
+	});
+
+	test('move multi-line selection down over fold', function () {
+		testMoveLinesOverFoldDown(
+			[
+				'line A',
+				'line B',
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line C',
+			],
+			new Selection(1, 1, 2, 7),
+			3, 5, // fold covers lines 3-5
+			[
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line A',
+				'line B',
+				'line C',
+			],
+			new Selection(4, 1, 5, 7)
+		);
+	});
+
+	test('move multi-line selection up over fold', function () {
+		testMoveLinesOverFoldUp(
+			[
+				'line A',
+				'function foo() {',
+				'    return 1;',
+				'}',
+				'line B',
+				'line C',
+			],
+			new Selection(5, 1, 6, 7),
+			2, 4, // fold covers lines 2-4
+			[
+				'line A',
+				'line B',
+				'line C',
+				'function foo() {',
+				'    return 1;',
+				'}',
+			],
+			new Selection(2, 1, 3, 7)
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #63972 — Move Line Up/Down (Alt+Up/Down) now skips over collapsed folding regions instead of moving one line at a time into the folded content.

## Problem

When a line is adjacent to a collapsed folding region, pressing Alt+Up or Alt+Down moves the line into the fold one model line at a time. This breaks the fold and produces confusing results, since the user expects the line to jump over the entire collapsed block.

## Solution

- **`MoveLinesOverFoldCommand`** — A new command class in `moveLinesCommand.ts` that swaps a selection block with an adjacent folded block in a single edit operation, preserving cursor tracking.
- **`AbstractMoveLinesAction._getAdjacentFold()`** — A helper that detects collapsed folds adjacent to the selection by inspecting the editor's hidden areas (`getHiddenAreas()` from the view model). Hidden areas represent the lines hidden by a collapsed fold (e.g., for a fold at lines 10–20, line 10 is visible, lines 11–20 are hidden).
- When a fold is detected, `MoveLinesOverFoldCommand` is used instead of the regular `MoveLinesCommand`. When no fold is adjacent, behavior is unchanged.

### Edge cases handled
- Multi-line selections moving over folds
- `endColumn === 1` selection boundary (matching `MoveLinesCommand` behavior)
- Moving up past a fold (fold ends just above selection)

## Testing

Added 4 unit tests in `moveLinesCommand.test.ts`:
- Single line down over fold
- Single line up over fold
- Multi-line selection down over fold
- Multi-line selection up over fold

## Files changed

| File | Change |
|------|--------|
| `linesOperations.ts` | Detect adjacent folds in `run()`, add `_getAdjacentFold()` helper |
| `moveLinesCommand.ts` | Add `MoveLinesOverFoldCommand` class |
| `moveLinesCommand.test.ts` | Add fold-skipping tests |