### PR TITLE
fix: allow specifying an icon for config enums (fixes #123786)

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -6,6 +6,7 @@
 import { Event } from '../../../common/event.js';
 import { IDisposable } from '../../../common/lifecycle.js';
 import { isMacintosh } from '../../../common/platform.js';
+import { ThemeIcon } from '../../../common/themables.js';
 import { MarkdownActionHandler } from '../../markdownRenderer.js';
 import { IContextViewProvider } from '../contextview/contextview.js';
 import { IListStyles, unthemedListStyles } from '../list/listWidget.js';
@@ -45,6 +46,7 @@ export interface ISelectBoxOptions {
 // Utilize optionItem interface to capture all option parameters
 export interface ISelectOptionItem {
 	text: string;
+	icon?: ThemeIcon;
 	detail?: string;
 	decoratorRight?: string;
 	description?: string;

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -55,10 +55,17 @@
 	padding-left: 2px;
 }
 
+.monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row > .option-icon,
+.monaco-select-box-dropdown-container > .select-box-dropdown-container-width-control > .width-control-div > .option-icon {
+	width: 16px;
+	padding-left: 6px;
+	float: left;
+}
+
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row > .option-text {
 	text-overflow: ellipsis;
 	overflow: hidden;
-	padding-left: 6px;
+	padding-left: 4px;
 	white-space: nowrap;
 	float: left;
 }
@@ -92,6 +99,10 @@
 	visibility: hidden;
 	width: 0;
 	float: none;
+}
+
+.monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.option-separator > .option-icon {
+	display: none;
 }
 
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.option-separator > .option-detail {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -10,6 +10,7 @@ import { KeyCode, KeyCodeUtils } from '../../../common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../common/lifecycle.js';
 import { isMacintosh } from '../../../common/platform.js';
 import { ScrollbarVisibility } from '../../../common/scrollable.js';
+import { ThemeIcon } from '../../../common/themables.js';
 import * as cssJs from '../../cssValue.js';
 import * as dom from '../../dom.js';
 import * as domStylesheetsJs from '../../domStylesheets.js';
@@ -32,6 +33,7 @@ const SELECT_OPTION_ENTRY_TEMPLATE_ID = 'selectOption.entry.template';
 
 interface ISelectListTemplateData {
 	root: HTMLElement;
+	icon: HTMLElement;
 	text: HTMLElement;
 	detail: HTMLElement;
 	decoratorRight: HTMLElement;
@@ -44,6 +46,7 @@ class SelectListRenderer implements IListRenderer<ISelectOptionItem, ISelectList
 	renderTemplate(container: HTMLElement): ISelectListTemplateData {
 		const data: ISelectListTemplateData = Object.create(null);
 		data.root = container;
+		data.icon = dom.append(container, $('.option-icon'));
 		data.text = dom.append(container, $('.option-text'));
 		data.detail = dom.append(container, $('.option-detail'));
 		data.decoratorRight = dom.append(container, $('.option-decorator-right'));
@@ -54,12 +57,18 @@ class SelectListRenderer implements IListRenderer<ISelectOptionItem, ISelectList
 	renderElement(element: ISelectOptionItem, index: number, templateData: ISelectListTemplateData): void {
 		const data: ISelectListTemplateData = templateData;
 
+		const icon = element.icon;
 		const text = element.text;
 		const detail = element.detail;
 		const decoratorRight = element.decoratorRight;
 
 		const isDisabled = element.isDisabled;
 
+		data.icon.className = 'option-icon';
+		data.icon.style.display = icon ? '' : 'none';
+		if (icon) {
+			data.icon.classList.add(...ThemeIcon.asClassNameArray(icon));
+		}
 		data.text.textContent = text;
 		data.detail.textContent = !!detail ? detail : '';
 		data.decoratorRight.textContent = !!decoratorRight ? decoratorRight : '';
@@ -711,9 +720,12 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 					longestLength = len;
 				}
 			});
-
-
-			container.textContent = this.options[longest].text + (!!this.options[longest].decoratorRight ? `${this.options[longest].decoratorRight} ` : '');
+			const option = this.options[longest];
+			dom.clearNode(container);
+			if (option.icon) {
+				dom.append(container, $('span.option-icon' + ThemeIcon.asCSSSelector(option.icon)));
+			}
+			dom.append(container, document.createTextNode(option.text + (!!option.decoratorRight ? `${option.decoratorRight} ` : '')));
 			elementWidth = dom.getTotalWidth(container);
 		}
 

--- a/src/vs/base/test/browser/selectBox.test.ts
+++ b/src/vs/base/test/browser/selectBox.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { IContextViewProvider } from '../../browser/ui/contextview/contextview.js';
+import { SelectBox, unthemedSelectBoxStyles } from '../../browser/ui/selectBox/selectBox.js';
+import { ThemeIcon } from '../../common/themables.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('SelectBox', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('renders option icons in the custom dropdown', () => {
+		const host = document.createElement('div');
+		host.style.width = '240px';
+		document.body.appendChild(host);
+
+		const renderedContainers: HTMLElement[] = [];
+		const contextViewProvider: IContextViewProvider = {
+			showContextView: delegate => {
+				const container = document.createElement('div');
+				renderedContainers.push(container);
+				document.body.appendChild(container);
+				delegate.render(container);
+			},
+			hideContextView: () => {
+				while (renderedContainers.length) {
+					renderedContainers.pop()!.remove();
+				}
+			},
+			layout: () => { }
+		};
+
+		const selectBox = store.add(new SelectBox([{
+			text: 'Fast',
+			icon: ThemeIcon.fromId('zap')
+		}], 0, contextViewProvider, unthemedSelectBoxStyles, { useCustomDrawn: true }));
+		selectBox.render(host);
+
+		host.querySelector('select')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		assert.ok(document.querySelector('.option-icon.codicon.codicon-zap'));
+
+		host.remove();
+		contextViewProvider.hideContextView();
+	});
+});

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BrowserFeatures } from '../../../../base/browser/canIUse.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import * as domStylesheetsJs from '../../../../base/browser/domStylesheets.js';
 import { StandardKeyboardEvent } from '../../../../base/browser/keyboardEvent.js';
@@ -57,7 +56,6 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { getIgnoredSettings } from '../../../../platform/userDataSync/common/settingsMerge.js';
 import { IUserDataSyncEnablementService, getDefaultIgnoredSettings } from '../../../../platform/userDataSync/common/userDataSync.js';
-import { hasNativeContextMenu } from '../../../../platform/window/common/window.js';
 import { APPLICATION_SCOPES, APPLY_ALL_PROFILES_SETTING, IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -71,7 +69,7 @@ import { SettingsTarget } from './preferencesWidgets.js';
 import { ISettingOverrideClickEvent, SettingsTreeIndicatorsLabel, getIndicatorsLabelAriaLabel } from './settingsEditorSettingIndicators.js';
 import { ITOCEntry, ITOCFilter } from './settingsLayout.js';
 import { ISettingsEditorViewState, SettingsTreeElement, SettingsTreeGroupChild, SettingsTreeGroupElement, SettingsTreeNewExtensionsElement, SettingsTreeSettingElement, inspectSetting, objectSettingSupportsRemoveDefaultValue, settingKeyToDisplayFormat } from './settingsTreeModels.js';
-import { ExcludeSettingWidget, IBoolObjectDataItem, IIncludeExcludeDataItem, IListDataItem, IObjectDataItem, IObjectEnumOption, IObjectKeySuggester, IObjectValueSuggester, IncludeSettingWidget, ListSettingWidget, ObjectSettingCheckboxWidget, ObjectSettingDropdownWidget, ObjectValue, SettingListEvent } from './settingsWidgets.js';
+import { ExcludeSettingWidget, getEnumItemDescriptionAndIcon, IBoolObjectDataItem, IIncludeExcludeDataItem, IListDataItem, IObjectDataItem, IObjectEnumOption, IObjectKeySuggester, IObjectValueSuggester, IncludeSettingWidget, ListSettingWidget, ObjectSettingCheckboxWidget, ObjectSettingDropdownWidget, ObjectValue, SettingListEvent } from './settingsWidgets.js';
 
 const $ = DOM.$;
 
@@ -126,14 +124,16 @@ function getEnumOptionsFromSchema(schema: IJSONSchema): IObjectEnumOption[] {
 		return schema.anyOf.map(getEnumOptionsFromSchema).flat();
 	}
 
-	const enumDescriptions = schema.enumDescriptions ?? [];
+	const enumDescriptions = schema.markdownEnumDescriptions ?? schema.enumDescriptions ?? [];
+	const enumDescriptionsAreMarkdown = !!schema.markdownEnumDescriptions;
 
 	return (schema.enum ?? []).map((value, idx) => {
-		const description = idx < enumDescriptions.length
+		const rawDescription = idx < enumDescriptions.length
 			? enumDescriptions[idx]
 			: undefined;
+		const { description, icon } = getEnumItemDescriptionAndIcon(rawDescription, enumDescriptionsAreMarkdown);
 
-		return { value, description };
+		return { value, description, descriptionIsMarkdown: enumDescriptionsAreMarkdown, icon };
 	});
 }
 
@@ -306,8 +306,8 @@ function createArraySuggester(element: SettingsTreeSettingElement): IObjectKeySu
 			element.setting.enum.forEach((key, i) => {
 				// include the currently selected value, even if uniqueItems is true
 				if (!element.setting.uniqueItems || (idx !== undefined && key === keys[idx]) || !keys.includes(key)) {
-					const description = element.setting.enumDescriptions?.[i];
-					enumOptions.push({ value: key, description });
+					const { description, icon } = getEnumItemDescriptionAndIcon(element.setting.enumDescriptions?.[i], element.setting.enumDescriptionsAreMarkdown);
+					enumOptions.push({ value: key, description, descriptionIsMarkdown: element.setting.enumDescriptionsAreMarkdown, icon });
 				}
 			});
 		}
@@ -429,9 +429,12 @@ function getListDisplayValue(element: SettingsTreeSettingElement): IListDataItem
 		let enumOptions: IObjectEnumOption[] = [];
 		if (element.setting.enum) {
 			enumOptions = element.setting.enum.map((setting, i) => {
+				const { description, icon } = getEnumItemDescriptionAndIcon(element.setting.enumDescriptions?.[i], element.setting.enumDescriptionsAreMarkdown);
 				return {
 					value: setting,
-					description: element.setting.enumDescriptions?.[i]
+					description,
+					descriptionIsMarkdown: element.setting.enumDescriptionsAreMarkdown,
+					icon
 				};
 			});
 		}
@@ -1881,7 +1884,8 @@ class SettingEnumRenderer extends AbstractSettingRenderer implements ITreeRender
 		});
 
 		const selectBox = new SelectBox([], 0, this._contextViewService, styles, {
-			useCustomDrawn: !hasNativeContextMenu(this._configService) || !(isIOS && BrowserFeatures.pointerEvents)
+			// Custom rendering is required to show enum icons inside the dropdown list.
+			useCustomDrawn: true
 		});
 
 		common.toDispose.add(selectBox);
@@ -1941,8 +1945,10 @@ class SettingEnumRenderer extends AbstractSettingRenderer implements ITreeRender
 			.map(String)
 			.map(escapeInvisibleChars)
 			.map((data, index) => {
-				const description = (enumDescriptions[index] && (enumDescriptionsAreMarkdown ? fixSettingLinks(enumDescriptions[index], false) : enumDescriptions[index]));
+				const { description: rawDescription, icon } = getEnumItemDescriptionAndIcon(enumDescriptions[index], enumDescriptionsAreMarkdown);
+				const description = rawDescription && (enumDescriptionsAreMarkdown ? fixSettingLinks(rawDescription, false) : rawDescription);
 				return {
+					icon,
 					text: enumItemLabels[index] ? enumItemLabels[index] : data,
 					detail: enumItemLabels[index] ? data : '',
 					description,

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -27,6 +27,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { defaultButtonStyles, getInputBoxStyle, getSelectBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
+import { getIconRegistry } from '../../../../platform/theme/common/iconRegistry.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { hasNativeContextMenu } from '../../../../platform/window/common/window.js';
 import { SettingValueType } from '../../../services/preferences/common/preferences.js';
@@ -37,6 +38,7 @@ import './media/settingsWidgets.css';
 import { settingsDiscardIcon, settingsEditIcon, settingsRemoveIcon } from './preferencesIcons.js';
 
 const $ = DOM.$;
+const enumDescriptionIconRegex = /^(\$\([A-Za-z0-9-]+(?:~[A-Za-z]+)?\))(?:\s+)?([\s\S]*)$/;
 
 type EditKey = 'none' | 'create' | number;
 
@@ -256,7 +258,7 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 	}
 
 	protected createBasicSelectBox(value: IObjectEnumData): SelectBox {
-		const selectBoxOptions = value.options.map(({ value, description }) => ({ text: value, description }));
+		const selectBoxOptions = value.options.map(({ value, description, descriptionIsMarkdown, icon }) => ({ text: value, description, descriptionIsMarkdown, icon }));
 		const selected = value.options.findIndex(option => value.data === option.value);
 
 		const styles = getSelectBoxStyles({
@@ -268,7 +270,7 @@ export abstract class AbstractListSettingWidget<TDataItem extends object> extend
 
 
 		const selectBox = new SelectBox(selectBoxOptions, selected, this.contextViewService, styles, {
-			useCustomDrawn: !hasNativeContextMenu(this.configurationService) || !(isIOS && BrowserFeatures.pointerEvents)
+			useCustomDrawn: value.options.some(option => !!option.icon) || !hasNativeContextMenu(this.configurationService) || !(isIOS && BrowserFeatures.pointerEvents)
 		});
 		return selectBox;
 	}
@@ -864,6 +866,8 @@ interface IObjectStringData {
 export interface IObjectEnumOption {
 	value: string;
 	description?: string;
+	descriptionIsMarkdown?: boolean;
+	icon?: ThemeIcon;
 }
 
 interface IObjectEnumData {
@@ -888,6 +892,28 @@ export interface IObjectDataItem {
 	source?: string;
 	removable: boolean;
 	resetable: boolean;
+}
+
+export function getEnumItemDescriptionAndIcon(description: string | undefined, descriptionIsMarkdown: boolean | undefined): { description?: string; icon?: ThemeIcon } {
+	if (!description || !descriptionIsMarkdown) {
+		return { description };
+	}
+
+	const match = enumDescriptionIconRegex.exec(description.trimStart());
+	if (!match) {
+		return { description };
+	}
+
+	const icon = ThemeIcon.fromString(match[1]);
+	if (!icon || !getIconRegistry().getIcon(icon.id)) {
+		return { description };
+	}
+
+	const remainingDescription = match[2].trimStart();
+	return {
+		icon,
+		description: remainingDescription || undefined
+	};
 }
 
 export interface IIncludeExcludeDataItem {

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsWidgets.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsWidgets.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { getEnumItemDescriptionAndIcon } from '../../browser/settingsWidgets.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+
+suite('SettingsWidgets', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('extracts an icon-only markdown enum description', () => {
+		const result = getEnumItemDescriptionAndIcon('$(terminal-bash)', true);
+
+		assert.strictEqual(result.icon?.id, 'terminal-bash');
+		assert.strictEqual(result.description, undefined);
+	});
+
+	test('extracts a leading icon and keeps the remaining markdown description', () => {
+		const result = getEnumItemDescriptionAndIcon('$(zap) **Fast** option', true);
+
+		assert.strictEqual(result.icon?.id, 'zap');
+		assert.strictEqual(result.description, '**Fast** option');
+	});
+
+	test('ignores icon markup in non-markdown enum descriptions', () => {
+		const result = getEnumItemDescriptionAndIcon('$(zap)', false);
+
+		assert.strictEqual(result.icon, undefined);
+		assert.strictEqual(result.description, '$(zap)');
+	});
+});

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsWidgets.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsWidgets.test.ts
@@ -8,7 +8,7 @@ import { getEnumItemDescriptionAndIcon } from '../../browser/settingsWidgets.js'
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 
 suite('SettingsWidgets', () => {
-	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('extracts an icon-only markdown enum description', () => {
 		const result = getEnumItemDescriptionAndIcon('$(terminal-bash)', true);


### PR DESCRIPTION
Fixes #123786

## Summary

This PR adds support for displaying icons alongside configuration enum values in the Settings UI dropdown. Extension authors can prefix `markdownEnumDescriptions` with a codicon reference (for example `$(zap) Fast mode`) and the icon will render in the custom select box dropdown.

## Changes

- Add optional `icon?: ThemeIcon` to `ISelectOptionItem`.
- Render a codicon `<span>` in `SelectListRenderer` when an option includes an icon.
- Add styles for `.option-icon` in `selectBoxCustom.css`.
- Parse leading `$(icon-id)` markers from `markdownEnumDescriptions` in `settingsWidgets.ts` and validate them against the codicon registry.
- Wire the parsed icon through `settingsTree.ts` so enum settings use the custom select box dropdown when icons are present.
- Add browser and unit coverage for icon extraction and rendering.

## Validation

- TypeScript typecheck passed.
- ESLint passed on the changed TypeScript files.
- Node unit tests passed.
- Format check passed with no reformatting needed.
- `git diff --name-only origin/main...HEAD` contains only the expected 7 changed files for this fix.
- No `package.json` or `tsconfig*.json` changes.

## How to test

1. Install an extension (or add a test setting) that uses `markdownEnumDescriptions` with a leading codicon, for example:
   ```json
   "markdownEnumDescriptions": [
     "$(zap) Fast mode",
     "$(shield) Safe mode"
   ]
   ```
2. Open **Settings**, find the setting, and open the dropdown.
3. Verify the codicon appears to the left of each option label.
4. Verify options without icons still render correctly.