### PR TITLE
feat(npm): autocomplete all package versions in package.json dependencies

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -190,26 +190,50 @@ export class PackageJSONContribution implements IJSONContribution {
 				const info = await this.fetchPackageInfo(currentKey, resource);
 				if (info && info.version) {
 
-					let name = JSON.stringify(info.version);
+					// Latest version with caret (most common pattern)
+					let name = JSON.stringify('^' + info.version);
 					let proposal = new CompletionItem(name);
 					proposal.kind = CompletionItemKind.Property;
 					proposal.insertText = name;
-					proposal.documentation = l10n.t("The currently latest version of the package");
+					proposal.documentation = l10n.t("Matches the most recent major version (1.x.x)");
+					proposal.sortText = '!0';
 					result.add(proposal);
 
-					name = JSON.stringify('^' + info.version);
+					// Latest exact version
+					name = JSON.stringify(info.version);
 					proposal = new CompletionItem(name);
 					proposal.kind = CompletionItemKind.Property;
 					proposal.insertText = name;
-					proposal.documentation = l10n.t("Matches the most recent major version (1.x.x)");
+					proposal.documentation = l10n.t("The currently latest version of the package");
+					proposal.sortText = '!1';
 					result.add(proposal);
 
+					// Latest version with tilde
 					name = JSON.stringify('~' + info.version);
 					proposal = new CompletionItem(name);
 					proposal.kind = CompletionItemKind.Property;
 					proposal.insertText = name;
 					proposal.documentation = l10n.t("Matches the most recent minor version (1.2.x)");
+					proposal.sortText = '!2';
 					result.add(proposal);
+
+					// All available versions (newest first, skip latest which is already shown)
+					if (info.versions) {
+						const maxVersions = 20;
+						let count = 0;
+						for (const ver of info.versions) {
+							if (ver === info.version || count >= maxVersions) {
+								continue;
+							}
+							name = JSON.stringify(ver);
+							proposal = new CompletionItem(name);
+							proposal.kind = CompletionItemKind.Property;
+							proposal.insertText = name;
+							proposal.sortText = `~${String(count).padStart(4, '0')}`;
+							result.add(proposal);
+							count++;
+						}
+					}
 				}
 			}
 		}
@@ -285,7 +309,7 @@ export class PackageJSONContribution implements IJSONContribution {
 
 	private npmView(npmCommandPath: string, pack: string, resource: Uri | undefined): Promise<ViewPackageInfo | undefined> {
 		return new Promise((resolve, _reject) => {
-			const args = ['view', '--json', '--', pack, 'description', 'dist-tags.latest', 'homepage', 'version', 'time'];
+			const args = ['view', '--json', '--', pack, 'description', 'dist-tags.latest', 'homepage', 'version', 'versions', 'time'];
 			const cwd = resource && resource.scheme === 'file' ? dirname(resource.fsPath) : undefined;
 
 			// corepack npm wrapper would automatically update package.json. disable that behavior.
@@ -304,9 +328,11 @@ export class PackageJSONContribution implements IJSONContribution {
 					try {
 						const content = JSON.parse(stdout);
 						const version = content['dist-tags.latest'] || content['version'];
+						const allVersions: string[] = Array.isArray(content['versions']) ? [...content['versions']].reverse() : [];
 						resolve({
 							description: content['description'],
 							version,
+							versions: allVersions,
 							time: content.time?.[version],
 							homepage: content['homepage']
 						});
@@ -329,9 +355,11 @@ export class PackageJSONContribution implements IJSONContribution {
 			});
 			const obj = JSON.parse(success.responseText);
 			const version = obj['dist-tags']?.latest || Object.keys(obj.versions).pop() || '';
+			const allVersions = obj.versions ? Object.keys(obj.versions).reverse() : [];
 			return {
 				description: obj.description || '',
 				version,
+				versions: allVersions,
 				time: obj.time?.[version],
 				homepage: obj.homepage || ''
 			};
@@ -396,6 +424,7 @@ interface SearchPackageInfo {
 interface ViewPackageInfo {
 	description: string;
 	version?: string;
+	versions?: string[];
 	time?: string;
 	homepage?: string;
 }


### PR DESCRIPTION
## Summary

Fixes #274545 — When editing dependency version values in `package.json`, the completion list now shows all available versions from the npm registry, not just the latest.

## Problem

VS Code currently only suggests 3 version completions for package.json dependencies: the latest exact version, `^` prefix, and `~` prefix. Users coming from WebStorm expect a dropdown of all available versions from the npm registry.

## Solution

### Before
```
"lodash": "|"
→ "4.17.21"
→ "^4.17.21"
→ "~4.17.21"
```

### After
```
"lodash": "|"
→ "^4.17.21"     (latest, caret)
→ "4.17.21"      (latest, exact)
→ "~4.17.21"     (latest, tilde)
→ "4.17.20"      (previous versions...)
→ "4.17.19"
→ ... (up to 20 recent versions)
```

### Implementation
- **`ViewPackageInfo`**: Added `versions?: string[]` to store all available versions
- **`npmjsView()`**: Now extracts all version keys from the registry response (`Object.keys(obj.versions).reverse()`)
- **`npmView()`**: Added `'versions'` to `npm view` args to fetch version list
- **`collectValueSuggestions()`**: Shows latest+caret/tilde at top (with `sortText` priority), then up to 20 recent versions in reverse chronological order
- Latest version is skipped in the version list to avoid duplication

## Files changed

| File | Change |
|------|--------|
| `packageJSONContribution.ts` | Fetch & display all versions, update interface |