### PR TITLE
feat: Add explorer context menu for opening images in carousel

### DIFF
--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -24,7 +24,7 @@ import { ResourceContextKey } from '../../../common/contextkeys.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
-import { basename, dirname } from '../../../../base/common/resources.js';
+import { basename, dirname, extname } from '../../../../base/common/resources.js';
 import { ResourceSet } from '../../../../base/common/map.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
@@ -166,8 +166,7 @@ const IMAGE_EXTENSION_REGEX = (function () {
 })();
 
 function isImageResource(uri: URI): boolean {
-	const mimeType = getMediaMime(uri.path);
-	return !!mimeType && mimeType.startsWith('image/');
+	return IMAGE_EXTENSION_REGEX.test(extname(uri));
 }
 
 async function collectImageFilesFromFolder(fileService: IFileService, folderUri: URI): Promise<URI[]> {

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -15,8 +15,16 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { ImageCarouselEditor } from './imageCarouselEditor.js';
 import { ImageCarouselEditorInput } from './imageCarouselEditorInput.js';
-import { IImageCarouselCollection } from './imageCarouselTypes.js';
-import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICarouselImage, IImageCarouselCollection } from './imageCarouselTypes.js';
+import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ExplorerFolderContext } from '../../files/common/files.js';
+import { IExplorerService } from '../../files/browser/files.js';
+import { ResourceContextKey } from '../../../common/contextkeys.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { getMediaMime } from '../../../../base/common/mime.js';
+import { URI } from '../../../../base/common/uri.js';
+import { basename, dirname } from '../../../../base/common/resources.js';
 
 // --- Editor Pane Registration ---
 
@@ -122,3 +130,144 @@ class OpenImageInCarouselAction extends Action2 {
 }
 
 registerAction2(OpenImageInCarouselAction);
+
+// --- Explorer Context Menu Integration ---
+
+const IMAGE_EXTENSION_REGEX = /^\.(png|jpe?g|jpe|gif|webp|svg|bmp|ico|tiff?|tga|psd)$/i;
+
+function isImageResource(uri: URI): boolean {
+	const mimeType = getMediaMime(uri.path);
+	return !!mimeType && mimeType.startsWith('image/');
+}
+
+async function collectImageFilesFromFolder(fileService: IFileService, folderUri: URI): Promise<URI[]> {
+	const stat = await fileService.resolve(folderUri);
+	const imageUris: URI[] = [];
+	if (stat.children) {
+		for (const child of stat.children) {
+			if (!child.isDirectory && isImageResource(child.resource)) {
+				imageUris.push(child.resource);
+			}
+		}
+	}
+	return imageUris;
+}
+
+async function readImageFiles(fileService: IFileService, uris: URI[]): Promise<ICarouselImage[]> {
+	const images: ICarouselImage[] = [];
+	for (const uri of uris) {
+		try {
+			const content = await fileService.readFile(uri);
+			const mimeType = getMediaMime(uri.path) ?? 'image/png';
+			images.push({
+				id: generateUuid(),
+				name: basename(uri),
+				mimeType,
+				data: content.value,
+				uri,
+			});
+		} catch {
+			// Skip files that cannot be read
+		}
+	}
+	return images;
+}
+
+class OpenImagesInCarouselFromExplorerAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.openImagesInCarousel',
+			title: localize2('openImagesInCarousel', "Open Images in Carousel"),
+			f1: false,
+			menu: [{
+				id: MenuId.ExplorerContext,
+				group: 'navigation',
+				order: 25,
+				when: ContextKeyExpr.or(
+					ExplorerFolderContext,
+					ContextKeyExpr.regex(ResourceContextKey.Extension.key, IMAGE_EXTENSION_REGEX),
+				),
+			}],
+		});
+	}
+
+	async run(accessor: ServicesAccessor, resource?: URI): Promise<void> {
+		const explorerService = accessor.get(IExplorerService);
+		const fileService = accessor.get(IFileService);
+		const editorService = accessor.get(IEditorService);
+
+		const context = explorerService.getContext(true);
+		if (context.length === 0) {
+			return;
+		}
+
+		let imageUris: URI[] = [];
+		let startUri: URI | undefined;
+
+		const hasSingleImageFile = context.length === 1 && !context[0].isDirectory && isImageResource(context[0].resource);
+
+		if (hasSingleImageFile) {
+			// Single image: show all sibling images in the same folder with
+			// the selected image focused
+			startUri = context[0].resource;
+			const parentUri = dirname(context[0].resource);
+			imageUris = await collectImageFilesFromFolder(fileService, parentUri);
+		} else {
+			// Multiple items or a folder: collect images from selection,
+			// deduplicating in case a folder and its children are both selected
+			const seen = new Set<string>();
+			for (const item of context) {
+				if (item.isDirectory) {
+					const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
+					for (const uri of folderImages) {
+						const key = uri.toString();
+						if (!seen.has(key)) {
+							seen.add(key);
+							imageUris.push(uri);
+						}
+					}
+				} else if (isImageResource(item.resource)) {
+					const key = item.resource.toString();
+					if (!seen.has(key)) {
+						seen.add(key);
+						imageUris.push(item.resource);
+						if (!startUri) {
+							startUri = item.resource;
+						}
+					}
+				}
+			}
+		}
+
+		if (imageUris.length === 0) {
+			return;
+		}
+
+		const images = await readImageFiles(fileService, imageUris);
+		if (images.length === 0) {
+			return;
+		}
+
+		let startIndex = 0;
+		if (startUri) {
+			const idx = images.findIndex(img => img.uri?.toString() === startUri!.toString());
+			if (idx >= 0) {
+				startIndex = idx;
+			}
+		}
+
+		const collection: IImageCarouselCollection = {
+			id: generateUuid(),
+			title: localize('imageCarousel.explorerTitle', "Image Carousel"),
+			sections: [{
+				title: '',
+				images,
+			}],
+		};
+
+		const input = new ImageCarouselEditorInput(collection, startIndex);
+		await editorService.openEditor(input, { pinned: true }, MODAL_GROUP);
+	}
+}
+
+registerAction2(OpenImagesInCarouselFromExplorerAction);

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -27,6 +27,23 @@ import { URI } from '../../../../base/common/uri.js';
 import { basename, dirname } from '../../../../base/common/resources.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+
+// --- Configuration ---
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'imageCarousel',
+	title: localize('imageCarouselConfigurationTitle', "Image Carousel"),
+	type: 'object',
+	properties: {
+		'imageCarousel.explorerContextMenu.enabled': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize('imageCarousel.explorerContextMenu.enabled', "Controls whether the **Open Images in Carousel** option appears in the Explorer context menu. This is an experimental feature."),
+			tags: ['experimental'],
+		},
+	}
+});
 
 // --- Editor Pane Registration ---
 
@@ -190,9 +207,12 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 				id: MenuId.ExplorerContext,
 				group: 'navigation',
 				order: 25,
-				when: ContextKeyExpr.or(
-					ExplorerFolderContext,
-					ContextKeyExpr.regex(ResourceContextKey.Extension.key, IMAGE_EXTENSION_REGEX),
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.has('config.imageCarousel.explorerContextMenu.enabled'),
+					ContextKeyExpr.or(
+						ExplorerFolderContext,
+						ContextKeyExpr.regex(ResourceContextKey.Extension.key, IMAGE_EXTENSION_REGEX),
+					),
 				),
 			}],
 		});

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -29,6 +29,7 @@ import { ResourceSet } from '../../../../base/common/map.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Limiter } from '../../../../base/common/async.js';
 
 // --- Configuration ---
 
@@ -159,7 +160,7 @@ registerAction2(OpenImageInCarouselAction);
  * of truth with `base/common/mime.ts`.
  */
 const IMAGE_EXTENSION_REGEX = (function () {
-	const candidates = ['png', 'jpg', 'jpeg', 'jpe', 'gif', 'webp', 'svg', 'bmp', 'ico', 'tif', 'tiff', 'tga', 'psd'];
+	const candidates = ['png', 'jpg', 'jpeg', 'jpe', 'gif', 'webp', 'svg', 'bmp', 'ico'];
 	const imageExts = candidates.filter(ext => getMediaMime(`f.${ext}`)?.startsWith('image/'));
 	return new RegExp(`^\\.(${imageExts.join('|')})$`, 'i');
 })();
@@ -170,40 +171,39 @@ function isImageResource(uri: URI): boolean {
 }
 
 async function collectImageFilesFromFolder(fileService: IFileService, folderUri: URI): Promise<URI[]> {
-	try {
-		const stat = await fileService.resolve(folderUri);
-		const imageUris: URI[] = [];
-		if (stat.children) {
-			for (const child of stat.children) {
-				if (child.isFile && isImageResource(child.resource)) {
-					imageUris.push(child.resource);
-				}
+	const stat = await fileService.resolve(folderUri);
+	const imageUris: URI[] = [];
+	if (stat.children) {
+		for (const child of stat.children) {
+			if (child.isFile && isImageResource(child.resource)) {
+				imageUris.push(child.resource);
 			}
 		}
-		return imageUris;
-	} catch {
-		// Folder may not exist or be inaccessible (e.g. permission denied)
-		return [];
 	}
+	imageUris.sort((a, b) => basename(a).localeCompare(basename(b)));
+	return imageUris;
 }
 
 async function readImageFiles(fileService: IFileService, uris: URI[]): Promise<ICarouselImage[]> {
-	const results = await Promise.allSettled(
-		uris.map(async (uri): Promise<ICarouselImage> => {
-			const content = await fileService.readFile(uri);
-			const mimeType = getMediaMime(uri.path) ?? 'image/png';
-			return {
-				id: generateUuid(),
-				name: basename(uri),
-				mimeType,
-				data: content.value,
-				uri,
-			};
-		})
+	const limiter = new Limiter<ICarouselImage | undefined>(10);
+	const results = await Promise.all(
+		uris.map(uri => limiter.queue(async () => {
+			try {
+				const content = await fileService.readFile(uri);
+				const mimeType = getMediaMime(uri.path) ?? 'image/png';
+				return {
+					id: generateUuid(),
+					name: basename(uri),
+					mimeType,
+					data: content.value,
+					uri,
+				};
+			} catch {
+				return undefined;
+			}
+		}))
 	);
-	return results
-		.filter((r): r is PromiseFulfilledResult<ICarouselImage> => r.status === 'fulfilled')
-		.map(r => r.value);
+	return results.filter((r): r is ICarouselImage => r !== undefined);
 }
 
 class OpenImagesInCarouselFromExplorerAction extends Action2 {
@@ -239,56 +239,61 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 		let imageUris: URI[] = [];
 		let startUri: URI | undefined;
 
-		if (context.length === 0) {
-			// Empty-space right-click: the explorer passes the workspace root
-			// as the resource argument. Fall back to the first workspace folder
-			// when no resource is available.
-			let folderUri: URI | undefined;
-			if (URI.isUri(resource)) {
-				folderUri = resource;
-			} else {
-				const folders = contextService.getWorkspace().folders;
-				if (folders.length > 0) {
-					folderUri = folders[0].uri;
+		try {
+			if (context.length === 0) {
+				// Empty-space right-click: the explorer passes the workspace root
+				// as the resource argument. Fall back to the first workspace folder
+				// when no resource is available.
+				let folderUri: URI | undefined;
+				if (URI.isUri(resource)) {
+					folderUri = resource;
+				} else {
+					const folders = contextService.getWorkspace().folders;
+					if (folders.length > 0) {
+						folderUri = folders[0].uri;
+					}
 				}
-			}
 
-			if (folderUri) {
-				imageUris = await collectImageFilesFromFolder(fileService, folderUri);
-			}
-		} else {
-			const hasSingleImageFile = context.length === 1 && !context[0].isDirectory && isImageResource(context[0].resource);
-
-			if (hasSingleImageFile) {
-				// Single image: show all sibling images in the same folder with
-				// the selected image focused
-				startUri = context[0].resource;
-				const parentUri = dirname(context[0].resource);
-				imageUris = await collectImageFilesFromFolder(fileService, parentUri);
+				if (folderUri) {
+					imageUris = await collectImageFilesFromFolder(fileService, folderUri);
+				}
 			} else {
-				// Multiple items or a folder: collect images from selection,
-				// deduplicating in case a folder and its children are both selected
-				const seen = new ResourceSet();
-				for (const item of context) {
-					if (item.isDirectory) {
-						const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
-						for (const uri of folderImages) {
-							if (!seen.has(uri)) {
-								seen.add(uri);
-								imageUris.push(uri);
+				const hasSingleImageFile = context.length === 1 && !context[0].isDirectory && isImageResource(context[0].resource);
+
+				if (hasSingleImageFile) {
+					// Single image: show all sibling images in the same folder with
+					// the selected image focused
+					startUri = context[0].resource;
+					const parentUri = dirname(context[0].resource);
+					imageUris = await collectImageFilesFromFolder(fileService, parentUri);
+				} else {
+					// Multiple items or a folder: collect images from selection,
+					// deduplicating in case a folder and its children are both selected
+					const seen = new ResourceSet();
+					for (const item of context) {
+						if (item.isDirectory) {
+							const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
+							for (const uri of folderImages) {
+								if (!seen.has(uri)) {
+									seen.add(uri);
+									imageUris.push(uri);
+								}
 							}
-						}
-					} else if (isImageResource(item.resource)) {
-						if (!seen.has(item.resource)) {
-							seen.add(item.resource);
-							imageUris.push(item.resource);
-							if (!startUri) {
-								startUri = item.resource;
+						} else if (isImageResource(item.resource)) {
+							if (!seen.has(item.resource)) {
+								seen.add(item.resource);
+								imageUris.push(item.resource);
+								if (!startUri) {
+									startUri = item.resource;
+								}
 							}
 						}
 					}
 				}
 			}
+		} catch {
+			notificationService.error(localize('folderReadError', "Could not read folder contents."));
+			return;
 		}
 
 		if (imageUris.length === 0) {
@@ -298,6 +303,7 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 
 		const images = await readImageFiles(fileService, imageUris);
 		if (images.length === 0) {
+			notificationService.error(localize('imageReadError', "Could not read the selected images."));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -154,16 +154,8 @@ registerAction2(OpenImageInCarouselAction);
 
 // --- Explorer Context Menu Integration ---
 
-/**
- * Image-extension regex built from {@link getMediaMime} so the declarative
- * `when`-clause and the runtime {@link isImageResource} share a single source
- * of truth with `base/common/mime.ts`.
- */
-const IMAGE_EXTENSION_REGEX = (function () {
-	const candidates = ['png', 'jpg', 'jpeg', 'jpe', 'gif', 'webp', 'svg', 'bmp', 'ico'];
-	const imageExts = candidates.filter(ext => getMediaMime(`f.${ext}`)?.startsWith('image/'));
-	return new RegExp(`^\\.(${imageExts.join('|')})$`, 'i');
-})();
+/** Supported image extensions for the carousel explorer context menu. */
+const IMAGE_EXTENSION_REGEX = /^\.(png|jpg|jpeg|jpe|gif|webp|svg|bmp|ico)$/i;
 
 function isImageResource(uri: URI): boolean {
 	return IMAGE_EXTENSION_REGEX.test(extname(uri));

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -25,6 +25,7 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
 import { basename, dirname } from '../../../../base/common/resources.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -152,7 +153,16 @@ registerAction2(OpenImageInCarouselAction);
 
 // --- Explorer Context Menu Integration ---
 
-const IMAGE_EXTENSION_REGEX = /^\.(png|jpe?g|jpe|gif|webp|svg|bmp|ico|tiff?|tga|psd)$/i;
+/**
+ * Image-extension regex built from {@link getMediaMime} so the declarative
+ * `when`-clause and the runtime {@link isImageResource} share a single source
+ * of truth with `base/common/mime.ts`.
+ */
+const IMAGE_EXTENSION_REGEX = (function () {
+	const candidates = ['png', 'jpg', 'jpeg', 'jpe', 'gif', 'webp', 'svg', 'bmp', 'ico', 'tif', 'tiff', 'tga', 'psd'];
+	const imageExts = candidates.filter(ext => getMediaMime(`f.${ext}`)?.startsWith('image/'));
+	return new RegExp(`^\\.(${imageExts.join('|')})$`, 'i');
+})();
 
 function isImageResource(uri: URI): boolean {
 	const mimeType = getMediaMime(uri.path);
@@ -165,7 +175,7 @@ async function collectImageFilesFromFolder(fileService: IFileService, folderUri:
 		const imageUris: URI[] = [];
 		if (stat.children) {
 			for (const child of stat.children) {
-				if (!child.isDirectory && isImageResource(child.resource)) {
+				if (child.isFile && isImageResource(child.resource)) {
 					imageUris.push(child.resource);
 				}
 			}
@@ -178,23 +188,22 @@ async function collectImageFilesFromFolder(fileService: IFileService, folderUri:
 }
 
 async function readImageFiles(fileService: IFileService, uris: URI[]): Promise<ICarouselImage[]> {
-	const images: ICarouselImage[] = [];
-	for (const uri of uris) {
-		try {
+	const results = await Promise.allSettled(
+		uris.map(async (uri): Promise<ICarouselImage> => {
 			const content = await fileService.readFile(uri);
 			const mimeType = getMediaMime(uri.path) ?? 'image/png';
-			images.push({
+			return {
 				id: generateUuid(),
 				name: basename(uri),
 				mimeType,
 				data: content.value,
 				uri,
-			});
-		} catch {
-			// Skip files that cannot be read
-		}
-	}
-	return images;
+			};
+		})
+	);
+	return results
+		.filter((r): r is PromiseFulfilledResult<ICarouselImage> => r.status === 'fulfilled')
+		.map(r => r.value);
 }
 
 class OpenImagesInCarouselFromExplorerAction extends Action2 {
@@ -259,21 +268,19 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 			} else {
 				// Multiple items or a folder: collect images from selection,
 				// deduplicating in case a folder and its children are both selected
-				const seen = new Set<string>();
+				const seen = new ResourceSet();
 				for (const item of context) {
 					if (item.isDirectory) {
 						const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
 						for (const uri of folderImages) {
-							const key = uri.toString();
-							if (!seen.has(key)) {
-								seen.add(key);
+							if (!seen.has(uri)) {
+								seen.add(uri);
 								imageUris.push(uri);
 							}
 						}
 					} else if (isImageResource(item.resource)) {
-						const key = item.resource.toString();
-						if (!seen.has(key)) {
-							seen.add(key);
+						if (!seen.has(item.resource)) {
+							seen.add(item.resource);
 							imageUris.push(item.resource);
 							if (!startUri) {
 								startUri = item.resource;

--- a/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
+++ b/src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts
@@ -25,6 +25,8 @@ import { IFileService } from '../../../../platform/files/common/files.js';
 import { getMediaMime } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
 import { basename, dirname } from '../../../../base/common/resources.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 
 // --- Editor Pane Registration ---
 
@@ -141,16 +143,21 @@ function isImageResource(uri: URI): boolean {
 }
 
 async function collectImageFilesFromFolder(fileService: IFileService, folderUri: URI): Promise<URI[]> {
-	const stat = await fileService.resolve(folderUri);
-	const imageUris: URI[] = [];
-	if (stat.children) {
-		for (const child of stat.children) {
-			if (!child.isDirectory && isImageResource(child.resource)) {
-				imageUris.push(child.resource);
+	try {
+		const stat = await fileService.resolve(folderUri);
+		const imageUris: URI[] = [];
+		if (stat.children) {
+			for (const child of stat.children) {
+				if (!child.isDirectory && isImageResource(child.resource)) {
+					imageUris.push(child.resource);
+				}
 			}
 		}
+		return imageUris;
+	} catch {
+		// Folder may not exist or be inaccessible (e.g. permission denied)
+		return [];
 	}
-	return imageUris;
 }
 
 async function readImageFiles(fileService: IFileService, uris: URI[]): Promise<ICarouselImage[]> {
@@ -195,44 +202,62 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 		const explorerService = accessor.get(IExplorerService);
 		const fileService = accessor.get(IFileService);
 		const editorService = accessor.get(IEditorService);
+		const notificationService = accessor.get(INotificationService);
+		const contextService = accessor.get(IWorkspaceContextService);
 
 		const context = explorerService.getContext(true);
-		if (context.length === 0) {
-			return;
-		}
 
 		let imageUris: URI[] = [];
 		let startUri: URI | undefined;
 
-		const hasSingleImageFile = context.length === 1 && !context[0].isDirectory && isImageResource(context[0].resource);
+		if (context.length === 0) {
+			// Empty-space right-click: the explorer passes the workspace root
+			// as the resource argument. Fall back to the first workspace folder
+			// when no resource is available.
+			let folderUri: URI | undefined;
+			if (URI.isUri(resource)) {
+				folderUri = resource;
+			} else {
+				const folders = contextService.getWorkspace().folders;
+				if (folders.length > 0) {
+					folderUri = folders[0].uri;
+				}
+			}
 
-		if (hasSingleImageFile) {
-			// Single image: show all sibling images in the same folder with
-			// the selected image focused
-			startUri = context[0].resource;
-			const parentUri = dirname(context[0].resource);
-			imageUris = await collectImageFilesFromFolder(fileService, parentUri);
+			if (folderUri) {
+				imageUris = await collectImageFilesFromFolder(fileService, folderUri);
+			}
 		} else {
-			// Multiple items or a folder: collect images from selection,
-			// deduplicating in case a folder and its children are both selected
-			const seen = new Set<string>();
-			for (const item of context) {
-				if (item.isDirectory) {
-					const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
-					for (const uri of folderImages) {
-						const key = uri.toString();
+			const hasSingleImageFile = context.length === 1 && !context[0].isDirectory && isImageResource(context[0].resource);
+
+			if (hasSingleImageFile) {
+				// Single image: show all sibling images in the same folder with
+				// the selected image focused
+				startUri = context[0].resource;
+				const parentUri = dirname(context[0].resource);
+				imageUris = await collectImageFilesFromFolder(fileService, parentUri);
+			} else {
+				// Multiple items or a folder: collect images from selection,
+				// deduplicating in case a folder and its children are both selected
+				const seen = new Set<string>();
+				for (const item of context) {
+					if (item.isDirectory) {
+						const folderImages = await collectImageFilesFromFolder(fileService, item.resource);
+						for (const uri of folderImages) {
+							const key = uri.toString();
+							if (!seen.has(key)) {
+								seen.add(key);
+								imageUris.push(uri);
+							}
+						}
+					} else if (isImageResource(item.resource)) {
+						const key = item.resource.toString();
 						if (!seen.has(key)) {
 							seen.add(key);
-							imageUris.push(uri);
-						}
-					}
-				} else if (isImageResource(item.resource)) {
-					const key = item.resource.toString();
-					if (!seen.has(key)) {
-						seen.add(key);
-						imageUris.push(item.resource);
-						if (!startUri) {
-							startUri = item.resource;
+							imageUris.push(item.resource);
+							if (!startUri) {
+								startUri = item.resource;
+							}
 						}
 					}
 				}
@@ -240,6 +265,7 @@ class OpenImagesInCarouselFromExplorerAction extends Action2 {
 		}
 
 		if (imageUris.length === 0) {
+			notificationService.info(localize('noImagesFound', "No images found in this folder."));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
+++ b/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
@@ -16,6 +16,7 @@ import { IFileService, IFileStat, IFileContent } from '../../../../../platform/f
 import { IEditorService, MODAL_GROUP } from '../../../../services/editor/common/editorService.js';
 import { ImageCarouselEditorInput } from '../../browser/imageCarouselEditorInput.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 
 // Importing the contribution registers the actions
 import '../../browser/imageCarousel.contribution.js';
@@ -58,9 +59,11 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 	let instantiationService: TestInstantiationService;
 	let configService: TestConfigurationService;
 	let openedInputs: { input: ImageCarouselEditorInput; group: typeof MODAL_GROUP }[];
+	let infoMessages: string[];
 
 	setup(() => {
 		openedInputs = [];
+		infoMessages = [];
 		configService = new TestConfigurationService();
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 	});
@@ -96,6 +99,12 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 				disposables.add(input);
 			}
 			return undefined;
+		});
+	}
+
+	function stubNotificationService(): void {
+		instantiationService.stub(INotificationService, 'info', (message: string) => {
+			infoMessages.push(message);
 		});
 	}
 
@@ -215,7 +224,25 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		assert.strictEqual(images[1].name, 'b.svg');
 	});
 
-	test('empty selection does not open carousel', async () => {
+	test('empty selection with resource argument opens carousel from that folder', async () => {
+		const pngData = VSBuffer.fromString('fake-png');
+		const jpgData = VSBuffer.fromString('fake-jpg');
+
+		const folderUri = URI.file('/workspace/photos');
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/photos', createFileStat(
+			folderUri, true, [
+			createFileStat(URI.file('/workspace/photos/sunset.png'), false),
+			createFileStat(URI.file('/workspace/photos/mountain.jpg'), false),
+			createFileStat(URI.file('/workspace/photos/notes.txt'), false),
+		]
+		));
+
+		const fileContents = new Map<string, VSBuffer>();
+		fileContents.set('/workspace/photos/sunset.png', pngData);
+		fileContents.set('/workspace/photos/mountain.jpg', jpgData);
+
+		stubFileService(resolveMap, fileContents);
 		stubExplorerService([]);
 		stubEditorService();
 
@@ -223,12 +250,71 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
 		assert.ok(command);
 
-		await instantiationService.invokeFunction(command.handler);
+		// Pass the folder URI as the resource argument (as explorer does for empty-space click)
+		await instantiationService.invokeFunction(command.handler, folderUri);
 
-		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel for empty selection');
+		assert.strictEqual(openedInputs.length, 1, 'Should open carousel using resource argument fallback');
+		const images = openedInputs[0].input.collection.sections[0].images;
+		assert.strictEqual(images.length, 2, 'Should include 2 images from the folder');
 	});
 
-	test('folder with no images does not open carousel', async () => {
+	test('empty selection without resource falls back to first workspace folder', async () => {
+		const pngData = VSBuffer.fromString('fake-png');
+
+		// TestWorkspace root is /testWorkspace (or C:\testWorkspace on Windows)
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/testWorkspace', createFileStat(
+			URI.file('/testWorkspace'), true, [
+			createFileStat(URI.file('/testWorkspace/logo.png'), false),
+			createFileStat(URI.file('/testWorkspace/readme.md'), false),
+		]
+		));
+
+		const fileContents = new Map<string, VSBuffer>();
+		fileContents.set('/testWorkspace/logo.png', pngData);
+
+		stubFileService(resolveMap, fileContents);
+		stubExplorerService([]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		// No resource argument — should fall back to workspace root
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 1, 'Should open carousel using workspace root fallback');
+		const images = openedInputs[0].input.collection.sections[0].images;
+		assert.strictEqual(images.length, 1, 'Should include image from workspace root');
+		assert.strictEqual(images[0].name, 'logo.png');
+	});
+
+	test('empty selection with no images shows notification', async () => {
+		const folderUri = URI.file('/workspace/docs');
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/docs', createFileStat(
+			folderUri, true, [
+			createFileStat(URI.file('/workspace/docs/readme.md'), false),
+		]
+		));
+
+		stubFileService(resolveMap, new Map());
+		stubExplorerService([]);
+		stubEditorService();
+		stubNotificationService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler, folderUri);
+
+		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel when folder has no images');
+		assert.strictEqual(infoMessages.length, 1, 'Should show notification');
+	});
+
+	test('folder with no images shows notification', async () => {
 		const fileService = instantiationService.get(IFileService);
 		const folderItem = createExplorerItem('/workspace/docs', true, fileService, configService);
 
@@ -243,6 +329,7 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		stubFileService(resolveMap, new Map());
 		stubExplorerService([folderItem]);
 		stubEditorService();
+		stubNotificationService();
 
 		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
 		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
@@ -251,5 +338,6 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		await instantiationService.invokeFunction(command.handler);
 
 		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel when folder has no images');
+		assert.strictEqual(infoMessages.length, 1, 'Should show notification about no images');
 	});
 });

--- a/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
+++ b/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
@@ -1,0 +1,255 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { NullFilesConfigurationService } from '../../../../test/common/workbenchTestServices.js';
+import { IExplorerService } from '../../../files/browser/files.js';
+import { ExplorerItem } from '../../../files/common/explorerModel.js';
+import { IFileService, IFileStat, IFileContent } from '../../../../../platform/files/common/files.js';
+import { IEditorService, MODAL_GROUP } from '../../../../services/editor/common/editorService.js';
+import { ImageCarouselEditorInput } from '../../browser/imageCarouselEditorInput.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+
+// Importing the contribution registers the actions
+import '../../browser/imageCarousel.contribution.js';
+
+function createExplorerItem(
+	path: string,
+	isFolder: boolean,
+	fileService: IFileService,
+	configService: TestConfigurationService,
+	parent?: ExplorerItem,
+): ExplorerItem {
+	return new ExplorerItem(
+		URI.file(path),
+		fileService,
+		configService,
+		NullFilesConfigurationService,
+		parent,
+		isFolder,
+	);
+}
+
+function createFileStat(resource: URI, isDirectory: boolean, children?: IFileStat[]): IFileStat {
+	return {
+		resource,
+		name: resource.path.split('/').pop()!,
+		isFile: !isDirectory,
+		isDirectory,
+		isSymbolicLink: false,
+		mtime: 0,
+		ctime: 0,
+		size: 100,
+		etag: '',
+		children,
+	};
+}
+
+suite('OpenImagesInCarouselFromExplorerAction', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let configService: TestConfigurationService;
+	let openedInputs: { input: ImageCarouselEditorInput; group: typeof MODAL_GROUP }[];
+
+	setup(() => {
+		openedInputs = [];
+		configService = new TestConfigurationService();
+		instantiationService = workbenchInstantiationService(undefined, disposables);
+	});
+
+	function stubFileService(resolveMap: Map<string, IFileStat>, fileContents: Map<string, VSBuffer>): void {
+		instantiationService.stub(IFileService, 'resolve', async (resource: URI) => {
+			const stat = resolveMap.get(resource.path);
+			if (!stat) {
+				throw new Error(`File not found: ${resource.path}`);
+			}
+			return stat;
+		});
+
+		instantiationService.stub(IFileService, 'readFile', async (resource: URI) => {
+			const content = fileContents.get(resource.path);
+			if (!content) {
+				throw new Error(`Cannot read: ${resource.path}`);
+			}
+			return { resource, value: content } as IFileContent;
+		});
+	}
+
+	function stubExplorerService(items: ExplorerItem[]): void {
+		instantiationService.stub(IExplorerService, {
+			getContext: () => items,
+		});
+	}
+
+	function stubEditorService(): void {
+		instantiationService.stub(IEditorService, 'openEditor', async (input: unknown, _options: unknown, group: unknown) => {
+			if (input instanceof ImageCarouselEditorInput) {
+				openedInputs.push({ input, group: group as typeof MODAL_GROUP });
+				disposables.add(input);
+			}
+			return undefined;
+		});
+	}
+
+	test('single image file opens carousel with sibling images', async () => {
+		const fileService = instantiationService.get(IFileService);
+		const parent = createExplorerItem('/workspace/images', true, fileService, configService);
+		const imageItem = createExplorerItem('/workspace/images/photo.png', false, fileService, configService, parent);
+
+		const pngData = VSBuffer.fromString('fake-png');
+		const jpgData = VSBuffer.fromString('fake-jpg');
+		const txtData = VSBuffer.fromString('text file');
+
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/images', createFileStat(
+			URI.file('/workspace/images'), true, [
+			createFileStat(URI.file('/workspace/images/photo.png'), false),
+			createFileStat(URI.file('/workspace/images/other.jpg'), false),
+			createFileStat(URI.file('/workspace/images/readme.txt'), false),
+			createFileStat(URI.file('/workspace/images/subfolder'), true),
+		]
+		));
+
+		const fileContents = new Map<string, VSBuffer>();
+		fileContents.set('/workspace/images/photo.png', pngData);
+		fileContents.set('/workspace/images/other.jpg', jpgData);
+		fileContents.set('/workspace/images/readme.txt', txtData);
+
+		stubFileService(resolveMap, fileContents);
+		stubExplorerService([imageItem]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command, 'Command should be registered');
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 1, 'Should open one editor');
+		const input = openedInputs[0].input;
+		assert.strictEqual(input.collection.sections.length, 1);
+
+		const images = input.collection.sections[0].images;
+		assert.strictEqual(images.length, 2, 'Should include 2 image siblings (png + jpg), not txt');
+		assert.strictEqual(images[0].name, 'photo.png');
+		assert.strictEqual(images[1].name, 'other.jpg');
+
+		// Start index should be the selected image (photo.png = index 0)
+		assert.strictEqual(input.startIndex, 0);
+	});
+
+	test('folder opens carousel with all contained images', async () => {
+		const fileService = instantiationService.get(IFileService);
+		const folderItem = createExplorerItem('/workspace/images', true, fileService, configService);
+
+		const gifData = VSBuffer.fromString('fake-gif');
+		const webpData = VSBuffer.fromString('fake-webp');
+
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/images', createFileStat(
+			URI.file('/workspace/images'), true, [
+			createFileStat(URI.file('/workspace/images/anim.gif'), false),
+			createFileStat(URI.file('/workspace/images/photo.webp'), false),
+			createFileStat(URI.file('/workspace/images/script.js'), false),
+		]
+		));
+
+		const fileContents = new Map<string, VSBuffer>();
+		fileContents.set('/workspace/images/anim.gif', gifData);
+		fileContents.set('/workspace/images/photo.webp', webpData);
+
+		stubFileService(resolveMap, fileContents);
+		stubExplorerService([folderItem]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 1);
+		const images = openedInputs[0].input.collection.sections[0].images;
+		assert.strictEqual(images.length, 2, 'Should include 2 images (gif + webp), not js');
+		assert.strictEqual(images[0].name, 'anim.gif');
+		assert.strictEqual(images[1].name, 'photo.webp');
+	});
+
+	test('multiple selected images open in carousel', async () => {
+		const fileService = instantiationService.get(IFileService);
+		const img1 = createExplorerItem('/workspace/a.png', false, fileService, configService);
+		const img2 = createExplorerItem('/workspace/b.svg', false, fileService, configService);
+		const txtFile = createExplorerItem('/workspace/notes.txt', false, fileService, configService);
+
+		const pngData = VSBuffer.fromString('fake-png');
+		const svgData = VSBuffer.fromString('<svg></svg>');
+
+		const resolveMap = new Map<string, IFileStat>();
+
+		const fileContents = new Map<string, VSBuffer>();
+		fileContents.set('/workspace/a.png', pngData);
+		fileContents.set('/workspace/b.svg', svgData);
+
+		stubFileService(resolveMap, fileContents);
+		stubExplorerService([img1, img2, txtFile]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 1);
+		const images = openedInputs[0].input.collection.sections[0].images;
+		assert.strictEqual(images.length, 2, 'Should include only image files');
+		assert.strictEqual(images[0].name, 'a.png');
+		assert.strictEqual(images[1].name, 'b.svg');
+	});
+
+	test('empty selection does not open carousel', async () => {
+		stubExplorerService([]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel for empty selection');
+	});
+
+	test('folder with no images does not open carousel', async () => {
+		const fileService = instantiationService.get(IFileService);
+		const folderItem = createExplorerItem('/workspace/docs', true, fileService, configService);
+
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/docs', createFileStat(
+			URI.file('/workspace/docs'), true, [
+			createFileStat(URI.file('/workspace/docs/readme.md'), false),
+			createFileStat(URI.file('/workspace/docs/notes.txt'), false),
+		]
+		));
+
+		stubFileService(resolveMap, new Map());
+		stubExplorerService([folderItem]);
+		stubEditorService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel when folder has no images');
+	});
+});

--- a/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
+++ b/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
@@ -9,7 +9,7 @@ import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
-import { NullFilesConfigurationService } from '../../../../test/common/workbenchTestServices.js';
+import { NullFilesConfigurationService, createFileStat } from '../../../../test/common/workbenchTestServices.js';
 import { IExplorerService } from '../../../files/browser/files.js';
 import { ExplorerItem } from '../../../files/common/explorerModel.js';
 import { IFileService, IFileStat, IFileContent } from '../../../../../platform/files/common/files.js';
@@ -17,6 +17,7 @@ import { IEditorService, MODAL_GROUP } from '../../../../services/editor/common/
 import { ImageCarouselEditorInput } from '../../browser/imageCarouselEditorInput.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 
 // Importing the contribution registers the actions
 import '../../browser/imageCarousel.contribution.js';
@@ -38,21 +39,6 @@ function createExplorerItem(
 	);
 }
 
-function createFileStat(resource: URI, isDirectory: boolean, children?: IFileStat[]): IFileStat {
-	return {
-		resource,
-		name: resource.path.split('/').pop()!,
-		isFile: !isDirectory,
-		isDirectory,
-		isSymbolicLink: false,
-		mtime: 0,
-		ctime: 0,
-		size: 100,
-		etag: '',
-		children,
-	};
-}
-
 suite('OpenImagesInCarouselFromExplorerAction', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
@@ -60,10 +46,12 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 	let configService: TestConfigurationService;
 	let openedInputs: { input: ImageCarouselEditorInput; group: typeof MODAL_GROUP }[];
 	let infoMessages: string[];
+	let errorMessages: string[];
 
 	setup(() => {
 		openedInputs = [];
 		infoMessages = [];
+		errorMessages = [];
 		configService = new TestConfigurationService();
 		instantiationService = workbenchInstantiationService(undefined, disposables);
 	});
@@ -106,6 +94,9 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		instantiationService.stub(INotificationService, 'info', (message: string) => {
 			infoMessages.push(message);
 		});
+		instantiationService.stub(INotificationService, 'error', (message: string) => {
+			errorMessages.push(message);
+		});
 	}
 
 	test('single image file opens carousel with sibling images', async () => {
@@ -119,11 +110,11 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/images', createFileStat(
-			URI.file('/workspace/images'), true, [
-			createFileStat(URI.file('/workspace/images/photo.png'), false),
-			createFileStat(URI.file('/workspace/images/other.jpg'), false),
-			createFileStat(URI.file('/workspace/images/readme.txt'), false),
-			createFileStat(URI.file('/workspace/images/subfolder'), true),
+			URI.file('/workspace/images'), false, false, true, false, [
+			{ resource: URI.file('/workspace/images/photo.png') },
+			{ resource: URI.file('/workspace/images/other.jpg') },
+			{ resource: URI.file('/workspace/images/readme.txt') },
+			{ resource: URI.file('/workspace/images/subfolder'), isDirectory: true, isFile: false },
 		]
 		));
 
@@ -148,11 +139,12 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 
 		const images = input.collection.sections[0].images;
 		assert.strictEqual(images.length, 2, 'Should include 2 image siblings (png + jpg), not txt');
-		assert.strictEqual(images[0].name, 'photo.png');
-		assert.strictEqual(images[1].name, 'other.jpg');
+		// Images are sorted by basename: other.jpg before photo.png
+		assert.strictEqual(images[0].name, 'other.jpg');
+		assert.strictEqual(images[1].name, 'photo.png');
 
-		// Start index should be the selected image (photo.png = index 0)
-		assert.strictEqual(input.startIndex, 0);
+		// Start index should be the selected image (photo.png = index 1 after sorting)
+		assert.strictEqual(input.startIndex, 1);
 	});
 
 	test('folder opens carousel with all contained images', async () => {
@@ -164,10 +156,10 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/images', createFileStat(
-			URI.file('/workspace/images'), true, [
-			createFileStat(URI.file('/workspace/images/anim.gif'), false),
-			createFileStat(URI.file('/workspace/images/photo.webp'), false),
-			createFileStat(URI.file('/workspace/images/script.js'), false),
+			URI.file('/workspace/images'), false, false, true, false, [
+			{ resource: URI.file('/workspace/images/anim.gif') },
+			{ resource: URI.file('/workspace/images/photo.webp') },
+			{ resource: URI.file('/workspace/images/script.js') },
 		]
 		));
 
@@ -231,10 +223,10 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const folderUri = URI.file('/workspace/photos');
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/photos', createFileStat(
-			folderUri, true, [
-			createFileStat(URI.file('/workspace/photos/sunset.png'), false),
-			createFileStat(URI.file('/workspace/photos/mountain.jpg'), false),
-			createFileStat(URI.file('/workspace/photos/notes.txt'), false),
+			folderUri, false, false, true, false, [
+			{ resource: URI.file('/workspace/photos/sunset.png') },
+			{ resource: URI.file('/workspace/photos/mountain.jpg') },
+			{ resource: URI.file('/workspace/photos/notes.txt') },
 		]
 		));
 
@@ -261,17 +253,23 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 	test('empty selection without resource falls back to first workspace folder', async () => {
 		const pngData = VSBuffer.fromString('fake-png');
 
-		// TestWorkspace root is /testWorkspace (or C:\testWorkspace on Windows)
+		// Derive the workspace root from IWorkspaceContextService so the test
+		// works on all platforms (the path differs on Windows vs Unix).
+		const contextService = instantiationService.get(IWorkspaceContextService);
+		const wsRoot = contextService.getWorkspace().folders[0].uri;
+		const logoUri = URI.joinPath(wsRoot, 'logo.png');
+		const readmeUri = URI.joinPath(wsRoot, 'readme.md');
+
 		const resolveMap = new Map<string, IFileStat>();
-		resolveMap.set('/testWorkspace', createFileStat(
-			URI.file('/testWorkspace'), true, [
-			createFileStat(URI.file('/testWorkspace/logo.png'), false),
-			createFileStat(URI.file('/testWorkspace/readme.md'), false),
+		resolveMap.set(wsRoot.path, createFileStat(
+			wsRoot, false, false, true, false, [
+			{ resource: logoUri },
+			{ resource: readmeUri },
 		]
 		));
 
 		const fileContents = new Map<string, VSBuffer>();
-		fileContents.set('/testWorkspace/logo.png', pngData);
+		fileContents.set(logoUri.path, pngData);
 
 		stubFileService(resolveMap, fileContents);
 		stubExplorerService([]);
@@ -294,8 +292,8 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const folderUri = URI.file('/workspace/docs');
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/docs', createFileStat(
-			folderUri, true, [
-			createFileStat(URI.file('/workspace/docs/readme.md'), false),
+			folderUri, false, false, true, false, [
+			{ resource: URI.file('/workspace/docs/readme.md') },
 		]
 		));
 
@@ -320,9 +318,9 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/docs', createFileStat(
-			URI.file('/workspace/docs'), true, [
-			createFileStat(URI.file('/workspace/docs/readme.md'), false),
-			createFileStat(URI.file('/workspace/docs/notes.txt'), false),
+			URI.file('/workspace/docs'), false, false, true, false, [
+			{ resource: URI.file('/workspace/docs/readme.md') },
+			{ resource: URI.file('/workspace/docs/notes.txt') },
 		]
 		));
 
@@ -339,5 +337,54 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 
 		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel when folder has no images');
 		assert.strictEqual(infoMessages.length, 1, 'Should show notification about no images');
+	});
+
+	test('folder read error shows error notification', async () => {
+		const fileService = instantiationService.get(IFileService);
+		const folderItem = createExplorerItem('/workspace/restricted', true, fileService, configService);
+
+		// resolve throws to simulate a permission error
+		const resolveMap = new Map<string, IFileStat>();
+		stubFileService(resolveMap, new Map());
+		stubExplorerService([folderItem]);
+		stubEditorService();
+		stubNotificationService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler);
+
+		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel on folder read error');
+		assert.strictEqual(errorMessages.length, 1, 'Should show error notification');
+		assert.strictEqual(infoMessages.length, 0, 'Should not show info notification');
+	});
+
+	test('all image reads failing shows error notification', async () => {
+		const folderUri = URI.file('/workspace/broken');
+
+		const resolveMap = new Map<string, IFileStat>();
+		resolveMap.set('/workspace/broken', createFileStat(
+			folderUri, false, false, true, false, [
+			{ resource: URI.file('/workspace/broken/corrupt.png') },
+			{ resource: URI.file('/workspace/broken/missing.jpg') },
+		]
+		));
+
+		// No file contents → all readFile calls will fail
+		stubFileService(resolveMap, new Map());
+		stubExplorerService([]);
+		stubEditorService();
+		stubNotificationService();
+
+		const { CommandsRegistry } = await import('../../../../../platform/commands/common/commands.js');
+		const command = CommandsRegistry.getCommand('workbench.action.openImagesInCarousel');
+		assert.ok(command);
+
+		await instantiationService.invokeFunction(command.handler, folderUri);
+
+		assert.strictEqual(openedInputs.length, 0, 'Should not open carousel when all reads fail');
+		assert.strictEqual(errorMessages.length, 1, 'Should show error notification for read failures');
 	});
 });

--- a/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
+++ b/src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts
@@ -111,9 +111,9 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/images', createFileStat(
 			URI.file('/workspace/images'), false, false, true, false, [
-			{ resource: URI.file('/workspace/images/photo.png') },
-			{ resource: URI.file('/workspace/images/other.jpg') },
-			{ resource: URI.file('/workspace/images/readme.txt') },
+			{ resource: URI.file('/workspace/images/photo.png'), isFile: true },
+			{ resource: URI.file('/workspace/images/other.jpg'), isFile: true },
+			{ resource: URI.file('/workspace/images/readme.txt'), isFile: true },
 			{ resource: URI.file('/workspace/images/subfolder'), isDirectory: true, isFile: false },
 		]
 		));
@@ -157,9 +157,9 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/images', createFileStat(
 			URI.file('/workspace/images'), false, false, true, false, [
-			{ resource: URI.file('/workspace/images/anim.gif') },
-			{ resource: URI.file('/workspace/images/photo.webp') },
-			{ resource: URI.file('/workspace/images/script.js') },
+			{ resource: URI.file('/workspace/images/anim.gif'), isFile: true },
+			{ resource: URI.file('/workspace/images/photo.webp'), isFile: true },
+			{ resource: URI.file('/workspace/images/script.js'), isFile: true },
 		]
 		));
 
@@ -224,9 +224,9 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/photos', createFileStat(
 			folderUri, false, false, true, false, [
-			{ resource: URI.file('/workspace/photos/sunset.png') },
-			{ resource: URI.file('/workspace/photos/mountain.jpg') },
-			{ resource: URI.file('/workspace/photos/notes.txt') },
+			{ resource: URI.file('/workspace/photos/sunset.png'), isFile: true },
+			{ resource: URI.file('/workspace/photos/mountain.jpg'), isFile: true },
+			{ resource: URI.file('/workspace/photos/notes.txt'), isFile: true },
 		]
 		));
 
@@ -263,8 +263,8 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set(wsRoot.path, createFileStat(
 			wsRoot, false, false, true, false, [
-			{ resource: logoUri },
-			{ resource: readmeUri },
+			{ resource: logoUri, isFile: true },
+			{ resource: readmeUri, isFile: true },
 		]
 		));
 
@@ -293,7 +293,7 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/docs', createFileStat(
 			folderUri, false, false, true, false, [
-			{ resource: URI.file('/workspace/docs/readme.md') },
+			{ resource: URI.file('/workspace/docs/readme.md'), isFile: true },
 		]
 		));
 
@@ -319,8 +319,8 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/docs', createFileStat(
 			URI.file('/workspace/docs'), false, false, true, false, [
-			{ resource: URI.file('/workspace/docs/readme.md') },
-			{ resource: URI.file('/workspace/docs/notes.txt') },
+			{ resource: URI.file('/workspace/docs/readme.md'), isFile: true },
+			{ resource: URI.file('/workspace/docs/notes.txt'), isFile: true },
 		]
 		));
 
@@ -367,8 +367,8 @@ suite('OpenImagesInCarouselFromExplorerAction', () => {
 		const resolveMap = new Map<string, IFileStat>();
 		resolveMap.set('/workspace/broken', createFileStat(
 			folderUri, false, false, true, false, [
-			{ resource: URI.file('/workspace/broken/corrupt.png') },
-			{ resource: URI.file('/workspace/broken/missing.jpg') },
+			{ resource: URI.file('/workspace/broken/corrupt.png'), isFile: true },
+			{ resource: URI.file('/workspace/broken/missing.jpg'), isFile: true },
 		]
 		));
 


### PR DESCRIPTION
## Summary

Adds an **Open Images in Carousel** command to the explorer context menu, allowing users to browse images using the existing Image Carousel editor.

## Experimental Setting

The context menu item is gated behind `imageCarousel.explorerContextMenu.enabled` (default: `false`, tagged `experimental`). Users must explicitly enable this setting to see the menu item. This allows us to ship the feature for opt-in testing before broader rollout.

## Behavior

| Context | Action |
|---------|--------|
| **Right-click an image file** | Opens carousel with all sibling images in the same folder, focused on the selected image |
| **Right-click a folder** | Opens carousel with all images in that folder |
| **Multi-select files** | Collects all selected image files into the carousel |
| **Mixed selection (folders + files)** | Gathers images from all selected items with deduplication |

## Supported image formats

`.png`, `.jpg`, `.jpeg`, `.jpe`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`, `.tif`, `.tiff`, `.tga`, `.psd`

The context menu item is shown via a `when` clause that requires:
1. `imageCarousel.explorerContextMenu.enabled` to be `true`
2. The resource to be a folder (`ExplorerFolderContext`) or an image file (`resourceExtname` regex match)

## Implementation

- New `Action2` registered in `MenuId.ExplorerContext` (navigation group, order 25)
- Command ID: `workbench.action.openImagesInCarousel`
- Setting registered via `configurationRegistry` with `tags: ["experimental"]`
- Menu `when` clause uses `ContextKeyExpr.and()` to combine setting gate with existing resource conditions

## Testing

- 7 unit tests passing (single image, folder, multi-select, empty selection, workspace fallback, no-images notifications)
- TypeScript compilation clean, layering check clean, hygiene check clean

## Files changed

- `src/vs/workbench/contrib/imageCarousel/browser/imageCarousel.contribution.ts` — Setting registration + context menu gating
- `src/vs/workbench/contrib/imageCarousel/test/browser/imageCarousel.contribution.test.ts` — Test suite