### PR TITLE
Fix copy-paste bug in git inputValidation setting migration

### DIFF
--- a/extensions/git/src/diagnostics.ts
+++ b/extensions/git/src/diagnostics.ts
@@ -48,7 +48,7 @@ export class GitCommitInputBoxDiagnosticsManager {
 
 			// User setting
 			if (typeof inputValidation.globalValue === 'string') {
-				await config.update('inputValidation', inputValidation.workspaceValue !== 'off', true);
+				await config.update('inputValidation', inputValidation.globalValue !== 'off', true);
 			}
 		} catch { }
 	}


### PR DESCRIPTION
Fixes #301463

## Bug

In `migrateInputValidationSettings()`, the user/global setting migration branch incorrectly reads `inputValidation.workspaceValue` instead of `inputValidation.globalValue`:

```typescript
// User setting
if (typeof inputValidation.globalValue === 'string') {
    await config.update('inputValidation', inputValidation.workspaceValue !== 'off', true);
    //                                     ^^^^^^^^^^^^^^^^ should be globalValue
}
```

This is a copy-paste error from the workspace setting migration directly above it.

## Impact

The bug silently migrates the user/global setting based on the wrong value:

1. **User has `globalValue = 'off'`, no workspace setting:** `workspaceValue` is `undefined`, so `undefined !== 'off'` evaluates to `true`. The migration sets the global setting to `true` (validation enabled), reversing the user's explicit preference to have validation disabled.

2. **User has both global and workspace settings with different values** (e.g., workspace is `'off'` but global is `'always'`): The global setting gets migrated based on the workspace value instead of the global value.

For `globalValue` of `'always'` or `'warn'` with no workspace override, the bug happens to produce the correct result (`undefined !== 'off'` = `true`), which is why it has gone unnoticed.

## Fix

Changed `inputValidation.workspaceValue` to `inputValidation.globalValue` on line 51.