### PR TITLE
fix: preserve X11 primary selection in quick input (fixes #167266)

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -320,13 +320,14 @@ export class InputBox extends Widget {
 	}
 
 	public select(range: IRange | null = null): void {
-		this.input.select();
-
 		if (range) {
+			this.input.focus();
 			this.input.setSelectionRange(range.start, range.end);
 			if (range.end === this.input.value.length) {
 				this.input.scrollLeft = this.input.scrollWidth;
 			}
+		} else {
+			this.input.select();
 		}
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string>;
+		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
+		placeholder: IEditorOption<EditorOption.placeholder, string>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -278,4 +278,35 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		assert.strictEqual(activeItemsFromEvent.length, 0);
 		assert.strictEqual(quickpick.activeItems.length, 0);
 	});
+
+	test('switching from hidden input to visible input focuses the quick pick input without selecting the full value #167266', () => {
+		const quickpick = store.add(controller.createQuickPick());
+		quickpick.items = [{ label: 'step 1' }];
+		quickpick.value = '>test';
+		quickpick.hideInput = true;
+		quickpick.show();
+
+		const input = mainWindow.document.querySelector('.quick-input-box input') as HTMLInputElement | null;
+		assert.ok(input);
+		assert.notStrictEqual(mainWindow.document.activeElement, input);
+
+		let selectCalls = 0;
+		const originalSelect = input.select.bind(input);
+		input.select = () => {
+			selectCalls++;
+			return originalSelect();
+		};
+
+		try {
+			quickpick.hideInput = false;
+			quickpick.valueSelection = [1, quickpick.value.length];
+
+			assert.strictEqual(mainWindow.document.activeElement, input);
+			assert.strictEqual(input.selectionStart, 1);
+			assert.strictEqual(input.selectionEnd, quickpick.value.length);
+			assert.strictEqual(selectCalls, 0);
+		} finally {
+			input.select = originalSelect;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #167266

On Linux/X11, quick inputs could overwrite the primary selection buffer because `InputBox.select()` always called `this.input.select()` before applying any range-based selection. This keeps full-value selection for the no-range case, but when a range is provided it focuses the input and applies `setSelectionRange(...)` directly so the existing X11 primary selection is preserved.

## Changes

- Update `src/vs/base/browser/ui/inputbox/inputBox.ts` so full-input `select()` only runs when no selection range is requested.
- Add a regression test in `src/vs/platform/quickinput/test/browser/quickinput.test.ts` that covers the reverted quick input focus case when switching from hidden to visible input with `valueSelection`.

## Validation

- `npm ci`
- `npm run compile`
- `npm run eslint`
- `node test/unit/browser/index.js --browser chromium --run src/vs/platform/quickinput/test/browser/quickinput.test.ts`
- Changed-file format/hygiene gate passed with no reformatting needed.
- `git diff --name-only origin/main...HEAD` now contains only `src/vs/base/browser/ui/inputbox/inputBox.ts` and `src/vs/platform/quickinput/test/browser/quickinput.test.ts`; no config files changed.

## Review routing

- PR #167274 was reverted by #168657 because quick input focus regressed; this change keeps focus in the range-selection path.
- `.github/CODENOTIFY` routes `src/vs/platform/quickinput/**` to `@TylerLeonhardt`.
