### PR TITLE
Update question text handling to render markdown question

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -1420,9 +1420,8 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 
 			const questionRow = dom.$('div.chat-question-summary-label');
 			const questionText = question.message ?? question.title;
-			let labelText = typeof questionText === 'string' ? questionText : questionText.value;
-			labelText = labelText.replace(/[:\s]+$/, '');
-			questionRow.textContent = localize('chat.questionCarousel.summaryQuestion', 'Q: {0}', labelText);
+			const messageContent = this.getQuestionText(questionText);
+			questionRow.textContent = localize('chat.questionCarousel.summaryQuestion', 'Q: {0}', messageContent);
 			summaryItem.appendChild(questionRow);
 
 			if (answer !== undefined) {


### PR DESCRIPTION
Enhance the question text rendering to support markdown formatting, improving the display of questions in the chat interface. Test by verifying that markdown is correctly rendered in the question summaries.

