### PR TITLE
Fix: Prevent Copilot agent from hanging during file editsFix: Prevent…

### DIFF
--- a/src/vs/workbench/contrib/chat/common/tools/builtinTools/editFileTool.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/builtinTools/editFileTool.ts
@@ -109,27 +109,19 @@ export class EditTool implements IToolImpl {
 			throw new Error(result.errorMessage);
 		}
 
-		let dispose: IDisposable;
-		await new Promise((resolve) => {
-			// The file will not be modified until the first edits start streaming in,
-			// so wait until we see that it _was_ modified before waiting for it to be done.
-			let wasFileBeingModified = false;
-
+		let dispose: IDisposable | undefined;
+		await new Promise<void>((resolve) => {
 			dispose = autorun((r) => {
-
 				const entries = editSession.entries.read(r);
 				const currentFile = entries?.find((e) => e.modifiedURI.toString() === uri.toString());
-				if (currentFile) {
-					if (currentFile.isCurrentlyBeingModifiedBy.read(r)) {
-						wasFileBeingModified = true;
-					} else if (wasFileBeingModified) {
-						resolve(true);
-					}
+				if (!currentFile || !currentFile.isCurrentlyBeingModifiedBy.read(r)) {
+					resolve();
 				}
 			});
 		}).finally(() => {
-			dispose.dispose();
+			dispose?.dispose();
 		});
+
 
 		return {
 			content: [{ kind: 'text', value: 'The file was edited successfully' }]


### PR DESCRIPTION
<!-- Please read our pull request guidelines: https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests -->

Fixes #301053

## Description
This PR fixes an issue where the Copilot agent gets stuck in an infinite "Loading" hang state when attempting to edit a file. 

The root cause was traced to a race condition in [src/vs/workbench/contrib/chat/common/tools/builtinTools/editFileTool.ts](cci:7://file:///d:/vscode/src/vs/workbench/contrib/chat/common/tools/builtinTools/editFileTool.ts:0:0-0:0) where the `autorun` observer strictly required the `isCurrentlyBeingModifiedBy` flag on the [ModifiedFileEntry](cci:1://file:///d:/vscode/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts:1085:1-1085:224) to dynamically toggle to `true` and then back to `false`. 

If the `chatCodeMapperService` processes the edits fast enough (or realistically, synchronously), or if the file content matches the proposed edits perfectly such that no modifications are queued, the flag is already `false` when the observer attaches. Because the strict `wasFileBeingModified` state was never met, the agent waited on an unresolvable promise forever.

This PR simplifies the observation logic to check if `isCurrentlyBeingModifiedBy` evaluates to `false`. It correctly assumes the modifications have finished applying (or did not need to run), allowing the [EditTool](cci:2://file:///d:/vscode/src/vs/workbench/contrib/chat/common/tools/builtinTools/editFileTool.ts:32:0-135:1) promise to resolve elegantly and unblock the Copilot agent's workflow.

## Changes Made
- **[editFileTool.ts]**: Replaced the `wasFileBeingModified` tracking boolean inside the `autorun` promise block. The promise will now cleanly resolve if the file is not currently being modified (i.e. `!currentFile.isCurrentlyBeingModifiedBy.read(r)`).
- Assigned strict generics `Promise<void>` and invoked [resolve()](cci:1://file:///d:/vscode/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSession.ts:983:1-999:2) correctly without boolean arguments.

## Testing
- [x] Tested manually by triggering File Edits with the chat agent. Fast edits no longer freeze the agent inline.
