### PR TITLE
git: improve error message for remote server failures on push

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -485,5 +485,6 @@ export const enum GitErrorCodes {
 	CherryPickConflict = 'CherryPickConflict',
 	WorktreeContainsChanges = 'WorktreeContainsChanges',
 	WorktreeAlreadyExists = 'WorktreeAlreadyExists',
-	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed'
+	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed',
+	RemoteInternalError = 'RemoteInternalError'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5437,6 +5437,9 @@ export class CommandCenter {
 					case GitErrorCodes.PushRejected:
 						message = l10n.t('Can\'t push refs to remote. Try running "Pull" first to integrate your changes.');
 						break;
+					case GitErrorCodes.RemoteInternalError:
+						message = l10n.t('Can\'t push refs to remote. The remote server encountered an internal error. If using GitHub, check https://www.githubstatus.com/ for details.');
+						break;
 					case GitErrorCodes.ForcePushWithLeaseRejected:
 					case GitErrorCodes.ForcePushWithLeaseIfIncludesRejected:
 						message = l10n.t('Can\'t force push refs to remote. The tip of the remote-tracking branch has been updated since the last checkout. Try running "Pull" first to pull the latest changes from the remote branch first.');

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2456,6 +2456,8 @@ export class Repository {
 					err.gitErrorCode = GitErrorCodes.ForcePushWithLeaseRejected;
 				} else if (forcePushMode === ForcePushMode.ForceWithLeaseIfIncludes && /! \[rejected\].*\(remote ref updated since checkout\)/m.test(err.stderr || '')) {
 					err.gitErrorCode = GitErrorCodes.ForcePushWithLeaseIfIncludesRejected;
+				} else if (/remote:.*fatal error in commit_refs/m.test(err.stderr || '')) {
+					err.gitErrorCode = GitErrorCodes.RemoteInternalError;
 				} else {
 					err.gitErrorCode = GitErrorCodes.PushRejected;
 				}


### PR DESCRIPTION
## Problem

When `git push` fails with `remote: fatal error in commit_refs` (indicating a GitHub server-side issue), VS Code shows the misleading message:

> Can't push refs to remote. Try running "Pull" first to integrate your changes.

This is incorrect because the error is caused by the remote server, not by local changes being out of date. Users waste time pulling and retrying when the actual issue is a GitHub outage.

## Fix

Added detection for `remote: fatal error in commit_refs` pattern in the push error handler. When detected, shows a more helpful message directing users to check the remote service status:

> Can't push refs to remote. The remote server encountered an internal error. If using GitHub, check https://www.githubstatus.com/ for details.

## Changes

- `extensions/git/src/api/git.d.ts` — Added `RemoteInternalError` to `GitErrorCodes` enum
- `extensions/git/src/git.ts` — Detect `fatal error in commit_refs` in push stderr before falling through to generic `PushRejected`
- `extensions/git/src/commands.ts` — Handle `RemoteInternalError` with improved error message

## Test Plan

1. Simulate a push failure with `remote: fatal error in commit_refs` in stderr
2. Verify the new message appears mentioning remote server error and githubstatus.com
3. Verify normal push rejections (non-fast-forward) still show the original "Try Pull first" message

Fixes #182679