### PR TITLE
plugins: support plugin specific paths, adding a plugin directly

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -3,12 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2 } from '../../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
+import { InstalledAgentPluginsViewId } from '../agentPluginsView.js';
 
 export class ManagePluginsAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.managePlugins';
@@ -32,6 +37,47 @@ export class ManagePluginsAction extends Action2 {
 	}
 }
 
+class InstallFromSourceAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.installPluginFromSource';
+
+	constructor() {
+		super({
+			id: InstallFromSourceAction.ID,
+			title: localize2('installPluginFromSource', 'Install Plugin from Source'),
+			category: CHAT_CATEGORY,
+			icon: Codicon.add,
+			precondition: ChatContextKeys.enabled,
+			f1: true,
+			menu: [{
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('view', InstalledAgentPluginsViewId),
+					ChatContextKeys.Setup.hidden.negate(),
+				),
+				group: 'navigation',
+				order: 1,
+			}],
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const pluginInstallService = accessor.get(IPluginInstallService);
+
+		const source = await quickInputService.input({
+			placeHolder: localize('pluginSourcePlaceholder', "owner/repo or git clone URL"),
+			prompt: localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from"),
+		});
+
+		if (!source) {
+			return;
+		}
+
+		await pluginInstallService.installPluginFromSource(source.trim());
+	}
+}
+
 export function registerChatPluginActions() {
 	registerAction2(ManagePluginsAction);
+	registerAction2(InstallFromSourceAction);
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -20,10 +20,12 @@ import { IOpenerService } from '../../../../../platform/opener/common/opener.js'
 import { URI } from '../../../../../base/common/uri.js';
 import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IContextMenuService, IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Delayer } from '../../../../../base/common/async.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { basename, dirname } from '../../../../../base/common/resources.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IAgentPlugin, IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 import { isContributionEnabled } from '../../common/enablement.js';
@@ -308,6 +310,7 @@ export class PluginListWidget extends Disposable {
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IHoverService private readonly hoverService: IHoverService,
 		@ILabelService private readonly labelService: ILabelService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget'); // reuse MCP list widget CSS
@@ -339,7 +342,7 @@ export class PluginListWidget extends Disposable {
 			}
 		}));
 
-		// Button container (Browse Marketplace)
+		// Button container (Browse Marketplace + Install from Source)
 		const buttonContainer = DOM.append(this.searchAndButtonContainer, $('.list-button-group'));
 
 		const browseButtonContainer = DOM.append(buttonContainer, $('.list-add-button-container'));
@@ -348,6 +351,14 @@ export class PluginListWidget extends Disposable {
 		this.browseButton.element.classList.add('list-add-button');
 		this._register(this.browseButton.onDidClick(() => {
 			this.toggleBrowseMode(!this.browseMode);
+		}));
+
+		const installFromSourceButton = this._register(new Button(buttonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
+		installFromSourceButton.label = `$(${Codicon.add.id})`;
+		installFromSourceButton.element.classList.add('list-icon-button');
+		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), installFromSourceButton.element, localize('installFromSourceTooltip', "Install Plugin from Source")));
+		this._register(installFromSourceButton.onDidClick(() => {
+			this.commandService.executeCommand('workbench.action.chat.installPluginFromSource');
 		}));
 
 		// Back to installed link (shown only in browse mode)

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -355,6 +355,7 @@ export class PluginListWidget extends Disposable {
 
 		const installFromSourceButton = this._register(new Button(buttonContainer, { ...defaultButtonStyles, secondary: true, supportIcons: true }));
 		installFromSourceButton.label = `$(${Codicon.add.id})`;
+		installFromSourceButton.setTitle(localize('installFromSource', "Install Plugin from Source"));
 		installFromSourceButton.element.classList.add('list-icon-button');
 		this._register(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), installFromSourceButton.element, localize('installFromSourceTooltip', "Install Plugin from Source")));
 		this._register(installFromSourceButton.onDidClick(() => {

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -6,6 +6,7 @@
 import { Action } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -14,9 +15,10 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../common/plugins/pluginInstallService.js';
-import { IMarketplacePlugin, IPluginMarketplaceService, hasSourceChanged, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
 
 export class PluginInstallService implements IPluginInstallService {
 	declare readonly _serviceBrand: undefined;
@@ -30,6 +32,7 @@ export class PluginInstallService implements IPluginInstallService {
 		@ILogService private readonly _logService: ILogService,
 		@IProgressService private readonly _progressService: IProgressService,
 		@ICommandService private readonly _commandService: ICommandService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 	) { }
 
 	async installPlugin(plugin: IMarketplacePlugin): Promise<void> {
@@ -50,6 +53,114 @@ export class PluginInstallService implements IPluginInstallService {
 
 		// GitHub / GitUrl
 		return this._installGitPlugin(plugin);
+	}
+
+	async installPluginFromSource(source: string): Promise<void> {
+		const reference = parseMarketplaceReference(source);
+		if (!reference) {
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source),
+			});
+			return;
+		}
+
+		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL."),
+			});
+			return;
+		}
+
+		// Build a source descriptor for the git clone.
+		const sourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
+			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo! }
+			: { kind: PluginSourceKind.GitUrl as const, url: reference.cloneUrl };
+
+		// Build a temporary plugin object for the trust gate and clone step.
+		const tempPlugin: IMarketplacePlugin = {
+			name: reference.displayLabel,
+			description: '',
+			version: '',
+			source: '',
+			sourceDescriptor,
+			marketplace: reference.displayLabel,
+			marketplaceReference: reference,
+			marketplaceType: MarketplaceType.OpenPlugin,
+		};
+
+		if (!await this._ensureMarketplaceTrusted(tempPlugin)) {
+			return;
+		}
+
+		// Clone the repository.
+		let repoDir: URI;
+		try {
+			repoDir = await this._pluginRepositoryService.ensurePluginSource(tempPlugin, {
+				progressTitle: localize('cloningSource', "Cloning plugin source '{0}'...", reference.displayLabel),
+				failureLabel: reference.displayLabel,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+		} catch {
+			return;
+		}
+
+		const repoExists = await this._fileService.exists(repoDir);
+		if (!repoExists) {
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('cloneFailed', "Failed to clone plugin source '{0}'.", reference.displayLabel),
+			});
+			return;
+		}
+
+		// Scan for marketplace.json to discover plugins.
+		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
+
+		if (discoveredPlugins.length === 0) {
+			// No marketplace.json — treat the repo root as a single plugin.
+			const repoName = basename(URI.parse(reference.cloneUrl));
+			const plugin: IMarketplacePlugin = {
+				name: repoName.replace(/\.git$/i, ''),
+				description: '',
+				version: '',
+				source: '',
+				sourceDescriptor,
+				marketplace: reference.displayLabel,
+				marketplaceReference: reference,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			};
+			this._pluginMarketplaceService.addInstalledPlugin(repoDir, plugin);
+			return;
+		}
+
+		if (discoveredPlugins.length === 1) {
+			const plugin = discoveredPlugins[0];
+			const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
+			this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+			return;
+		}
+
+		// Multiple plugins — let the user choose.
+		const picks: (IQuickPickItem & { plugin: IMarketplacePlugin })[] = discoveredPlugins.map(p => ({
+			label: p.name,
+			description: p.description,
+			plugin: p,
+		}));
+
+		const selected = await this._quickInputService.pick(picks, {
+			placeHolder: localize('selectPlugin', "Select a plugin to install from '{0}'", reference.displayLabel),
+			canPickMany: false,
+		});
+
+		if (!selected) {
+			return;
+		}
+
+		const plugin = selected.plugin;
+		const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
+		this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -4,22 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { Iterable } from '../../../../../base/common/iterator.js';
 import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { untildify } from '../../../../../base/common/labels.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
-import { cloneAndChange } from '../../../../../base/common/objects.js';
-import { autorun, derived, IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { cloneAndChange, equals } from '../../../../../base/common/objects.js';
+import { autorun, derived, derivedOpts, IObservable, ObservablePromise, observableSignal, observableValue } from '../../../../../base/common/observable.js';
 import {
 	posix,
 	win32
 } from '../../../../../base/common/path.js';
 import {
 	basename,
-	extname, joinPath
+	extname, isEqualOrParent, joinPath, normalizePath
 } from '../../../../../base/common/resources.js';
 import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
-import { Mutable } from '../../../../../base/common/types.js';
+import { hasKey, Mutable } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
@@ -27,17 +28,17 @@ import { IInstantiationService } from '../../../../../platform/instantiation/com
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IMcpServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
+import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatConfiguration } from '../constants.js';
+import { EnablementModel, IEnablementModel } from '../enablement.js';
 import { parseClaudeHooks } from '../promptSyntax/hookClaudeCompat.js';
 import { parseCopilotHooks } from '../promptSyntax/hookCompatibility.js';
 import { IHookCommand } from '../promptSyntax/hookSchema.js';
-import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginAgent, IAgentPluginCommand, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from './agentPluginService.js';
-import { EnablementModel, IEnablementModel } from '../enablement.js';
 import { IAgentPluginRepositoryService } from './agentPluginRepositoryService.js';
+import { agentPluginDiscoveryRegistry, IAgentPlugin, IAgentPluginDiscovery, IAgentPluginHook, IAgentPluginMcpServerDefinition, IAgentPluginService, IAgentPluginSkill } from './agentPluginService.js';
 import { IMarketplacePlugin, IPluginMarketplaceService } from './pluginMarketplaceService.js';
-import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 
 const COMMAND_FILE_SUFFIX = '.md';
 
@@ -49,9 +50,8 @@ const enum AgentPluginFormat {
 
 interface IAgentPluginFormatAdapter {
 	readonly format: AgentPluginFormat;
-	readonly manifestPaths: readonly string[];
-	readonly hookConfigPaths: readonly string[];
-	readonly hookWatchPaths: readonly string[];
+	readonly manifestPath: string;
+	readonly hookConfigPath: string;
 	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[];
 }
 
@@ -71,9 +71,8 @@ function resolveWorkspaceRoot(pluginUri: URI, workspaceContextService: IWorkspac
 
 class CopilotPluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.Copilot;
-	readonly manifestPaths = ['plugin.json'];
-	readonly hookConfigPaths = ['hooks.json'];
-	readonly hookWatchPaths = ['hooks.json'];
+	readonly manifestPath = 'plugin.json';
+	readonly hookConfigPath = 'hooks.json';
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -197,9 +196,8 @@ function parsePluginRootHooks(
 
 class ClaudePluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.Claude;
-	readonly manifestPaths = ['.claude-plugin/plugin.json'];
-	readonly hookConfigPaths = ['hooks/hooks.json'];
-	readonly hookWatchPaths = ['hooks'];
+	readonly manifestPath = '.claude-plugin/plugin.json';
+	readonly hookConfigPath = 'hooks/hooks.json';
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -212,9 +210,8 @@ class ClaudePluginFormatAdapter implements IAgentPluginFormatAdapter {
 
 class OpenPluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.OpenPlugin;
-	readonly manifestPaths = ['.plugin/plugin.json'];
-	readonly hookConfigPaths = ['hooks/hooks.json'];
-	readonly hookWatchPaths = ['hooks'];
+	readonly manifestPath = '.plugin/plugin.json';
+	readonly hookConfigPath = 'hooks/hooks.json';
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -223,6 +220,76 @@ class OpenPluginFormatAdapter implements IAgentPluginFormatAdapter {
 	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[] {
 		return parsePluginRootHooks(json, pluginUri, userHome, this._workspaceContextService, '${PLUGIN_ROOT}', 'PLUGIN_ROOT');
 	}
+}
+
+interface IComponentPathConfig {
+	readonly paths: readonly string[];
+	readonly exclusive: boolean;
+}
+
+const emptyComponentPathConfig: IComponentPathConfig = { paths: [], exclusive: false };
+
+/**
+ * Parses a manifest component path field (e.g. `commands`, `skills`, `agents`)
+ * into a normalized config. Supports:
+ * - `undefined` → empty supplemental config
+ * - `string` → single supplemental path
+ * - `string[]` → multiple supplemental paths
+ * - `{ paths: string[], exclusive?: boolean }` → as-is
+ *
+ * Paths that resolve outside the plugin root are silently dropped
+ * in {@link resolveComponentDirs}.
+ */
+function parseComponentPathConfig(raw: unknown): IComponentPathConfig {
+	if (raw === undefined || raw === null) {
+		return emptyComponentPathConfig;
+	}
+
+	if (typeof raw === 'string') {
+		const trimmed = raw.trim();
+		return trimmed ? { paths: [trimmed], exclusive: false } : emptyComponentPathConfig;
+	}
+
+	if (Array.isArray(raw)) {
+		const paths = raw
+			.filter(v => typeof v === 'string')
+			.map(v => v.trim())
+			.filter(v => v.length > 0);
+		return { paths, exclusive: false };
+	}
+
+	if (typeof raw === 'object') {
+		const obj = raw as Record<string, unknown>;
+		if (Array.isArray(obj['paths'])) {
+			const paths = (obj['paths'] as unknown[])
+				.filter(v => typeof v === 'string')
+				.map(v => v.trim())
+				.filter(v => v.length > 0);
+			const exclusive = obj['exclusive'] === true;
+			return { paths, exclusive };
+		}
+	}
+
+	return emptyComponentPathConfig;
+}
+
+/**
+ * Resolves the directories to scan for a given component type, combining
+ * the default directory with any custom paths from the manifest config.
+ * Paths that resolve outside the plugin root are silently ignored.
+ */
+function resolveComponentDirs(pluginUri: URI, defaultDir: string, config: IComponentPathConfig): readonly URI[] {
+	const dirs: URI[] = [];
+	if (!config.exclusive) {
+		dirs.push(joinPath(pluginUri, defaultDir));
+	}
+	for (const p of config.paths) {
+		const resolved = normalizePath(joinPath(pluginUri, p));
+		if (isEqualOrParent(resolved, pluginUri)) {
+			dirs.push(resolved);
+		}
+	}
+	return dirs;
 }
 
 export class AgentPluginService extends Disposable implements IAgentPluginService {
@@ -306,7 +373,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 	private readonly _plugins = observableValue<readonly IAgentPlugin[]>('discoveredAgentPlugins', []);
 	public readonly plugins: IObservable<readonly IAgentPlugin[]> = this._plugins;
 
-	protected _discoverVersion = 0;
+	private _discoverVersion = 0;
 	protected _enablementModel!: IEnablementModel;
 
 	constructor(
@@ -388,58 +455,90 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 
 		const store = new DisposableStore();
-		const commands = observableValue<readonly IAgentPluginCommand[]>('agentPluginCommands', []);
-		const skills = observableValue<readonly IAgentPluginSkill[]>('agentPluginSkills', []);
-		const agents = observableValue<readonly IAgentPluginAgent[]>('agentPluginAgents', []);
-		const hooks = observableValue<readonly IAgentPluginHook[]>('agentPluginHooks', []);
-		const mcpServerDefinitions = observableValue<readonly IAgentPluginMcpServerDefinition[]>('agentPluginMcpServerDefinitions', []);
 		const enablement = derived(r => this._enablementModel.readEnabled(key, r));
 
-		const commandsDir = joinPath(uri, 'commands');
-		const skillsDir = joinPath(uri, 'skills');
-		const agentsDir = joinPath(uri, 'agents');
+		// Track current component directories for the file watcher. These are
+		// updated whenever the manifest is read (inside each component reader).
+		const manifest = observableValue<Record<string, unknown> | undefined>('agentPluginManifest', undefined);
 
-		const commandsScheduler = store.add(new RunOnceScheduler(async () => {
-			commands.set(await this._readCommands(uri), undefined);
-		}, 200));
-		const skillsScheduler = store.add(new RunOnceScheduler(async () => {
-			skills.set(await this._readSkills(uri), undefined);
-		}, 200));
-		const agentsScheduler = store.add(new RunOnceScheduler(async () => {
-			agents.set(await this._readAgents(uri), undefined);
-		}, 200));
-		const hooksScheduler = store.add(new RunOnceScheduler(async () => {
-			hooks.set(await this._readHooks(uri, adapter), undefined);
-		}, 200));
-		const mcpScheduler = store.add(new RunOnceScheduler(async () => {
-			mcpServerDefinitions.set(await this._readMcpDefinitions(uri, adapter), undefined);
-		}, 200));
+		const observeComponent = <T>(
+			prop: string,
+			doRead: (uris: readonly URI[]) => Promise<readonly T[]>,
+			tryReadEmbedded?: (section: unknown) => Promise<T[] | undefined>,
+			defaultPath = prop,
+		): IObservable<readonly T[]> => {
+			const secondObs = derivedOpts({ equalsFn: equals }, reader => manifest.read(reader)?.[prop]);
+
+			const wrapped = derived(reader => {
+				const section = secondObs.read(reader);
+				if (tryReadEmbedded) {
+					if (section && typeof section === 'object' && !Array.isArray(section) && !(hasKey(section, { paths: true }))) {
+						return { kind: 'const', data: new ObservablePromise(tryReadEmbedded(section)) } as const;
+					}
+				}
+
+				const paths = parseComponentPathConfig(section);
+				const dirs = resolveComponentDirs(uri, defaultPath, paths);
+				reader.store.add(this._fileService.onDidFilesChange(e => {
+					if (dirs.some(d => e.affects(d))) {
+						changeTrigger.trigger(undefined);
+					}
+				}));
+
+				return { kind: 'dirs', dirs: dirs } as const;
+			});
+
+			const changeTrigger = observableSignal('fileChange');
+
+			const promised = derived(reader => {
+				const w = wrapped.read(reader);
+				if (w.kind === 'const') {
+					return w.data.promiseResult;
+				} else {
+					changeTrigger.read(reader); // re-run when a relevant file change occurs
+					const promise = new ObservablePromise(doRead(w.dirs));
+					return promise.promiseResult;
+				}
+			});
+
+			const result = promised.map((w, r) => w.read(r)?.data ?? Iterable.empty());
+
+			return result.recomputeInitiallyAndOnChange(store);
+		};
+
+		const commands = observeComponent('commands', d => this._readMarkdownComponents(d));
+		const skills = observeComponent('skills', d => this._readSkills(d));
+		const agents = observeComponent('agents', d => this._readMarkdownComponents(d));
+		const hooks = observeComponent(
+			'hooks',
+			paths => this._readHooksFromPaths(uri, paths, adapter),
+			async section => {
+				const userHome = (await this._pathService.userHome()).fsPath;
+				return adapter.parseHooks(section, uri, userHome);
+			},
+			adapter.hookConfigPath,
+		);
+
+		const mcpServerDefinitions = observeComponent(
+			'mcpServers',
+			paths => this._readMcpDefinitionsFromPaths(paths),
+			async section => this._parseMcpServerDefinitionMap({ mcpServers: section }),
+			'.mcp.json',
+		);
+
+		// Read the manifest initially and re-read whenever manifest files change.
+		const readManifest = async () => {
+			manifest.set(await this._readManifest(uri, adapter), undefined);
+		};
 
 		store.add(this._fileService.watch(uri, { recursive: true, excludes: [] }));
 		store.add(this._fileService.onDidFilesChange(e => {
-			if (e.affects(commandsDir)) {
-				commandsScheduler.schedule();
-			}
-			if (e.affects(skillsDir)) {
-				skillsScheduler.schedule();
-			}
-			if (e.affects(agentsDir)) {
-				agentsScheduler.schedule();
-			}
-			if (adapter.hookWatchPaths.some(path => e.affects(joinPath(uri, path)))) {
-				hooksScheduler.schedule();
-			}
-			if (e.affects(joinPath(uri, '.mcp.json')) || adapter.manifestPaths.some(path => e.affects(joinPath(uri, path)))) {
-				mcpScheduler.schedule();
-				hooksScheduler.schedule();
+			if (e.affects(joinPath(uri, adapter.manifestPath))) {
+				readManifest();
 			}
 		}));
 
-		commandsScheduler.schedule();
-		skillsScheduler.schedule();
-		agentsScheduler.schedule();
-		hooksScheduler.schedule();
-		mcpScheduler.schedule();
+		readManifest();
 
 		const plugin: PluginEntry = {
 			uri,
@@ -459,45 +558,52 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		return plugin;
 	}
 
-	private async _readMcpDefinitions(pluginUri: URI, adapter: IAgentPluginFormatAdapter): Promise<readonly IAgentPluginMcpServerDefinition[]> {
-		const mcpUri = joinPath(pluginUri, '.mcp.json');
-
-		const mcpFileConfig = await this._readJsonFile(mcpUri);
-		const fileDefinitions = this._parseMcpServerDefinitionMap(mcpFileConfig);
-
-		const pluginJsonDefinitions = await this._readInlinePluginJsonMcpDefinitions(pluginUri, adapter);
-
-		const merged = new Map<string, IMcpServerConfiguration>();
-		for (const definition of fileDefinitions) {
-			merged.set(definition.name, definition.configuration);
+	private async _readManifest(pluginUri: URI, adapter: IAgentPluginFormatAdapter): Promise<Record<string, unknown> | undefined> {
+		const json = await this._readJsonFile(joinPath(pluginUri, adapter.manifestPath));
+		if (json && typeof json === 'object') {
+			return json as Record<string, unknown>;
 		}
-		for (const definition of pluginJsonDefinitions) {
-			if (!merged.has(definition.name)) {
-				merged.set(definition.name, definition.configuration);
-			}
-		}
-
-		const definitions = [...merged.entries()]
-			.map(([name, configuration]) => ({ name, configuration } satisfies IAgentPluginMcpServerDefinition))
-			.sort((a, b) => a.name.localeCompare(b.name));
-
-		return definitions;
+		return undefined;
 	}
 
-	private async _readInlinePluginJsonMcpDefinitions(pluginUri: URI, adapter: IAgentPluginFormatAdapter): Promise<readonly IAgentPluginMcpServerDefinition[]> {
-		for (const manifestPath of adapter.manifestPaths.map(path => joinPath(pluginUri, path))) {
-			const manifest = await this._readJsonFile(manifestPath);
-			if (!manifest || typeof manifest !== 'object') {
-				continue;
-			}
-
-			const definitions = this._parseMcpServerDefinitionMap(manifest);
-			if (definitions.length > 0) {
-				return definitions;
+	/**
+	 * Reads hook definitions from a list of resolved paths (JSON files).
+	 * Each path is tried in order; the first one that contains valid hook
+	 * JSON is used.
+	 */
+	private async _readHooksFromPaths(pluginUri: URI, paths: readonly URI[], adapter: IAgentPluginFormatAdapter): Promise<readonly IAgentPluginHook[]> {
+		const userHome = (await this._pathService.userHome()).fsPath;
+		for (const hookPath of paths) {
+			const json = await this._readJsonFile(hookPath);
+			if (json) {
+				try {
+					return adapter.parseHooks(json, pluginUri, userHome);
+				} catch (e) {
+					this._logService.info(`[AgentPluginDiscovery] Failed to parse hooks from ${hookPath.toString()}:`, e);
+				}
 			}
 		}
-
 		return [];
+	}
+
+	/**
+	 * Reads MCP server definitions from a list of resolved paths (JSON files).
+	 * Definitions from all files are merged; the first definition for a given
+	 * server name wins.
+	 */
+	private async _readMcpDefinitionsFromPaths(paths: readonly URI[]): Promise<readonly IAgentPluginMcpServerDefinition[]> {
+		const merged = new Map<string, IMcpServerConfiguration>();
+		for (const mcpPath of paths) {
+			const json = await this._readJsonFile(mcpPath);
+			for (const def of this._parseMcpServerDefinitionMap(json)) {
+				if (!merged.has(def.name)) {
+					merged.set(def.name, def.configuration);
+				}
+			}
+		}
+		return [...merged.entries()]
+			.map(([name, configuration]) => ({ name, configuration } satisfies IAgentPluginMcpServerDefinition))
+			.sort((a, b) => a.name.localeCompare(b.name));
 	}
 
 	private _parseMcpServerDefinitionMap(raw: unknown): IAgentPluginMcpServerDefinition[] {
@@ -579,36 +685,6 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		return undefined;
 	}
 
-	private async _readHooks(pluginUri: URI, adapter: IAgentPluginFormatAdapter): Promise<readonly IAgentPluginHook[]> {
-		const userHome = (await this._pathService.userHome()).fsPath;
-		for (const hooksUri of adapter.hookConfigPaths.map(path => joinPath(pluginUri, path))) {
-			const json = await this._readJsonFile(hooksUri);
-			if (json) {
-				try {
-					return adapter.parseHooks(json, pluginUri, userHome);
-				} catch (e) {
-					this._logService.info(`[ConfiguredAgentPluginDiscovery] Failed to parse hooks from ${hooksUri.toString()}:`, e);
-				}
-			}
-		}
-
-		for (const manifestPath of adapter.manifestPaths.map(path => joinPath(pluginUri, path))) {
-			const manifest = await this._readJsonFile(manifestPath);
-			if (manifest && typeof manifest === 'object') {
-				const hooks = (manifest as Record<string, unknown>)['hooks'];
-				if (hooks && typeof hooks === 'object') {
-					try {
-						return adapter.parseHooks({ hooks }, pluginUri, userHome);
-					} catch (e) {
-						this._logService.info(`[ConfiguredAgentPluginDiscovery] Failed to parse hooks from manifest ${manifestPath.toString()}:`, e);
-					}
-				}
-			}
-		}
-
-		return [];
-	}
-
 	private async _readJsonFile(uri: URI): Promise<unknown | undefined> {
 		try {
 			const fileContents = await this._fileService.readFile(uri);
@@ -618,96 +694,96 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 		}
 	}
 
-	private async _readSkills(uri: URI): Promise<readonly IAgentPluginSkill[]> {
-		const skillsDir = joinPath(uri, 'skills');
-		let stat;
-		try {
-			stat = await this._fileService.resolve(skillsDir);
-		} catch {
-			return [];
-		}
-
-		if (!stat.isDirectory || !stat.children) {
-			return [];
-		}
-
+	private async _readSkills(dirs: readonly URI[]): Promise<readonly IAgentPluginSkill[]> {
+		const seen = new Set<string>();
 		const skills: IAgentPluginSkill[] = [];
-		for (const child of stat.children) {
-			const skillMd = URI.joinPath(child.resource, 'SKILL.md');
-			if (!(await this._pathExists(skillMd))) {
+
+		const addSkill = (name: string, skillMd: URI) => {
+			if (!seen.has(name)) {
+				seen.add(name);
+				skills.push({ uri: skillMd, name });
+			}
+		};
+
+		for (const dir of dirs) {
+			// If the path points directly to a skill directory (contains SKILL.md),
+			// add it as a single skill instead of scanning its children.
+			const skillMd = URI.joinPath(dir, 'SKILL.md');
+			if (await this._pathExists(skillMd)) {
+				addSkill(basename(dir), skillMd);
 				continue;
 			}
 
-			skills.push({
-				uri: skillMd,
-				name: basename(child.resource),
-			});
+			let stat;
+			try {
+				stat = await this._fileService.resolve(dir);
+			} catch {
+				continue;
+			}
+
+			if (!stat.isDirectory || !stat.children) {
+				continue;
+			}
+
+			for (const child of stat.children) {
+				const childSkillMd = URI.joinPath(child.resource, 'SKILL.md');
+				if (await this._pathExists(childSkillMd)) {
+					addSkill(basename(child.resource), childSkillMd);
+				}
+			}
 		}
 
 		skills.sort((a, b) => a.name.localeCompare(b.name));
 		return skills;
 	}
 
-	private async _readAgents(uri: URI): Promise<readonly IAgentPluginAgent[]> {
-		const agentsDir = joinPath(uri, 'agents');
-		let stat;
-		try {
-			stat = await this._fileService.resolve(agentsDir);
-		} catch {
-			return [];
-		}
+	/**
+	 * Scans directories for `.md` files, returning `{ uri, name }` entries
+	 * where name is derived from the filename (minus the `.md` extension).
+	 * If a path points to a specific `.md` file, it is included directly.
+	 * Used for both commands and agents.
+	 */
+	private async _readMarkdownComponents(dirs: readonly URI[]): Promise<readonly { uri: URI; name: string }[]> {
+		const seen = new Set<string>();
+		const items: { uri: URI; name: string }[] = [];
 
-		if (!stat.isDirectory || !stat.children) {
-			return [];
-		}
+		const addItem = (name: string, uri: URI) => {
+			if (!seen.has(name)) {
+				seen.add(name);
+				items.push({ uri, name });
+			}
+		};
 
-		const agents: IAgentPluginAgent[] = [];
-		for (const child of stat.children) {
-			if (!child.isFile || extname(child.resource).toLowerCase() !== COMMAND_FILE_SUFFIX) {
+		for (const dir of dirs) {
+			let stat;
+			try {
+				stat = await this._fileService.resolve(dir);
+			} catch {
 				continue;
 			}
 
-			const name = basename(child.resource).slice(0, -COMMAND_FILE_SUFFIX.length);
 
-			agents.push({
-				uri: child.resource,
-				name,
-			});
-		}
-
-		agents.sort((a, b) => a.name.localeCompare(b.name));
-		return agents;
-	}
-
-	private async _readCommands(uri: URI): Promise<readonly IAgentPluginCommand[]> {
-		const commandsDir = joinPath(uri, 'commands');
-		let stat;
-		try {
-			stat = await this._fileService.resolve(commandsDir);
-		} catch {
-			return [];
-		}
-
-		if (!stat.isDirectory || !stat.children) {
-			return [];
-		}
-
-		const commands: IAgentPluginCommand[] = [];
-		for (const child of stat.children) {
-			if (!child.isFile || extname(child.resource).toLowerCase() !== COMMAND_FILE_SUFFIX) {
+			// If the path points to a specific .md file, include it directly.
+			if (stat.isFile && extname(dir).toLowerCase() === COMMAND_FILE_SUFFIX) {
+				addItem(basename(dir).slice(0, -COMMAND_FILE_SUFFIX.length), dir);
 				continue;
 			}
 
-			const name = basename(child.resource).slice(0, -COMMAND_FILE_SUFFIX.length);
 
-			commands.push({
-				uri: child.resource,
-				name,
-			});
+			if (!stat.isDirectory || !stat.children) {
+				continue;
+			}
+
+			for (const child of stat.children) {
+				if (!child.isFile || extname(child.resource).toLowerCase() !== COMMAND_FILE_SUFFIX) {
+					continue;
+				}
+				addItem(basename(child.resource).slice(0, -COMMAND_FILE_SUFFIX.length), child.resource);
+			}
 		}
 
-		commands.sort((a, b) => a.name.localeCompare(b.name));
-		return commands;
+		items.sort((a, b) => a.name.localeCompare(b.name));
+		return items;
 	}
 
 	private _disposePluginEntriesExcept(keep: Set<string>): void {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -479,11 +479,11 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 
 				const paths = parseComponentPathConfig(section);
 				const dirs = resolveComponentDirs(uri, defaultPath, paths);
-				reader.store.add(this._fileService.onDidFilesChange(e => {
-					if (dirs.some(d => e.affects(d))) {
-						changeTrigger.trigger(undefined);
-					}
-				}));
+				for (const d of dirs) {
+					const watcher = this._fileService.createWatcher(d, { recursive: false, excludes: [] });
+					reader.store.add(watcher);
+					reader.store.add(watcher.onDidChange(() => changeTrigger.trigger(undefined)));
+				}
 
 				return { kind: 'dirs', dirs: dirs } as const;
 			});
@@ -531,12 +531,12 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			manifest.set(await this._readManifest(uri, adapter), undefined);
 		};
 
-		store.add(this._fileService.watch(uri, { recursive: true, excludes: [] }));
-		store.add(this._fileService.onDidFilesChange(e => {
-			if (e.affects(joinPath(uri, adapter.manifestPath))) {
-				readManifest();
-			}
-		}));
+		const manifestWatcher = this._fileService.createWatcher(
+			joinPath(uri, adapter.manifestPath),
+			{ recursive: false, excludes: [] },
+		);
+		store.add(manifestWatcher);
+		store.add(manifestWatcher.onDidChange(() => readManifest()));
 
 		readManifest();
 

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
@@ -42,6 +42,13 @@ export interface IPluginInstallService {
 	 */
 	installPlugin(plugin: IMarketplacePlugin): Promise<void>;
 
+	/**
+	 * Installs a plugin directly from a source location string. Accepts
+	 * GitHub shorthand (`owner/repo`) or a full git clone URL. Clones the
+	 * repository, reads marketplace metadata to discover plugins, and
+	 * registers the selected plugin.
+	 */
+	installPluginFromSource(source: string): Promise<void>;
 
 	/**
 	 * Pulls the latest changes for an already-cloned marketplace repository.

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginMarketplaceService.ts
@@ -171,6 +171,12 @@ export interface IPluginMarketplaceService {
 	isMarketplaceTrusted(ref: IMarketplaceReference): boolean;
 	/** Records that the user trusts the given marketplace, persisted permanently. */
 	trustMarketplace(ref: IMarketplaceReference): void;
+	/**
+	 * Reads marketplace definition files from an already-cloned repository
+	 * directory and returns the declared plugins. Used by direct-install flows
+	 * that clone a repo first, then need to discover its plugins.
+	 */
+	readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin[]>;
 }
 
 /**
@@ -690,8 +696,16 @@ export class PluginMarketplaceService extends Disposable implements IPluginMarke
 			return [];
 		}
 
+		return this._readPluginsFromDirectory(repoDir, reference, token);
+	}
+
+	async readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference): Promise<IMarketplacePlugin[]> {
+		return this._readPluginsFromDirectory(repoDir, reference);
+	}
+
+	private async _readPluginsFromDirectory(repoDir: URI, reference: IMarketplaceReference, token?: CancellationToken): Promise<IMarketplacePlugin[]> {
 		for (const def of MARKETPLACE_DEFINITIONS) {
-			if (token.isCancellationRequested) {
+			if (token?.isCancellationRequested) {
 				return [];
 			}
 

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -12,6 +12,7 @@ import { TestInstantiationService } from '../../../../../../platform/instantiati
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { IProgressService } from '../../../../../../platform/progress/common/progress.js';
+import { IQuickInputService } from '../../../../../../platform/quickinput/common/quickInput.js';
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { PluginInstallService } from '../../../browser/pluginInstallService.js';
 import { IAgentPluginRepositoryService, IEnsureRepositoryOptions, IPullRepositoryOptions } from '../../../common/plugins/agentPluginRepositoryService.js';
@@ -66,6 +67,12 @@ suite('PluginInstallService', () => {
 		marketplaceTrusted: boolean;
 		/** Canonical IDs that were trusted via trustMarketplace() */
 		trustedMarketplaces: string[];
+		/** Plugins returned by readPluginsFromDirectory */
+		readPluginsResult: IMarketplacePlugin[];
+		/** Result of the quick pick dialog */
+		quickPickResult: { label: string } | undefined;
+		/** Result of the quick input dialog */
+		quickInputResult: string | undefined;
 	}
 
 	function createDefaults(): MockState {
@@ -84,6 +91,9 @@ suite('PluginInstallService', () => {
 			updatePluginSourceCalls: [],
 			marketplaceTrusted: true,
 			trustedMarketplaces: [],
+			readPluginsResult: [],
+			quickPickResult: undefined,
+			quickInputResult: undefined,
 		};
 	}
 
@@ -247,7 +257,19 @@ suite('PluginInstallService', () => {
 			trustMarketplace: (ref: IMarketplaceReference) => {
 				state.trustedMarketplaces.push(ref.canonicalId);
 			},
+			readPluginsFromDirectory: async () => state.readPluginsResult,
 		} as unknown as IPluginMarketplaceService);
+
+		// IQuickInputService
+		instantiationService.stub(IQuickInputService, {
+			input: async () => state.quickInputResult,
+			pick: async (picks: { label: string }[]) => {
+				if (!state.quickPickResult) {
+					return undefined;
+				}
+				return picks.find(p => p.label === state.quickPickResult!.label);
+			},
+		} as unknown as IQuickInputService);
 
 		const service = instantiationService.createInstance(PluginInstallService);
 		return { service, state };
@@ -779,6 +801,152 @@ suite('PluginInstallService', () => {
 			}
 
 			assert.strictEqual(state.addedPlugins.length, 0, 'no plugins should be installed when trust is declined');
+		});
+	});
+
+	// =========================================================================
+	// installPluginFromSource
+	// =========================================================================
+
+	suite('installPluginFromSource', () => {
+
+		test('rejects invalid source strings', async () => {
+			const { service, state } = createService();
+			await service.installPluginFromSource('not a valid source');
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
+		});
+
+		test('rejects local file URIs', async () => {
+			const { service, state } = createService();
+			await service.installPluginFromSource('file:///some/local/path');
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
+		});
+
+		test('installs single plugin from GitHub shorthand with marketplace.json', async () => {
+			const ref = makeMarketplaceRef('owner/my-plugin');
+			const discoveredPlugin = createPlugin({
+				name: 'my-discovered-plugin',
+				description: 'A discovered plugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/my-plugin'),
+				readPluginsResult: [discoveredPlugin],
+			});
+
+			await service.installPluginFromSource('owner/my-plugin');
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'my-discovered-plugin');
+		});
+
+		test('installs repo-root plugin when no marketplace.json found', async () => {
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/cool-tool'),
+				readPluginsResult: [],
+			});
+
+			await service.installPluginFromSource('owner/cool-tool');
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'cool-tool');
+			assert.strictEqual(state.addedPlugins[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitHub);
+		});
+
+		test('shows quick pick for multi-plugin repos', async () => {
+			const ref = makeMarketplaceRef('owner/multi-repo');
+			const pluginA = createPlugin({
+				name: 'plugin-a',
+				source: 'plugins/a',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/a' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const pluginB = createPlugin({
+				name: 'plugin-b',
+				source: 'plugins/b',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/b' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/multi-repo'),
+				readPluginsResult: [pluginA, pluginB],
+				quickPickResult: { label: 'plugin-b' },
+			});
+
+			await service.installPluginFromSource('owner/multi-repo');
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'plugin-b');
+			assert.ok(state.addedPlugins[0].uri.includes('plugins/b'));
+		});
+
+		test('does not install when quick pick is cancelled', async () => {
+			const ref = makeMarketplaceRef('owner/multi-repo');
+			const pluginA = createPlugin({
+				name: 'plugin-a',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/a' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const pluginB = createPlugin({
+				name: 'plugin-b',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/b' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/multi-repo'),
+				readPluginsResult: [pluginA, pluginB],
+				quickPickResult: undefined,
+			});
+
+			await service.installPluginFromSource('owner/multi-repo');
+
+			assert.strictEqual(state.addedPlugins.length, 0);
+		});
+
+		test('does not install when trust is declined', async () => {
+			const { service, state } = createService({
+				marketplaceTrusted: false,
+				dialogConfirmResult: false,
+				readPluginsResult: [],
+			});
+
+			await service.installPluginFromSource('owner/repo');
+
+			assert.strictEqual(state.addedPlugins.length, 0);
+		});
+
+		test('installs from full git URL', async () => {
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/my-tool'),
+				readPluginsResult: [],
+			});
+
+			await service.installPluginFromSource('https://github.com/owner/my-tool.git');
+
+			assert.strictEqual(state.addedPlugins.length, 1);
+			assert.strictEqual(state.addedPlugins[0].plugin.name, 'my-tool');
+			assert.strictEqual(state.addedPlugins[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitUrl);
+		});
+
+		test('shows error when clone directory does not exist', async () => {
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/missing'),
+				fileExistsResult: false,
+			});
+
+			await service.installPluginFromSource('owner/missing');
+
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -257,4 +257,448 @@ suite('AgentPlugin format detection', () => {
 		await waitForState(plugins[0].agents, a => a.length > 0);
 		assert.strictEqual(plugins[0].agents.get()[0].name, 'reviewer');
 	}));
+
+	test('manifest skills field adds supplemental skill directories', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/custom-skills');
+		await writeFile('/plugins/custom-skills/.plugin/plugin.json', JSON.stringify({
+			name: 'custom-skills',
+			skills: './extra-skills/',
+		}));
+		await writeFile('/plugins/custom-skills/skills/default-skill/SKILL.md', '# Default skill');
+		await writeFile('/plugins/custom-skills/extra-skills/bonus-skill/SKILL.md', '# Bonus skill');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].skills, s => s.length >= 2);
+		assert.deepStrictEqual(
+			plugins[0].skills.get().map(s => s.name).sort(),
+			['bonus-skill', 'default-skill'],
+		);
+	}));
+
+	test('manifest skills field with exclusive mode skips default directory', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/exclusive-skills');
+		await writeFile('/plugins/exclusive-skills/.plugin/plugin.json', JSON.stringify({
+			name: 'exclusive-skills',
+			skills: { paths: ['./only-here/'], exclusive: true },
+		}));
+		await writeFile('/plugins/exclusive-skills/skills/ignored/SKILL.md', '# Should be ignored');
+		await writeFile('/plugins/exclusive-skills/only-here/visible/SKILL.md', '# Should be visible');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].skills, s => s.length > 0);
+		assert.deepStrictEqual(
+			plugins[0].skills.get().map(s => s.name),
+			['visible'],
+		);
+	}));
+
+	test('manifest commands field with string array scans multiple directories', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/multi-commands');
+		await writeFile('/plugins/multi-commands/.plugin/plugin.json', JSON.stringify({
+			name: 'multi-commands',
+			commands: ['./cmd1/', './cmd2/'],
+		}));
+		await writeFile('/plugins/multi-commands/commands/default.md', '# Default');
+		await writeFile('/plugins/multi-commands/cmd1/alpha.md', '# Alpha');
+		await writeFile('/plugins/multi-commands/cmd2/beta.md', '# Beta');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].commands, c => c.length >= 3);
+		assert.deepStrictEqual(
+			plugins[0].commands.get().map(c => c.name).sort(),
+			['alpha', 'beta', 'default'],
+		);
+	}));
+
+	test('manifest agents field adds supplemental agent directories', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/custom-agents');
+		await writeFile('/plugins/custom-agents/.plugin/plugin.json', JSON.stringify({
+			name: 'custom-agents',
+			agents: './extra-agents/',
+		}));
+		await writeFile('/plugins/custom-agents/agents/default-agent.md', '# Default');
+		await writeFile('/plugins/custom-agents/extra-agents/bonus-agent.md', '# Bonus');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].agents, a => a.length >= 2);
+		assert.deepStrictEqual(
+			plugins[0].agents.get().map(a => a.name).sort(),
+			['bonus-agent', 'default-agent'],
+		);
+	}));
+
+	test('path traversal in manifest is rejected', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/traversal');
+		await writeFile('/plugins/traversal/.plugin/plugin.json', JSON.stringify({
+			name: 'traversal',
+			skills: '../outside/',
+		}));
+		await writeFile('/plugins/outside/evil/SKILL.md', '# Evil skill');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		// Only default skills/ directory should be scanned; the traversal path is rejected.
+		// Since there are no skills in skills/, result should be empty.
+		await waitForState(plugins[0].skills, () => true);
+		assert.deepStrictEqual(plugins[0].skills.get(), []);
+	}));
+
+	test('duplicate names across directories deduplicate (first wins)', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/dedup');
+		await writeFile('/plugins/dedup/.plugin/plugin.json', JSON.stringify({
+			name: 'dedup',
+			commands: './extra-commands/',
+		}));
+		await writeFile('/plugins/dedup/commands/shared.md', '# Default version');
+		await writeFile('/plugins/dedup/extra-commands/shared.md', '# Custom version');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].commands, c => c.length > 0);
+		const cmds = plugins[0].commands.get();
+		assert.strictEqual(cmds.length, 1);
+		assert.strictEqual(cmds[0].name, 'shared');
+		// The default directory is scanned first, so the URI should come from commands/
+		assert.ok(cmds[0].uri.path.includes('/commands/shared.md'));
+	}));
+
+	test('discovers components without a manifest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/no-manifest');
+		await writeFile('/plugins/no-manifest/commands/hello.md', '# Hello');
+		await writeFile('/plugins/no-manifest/skills/my-skill/SKILL.md', '# My skill');
+		await writeFile('/plugins/no-manifest/agents/helper.md', '# Helper');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		assert.strictEqual(plugins[0].label, 'no-manifest');
+
+		await waitForState(plugins[0].commands, c => c.length > 0);
+		assert.strictEqual(plugins[0].commands.get()[0].name, 'hello');
+
+		await waitForState(plugins[0].skills, s => s.length > 0);
+		assert.strictEqual(plugins[0].skills.get()[0].name, 'my-skill');
+
+		await waitForState(plugins[0].agents, a => a.length > 0);
+		assert.strictEqual(plugins[0].agents.get()[0].name, 'helper');
+	}));
+
+	test('reads hooks from default hooks/hooks.json', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/hooks-default');
+		await writeFile('/plugins/hooks-default/.plugin/plugin.json', JSON.stringify({ name: 'hooks-default' }));
+		await writeFile('/plugins/hooks-default/hooks/hooks.json', JSON.stringify({
+			hooks: {
+				PostToolUse: [{ matcher: 'Write', hooks: [{ type: 'command', command: 'echo done' }] }],
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].hooks, h => h.length > 0);
+		assert.strictEqual(plugins[0].hooks.get().length, 1);
+	}));
+
+	test('reads inline hooks from manifest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/hooks-inline');
+		await writeFile('/plugins/hooks-inline/.plugin/plugin.json', JSON.stringify({
+			name: 'hooks-inline',
+			hooks: {
+				hooks: {
+					SessionStart: [{ hooks: [{ type: 'command', command: 'echo start' }] }],
+				},
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].hooks, h => h.length > 0);
+		assert.strictEqual(plugins[0].hooks.get().length, 1);
+	}));
+
+	test('reads hooks from custom path in manifest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/hooks-custom');
+		await writeFile('/plugins/hooks-custom/.plugin/plugin.json', JSON.stringify({
+			name: 'hooks-custom',
+			hooks: './config/my-hooks.json',
+		}));
+		await writeFile('/plugins/hooks-custom/config/my-hooks.json', JSON.stringify({
+			hooks: {
+				PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: 'echo edited' }] }],
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].hooks, h => h.length > 0);
+		assert.strictEqual(plugins[0].hooks.get().length, 1);
+	}));
+
+	test('reads MCP from custom path in manifest', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/mcp-custom');
+		await writeFile('/plugins/mcp-custom/.plugin/plugin.json', JSON.stringify({
+			name: 'mcp-custom',
+			mcpServers: './config/servers.json',
+		}));
+		await writeFile('/plugins/mcp-custom/config/servers.json', JSON.stringify({
+			mcpServers: {
+				'custom-server': { command: 'node', args: ['custom.js'] },
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
+		assert.strictEqual(plugins[0].mcpServerDefinitions.get()[0].name, 'custom-server');
+	}));
+
+	test('inline MCP in manifest takes priority over standalone .mcp.json', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/mcp-merged');
+		await writeFile('/plugins/mcp-merged/.plugin/plugin.json', JSON.stringify({
+			name: 'mcp-merged',
+			mcpServers: {
+				'inline-server': { command: 'echo', args: ['inline'] },
+			},
+		}));
+		await writeFile('/plugins/mcp-merged/.mcp.json', JSON.stringify({
+			mcpServers: {
+				'file-server': { command: 'echo', args: ['file'] },
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		// When inline mcpServers is an object in the manifest, it is treated as
+		// embedded configuration and the default .mcp.json file is not read.
+		// Wait for the inline server to appear (manifest loads asynchronously).
+		await waitForState(plugins[0].mcpServerDefinitions, d =>
+			[...d].some(s => s.name === 'inline-server'));
+		assert.deepStrictEqual(
+			plugins[0].mcpServerDefinitions.get().map(d => d.name),
+			['inline-server'],
+		);
+	}));
+
+	test('PLUGIN_ROOT expansion in hook commands', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/root-expansion');
+		await writeFile('/plugins/root-expansion/.plugin/plugin.json', JSON.stringify({
+			name: 'root-expansion',
+			hooks: {
+				hooks: {
+					PostToolUse: [{
+						hooks: [{
+							type: 'command',
+							command: '${PLUGIN_ROOT}/scripts/format.sh',
+						}],
+					}],
+				},
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].hooks, h => h.length > 0);
+
+		const hookCommands = plugins[0].hooks.get()[0].hooks;
+		assert.ok(hookCommands.length > 0);
+		// ${PLUGIN_ROOT} should be expanded to the plugin's fsPath
+		const command = hookCommands[0].command;
+		assert.ok(command && !command.includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded, got: ${command}`);
+	}));
+
+	test('manifest commands field pointing to a specific file', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/cmd-file');
+		await writeFile('/plugins/cmd-file/.plugin/plugin.json', JSON.stringify({
+			name: 'cmd-file',
+			commands: './special/deploy.md',
+		}));
+		await writeFile('/plugins/cmd-file/commands/default.md', '# Default');
+		await writeFile('/plugins/cmd-file/special/deploy.md', '# Deploy');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].commands, c => c.length >= 2);
+		assert.deepStrictEqual(
+			plugins[0].commands.get().map(c => c.name).sort(),
+			['default', 'deploy'],
+		);
+	}));
+
+	test('manifest commands field with array of specific files', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/cmd-files');
+		await writeFile('/plugins/cmd-files/.plugin/plugin.json', JSON.stringify({
+			name: 'cmd-files',
+			commands: ['./extras/alpha.md', './extras/beta.md'],
+		}));
+		await writeFile('/plugins/cmd-files/extras/alpha.md', '# Alpha');
+		await writeFile('/plugins/cmd-files/extras/beta.md', '# Beta');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].commands, c => c.length >= 2);
+		assert.deepStrictEqual(
+			plugins[0].commands.get().map(c => c.name).sort(),
+			['alpha', 'beta'],
+		);
+	}));
+
+	test('manifest agents field pointing to a specific file', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/agent-file');
+		await writeFile('/plugins/agent-file/.plugin/plugin.json', JSON.stringify({
+			name: 'agent-file',
+			agents: './custom/specialist.md',
+		}));
+		await writeFile('/plugins/agent-file/agents/default.md', '# Default');
+		await writeFile('/plugins/agent-file/custom/specialist.md', '# Specialist');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].agents, a => a.length >= 2);
+		assert.deepStrictEqual(
+			plugins[0].agents.get().map(a => a.name).sort(),
+			['default', 'specialist'],
+		);
+	}));
+
+	test('manifest skills field pointing to a specific skill directory', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/skill-dir');
+		await writeFile('/plugins/skill-dir/.plugin/plugin.json', JSON.stringify({
+			name: 'skill-dir',
+			skills: './custom/my-skill',
+		}));
+		await writeFile('/plugins/skill-dir/custom/my-skill/SKILL.md', '# My Skill');
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].skills, s => s.length > 0);
+		assert.deepStrictEqual(
+			plugins[0].skills.get().map(s => s.name),
+			['my-skill'],
+		);
+	}));
+
+	test('manifest hooks field pointing to a specific file', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/hook-file');
+		await writeFile('/plugins/hook-file/.plugin/plugin.json', JSON.stringify({
+			name: 'hook-file',
+			hooks: './config/custom-hooks.json',
+		}));
+		await writeFile('/plugins/hook-file/config/custom-hooks.json', JSON.stringify({
+			hooks: {
+				SessionStart: [{ hooks: [{ type: 'command', command: 'echo hi' }] }],
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].hooks, h => h.length > 0);
+		assert.strictEqual(plugins[0].hooks.get().length, 1);
+	}));
+
+	test('manifest mcpServers field pointing to a specific file', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/mcp-file');
+		await writeFile('/plugins/mcp-file/.plugin/plugin.json', JSON.stringify({
+			name: 'mcp-file',
+			mcpServers: './config/servers.json',
+		}));
+		await writeFile('/plugins/mcp-file/config/servers.json', JSON.stringify({
+			mcpServers: {
+				'custom-server': { command: 'node', args: ['serve.js'] },
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
+		assert.strictEqual(plugins[0].mcpServerDefinitions.get()[0].name, 'custom-server');
+	}));
 });


### PR DESCRIPTION
- Supports custom fields for commands/skills/agents/etc in plugins, matching the new plugins spec.
- Support adding a plugin (without needing a repo) directly via 'Chat: Install Plugin from Source' in the command palette, installed plugins view, or the chat customizations view.

Closes https://github.com/microsoft/vscode/issues/300945?reload=1

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
