### PR TITLE
Allow vscode-sessions strings in the main bundle

### DIFF
--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -743,9 +743,8 @@ export function prepareI18nPackFiles(resultingTranslationPaths: TranslationPath[
 		if (EXTERNAL_EXTENSIONS.find(e => e === resource)) {
 			project = extensionsProject;
 		}
-		// TODO(tyleonha): Support localization for the Sessions app (https://github.com/microsoft/vscode-internalbacklog/issues/7045)
 		// vscode-setup has its own import path via prepareIslFiles
-		if (project === sessionsProject || project === setupProject) {
+		if (project === setupProject) {
 			return;
 		}
 		const contents = xlf.contents!.toString();


### PR DESCRIPTION
It seems like the sessions experience _can_ run in the VS Code world, so we actually do need these strings.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode-internalbacklog/issues/7045