### PR TITLE
feat(css): resolve bare @import specifiers to node_modules as fallback

### DIFF
--- a/extensions/css-language-features/server/src/cssServer.ts
+++ b/extensions/css-language-features/server/src/cssServer.ts
@@ -14,6 +14,7 @@ import { DiagnosticsSupport, registerDiagnosticsPullSupport, registerDiagnostics
 import { getDocumentContext } from './utils/documentContext';
 import { fetchDataProviders } from './customData';
 import { RequestService, getRequestService } from './requests';
+import { resolveNodeModuleLinks } from './utils/nodeModuleLinks';
 
 namespace CustomDataChangedNotification {
 	export const type: NotificationType<string[]> = new NotificationType('css/customDataChanged');
@@ -264,7 +265,8 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 				await dataProvidersReady;
 				const documentContext = getDocumentContext(document.uri, workspaceFolders);
 				const stylesheet = stylesheets.get(document);
-				return getLanguageService(document).findDocumentLinks2(document, stylesheet, documentContext);
+				const links = await getLanguageService(document).findDocumentLinks2(document, stylesheet, documentContext);
+				return resolveNodeModuleLinks(links, document, workspaceFolders, requestService);
 			}
 			return [];
 		}, [], `Error while computing document links for ${documentLinkParams.textDocument.uri}`, token);

--- a/extensions/css-language-features/server/src/test/links.test.ts
+++ b/extensions/css-language-features/server/src/test/links.test.ts
@@ -11,6 +11,7 @@ import { WorkspaceFolder } from 'vscode-languageserver-protocol';
 import { getCSSLanguageService } from 'vscode-css-languageservice';
 import { getDocumentContext } from '../utils/documentContext';
 import { getNodeFSRequestService } from '../node/nodeFs';
+import { resolveNodeModuleLinks } from '../utils/nodeModuleLinks';
 
 export interface ItemDescription {
 	offset: number;
@@ -96,5 +97,65 @@ suite('Links', () => {
 		await assertLinks('html { background-image: url("~foo/hello.html|")',
 			[{ offset: 29, value: '"~foo/hello.html"', target: getTestResource('node_modules/foo/hello.html') }], testUri, folders
 		);
+	});
+
+	test('bare module import fallback to node_modules', async function () {
+
+		const testUri = getTestResource('about.css');
+		const folders: WorkspaceFolder[] = [{ name: 'x', uri: getTestResource('') }];
+		const requestService = getNodeFSRequestService();
+
+		const value = '@import "foo/hello.html|";';
+		const cleanValue = value.replace('|', '');
+
+		const document = TextDocument.create(testUri, 'css', 0, cleanValue);
+		const context = getDocumentContext(testUri, folders);
+		const stylesheet = cssLanguageService.parseStylesheet(document);
+		const links = await cssLanguageService.findDocumentLinks2(document, stylesheet, context);
+		const resolved = await resolveNodeModuleLinks(links, document, folders, requestService);
+
+		assert.strictEqual(resolved.length, 1);
+		assert.strictEqual(resolved[0].target, getTestResource('node_modules/foo/hello.html'));
+	});
+
+	test('bare module import keeps local file when it exists', async function () {
+
+		const testUri = getTestResource('about.css');
+		const folders: WorkspaceFolder[] = [{ name: 'x', uri: getTestResource('') }];
+		const requestService = getNodeFSRequestService();
+
+		// node_modules/foo/package.json exists as a local file relative to the fixture dir
+		const value = '@import "node_modules/foo/package.json|";';
+		const cleanValue = value.replace('|', '');
+
+		const document = TextDocument.create(testUri, 'css', 0, cleanValue);
+		const context = getDocumentContext(testUri, folders);
+		const stylesheet = cssLanguageService.parseStylesheet(document);
+		const links = await cssLanguageService.findDocumentLinks2(document, stylesheet, context);
+		const resolved = await resolveNodeModuleLinks(links, document, folders, requestService);
+
+		assert.strictEqual(resolved.length, 1);
+		// Should keep the original local resolution (not double node_modules)
+		assert.strictEqual(resolved[0].target, getTestResource('node_modules/foo/package.json'));
+	});
+
+	test('relative import is not affected by node_modules fallback', async function () {
+
+		const testUri = getTestResource('about.css');
+		const folders: WorkspaceFolder[] = [{ name: 'x', uri: getTestResource('') }];
+		const requestService = getNodeFSRequestService();
+
+		const value = '@import "./nonexistent.css|";';
+		const cleanValue = value.replace('|', '');
+
+		const document = TextDocument.create(testUri, 'css', 0, cleanValue);
+		const context = getDocumentContext(testUri, folders);
+		const stylesheet = cssLanguageService.parseStylesheet(document);
+		const links = await cssLanguageService.findDocumentLinks2(document, stylesheet, context);
+		const resolved = await resolveNodeModuleLinks(links, document, folders, requestService);
+
+		assert.strictEqual(resolved.length, 1);
+		// Should stay as relative resolution, NOT try node_modules
+		assert.strictEqual(resolved[0].target, getTestResource('nonexistent.css'));
 	});
 });

--- a/extensions/css-language-features/server/src/utils/nodeModuleLinks.ts
+++ b/extensions/css-language-features/server/src/utils/nodeModuleLinks.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DocumentLink, TextDocument } from 'vscode-css-languageservice';
+import { WorkspaceFolder } from 'vscode-languageserver';
+import { URI, Utils } from 'vscode-uri';
+import { RequestService } from '../requests';
+
+/**
+ * For CSS @import paths that look like bare module specifiers (e.g. "some-module/style.css"),
+ * try resolving against node_modules/ as a fallback when the local file doesn't exist.
+ * This supports bundler-style imports (Vite, Webpack, etc.) without requiring the ~ prefix.
+ */
+export async function resolveNodeModuleLinks(
+	links: DocumentLink[],
+	document: TextDocument,
+	workspaceFolders: WorkspaceFolder[],
+	requestService: RequestService
+): Promise<DocumentLink[]> {
+	const resolvedLinks: DocumentLink[] = [];
+
+	for (const link of links) {
+		if (!link.target) {
+			resolvedLinks.push(link);
+			continue;
+		}
+
+		// Extract the original reference text from the document (without quotes)
+		const refText = document.getText(link.range).replace(/['"]/g, '');
+
+		// Only apply fallback for bare specifiers — skip relative, absolute, tilde, URLs
+		if (!refText || refText.startsWith('.') || refText.startsWith('/') || refText.startsWith('~') || refText.includes('://')) {
+			resolvedLinks.push(link);
+			continue;
+		}
+
+		// Check if the resolved target actually exists
+		let exists = false;
+		try {
+			await requestService.stat(link.target);
+			exists = true;
+		} catch {
+			// File does not exist at resolved path
+		}
+
+		if (!exists) {
+			// Try node_modules fallback in each workspace folder
+			for (const folder of workspaceFolders) {
+				const nodeModuleTarget = Utils.joinPath(URI.parse(folder.uri), 'node_modules', refText).toString(true);
+				try {
+					await requestService.stat(nodeModuleTarget);
+					link.target = nodeModuleTarget;
+					break;
+				} catch {
+					// Not found in this workspace folder's node_modules
+				}
+			}
+		}
+
+		resolvedLinks.push(link);
+	}
+
+	return resolvedLinks;
+}


### PR DESCRIPTION
## Summary

Fixes #295074 — CSS `@import "some-module/style.css"` now resolves to `node_modules/some-module/style.css` as a fallback when the local file doesn't exist.

## Problem

CSS `@import` supports relative paths without leading `./`, and VS Code resolves them correctly as relative paths. However, when using a bundler like Vite or Webpack, it's common to import from `node_modules` with a bare specifier:

```css
@import "some-module/style.css";
```

Currently, Ctrl+Click on such imports doesn't work because VS Code only resolves the path relative to the current file directory. The `~` prefix workaround (`@import "~some-module/style.css"`) works but is non-standard and not used by most modern bundlers.

## Solution

Added a post-processing step in the CSS language server's document link handler:

1. After `findDocumentLinks2()` returns links, check if each link target actually exists on disk
2. For **bare specifiers** (not starting with `.`, `/`, `~`, or containing `://`), if the local file doesn't exist, try resolving against `node_modules/` in the workspace root
3. If the `node_modules/` version exists, use it as the link target

### Rules:
- ✅ `@import "foo/style.css"` → tries `node_modules/foo/style.css` if local doesn't exist
- ✅ `@import "./foo.css"` → keeps relative resolution (no fallback)
- ✅ `@import "/foo.css"` → keeps absolute resolution (no fallback)
- ✅ `@import "~foo/style.css"` → keeps existing tilde behavior (no fallback)
- ✅ Local file always takes priority over node_modules

## Files Changed

| File | Change |
|------|--------|
| `server/src/utils/nodeModuleLinks.ts` | New: `resolveNodeModuleLinks()` utility function |
| `server/src/cssServer.ts` | Use node_modules fallback in `onDocumentLinks` handler |
| `server/src/test/links.test.ts` | 3 test cases: bare module fallback, local priority, relative skip |
| `server/test/linksTestFixtures/node_modules/foo/hello.html` | Test fixture file |