### PR TITLE
feat(git): add 'default' option to git.untrackedChanges setting

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3711,12 +3711,14 @@
           "enum": [
             "mixed",
             "separate",
-            "hidden"
+            "hidden",
+            "default"
           ],
           "enumDescriptions": [
             "%config.untrackedChanges.mixed%",
             "%config.untrackedChanges.separate%",
-            "%config.untrackedChanges.hidden%"
+            "%config.untrackedChanges.hidden%",
+            "%config.untrackedChanges.default%"
           ],
           "default": "mixed",
           "description": "%config.untrackedChanges%",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -271,6 +271,7 @@
 	"config.untrackedChanges.mixed": "All changes, tracked and untracked, appear together and behave equally.",
 	"config.untrackedChanges.separate": "Untracked changes appear separately in the Source Control view. They are also excluded from several actions.",
 	"config.untrackedChanges.hidden": "Untracked changes are hidden and excluded from several actions.",
+	"config.untrackedChanges.default": "Use the value of git's `status.showUntrackedFiles` configuration. When set to `no`, behaves like \"hidden\". Otherwise, behaves like \"mixed\".",
 	"config.requireGitUserConfig": "Controls whether to require explicit Git user configuration or allow Git to guess if missing.",
 	"config.showCommitInput": "Controls whether to show the commit input in the Git source control panel.",
 	"config.terminalAuthentication": "Controls whether to enable VS Code to be the authentication handler for Git processes spawned in the Integrated Terminal. Note: Terminals need to be restarted to pick up a change in this setting.",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1348,8 +1348,8 @@ export class Repository implements Disposable {
 			},
 			() => {
 				const config = workspace.getConfiguration('git', Uri.file(this.repository.root));
-				const untrackedChanges = config.get<'mixed' | 'separate' | 'hidden'>('untrackedChanges');
-				const untrackedChangesResourceGroupType = untrackedChanges === 'mixed' ? ResourceGroupType.WorkingTree : ResourceGroupType.Untracked;
+				const untrackedChanges = config.get<'mixed' | 'separate' | 'hidden' | 'default'>('untrackedChanges');
+				const untrackedChangesResourceGroupType = untrackedChanges === 'mixed' || untrackedChanges === 'default' ? ResourceGroupType.WorkingTree : ResourceGroupType.Untracked;
 
 				const resourcePaths = resources.length === 0 ?
 					this.indexGroup.resourceStates.map(r => r.resourceUri.fsPath) : resources.map(r => r.fsPath);
@@ -1372,7 +1372,7 @@ export class Repository implements Disposable {
 					.filter(r => !resourcePaths.includes(r.resourceUri.fsPath));
 
 				// Add resource(s) to working group
-				const workingTreeGroup = untrackedChanges === 'mixed' ?
+				const workingTreeGroup = untrackedChanges === 'mixed' || untrackedChanges === 'default' ?
 					[...this.workingTreeGroup.resourceStates, ...trackedResources, ...untrackedResources] :
 					[...this.workingTreeGroup.resourceStates, ...trackedResources];
 
@@ -2677,7 +2677,14 @@ export class Repository implements Disposable {
 		}
 
 		const scopedConfig = workspace.getConfiguration('git', Uri.file(this.repository.root));
-		const untrackedChanges = scopedConfig.get<'mixed' | 'separate' | 'hidden'>('untrackedChanges');
+		let untrackedChanges = scopedConfig.get<'mixed' | 'separate' | 'hidden' | 'default'>('untrackedChanges');
+
+		// Resolve 'default' by reading git's status.showUntrackedFiles config
+		if (untrackedChanges === 'default') {
+			const gitConfig = await this.repository.config('get', '', 'status.showUntrackedFiles');
+			untrackedChanges = gitConfig.trim() === 'no' ? 'hidden' : 'mixed';
+		}
+
 		const ignoreSubmodules = scopedConfig.get<boolean>('ignoreSubmodules');
 
 		const limit = scopedConfig.get<number>('statusLimit', 10000);
@@ -2817,7 +2824,7 @@ export class Repository implements Disposable {
 	private setCountBadge(): void {
 		const config = workspace.getConfiguration('git', Uri.file(this.repository.root));
 		const countBadge = config.get<'all' | 'tracked' | 'off'>('countBadge');
-		const untrackedChanges = config.get<'mixed' | 'separate' | 'hidden'>('untrackedChanges');
+		const untrackedChanges = config.get<'mixed' | 'separate' | 'hidden' | 'default'>('untrackedChanges');
 
 		let count =
 			this.mergeGroup.resourceStates.length +
@@ -2827,7 +2834,7 @@ export class Repository implements Disposable {
 		switch (countBadge) {
 			case 'off': count = 0; break;
 			case 'tracked':
-				if (untrackedChanges === 'mixed') {
+				if (untrackedChanges === 'mixed' || untrackedChanges === 'default') {
 					count -= this.workingTreeGroup.resourceStates.filter(r => r.type === Status.UNTRACKED || r.type === Status.IGNORED).length;
 				}
 				break;


### PR DESCRIPTION
## Summary

Fixes #249351 — Adds a `default` option to `git.untrackedChanges` that reads from git's own `status.showUntrackedFiles` configuration.

## Problem

Users managing dotfiles with a bare git repository (a common pattern) set `status.showUntrackedFiles=no` in their repo's git config to avoid showing every file in the home directory as untracked. VS Code's `git.untrackedChanges` setting doesn't respect this git configuration, forcing users to manually set it to `hidden` — which then applies to all repositories.

## Solution

Add a 4th enum value `"default"` to the `git.untrackedChanges` setting. When selected:

1. Reads `status.showUntrackedFiles` from the repository's effective git config
2. If `no` → behaves like `"hidden"` (uses `-uno` flag)
3. Otherwise → behaves like `"mixed"` (uses `-uall` flag)

The resolution happens at the start of `getStatus()`, so all downstream logic (resource grouping, count badge, unstaging) works transparently.

## Files changed

| File | Change |
|------|--------|
| `package.json` | Add `"default"` to enum + enumDescriptions |
| `package.nls.json` | Add description string for new option |
| `repository.ts` | Resolve `"default"` via `git config`, update type annotations |