### PR TITLE
Add inline hover action buttons to Chat Customizations views

### DIFF
--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string>;
+		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
+		placeholder: IEditorOption<EditorOption.placeholder, string>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -14,6 +14,9 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 
 //#region Utilities
 
@@ -79,7 +82,60 @@ registerAction2(class extends Action2 {
 	}
 });
 
+// Delete file action
+const DELETE_AI_CUSTOMIZATION_FILE_ID = 'aiCustomization.deleteFile';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: DELETE_AI_CUSTOMIZATION_FILE_ID,
+			title: localize2('delete', "Delete"),
+			icon: Codicon.trash,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+		const fileService = accessor.get(IFileService);
+		const dialogService = accessor.get(IDialogService);
+		const uri = extractURI(context);
+		const name = typeof context === 'object' && !URI.isUri(context) ? (context as { name?: string }).name ?? '' : '';
+
+		const confirmation = await dialogService.confirm({
+			message: localize('confirmDelete', "Are you sure you want to delete '{0}'?", name || uri.path),
+			primaryButton: localize('delete', "Delete"),
+		});
+
+		if (confirmation.confirmed) {
+			await fileService.del(uri);
+		}
+	}
+});
+
+// Copy path action
+const COPY_AI_CUSTOMIZATION_PATH_ID = 'aiCustomization.copyPath';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: COPY_AI_CUSTOMIZATION_PATH_ID,
+			title: localize2('copyPath', "Copy Path"),
+			icon: Codicon.clippy,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+		const clipboardService = accessor.get(IClipboardService);
+		const uri = extractURI(context);
+		await clipboardService.writeText(uri.fsPath);
+	}
+});
+
 // Register context menu items
+
+// Inline hover actions (shown as icon buttons on hover)
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: DELETE_AI_CUSTOMIZATION_FILE_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
+	group: 'inline',
+	order: 10,
+});
+
+// Context menu items (shown on right-click)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: OPEN_AI_CUSTOMIZATION_FILE_ID, title: localize('open', "Open") },
 	group: '1_open',
@@ -91,6 +147,18 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	group: '2_run',
 	order: 1,
 	when: ContextKeyExpr.equals(AICustomizationItemTypeContextKey.key, PromptsType.prompt),
+});
+
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: COPY_AI_CUSTOMIZATION_PATH_ID, title: localize('copyPath', "Copy Path") },
+	group: '3_modify',
+	order: 1,
+});
+
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: DELETE_AI_CUSTOMIZATION_FILE_ID, title: localize('delete', "Delete") },
+	group: '3_modify',
+	order: 10,
 });
 
 //#endregion

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -98,13 +98,17 @@ registerAction2(class extends Action2 {
 		const uri = extractURI(context);
 		const name = typeof context === 'object' && !URI.isUri(context) ? (context as { name?: string }).name ?? '' : '';
 
+		if (uri.scheme !== 'file') {
+			return;
+		}
+
 		const confirmation = await dialogService.confirm({
 			message: localize('confirmDelete', "Are you sure you want to delete '{0}'?", name || uri.path),
 			primaryButton: localize('delete', "Delete"),
 		});
 
 		if (confirmation.confirmed) {
-			await fileService.del(uri);
+			await fileService.del(uri, { useTrash: true, recursive: true });
 		}
 	}
 });
@@ -122,7 +126,8 @@ registerAction2(class extends Action2 {
 	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
 		const clipboardService = accessor.get(IClipboardService);
 		const uri = extractURI(context);
-		await clipboardService.writeText(uri.fsPath);
+		const textToCopy = uri.scheme === 'file' ? uri.fsPath : uri.toString(true);
+		await clipboardService.writeText(textToCopy);
 	}
 });
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -249,6 +249,7 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
 			uri: item.uri.toString(),
 			name: item.name,
 			promptType: item.promptType,
+			storage: item.storage,
 		};
 
 		// Create scoped context key service with item type for when-clause filtering

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -5,6 +5,7 @@
 
 import './media/aiCustomizationTreeView.css';
 import * as dom from '../../../../base/browser/dom.js';
+import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
@@ -12,7 +13,7 @@ import { basename, dirname } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
-import { getContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { createActionViewItem, getContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IMenuService } from '../../../../platform/actions/common/actions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
@@ -149,6 +150,9 @@ interface IFileTemplateData {
 	readonly container: HTMLElement;
 	readonly icon: HTMLElement;
 	readonly name: HTMLElement;
+	readonly actionBar: ActionBar;
+	readonly elementDisposables: DisposableStore;
+	readonly templateDisposables: DisposableStore;
 }
 
 class AICustomizationCategoryRenderer implements ITreeRenderer<IAICustomizationTypeItem | IAICustomizationLinkItem, FuzzyScore, ICategoryTemplateData> {
@@ -189,15 +193,29 @@ class AICustomizationGroupRenderer implements ITreeRenderer<IAICustomizationGrou
 class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileItem, FuzzyScore, IFileTemplateData> {
 	readonly templateId = 'file';
 
+	constructor(
+		private readonly menuService: IMenuService,
+		private readonly contextKeyService: IContextKeyService,
+		private readonly instantiationService: IInstantiationService,
+	) { }
+
 	renderTemplate(container: HTMLElement): IFileTemplateData {
 		const element = dom.append(container, dom.$('.ai-customization-tree-item'));
 		const icon = dom.append(element, dom.$('.icon'));
 		const name = dom.append(element, dom.$('.name'));
-		return { container: element, icon, name };
+		const actionsContainer = dom.append(element, dom.$('.actions'));
+
+		const templateDisposables = new DisposableStore();
+		const actionBar = templateDisposables.add(new ActionBar(actionsContainer, {
+			actionViewItemProvider: createActionViewItem.bind(undefined, this.instantiationService),
+		}));
+
+		return { container: element, icon, name, actionBar, elementDisposables: new DisposableStore(), templateDisposables };
 	}
 
 	renderElement(node: ITreeNode<IAICustomizationFileItem, FuzzyScore>, _index: number, templateData: IFileTemplateData): void {
 		const item = node.element;
+		templateData.elementDisposables.clear();
 
 		// Set icon based on prompt type
 		let icon: ThemeIcon;
@@ -225,9 +243,44 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
 		// Set tooltip with name and description
 		const tooltip = item.description ? `${item.name} - ${item.description}` : item.name;
 		templateData.container.title = tooltip;
+
+		// Build context for menu actions
+		const context = {
+			uri: item.uri.toString(),
+			name: item.name,
+			promptType: item.promptType,
+		};
+
+		// Create scoped context key service with item type for when-clause filtering
+		const overlay = this.contextKeyService.createOverlay([
+			[AICustomizationItemTypeContextKey.key, item.promptType],
+		]);
+
+		// Create menu and extract inline actions
+		const menu = templateData.elementDisposables.add(
+			this.menuService.createMenu(AICustomizationItemMenuId, overlay)
+		);
+
+		const updateActions = () => {
+			const actions = menu.getActions({ arg: context, shouldForwardArgs: true });
+			const { primary } = getContextMenuActions(actions, 'inline');
+			templateData.actionBar.clear();
+			templateData.actionBar.push(primary, { icon: true, label: false });
+		};
+		updateActions();
+		templateData.elementDisposables.add(menu.onDidChange(updateActions));
+
+		templateData.actionBar.context = context;
 	}
 
-	disposeTemplate(_templateData: IFileTemplateData): void { }
+	disposeElement(_node: ITreeNode<IAICustomizationFileItem, FuzzyScore>, _index: number, templateData: IFileTemplateData): void {
+		templateData.elementDisposables.clear();
+	}
+
+	disposeTemplate(templateData: IFileTemplateData): void {
+		templateData.templateDisposables.dispose();
+		templateData.elementDisposables.dispose();
+	}
 }
 
 /**
@@ -575,7 +628,7 @@ export class AICustomizationViewPane extends ViewPane {
 			[
 				new AICustomizationCategoryRenderer(),
 				new AICustomizationGroupRenderer(),
-				new AICustomizationFileRenderer(),
+				new AICustomizationFileRenderer(this.menuService, this.contextKeyService, this.instantiationService),
 			],
 			this.dataSource,
 			{

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/media/aiCustomizationTreeView.css
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/media/aiCustomizationTreeView.css
@@ -31,9 +31,22 @@
 }
 
 .ai-customization-view .ai-customization-tree-item .name {
+	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.ai-customization-view .ai-customization-tree-item .actions {
+	display: none;
+	flex-shrink: 0;
+	max-width: fit-content;
+}
+
+.ai-customization-view .monaco-list .monaco-list-row:hover .ai-customization-tree-item > .actions,
+.ai-customization-view .monaco-list .monaco-list-row.focused .ai-customization-tree-item > .actions,
+.ai-customization-view .monaco-list .monaco-list-row.selected .ai-customization-tree-item > .actions {
+	display: flex;
 }
 
 .ai-customization-view .ai-customization-tree-item .description {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -575,6 +575,13 @@ export class AICustomizationListWidget extends Disposable {
 		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
 		this._register(this.promptsService.onDidChangeSlashCommands(() => this.refresh()));
 
+		// Refresh on file deletions so the list updates after inline delete actions
+		this._register(this.fileService.onDidFilesChange(e => {
+			if (e.gotDeleted()) {
+				this.refresh();
+			}
+		}));
+
 		// Section footer at bottom with description and link
 		this.sectionHeader = DOM.append(this.element, $('.section-footer'));
 		this.sectionDescription = DOM.append(this.sectionHeader, $('p.section-footer-description'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -5,6 +5,7 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { ActionBar } from '../../../../../base/browser/ui/actionbar/actionbar.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
@@ -31,7 +32,7 @@ import { IOpenerService } from '../../../../../platform/opener/common/opener.js'
 import { Button, ButtonWithDropdown } from '../../../../../base/browser/ui/button/button.js';
 import { IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
-import { getFlatContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { createActionViewItem, getContextMenuActions, getFlatContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
@@ -135,6 +136,7 @@ class AICustomizationListDelegate implements IListVirtualDelegate<IListEntry> {
 interface IAICustomizationItemTemplateData {
 	readonly container: HTMLElement;
 	readonly actionsContainer: HTMLElement;
+	readonly actionBar: ActionBar;
 	readonly typeIcon: HTMLElement;
 	readonly nameLabel: HighlightedLabel;
 	readonly description: HighlightedLabel;
@@ -251,6 +253,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 	constructor(
 		@IHoverService private readonly hoverService: IHoverService,
 		@ILabelService private readonly labelService: ILabelService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) { }
 
 	renderTemplate(container: HTMLElement): IAICustomizationItemTemplateData {
@@ -267,10 +272,14 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 
 		// Right section for actions (hover-visible)
 		const actionsContainer = DOM.append(container, $('.item-right'));
+		const actionBar = disposables.add(new ActionBar(actionsContainer, {
+			actionViewItemProvider: createActionViewItem.bind(undefined, this.instantiationService),
+		}));
 
 		return {
 			container,
 			actionsContainer,
+			actionBar,
 			typeIcon,
 			nameLabel,
 			description,
@@ -334,6 +343,29 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			templateData.description.set('', undefined);
 			templateData.description.element.style.display = 'none';
 		}
+
+		// Inline action bar from menu
+		const context = {
+			uri: element.uri.toString(),
+			name: element.name,
+			promptType: element.promptType,
+			storage: element.storage,
+		};
+
+		const menu = templateData.elementDisposables.add(
+			this.menuService.createMenu(AICustomizationManagementItemMenuId, this.contextKeyService)
+		);
+
+		const updateActions = () => {
+			const actions = menu.getActions({ arg: context, shouldForwardArgs: true });
+			const { primary } = getContextMenuActions(actions, 'inline');
+			templateData.actionBar.clear();
+			templateData.actionBar.push(primary, { icon: true, label: false });
+		};
+		updateActions();
+		templateData.elementDisposables.add(menu.onDidChange(updateActions));
+
+		templateData.actionBar.context = context;
 	}
 
 	disposeTemplate(templateData: IAICustomizationItemTemplateData): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -32,7 +32,7 @@ import { IOpenerService } from '../../../../../platform/opener/common/opener.js'
 import { Button, ButtonWithDropdown } from '../../../../../base/browser/ui/button/button.js';
 import { IMenuService } from '../../../../../platform/actions/common/actions.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
-import { createActionViewItem, getContextMenuActions, getFlatContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { createActionViewItem, getContextMenuActions } from '../../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
 import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
@@ -607,13 +607,13 @@ export class AICustomizationListWidget extends Disposable {
 			storage: item.storage,
 		};
 
-		// Get menu actions
+		// Get menu actions, excluding inline actions to avoid duplicates
 		const actions = this.menuService.getMenuActions(AICustomizationManagementItemMenuId, this.contextKeyService, {
 			arg: context,
 			shouldForwardArgs: true,
 		});
 
-		const flatActions = getFlatContextMenuActions(actions);
+		const { secondary } = getContextMenuActions(actions, 'inline');
 
 		// Add copy path actions
 		const copyActions = [
@@ -636,7 +636,7 @@ export class AICustomizationListWidget extends Disposable {
 
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => e.anchor,
-			getActions: () => [...flatActions, ...copyActions],
+			getActions: () => [...secondary, ...copyActions],
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -39,6 +39,7 @@ import { basename, dirname } from '../../../../../base/common/resources.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, isMacintosh } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 
 //#region Telemetry
 
@@ -270,10 +271,42 @@ registerAction2(class extends Action2 {
 	}
 });
 
+// Copy path action
+const COPY_AI_CUSTOMIZATION_PATH_ID = 'aiCustomizationManagement.copyPath';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: COPY_AI_CUSTOMIZATION_PATH_ID,
+			title: localize2('copyPath', "Copy Path"),
+			icon: Codicon.clippy,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
+		const clipboardService = accessor.get(IClipboardService);
+		const uri = extractURI(context);
+		await clipboardService.writeText(uri.fsPath);
+	}
+});
+
 // Context Key for prompt type to conditionally show "Run Prompt"
 const AI_CUSTOMIZATION_ITEM_TYPE_KEY = 'aiCustomizationManagementItemType';
 
 // Register context menu items
+
+// Inline hover actions (shown as icon buttons on hover)
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: COPY_AI_CUSTOMIZATION_PATH_ID, title: localize('copyPath', "Copy Path"), icon: Codicon.clippy },
+	group: 'inline',
+	order: 1,
+});
+
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: DELETE_AI_CUSTOMIZATION_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
+	group: 'inline',
+	order: 10,
+});
+
+// Context menu items (shown on right-click)
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: OPEN_AI_CUSTOMIZATION_MGMT_FILE_ID, title: localize('open', "Open") },
 	group: '1_open',

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -284,7 +284,8 @@ registerAction2(class extends Action2 {
 	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
 		const clipboardService = accessor.get(IClipboardService);
 		const uri = extractURI(context);
-		await clipboardService.writeText(uri.fsPath);
+		const textToCopy = uri.scheme === 'file' ? uri.fsPath : uri.toString(true);
+		await clipboardService.writeText(textToCopy);
 	}
 });
 


### PR DESCRIPTION
## Summary

Adds menu-contributable inline hover action buttons to the Chat Customizations UI, addressing part of #297343.

### Management Editor (main UI)
- Added an `ActionBar` to `AICustomizationItemRenderer` inside the existing `.item-right` container
- The container already had CSS opacity transitions for hover — now populated with menu-driven actions
- **Delete** (trash icon) appears as a hover button on each list item
- Actions are sourced from `AICustomizationManagementItemMenuId` menu's `inline` group

### Sidebar Tree View (sessions window)  
- Updated `AICustomizationFileRenderer` with an `ActionBar` populated from `AICustomizationItemMenuId`
- Added new actions: **Delete** (with confirmation dialog), **Copy Path** (to clipboard)
- Delete appears as inline hover button; Copy Path in context menu
- Added CSS for hover/focused/selected visibility states

### Architecture
Both views use the standard VS Code pattern: `ActionBar` in renderer + `IMenuService` with `inline` group filtering. Any contribution can add hover buttons by registering actions in the respective menu ID with `group: 'inline'`.