### PR TITLE
Fix JWT token parsing bug and improve empty catch block handling

### DIFF
--- a/src/vs/base/common/oauth.ts
+++ b/src/vs/base/common/oauth.ts
@@ -5,6 +5,8 @@
 
 import { decodeBase64 } from './buffer.js';
 
+const textDecoder = new TextDecoder();
+
 const WELL_KNOWN_ROUTE = '/.well-known';
 export const AUTH_PROTECTED_RESOURCE_METADATA_DISCOVERY_PATH = `${WELL_KNOWN_ROUTE}/oauth-protected-resource`;
 export const AUTH_SERVER_METADATA_DISCOVERY_PATH = `${WELL_KNOWN_ROUTE}/oauth-authorization-server`;
@@ -1024,12 +1026,12 @@ export function getClaimsFromJWT(token: string): IAuthorizationJWTClaims {
 	const [header, payload, _signature] = parts;
 
 	try {
-		const decodedHeader = JSON.parse(decodeBase64(header).toString());
+		const decodedHeader = JSON.parse(textDecoder.decode(decodeBase64(header)));
 		if (typeof decodedHeader !== 'object') {
 			throw new Error('Invalid JWT token format: header is not a JSON object');
 		}
 
-		const decodedPayload = JSON.parse(decodeBase64(payload).toString());
+		const decodedPayload = JSON.parse(textDecoder.decode(decodeBase64(payload)));
 		if (typeof decodedPayload !== 'object') {
 			throw new Error('Invalid JWT token format: payload is not a JSON object');
 		}

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -396,7 +396,9 @@ export class SimpleSuggestWidget<TModel extends SimpleCompletionModel<TItem>, TI
 					this.element.domNode.classList.remove('docs-side');
 				}
 
-			}).catch();
+			}).catch(() => {
+				// Ignore errors - the suggestion details are not critical
+			});
 		}
 
 		this._ctxFirstSuggestionFocused.set(index === 0);


### PR DESCRIPTION
- Fix OAuth JWT parsing: use TextDecoder to properly decode Uint8Array instead of calling toString() which produces comma-separated byte values
- Replace empty .catch() with explicit comment explaining why errors are ignored