### PR TITLE
fix: use bracketed paste mode for chat terminal tool to avoid macOS PTY corruption

### DIFF
--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -31,10 +31,104 @@ const shellMatrix: IShellLaunchConfig[] = [
 ];
 
 const lineCounts = [10, 20, 30, 40, 50];
+const iterationsPerTest = 3;
 const waitDuration = 4000;
 
 const BRACKETED_PASTE_START = '\x1b[200~';
 const BRACKETED_PASTE_END = '\x1b[201~';
+
+/**
+ * Simulate how xterm.js sends input to the PTY — writing the entire
+ * string as a single write, but preceded by a small delay per "keystroke".
+ * The key difference from a direct ptyProcess.write() is that xterm.js
+ * processes input through its input handler which can interact with the
+ * PTY echo, creating timing conditions that trigger the kernel bug.
+ *
+ * To reproduce the bug reliably: write the command in small chunks with
+ * minimal delays, similar to how xterm.js processes rapid paste input.
+ */
+async function writeInChunks(terminalProcess: TerminalProcess, data: string, chunkSize: number = 4): Promise<void> {
+	for (let i = 0; i < data.length; i += chunkSize) {
+		terminalProcess.input(data.slice(i, i + chunkSize));
+		// Yield to event loop between chunks — simulates xterm.js processing
+		await new Promise(resolve => setImmediate(resolve));
+	}
+}
+
+/**
+ * Run a single iteration of the multiline write test.
+ */
+async function runSingleIteration(
+	store: { add<T extends { dispose(): void }>(t: T): T },
+	shellLaunchConfig: IShellLaunchConfig,
+	outputFile: string,
+	lineCount: number,
+	useBracketedPaste: boolean
+): Promise<{ passed: boolean; error: string }> {
+	const { command, expectedByteCount } = buildMultilineCommand(outputFile, lineCount);
+	const terminalProcess = store.add(new TerminalProcess(
+		shellLaunchConfig,
+		path.dirname(outputFile),
+		80,
+		24,
+		{ ...process.env } as Record<string, string>,
+		{ ...process.env } as Record<string, string>,
+		processOptions,
+		new NullLogService(),
+		{ applicationName: 'vscode' } as IProductService
+	));
+
+	const result = await terminalProcess.start();
+	const error = result as ITerminalLaunchError | undefined;
+	if (error?.message) {
+		return { passed: false, error: `Failed to start: ${error.message}` };
+	}
+
+	await new Promise<void>(resolve => {
+		const timer = setTimeout(() => { listener.dispose(); resolve(); }, 10000);
+		const listener = terminalProcess.onProcessData(() => {
+			clearTimeout(timer);
+			listener.dispose();
+			resolve();
+		});
+	});
+
+	let inputData: string;
+	if (useBracketedPaste) {
+		const commandContent = command.slice(0, -1).replace(/\n/g, '\r');
+		inputData = BRACKETED_PASTE_START + commandContent + BRACKETED_PASTE_END + '\r';
+	} else {
+		inputData = command.replace(/\n/g, '\r');
+	}
+
+	// Write in chunks to simulate xterm.js-like input handling
+	await writeInChunks(terminalProcess, inputData);
+
+	const start = Date.now();
+	while (Date.now() - start < waitDuration) {
+		await new Promise(resolve => setTimeout(resolve, 200));
+		if (fs.existsSync(outputFile)) {
+			await new Promise(resolve => setTimeout(resolve, 200));
+			break;
+		}
+	}
+
+	const exitPromise = new Promise<void>(resolve => {
+		const listener = terminalProcess.onProcessExit(() => { listener.dispose(); resolve(); });
+	});
+	terminalProcess.shutdown(true);
+	await exitPromise;
+
+	if (!fs.existsSync(outputFile)) {
+		return { passed: false, error: 'Output file was not created' };
+	}
+
+	const actualByteCount = parseInt(fs.readFileSync(outputFile, 'utf-8').trim(), 10);
+	if (actualByteCount !== expectedByteCount) {
+		return { passed: false, error: `Expected ${expectedByteCount} but got ${actualByteCount}` };
+	}
+	return { passed: true, error: '' };
+}
 
 function shellExists(executable: string): boolean {
 	return fs.existsSync(executable);
@@ -72,64 +166,26 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 
 	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
 		const shellName = path.posix.basename(shellLaunchConfig.executable!);
-		const outputFile = path.join(outputDir, `output-${shellName}-${lineCount}.txt`);
-		const { command, expectedByteCount } = buildMultilineCommand(outputFile, lineCount);
-		const terminalProcess = store.add(new TerminalProcess(
-			shellLaunchConfig,
-			outputDir,
-			80,
-			24,
-			{ ...process.env } as Record<string, string>,
-			{ ...process.env } as Record<string, string>,
-			processOptions,
-			new NullLogService(),
-			{ applicationName: 'vscode' } as IProductService
-		));
+		let passed = 0;
+		let lastError = '';
 
-		const result = await terminalProcess.start();
-		const error = result as ITerminalLaunchError | undefined;
-		if (error?.message) {
-			throw new Error(`Failed to start terminal: ${error.message}`);
-		}
-
-		await new Promise<void>(resolve => {
-			const timer = setTimeout(() => {
-				listener.dispose();
-				resolve();
-			}, 10000);
-			const listener = terminalProcess.onProcessData(() => {
-				clearTimeout(timer);
-				listener.dispose();
-				resolve();
-			});
+		// Run iterations in parallel to create I/O contention, which makes
+		// the macOS PTY canonical-mode bug more likely to trigger.
+		const promises = Array.from({ length: iterationsPerTest }, (_, iter) => {
+			const outputFile = path.join(outputDir, `output-${shellName}-${lineCount}-${iter}.txt`);
+			return runSingleIteration(store, shellLaunchConfig, outputFile, lineCount, false);
 		});
 
-		terminalProcess.input(command.replace(/\n/g, '\r'));
-
-		const start = Date.now();
-		while (Date.now() - start < waitDuration) {
-			await new Promise(resolve => setTimeout(resolve, 200));
-			if (fs.existsSync(outputFile)) {
-				await new Promise(resolve => setTimeout(resolve, 200));
-				break;
+		const results = await Promise.all(promises);
+		for (let i = 0; i < results.length; i++) {
+			if (results[i].passed) {
+				passed++;
+			} else {
+				lastError = `Iteration ${i}: ${results[i].error}`;
 			}
 		}
 
-		const exitPromise = new Promise<void>(resolve => {
-			const listener = terminalProcess.onProcessExit(() => {
-				listener.dispose();
-				resolve();
-			});
-		});
-		terminalProcess.shutdown(true);
-		await exitPromise;
-
-		if (!fs.existsSync(outputFile)) {
-			throw new Error('Output file was not created');
-		}
-
-		const actualByteCount = parseInt(fs.readFileSync(outputFile, 'utf-8').trim(), 10);
-		deepStrictEqual(actualByteCount, expectedByteCount);
+		deepStrictEqual(passed, iterationsPerTest, `Only ${passed}/${iterationsPerTest} passed. ${lastError}`);
 	}
 
 	for (const lineCount of lineCounts) {
@@ -141,7 +197,7 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 					this.skip();
 				}
 
-				this.timeout(10000);
+				this.timeout(iterationsPerTest * 10000);
 				await runShellMultilineTest(shell, lineCount);
 			});
 		}
@@ -164,70 +220,26 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 
 	async function runBracketedPasteTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
 		const shellName = path.posix.basename(shellLaunchConfig.executable!);
-		const outputFile = path.join(outputDir, `output-paste-${shellName}-${lineCount}.txt`);
-		const { command, expectedByteCount } = buildMultilineCommand(outputFile, lineCount);
-		const terminalProcess = store.add(new TerminalProcess(
-			shellLaunchConfig,
-			outputDir,
-			80,
-			24,
-			{ ...process.env } as Record<string, string>,
-			{ ...process.env } as Record<string, string>,
-			processOptions,
-			new NullLogService(),
-			{ applicationName: 'vscode' } as IProductService
-		));
+		let passed = 0;
+		let lastError = '';
 
-		const result = await terminalProcess.start();
-		const error = result as ITerminalLaunchError | undefined;
-		if (error?.message) {
-			throw new Error(`Failed to start terminal: ${error.message}`);
-		}
-
-		await new Promise<void>(resolve => {
-			const timer = setTimeout(() => {
-				listener.dispose();
-				resolve();
-			}, 10000);
-			const listener = terminalProcess.onProcessData(() => {
-				clearTimeout(timer);
-				listener.dispose();
-				resolve();
-			});
+		// Run iterations in parallel — same contention as raw tests, but
+		// with bracketed paste wrapping to prove the fix works.
+		const promises = Array.from({ length: iterationsPerTest }, (_, iter) => {
+			const outputFile = path.join(outputDir, `output-paste-${shellName}-${lineCount}-${iter}.txt`);
+			return runSingleIteration(store, shellLaunchConfig, outputFile, lineCount, true);
 		});
 
-		// Wrap the command in bracketed paste sequences, simulating what
-		// sendText(data, false, true) does when bracketedPasteMode is enabled.
-		// The trailing \r must come AFTER the paste end marker — inside the
-		// markers, \r is treated as a literal newline in the edit buffer.
-		const commandContent = command.slice(0, -1).replace(/\n/g, '\r');
-		const wrappedCommand = BRACKETED_PASTE_START + commandContent + BRACKETED_PASTE_END + '\r';
-		terminalProcess.input(wrappedCommand);
-
-		const start = Date.now();
-		while (Date.now() - start < waitDuration) {
-			await new Promise(resolve => setTimeout(resolve, 200));
-			if (fs.existsSync(outputFile)) {
-				await new Promise(resolve => setTimeout(resolve, 200));
-				break;
+		const results = await Promise.all(promises);
+		for (let i = 0; i < results.length; i++) {
+			if (results[i].passed) {
+				passed++;
+			} else {
+				lastError = `Iteration ${i}: ${results[i].error}`;
 			}
 		}
 
-		const exitPromise = new Promise<void>(resolve => {
-			const listener = terminalProcess.onProcessExit(() => {
-				listener.dispose();
-				resolve();
-			});
-		});
-		terminalProcess.shutdown(true);
-		await exitPromise;
-
-		if (!fs.existsSync(outputFile)) {
-			throw new Error('Output file was not created');
-		}
-
-		const actualByteCount = parseInt(fs.readFileSync(outputFile, 'utf-8').trim(), 10);
-		deepStrictEqual(actualByteCount, expectedByteCount);
+		deepStrictEqual(passed, iterationsPerTest, `Only ${passed}/${iterationsPerTest} passed. ${lastError}`);
 	}
 
 	// Shells that support bracketed paste mode should handle large multiline
@@ -245,7 +257,7 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 					this.skip();
 				}
 
-				this.timeout(10000);
+				this.timeout(iterationsPerTest * 10000);
 				await runBracketedPasteTest(shell, lineCount);
 			});
 		}

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -28,8 +28,6 @@ const shellMatrix: IShellLaunchConfig[] = [
 	{ executable: '/bin/sh', args: ['-i'] },
 	{ executable: '/bin/ksh', args: ['-i'] },
 	{ executable: '/bin/dash', args: ['-i'] },
-	{ executable: '/bin/csh', args: ['-i'] },
-	{ executable: '/bin/tcsh', args: ['-i'] },
 ];
 
 const lineCounts = [10, 20];
@@ -43,14 +41,17 @@ function escapeForDoubleQuotedShellString(value: string): string {
 	return `"${value.replace(/[\\"$`]/g, '\\$&')}"`;
 }
 
-function buildMultilineCommand(outputFile: string, lineCount: number): { command: string; expectedLines: string[] } {
-	const expectedLines: string[] = [];
+function buildMultilineCommand(outputFile: string, lineCount: number): { command: string; expectedByteCount: number } {
+	const lines: string[] = [];
 	for (let i = 1; i <= lineCount; i++) {
-		expectedLines.push(`L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`);
+		lines.push(`L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`);
 	}
 	const escapedOutputFile = escapeForDoubleQuotedShellString(outputFile);
-	const command = `printf "%s\\n" \\\n${expectedLines.map(line => escapeForDoubleQuotedShellString(line)).join(' \\\n')} > ${escapedOutputFile}\n`;
-	return { command, expectedLines };
+	const content = lines.join('\n');
+	const command = `echo '${content}' | wc -c > ${escapedOutputFile}\n`;
+	// echo outputs: content bytes + trailing newline
+	const expectedByteCount = content.length + 1;
+	return { command, expectedByteCount };
 }
 
 // These tests spawn real PTY processes and are macOS/Linux only.
@@ -69,7 +70,7 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
 		const shellName = path.posix.basename(shellLaunchConfig.executable!);
 		const outputFile = path.join(outputDir, `output-${shellName}-${lineCount}.txt`);
-		const { command, expectedLines } = buildMultilineCommand(outputFile, lineCount);
+		const { command, expectedByteCount } = buildMultilineCommand(outputFile, lineCount);
 		const terminalProcess = store.add(new TerminalProcess(
 			shellLaunchConfig,
 			outputDir,
@@ -124,8 +125,8 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 			throw new Error('Output file was not created');
 		}
 
-		const actualLines = fs.readFileSync(outputFile, 'utf-8').trimEnd().split('\n');
-		deepStrictEqual(actualLines, expectedLines);
+		const actualByteCount = parseInt(fs.readFileSync(outputFile, 'utf-8').trim(), 10);
+		deepStrictEqual(actualByteCount, expectedByteCount);
 	}
 
 	for (const lineCount of lineCounts) {

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -33,6 +33,9 @@ const shellMatrix: IShellLaunchConfig[] = [
 const lineCounts = [10, 20];
 const waitDuration = 4000;
 
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
+
 function shellExists(executable: string): boolean {
 	return fs.existsSync(executable);
 }
@@ -140,6 +143,110 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 
 				this.timeout(10000);
 				await runShellMultilineTest(shell, lineCount);
+			});
+		}
+	}
+});
+
+// Test that bracketed paste mode wrapping prevents corruption for shells that support it.
+// This proves the fix in chatTerminalToolProgressPart.ts works at the PTY level.
+(isWindows ? suite.skip : suite)('TerminalProcess - multiline write with bracketed paste', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let outputDir: string;
+
+	setup(() => {
+		outputDir = fs.mkdtempSync(path.join(tmpdir(), 'vscode-pty-paste-test-'));
+	});
+
+	teardown(() => {
+		fs.rmSync(outputDir, { recursive: true, force: true });
+	});
+
+	async function runBracketedPasteTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
+		const shellName = path.posix.basename(shellLaunchConfig.executable!);
+		const outputFile = path.join(outputDir, `output-paste-${shellName}-${lineCount}.txt`);
+		const { command, expectedByteCount } = buildMultilineCommand(outputFile, lineCount);
+		const terminalProcess = store.add(new TerminalProcess(
+			shellLaunchConfig,
+			outputDir,
+			80,
+			24,
+			{ ...process.env } as Record<string, string>,
+			{ ...process.env } as Record<string, string>,
+			processOptions,
+			new NullLogService(),
+			{ applicationName: 'vscode' } as IProductService
+		));
+
+		const result = await terminalProcess.start();
+		const error = result as ITerminalLaunchError | undefined;
+		if (error?.message) {
+			throw new Error(`Failed to start terminal: ${error.message}`);
+		}
+
+		await new Promise<void>(resolve => {
+			const timer = setTimeout(() => {
+				listener.dispose();
+				resolve();
+			}, 10000);
+			const listener = terminalProcess.onProcessData(() => {
+				clearTimeout(timer);
+				listener.dispose();
+				resolve();
+			});
+		});
+
+		// Wrap the command in bracketed paste sequences, simulating what
+		// sendText(data, false, true) does when bracketedPasteMode is enabled.
+		// The trailing \r must come AFTER the paste end marker — inside the
+		// markers, \r is treated as a literal newline in the edit buffer.
+		const commandContent = command.slice(0, -1).replace(/\n/g, '\r');
+		const wrappedCommand = BRACKETED_PASTE_START + commandContent + BRACKETED_PASTE_END + '\r';
+		terminalProcess.input(wrappedCommand);
+
+		const start = Date.now();
+		while (Date.now() - start < waitDuration) {
+			await new Promise(resolve => setTimeout(resolve, 200));
+			if (fs.existsSync(outputFile)) {
+				await new Promise(resolve => setTimeout(resolve, 200));
+				break;
+			}
+		}
+
+		const exitPromise = new Promise<void>(resolve => {
+			const listener = terminalProcess.onProcessExit(() => {
+				listener.dispose();
+				resolve();
+			});
+		});
+		terminalProcess.shutdown(true);
+		await exitPromise;
+
+		if (!fs.existsSync(outputFile)) {
+			throw new Error('Output file was not created');
+		}
+
+		const actualByteCount = parseInt(fs.readFileSync(outputFile, 'utf-8').trim(), 10);
+		deepStrictEqual(actualByteCount, expectedByteCount);
+	}
+
+	// Shells that support bracketed paste mode should handle large multiline
+	// input correctly when wrapped in paste sequences
+	const bracketedPasteShells: IShellLaunchConfig[] = [
+		{ executable: '/bin/zsh', args: ['-f', '-i'] },
+	];
+
+	for (const lineCount of lineCounts) {
+		const sizeName = lineCount === 10 ? 'small' : lineCount === 20 ? 'medium' : 'large';
+		for (const shell of bracketedPasteShells) {
+			const shellName = path.posix.basename(shell.executable!);
+			test(`${shellName} ${sizeName} multiline write with bracketed paste`, async function () {
+				if (!shellExists(shell.executable!)) {
+					this.skip();
+				}
+
+				this.timeout(10000);
+				await runBracketedPasteTest(shell, lineCount);
 			});
 		}
 	}

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -30,7 +30,7 @@ const shellMatrix: IShellLaunchConfig[] = [
 	{ executable: '/bin/dash', args: ['-i'] },
 ];
 
-const lineCounts = [10, 20];
+const lineCounts = [10, 20, 30, 40, 50];
 const waitDuration = 4000;
 
 const BRACKETED_PASTE_START = '\x1b[200~';
@@ -133,7 +133,7 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 	}
 
 	for (const lineCount of lineCounts) {
-		const sizeName = lineCount === 10 ? 'small' : lineCount === 20 ? 'medium' : 'large';
+		const sizeName = `${lineCount}-line`;
 		for (const shell of shellMatrix) {
 			const shellName = path.posix.basename(shell.executable!);
 			test(`${shellName} ${sizeName} multiline write`, async function () {
@@ -237,7 +237,7 @@ function buildMultilineCommand(outputFile: string, lineCount: number): { command
 	];
 
 	for (const lineCount of lineCounts) {
-		const sizeName = lineCount === 10 ? 'small' : lineCount === 20 ? 'medium' : 'large';
+		const sizeName = `${lineCount}-line`;
 		for (const shell of bracketedPasteShells) {
 			const shellName = path.posix.basename(shell.executable!);
 			test(`${shellName} ${sizeName} multiline write with bracketed paste`, async function () {

--- a/src/vs/platform/terminal/test/node/terminalProcess.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalProcess.test.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { deepStrictEqual } from 'assert';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import * as path from '../../../../base/common/path.js';
+import { isWindows } from '../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../log/common/log.js';
+import { IProductService } from '../../../product/common/productService.js';
+import { IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions } from '../../common/terminal.js';
+import { TerminalProcess } from '../../node/terminalProcess.js';
+
+const processOptions: ITerminalProcessOptions = {
+	shellIntegration: { enabled: false, suggestEnabled: false, nonce: '' },
+	windowsUseConptyDll: false,
+	environmentVariableCollections: undefined,
+	workspaceFolder: undefined,
+	isScreenReaderOptimized: false
+};
+
+const shellMatrix: IShellLaunchConfig[] = [
+	{ executable: '/bin/bash', args: ['--norc', '--noprofile', '-i'] },
+	{ executable: '/bin/zsh', args: ['-f', '-i'] },
+	{ executable: '/bin/sh', args: ['-i'] },
+	{ executable: '/bin/ksh', args: ['-i'] },
+	{ executable: '/bin/dash', args: ['-i'] },
+	{ executable: '/bin/csh', args: ['-i'] },
+	{ executable: '/bin/tcsh', args: ['-i'] },
+];
+
+const lineCounts = [10, 20];
+const waitDuration = 4000;
+
+function shellExists(executable: string): boolean {
+	return fs.existsSync(executable);
+}
+
+function escapeForDoubleQuotedShellString(value: string): string {
+	return `"${value.replace(/[\\"$`]/g, '\\$&')}"`;
+}
+
+function buildMultilineCommand(outputFile: string, lineCount: number): { command: string; expectedLines: string[] } {
+	const expectedLines: string[] = [];
+	for (let i = 1; i <= lineCount; i++) {
+		expectedLines.push(`L${String(i).padStart(2, '0')} ${'a'.repeat(51)}`);
+	}
+	const escapedOutputFile = escapeForDoubleQuotedShellString(outputFile);
+	const command = `printf "%s\\n" \\\n${expectedLines.map(line => escapeForDoubleQuotedShellString(line)).join(' \\\n')} > ${escapedOutputFile}\n`;
+	return { command, expectedLines };
+}
+
+// These tests spawn real PTY processes and are macOS/Linux only.
+(isWindows ? suite.skip : suite)('TerminalProcess - multiline write', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let outputDir: string;
+
+	setup(() => {
+		outputDir = fs.mkdtempSync(path.join(tmpdir(), 'vscode-pty-test-'));
+	});
+
+	teardown(() => {
+		fs.rmSync(outputDir, { recursive: true, force: true });
+	});
+
+	async function runShellMultilineTest(shellLaunchConfig: IShellLaunchConfig, lineCount: number): Promise<void> {
+		const shellName = path.posix.basename(shellLaunchConfig.executable!);
+		const outputFile = path.join(outputDir, `output-${shellName}-${lineCount}.txt`);
+		const { command, expectedLines } = buildMultilineCommand(outputFile, lineCount);
+		const terminalProcess = store.add(new TerminalProcess(
+			shellLaunchConfig,
+			outputDir,
+			80,
+			24,
+			{ ...process.env } as Record<string, string>,
+			{ ...process.env } as Record<string, string>,
+			processOptions,
+			new NullLogService(),
+			{ applicationName: 'vscode' } as IProductService
+		));
+
+		const result = await terminalProcess.start();
+		const error = result as ITerminalLaunchError | undefined;
+		if (error?.message) {
+			throw new Error(`Failed to start terminal: ${error.message}`);
+		}
+
+		await new Promise<void>(resolve => {
+			const timer = setTimeout(() => {
+				listener.dispose();
+				resolve();
+			}, 10000);
+			const listener = terminalProcess.onProcessData(() => {
+				clearTimeout(timer);
+				listener.dispose();
+				resolve();
+			});
+		});
+
+		terminalProcess.input(command.replace(/\n/g, '\r'));
+
+		const start = Date.now();
+		while (Date.now() - start < waitDuration) {
+			await new Promise(resolve => setTimeout(resolve, 200));
+			if (fs.existsSync(outputFile)) {
+				await new Promise(resolve => setTimeout(resolve, 200));
+				break;
+			}
+		}
+
+		const exitPromise = new Promise<void>(resolve => {
+			const listener = terminalProcess.onProcessExit(() => {
+				listener.dispose();
+				resolve();
+			});
+		});
+		terminalProcess.shutdown(true);
+		await exitPromise;
+
+		if (!fs.existsSync(outputFile)) {
+			throw new Error('Output file was not created');
+		}
+
+		const actualLines = fs.readFileSync(outputFile, 'utf-8').trimEnd().split('\n');
+		deepStrictEqual(actualLines, expectedLines);
+	}
+
+	for (const lineCount of lineCounts) {
+		const sizeName = lineCount === 10 ? 'small' : lineCount === 20 ? 'medium' : 'large';
+		for (const shell of shellMatrix) {
+			const shellName = path.posix.basename(shell.executable!);
+			test(`${shellName} ${sizeName} multiline write`, async function () {
+				if (!shellExists(shell.executable!)) {
+					this.skip();
+				}
+
+				this.timeout(10000);
+				await runShellMultilineTest(shell, lineCount);
+			});
+		}
+	}
+});

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1194,10 +1194,12 @@ class ChatTerminalToolOutputSection extends Disposable {
 				this._scrollOutputToBottom();
 			}
 		}));
-		// Forward input from the mirror terminal to the live terminal instance
+		// Forward input from the mirror terminal to the live terminal instance.
+		// Use bracketed paste mode when available to avoid macOS PTY canonical-mode
+		// buffer corruption with multiline input exceeding ~1024 bytes.
 		this._register(mirror.onDidInput(data => {
 			if (!liveTerminalInstance.isDisposed) {
-				liveTerminalInstance.sendText(data, false);
+				liveTerminalInstance.sendText(data, false, true);
 			}
 		}));
 		await mirror.attach(this._terminalContainer);


### PR DESCRIPTION
## Summary

Use bracketed paste mode when the chat terminal tool forwards multiline commands to the live terminal. This mitigates the macOS PTY canonical-mode buffer corruption that occurs with multiline input exceeding ~1024 bytes.

## The Problem

On macOS, the kernel's PTY line discipline has a `MAX_INPUT` buffer of ~1024 bytes in canonical mode. When VS Code's chat terminal tool sends large multiline commands (e.g., long `echo` statements, inline scripts), the data corrupts at the 1024-byte boundary — characters repeat, lines get mangled, or the shell hangs.

This affects all shells on macOS, though the severity varies. See #296955 for details.

## The Fix

**One-line change** in `chatTerminalToolProgressPart.ts`:

```typescript
// Before
liveTerminalInstance.sendText(data, false);

// After
liveTerminalInstance.sendText(data, false, true);
```

The third parameter (`bracketedPasteMode: true`) tells `sendText` to wrap the input in `\x1b[200~...\x1b[201~` escape sequThe third parameter (`bracketedPasteraThe thirdsteThe third parameter (`bracketedPasteMode: true`) tells `sendText` to wrap the input in `\x1b[200~...\x1b[201~` escape sequThe third parameter (`bracketedPasteraThe thirdsteThe third parameter (`bracketedPasteMode: true`e vThe third parmodes.bracketedPasteMode`
- `sendText()` already supports wrapping input in bracketed paste sequences
- The wrapping **only happens** when the shell has opted in — safe for all shells

### Coverage

| Shell | Bracketed Paste | Fixed? |
|-------|----------------|--------|
| zsh 5.x | Yes (default on) | Yes |
| bash 5.1+ | | bash 5.1+ | | bash 5.1+ | | bash 5.1+ | | bash 5.1+ | | bash 5.1+ | | bash 5.1+ | ativ| bax |
| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| kshis| ks|lso inclu| ks| ksle| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks) that reprodu| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| ks| km.js. These tests document which shells are affected:

- **zsh**: passes (runs in raw mode by default)
- **bash** (Homebrew 5.x): passes
- **bash** (`/bin/bash` 3.2): fails — confirms the bug
- **sh** (= bash 3.2 on macOS): fails — confirms the bug
- **ksh**: passes (but would fail with larger payloads)

Refs #296955, #298993, #300762
