### PR TITLE
feat(scm): add 'Reveal Active File in Source Control View' command

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -35,6 +35,8 @@ import { QuickDiffService } from '../common/quickDiffService.js';
 import { getActiveElement, isActiveElement } from '../../../../base/browser/dom.js';
 import { SCMWorkingSetController } from './workingSet.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
 import { IListService, WorkbenchList } from '../../../../platform/list/browser/listService.js';
 import { isSCMRepository } from './util.js';
 import { SCMHistoryViewPane } from './scmHistoryViewPane.js';
@@ -527,6 +529,30 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'scm.forceViewPreviousCommit',
 	when: ContextKeyExpr.has('scmRepository'),
 	primary: KeyMod.Alt | KeyCode.UpArrow
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.scm.action.revealActiveFile',
+			title: localize2('revealActiveFileInSCM', "Reveal Active File in Source Control View"),
+			f1: true,
+			category: localize2('sourceControl', "Source Control"),
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const viewsService = accessor.get(IViewsService);
+
+		const uri = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+		if (!uri) {
+			return;
+		}
+
+		const view = await viewsService.openView<SCMViewPane>(VIEW_PANE_ID, false);
+		view?.revealActiveResource();
+	}
 });
 
 CommandsRegistry.registerCommand('scm.openInIntegratedTerminal', async (accessor, ...providers: ISCMProvider[]) => {

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2593,6 +2593,42 @@ export class SCMViewPane extends ViewPane {
 				}));
 	}
 
+	revealActiveResource(): void {
+		const uri = EditorResourceAccessor.getOriginalUri(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
+
+		if (!uri) {
+			return;
+		}
+
+		this.revealResourceThrottler.queue(
+			() => this.treeOperationSequencer.queue(
+				async () => {
+					for (const repository of this.scmViewService.visibleRepositories) {
+						const item = this.items.get(repository);
+
+						if (!item) {
+							continue;
+						}
+
+						for (let j = repository.provider.groups.length - 1; j >= 0; j--) {
+							const groupItem = repository.provider.groups[j];
+							const resource = this.viewMode === ViewMode.Tree
+								? groupItem.resourceTree.getNode(uri)?.element
+								: groupItem.resources.find(r => this.uriIdentityService.extUri.isEqual(r.sourceUri, uri));
+
+							if (resource) {
+								await this.tree.expandTo(resource);
+								this.tree.reveal(resource);
+
+								this.tree.setSelection([resource]);
+								this.tree.setFocus([resource]);
+								return;
+							}
+						}
+					}
+				}));
+	}
+
 	private onDidChangeVisibleRepositories({ added, removed }: ISCMViewVisibleRepositoryChangeEvent): void {
 		// Added repositories
 		for (const repository of added) {


### PR DESCRIPTION
## Summary

Fixes #170819 — Adds a new command **"Source Control: Reveal Active File in Source Control View"** to the Command Palette, mirroring the existing "Reveal Active File in Explorer View".

## Problem

There is no way to quickly jump to the currently open file in the Source Control view. Users working with many changed files need to manually scroll through the Changes/Staged groups to find the active file.

## Solution

- Add `revealActiveResource()` method to `SCMViewPane` that searches all visible repositories and resource groups for the active editor's URI, then expands/reveals/selects it in the tree
- Register an `Action2` command (`workbench.scm.action.revealActiveFile`) under the "Source Control" category (`f1: true`)
- Reuse existing throttler + sequencer infrastructure from auto-reveal logic
- Supports both List and Tree view modes

## Files changed

| File | Change |
|------|--------|
| `scmViewPane.ts` | Add public `revealActiveResource()` method |
| `scm.contribution.ts` | Register Action2 command for Command Palette |