### PR TITLE
git: sort repository picker by workspace folder order

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -885,6 +885,14 @@ export class Model implements IRepositoryResolver, IBranchProtectionProviderRegi
 			return repositories[0].repository;
 		}
 
+		// Sort repositories by workspace folder order
+		const workspaceFolders = workspace.workspaceFolders ?? [];
+		repositories.sort((a, b) => {
+			const aIndex = workspaceFolders.findIndex(f => isDescendant(f.uri.fsPath, a.repository.root));
+			const bIndex = workspaceFolders.findIndex(f => isDescendant(f.uri.fsPath, b.repository.root));
+			return (aIndex === -1 ? Infinity : aIndex) - (bIndex === -1 ? Infinity : bIndex);
+		});
+
 		const active = window.activeTextEditor;
 		const picks = repositories.map((e, index) => new RepositoryPick(e.repository, index));
 		const repository = active && this.getRepository(active.document.fileName);


### PR DESCRIPTION
## Problem

When running git commands in a multi-root workspace that require selecting a repository (e.g., "Undo Last Commit"), the picker shows repositories in discovery order rather than the workspace configuration order. This makes the order unpredictable and inconsistent with the Explorer sidebar.

<img src="https://github.com/microsoft/vscode/assets/323878/7b66adde-5700-4847-86f7-4b378d8fdb89">

## Fix

Sort the repository list by workspace folder index before displaying the quick pick. Uses `isDescendant()` to map each repository to its workspace folder and sorts accordingly. Repositories not belonging to any workspace folder are placed at the end.

The active editor's repository is still promoted to the top of the list after sorting.

## Changes

- `extensions/git/src/model.ts` — Added workspace folder order sorting in `pickRepository()`

## Test Plan

1. Create a multi-root workspace with folders A, B, C (each containing a git repo)
2. Open a file from repo C
3. Run "Git: Undo Last Commit" from command palette
4. Verify the picker shows repos in workspace order: C (active, promoted), A, B
5. Close the file, run the command again
6. Verify picker shows: A, B, C (matching workspace config order)

Fixes #186549