### PR TITLE
git: fix stash parsing for custom message formats

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -995,12 +995,13 @@ export function parseLsFiles(raw: string): LsFilesElement[] {
 		.map(([, mode, object, stage, file]) => ({ mode, object, stage, file }));
 }
 
-const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
+const stashRegex = /([0-9a-f]{40})\n(.*)\nstash@{(\d+)}\n(.*)\n(\d+)\n(\d+)(?:\x00)/gmi;
+const stashDescriptionRegex = /^(WIP\s)?on\s([^:]+):\s(.*)$/i;
 
-function parseGitStashes(raw: string): Stash[] {
+export function parseGitStashes(raw: string): Stash[] {
 	const result: Stash[] = [];
 
-	let match, hash, parents, index, wip, branchName, description, authorDate, commitDate;
+	let match;
 
 	do {
 		match = stashRegex.exec(raw);
@@ -1008,13 +1009,28 @@ function parseGitStashes(raw: string): Stash[] {
 			break;
 		}
 
-		[, hash, parents, index, wip, branchName, description, authorDate, commitDate] = match;
+		const [, hash, parents, index, message, authorDate, commitDate] = match;
+		const descriptionMatch = stashDescriptionRegex.exec(message);
+
+		let branchName: string | undefined;
+		let description: string;
+
+		if (descriptionMatch) {
+			// Standard format: "(WIP )?on <branch>: <description>"
+			const [, wip, branch, desc] = descriptionMatch;
+			branchName = branch.trim();
+			description = wip ? `WIP (${desc.trim()})` : desc.trim();
+		} else {
+			// Custom message format (e.g., lint-staged, git stash push -m)
+			description = message.trim();
+		}
+
 		result.push({
 			hash,
 			parents: parents.split(' '),
 			index: parseInt(index),
-			branchName: branchName.trim(),
-			description: wip ? `WIP (${description.trim()})` : description.trim(),
+			branchName,
+			description,
 			authorDate: authorDate ? new Date(Number(authorDate) * 1000) : undefined,
 			commitDate: commitDate ? new Date(Number(commitDate) * 1000) : undefined,
 		});

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes } from '../git';
+import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseGitStashes } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -661,6 +661,51 @@ suite('git', () => {
 				[...splitInChunks(['0', '01', '012', '0', '01', '012', '0', '01', '012'], 9)],
 				[['0', '01', '012', '0', '01'], ['012', '0', '01', '012']]
 			);
+		});
+	});
+
+	suite('parseGitStashes', () => {
+		test('standard stash format', () => {
+			const raw = 'a'.repeat(40) + '\n' + 'b'.repeat(40) + '\nstash@{0}\nWIP on main: abc1234 commit message\n1710000000\n1710000000\x00';
+			const stashes = parseGitStashes(raw);
+			assert.strictEqual(stashes.length, 1);
+			assert.strictEqual(stashes[0].index, 0);
+			assert.strictEqual(stashes[0].branchName, 'main');
+			assert.strictEqual(stashes[0].description, 'WIP (abc1234 commit message)');
+		});
+
+		test('standard stash without WIP prefix', () => {
+			const raw = 'a'.repeat(40) + '\n' + 'b'.repeat(40) + '\nstash@{0}\nOn main: custom save\n1710000000\n1710000000\x00';
+			const stashes = parseGitStashes(raw);
+			assert.strictEqual(stashes.length, 1);
+			assert.strictEqual(stashes[0].branchName, 'main');
+			assert.strictEqual(stashes[0].description, 'custom save');
+		});
+
+		test('custom stash message (lint-staged)', () => {
+			const raw = 'a'.repeat(40) + '\n' + 'b'.repeat(40) + '\nstash@{0}\nlint-staged automatic backup\n1710000000\n1710000000\x00';
+			const stashes = parseGitStashes(raw);
+			assert.strictEqual(stashes.length, 1);
+			assert.strictEqual(stashes[0].index, 0);
+			assert.strictEqual(stashes[0].branchName, undefined);
+			assert.strictEqual(stashes[0].description, 'lint-staged automatic backup');
+		});
+
+		test('multiple stashes with mixed formats', () => {
+			const hash = 'a'.repeat(40);
+			const parent = 'b'.repeat(40);
+			const raw =
+				`${hash}\n${parent}\nstash@{0}\nWIP on main: abc1234 work in progress\n1710000000\n1710000000\x00` +
+				`${hash}\n${parent}\nstash@{1}\nlint-staged automatic backup (def5678)\n1710000000\n1710000000\x00` +
+				`${hash}\n${parent}\nstash@{2}\nOn feature: manual save\n1710000000\n1710000000\x00`;
+			const stashes = parseGitStashes(raw);
+			assert.strictEqual(stashes.length, 3);
+			assert.strictEqual(stashes[0].branchName, 'main');
+			assert.strictEqual(stashes[0].description, 'WIP (abc1234 work in progress)');
+			assert.strictEqual(stashes[1].branchName, undefined);
+			assert.strictEqual(stashes[1].description, 'lint-staged automatic backup (def5678)');
+			assert.strictEqual(stashes[2].branchName, 'feature');
+			assert.strictEqual(stashes[2].description, 'manual save');
 		});
 	});
 });


### PR DESCRIPTION
## Problem

Git stashes created with custom messages (e.g., by lint-staged's `git stash push -m "lint-staged automatic backup"`) are not visible in VS Code's "View Stash" panel, even though `git stash list` shows them in the terminal.

## Root Cause

The stash parsing regex required the `(WIP )?on <branch>: <description>` pattern in the reflog subject (`%gs`). Stashes created with `git stash push -m` or by tools like lint-staged produce custom messages that don't follow this format, causing them to be silently dropped during parsing.

**Old regex:**
```
/(hash)\n(.*)\nstash@{(\d+)}\n(WIP\s)?on\s([^:]+):\s(.*)\n(\d+)\n(\d+)(?:\x00)/
```

This requires `on <branch>: <description>` — lint-staged's `lint-staged automatic backup` doesn't match.

## Fix

Split parsing into two steps:
1. A **permissive regex** that captures the raw stash message without assuming any format
2. A **secondary regex** that extracts branch name and description from the standard `on <branch>:` format if present

Stashes with non-standard messages now appear with their full message as the description, with `branchName` set to `undefined`.

## Changes

- `extensions/git/src/git.ts` — Refactored stash regex and `parseGitStashes()` to handle custom messages
- `extensions/git/src/test/git.test.ts` — Added tests for standard, WIP, custom (lint-staged), and mixed format stashes

## Test Plan

1. Create a stash with `git stash push -m "custom message"`
2. Open Source Control → View Stashes
3. Verify the stash appears with "custom message" as description
4. Create a normal stash with `git stash`
5. Verify it appears with branch name and "WIP" description as before
6. Run: `git stash push -m "lint-staged automatic backup (abc123)"`
7. Verify it appears in the stash panel

Fixes #257960