### PR TITLE
fix: inline chat toolbars not vertically centered

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1292,6 +1292,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	position: relative;
 }
 
+.interactive-session .interactive-input-and-side-toolbar .chat-input-toolbars {
+	margin-top: 0;
+}
+
 .interactive-session .chat-input-container.focused {
 	border-color: var(--vscode-focusBorder);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #297735

## Problem
It was mentioned in #297735 that the `chat model picker` button in terminal inline chat was not vertically centered.

## Root Cause
The problem was that the `.chat-input-toolbars` element (where the button is nested) had a `margin-top: 4px` applied to it. This was introduced in #297052 to create spacing between the toolbar and the chat input area, but it was intended for chats where the toolbar is placed below the input area.

For chat types such as `inline chat` and `quick chat`, where the toolbar is placed to the right of the input area, this margin created a slight misalignment.

## Fix
This change overrides the `margin-top` property when `.chat-input-toolbars` is nested inside `.interactive-input-and-side-toolbar`. This fixes the alignment in inline chat, terminal inline chat, and quick chat without affecting other chat layouts.