### PR TITLE
Split activity bar position setting into separate options for primary and secondary side bars

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -123,6 +123,7 @@ export class MenuId {
 	static readonly PanelAlignmentMenu = new MenuId('PanelAlignmentMenu');
 	static readonly PanelPositionMenu = new MenuId('PanelPositionMenu');
 	static readonly ActivityBarPositionMenu = new MenuId('ActivityBarPositionMenu');
+	static readonly SecondaryActivityBarPositionMenu = new MenuId('SecondaryActivityBarPositionMenu');
 	static readonly NotificationsCenterPositionMenu = new MenuId('NotificationsCenterPositionMenu');
 	static readonly MenubarPreferencesMenu = new MenuId('MenubarPreferencesMenu');
 	static readonly MenubarRecentMenu = new MenuId('MenubarRecentMenu');

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -673,7 +673,7 @@ registerAction2(class extends Action2 {
 
 MenuRegistry.appendMenuItem(MenuId.ViewContainerTitleContext, {
 	submenu: MenuId.SecondaryActivityBarPositionMenu,
-	title: localize('positionSecondaryActivityBar', "Activity Bar Position"),
+	title: localize('positionSecondaryActivityBar', "Secondary Activity Bar Position"),
 	when: ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.AuxiliaryBar)),
 	group: '3_workbench_layout_move',
 	order: 1

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -561,10 +561,120 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 MenuRegistry.appendMenuItem(MenuId.ViewContainerTitleContext, {
 	submenu: MenuId.ActivityBarPositionMenu,
 	title: localize('positionActivituBar', "Activity Bar Position"),
-	when: ContextKeyExpr.or(
-		ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.Sidebar)),
-		ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.AuxiliaryBar))
-	),
+	when: ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.Sidebar)),
+	group: '3_workbench_layout_move',
+	order: 1
+});
+
+// Secondary Activity Bar Position Actions
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.secondaryActivityBarLocation.default',
+			title: {
+				...localize2('positionSecondaryActivityBarDefault', 'Move Secondary Activity Bar to Title'),
+				mnemonicTitle: localize({ key: 'miDefaultSecondaryActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Default"),
+			},
+			shortTitle: localize('secondaryDefault', "Default"),
+			category: Categories.View,
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.DEFAULT),
+			menu: [{
+				id: MenuId.SecondaryActivityBarPositionMenu,
+				order: 1
+			}, {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.DEFAULT),
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		configurationService.updateValue(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION, ActivityBarPosition.DEFAULT);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.secondaryActivityBarLocation.top',
+			title: {
+				...localize2('positionSecondaryActivityBarTop', 'Move Secondary Activity Bar to Top'),
+				mnemonicTitle: localize({ key: 'miTopSecondaryActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Top"),
+			},
+			shortTitle: localize('secondaryTop', "Top"),
+			category: Categories.View,
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP),
+			menu: [{
+				id: MenuId.SecondaryActivityBarPositionMenu,
+				order: 2
+			}, {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP),
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		configurationService.updateValue(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION, ActivityBarPosition.TOP);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.secondaryActivityBarLocation.bottom',
+			title: {
+				...localize2('positionSecondaryActivityBarBottom', 'Move Secondary Activity Bar to Bottom'),
+				mnemonicTitle: localize({ key: 'miBottomSecondaryActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Bottom"),
+			},
+			shortTitle: localize('secondaryBottom', "Bottom"),
+			category: Categories.View,
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.BOTTOM),
+			menu: [{
+				id: MenuId.SecondaryActivityBarPositionMenu,
+				order: 3
+			}, {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.BOTTOM),
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		configurationService.updateValue(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION, ActivityBarPosition.BOTTOM);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.secondaryActivityBarLocation.hide',
+			title: {
+				...localize2('hideSecondaryActivityBar', 'Hide Secondary Activity Bar'),
+				mnemonicTitle: localize({ key: 'miHideSecondaryActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Hidden"),
+			},
+			shortTitle: localize('secondaryHide', "Hidden"),
+			category: Categories.View,
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.HIDDEN),
+			menu: [{
+				id: MenuId.SecondaryActivityBarPositionMenu,
+				order: 4
+			}, {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.HIDDEN),
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		configurationService.updateValue(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION, ActivityBarPosition.HIDDEN);
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.ViewContainerTitleContext, {
+	submenu: MenuId.SecondaryActivityBarPositionMenu,
+	title: localize('positionSecondaryActivityBar', "Activity Bar Position"),
+	when: ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.AuxiliaryBar)),
 	group: '3_workbench_layout_move',
 	order: 1
 });

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -136,7 +136,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		this.configuration = this.resolveConfiguration();
 
 		this._register(configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION)) {
+			if (e.affectsConfiguration(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION)) {
 				this.configuration = this.resolveConfiguration();
 				this.onDidChangeActivityBarLocation();
 			} else if (e.affectsConfiguration('workbench.secondarySideBar.showLabels')) {
@@ -161,9 +161,9 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	}
 
 	private resolveConfiguration(): IAuxiliaryBarPartConfiguration {
-		const position = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
+		const position = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION);
 
-		const canShowLabels = position !== ActivityBarPosition.TOP && position !== ActivityBarPosition.BOTTOM; // use same style as activity bar in this case
+		const canShowLabels = position !== ActivityBarPosition.TOP && position !== ActivityBarPosition.BOTTOM;
 		const showLabels = canShowLabels && this.configurationService.getValue('workbench.secondarySideBar.showLabels') !== false;
 
 		return { position, canShowLabels, showLabels };

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -241,7 +241,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			}
 		}
 
-		const activityBarPositionMenu = this.menuService.getMenuActions(MenuId.ActivityBarPositionMenu, this.contextKeyService, { shouldForwardArgs: true, renderShortTitle: true });
+		const activityBarPositionMenu = this.menuService.getMenuActions(MenuId.SecondaryActivityBarPositionMenu, this.contextKeyService, { shouldForwardArgs: true, renderShortTitle: true });
 		const positionActions = getContextMenuActions(activityBarPositionMenu).secondary;
 
 		const toggleShowLabelsAction = toAction({
@@ -253,7 +253,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 
 		actions.push(...[
 			new Separator(),
-			new SubmenuAction('workbench.action.panel.position', localize('activity bar position', "Activity Bar Position"), positionActions),
+			new SubmenuAction('workbench.action.panel.position', localize('secondary activity bar position', "Secondary Activity Bar Position"), positionActions),
 			toAction({ id: ToggleSidebarPositionAction.ID, label: currentPositionRight ? localize('move second side bar left', "Move Secondary Side Bar Left") : localize('move second side bar right', "Move Secondary Side Bar Right"), run: () => this.commandService.executeCommand(ToggleSidebarPositionAction.ID) }),
 			toggleShowLabelsAction,
 			toAction({ id: ToggleAuxiliaryBarAction.ID, label: localize('hide second side bar', "Hide Secondary Side Bar"), run: () => this.commandService.executeCommand(ToggleAuxiliaryBarAction.ID) })

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -610,7 +610,19 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.secondarySideBar.showLabels': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize('secondarySideBarShowLabels', "Controls whether activity items in the secondary side bar title are shown as label or icon. This setting only has an effect when {0} is not set to {1}.", '`#workbench.activityBar.location#`', '`top`'),
+				'markdownDescription': localize('secondarySideBarShowLabels', "Controls whether activity items in the secondary side bar title are shown as label or icon. This setting only has an effect when {0} is not set to {1}.", '`#workbench.secondarySideBar.activityBar.location#`', '`top`'),
+			},
+			[LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION]: {
+				'type': 'string',
+				'enum': ['default', 'top', 'bottom', 'hidden'],
+				'default': 'default',
+				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'secondarySideBarActivityBarLocation' }, "Controls the location of the Activity Bar in the Secondary Side Bar."),
+				'enumDescriptions': [
+					localize('workbench.secondarySideBar.activityBar.location.default', "Show the Activity Bar inline in the Secondary Side Bar title area."),
+					localize('workbench.secondarySideBar.activityBar.location.top', "Show the Activity Bar on top of the Secondary Side Bar."),
+					localize('workbench.secondarySideBar.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Secondary Side Bar."),
+					localize('workbench.secondarySideBar.activityBar.location.hide', "Hide the Activity Bar in the Secondary Side Bar.")
+				],
 			},
 			'workbench.statusBar.visible': {
 				'type': 'boolean',
@@ -641,12 +653,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'enum': ['default', 'top', 'bottom', 'hidden'],
 				'default': 'default',
-				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar relative to the Primary and Secondary Side Bars."),
+				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar in the Primary Side Bar."),
 				'enumDescriptions': [
-					localize('workbench.activityBar.location.default', "Show the Activity Bar on the side of the Primary Side Bar and on top of the Secondary Side Bar."),
-					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary and Secondary Side Bars."),
-					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary and Secondary Side Bars."),
-					localize('workbench.activityBar.location.hide', "Hide the Activity Bar in the Primary and Secondary Side Bars.")
+					localize('workbench.activityBar.location.default', "Show the Activity Bar on the side of the Primary Side Bar."),
+					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary Side Bar."),
+					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary Side Bar."),
+					localize('workbench.activityBar.location.hide', "Hide the Activity Bar in the Primary Side Bar.")
 				],
 			},
 			[LayoutSettings.ACTIVITY_BAR_AUTO_HIDE]: {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -610,7 +610,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.secondarySideBar.showLabels': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize('secondarySideBarShowLabels', "Controls whether activity items in the secondary side bar title are shown as label or icon. This setting only has an effect when {0} is not set to {1}.", '`#workbench.secondarySideBar.activityBar.location#`', '`top`'),
+				'markdownDescription': localize('secondarySideBarShowLabels', "Controls whether activity items in the secondary side bar title are shown as label or icon. This setting only has an effect when {0} is not set to {1} or {2}.", '`#workbench.secondarySideBar.activityBar.location#`', '`top`', '`bottom`'),
 			},
 			[LayoutSettings.SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION]: {
 				'type': 'string',

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -45,6 +45,7 @@ export const enum LayoutSettings {
 	ACTIVITY_BAR_LOCATION = 'workbench.activityBar.location',
 	ACTIVITY_BAR_AUTO_HIDE = 'workbench.activityBar.autoHide',
 	ACTIVITY_BAR_COMPACT = 'workbench.activityBar.compact',
+	SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION = 'workbench.secondarySideBar.activityBar.location',
 	EDITOR_TABS_MODE = 'workbench.editor.showTabs',
 	EDITOR_ACTIONS_LOCATION = 'workbench.editor.editorActionsLocation',
 	COMMAND_CENTER = 'window.commandCenter',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

# Summary 

Fixes #210027 by implementing a separate setting for the position of the activity bar for the secondary side bar (along with relevant context menu and relevant commands) 

Many thanks in advance for your consideration of this PR.

# Problem

As per the issue, multiple people expressed that would like to be able to configure the position of the activity bars of the primary and secondary side bars independently. There was a consensus that an additional setting for the position of the secondary one should be created and that they should not rely on the same attribute ("workbench.activityBar.location").

Furthermore, many people have expressed desire to have the possibility of a vertical layout for the secondary activity bar in #195561. Even though this was marked as out of scope, there has been much discussion and interest in this since the issue was marked as out of scope. Furthermore, tools like copilot, codex and claude which often sit in the secondary sidebar have changed the calculus on the importance of this. I have a working draft solution to this in my fork, which I can submit, however this PR's change is a necessary **prerequisite** (and I wanted to focus on one issue per PR as per the contributing guidelines).

# Solution

Add an additional setting in [workbench.contribution.ts](https://github.com/microsoft/vscode/compare/main...ajhawkings:feat/split-secondary-sidebar-setting?expand=1#diff-e2fff02847b3a908c6d7da18b89daa74c1aac378548cf83065141e8a705af76d) and update [auxiliaryBarPart.ts](https://github.com/microsoft/vscode/compare/main...ajhawkings:feat/split-secondary-sidebar-setting?expand=1#diff-3c10280529bce6feec300c3a22ce196b645bf0a2c0ddc5bcee3d59c80f7692fb) to use this setting for position of its activity bar. Add relevant command palette commands to [activitybarPart.ts](https://github.com/microsoft/vscode/compare/main...ajhawkings:feat/split-secondary-sidebar-setting?expand=1#diff-7aaf3f75660a11bc7c949d968b2c9c0178d9aed7eebeae75c4255e2e1a597b9b)

# Changes

| File | Change |
|------|--------|
| `actions.ts` | New `SecondaryActivityBarPositionMenu` MenuId |
| `activitybarPart.ts` | 4 position actions (default/top/bottom/hidden) + context menu entry for secondary side bar |
| `auxiliaryBarPart.ts` | Use new menu + new setting key, label renamed |
| `workbench.contribution.ts` | Register new setting, update primary descriptions |
| `layoutService.ts` | Add `SECONDARY_SIDEBAR_ACTIVITY_BAR_LOCATION` setting key |




