### PR TITLE
Fix incorrect inspect property usage in scope detection

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/autoApprove/commandLineAutoApprover.ts
@@ -279,7 +279,7 @@ export class CommandLineAutoApprover extends Disposable {
 				);
 			}
 			const sourceTarget = (
-				checkTarget(configInspectValue.workspaceFolder) ? ConfigurationTarget.WORKSPACE_FOLDER
+				checkTarget(configInspectValue.workspaceFolderValue) ? ConfigurationTarget.WORKSPACE_FOLDER
 					: checkTarget(configInspectValue.workspaceValue) ? ConfigurationTarget.WORKSPACE
 						: checkTarget(configInspectValue.userRemoteValue) ? ConfigurationTarget.USER_REMOTE
 							: checkTarget(configInspectValue.userLocalValue) ? ConfigurationTarget.USER_LOCAL

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
@@ -1244,7 +1244,7 @@ suite('CommandLineAutoApprover', () => {
 		});
 
 		test('should attribute workspace-folder-scoped rules to WORKSPACE_FOLDER target', async () => {
-			const workspaceFolderConfig = { 'git*': true };
+			const workspaceFolderConfig = { 'git': true };
 			configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.AutoApprove, workspaceFolderConfig);
 
 			const originalInspect = configurationService.inspect;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApprover.test.ts
@@ -1242,5 +1242,49 @@ suite('CommandLineAutoApprover', () => {
 			ok(!await isAutoApproved('echo hello'), 'Default rule should be ignored');
 			ok(!await isAutoApproved('cat file.txt'), 'Default rule should be ignored');
 		});
+
+		test('should attribute workspace-folder-scoped rules to WORKSPACE_FOLDER target', async () => {
+			const workspaceFolderConfig = { 'git*': true };
+			configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.AutoApprove, workspaceFolderConfig);
+
+			const originalInspect = configurationService.inspect;
+			const originalGetValue = configurationService.getValue;
+
+			configurationService.inspect = (key: string): any => {
+				if (key === TerminalChatAgentToolsSettingId.AutoApprove) {
+					return {
+						default: undefined,
+						user: undefined,
+						workspace: undefined,
+						workspaceFolder: undefined,
+						workspaceFolderValue: workspaceFolderConfig,
+						application: undefined,
+						policy: undefined,
+						memory: undefined,
+						value: workspaceFolderConfig
+					};
+				}
+				return originalInspect.call(configurationService, key);
+			};
+
+			configurationService.getValue = (key: string): any => {
+				if (key === TerminalChatAgentToolsSettingId.AutoApprove) {
+					return workspaceFolderConfig;
+				}
+				return originalGetValue.call(configurationService, key);
+			};
+
+			configurationService.onDidChangeConfigurationEmitter.fire({
+				affectsConfiguration: () => true,
+				affectedKeys: new Set([TerminalChatAgentToolsSettingId.AutoApprove]),
+				source: ConfigurationTarget.WORKSPACE_FOLDER,
+				change: null!,
+			});
+
+			const result = await commandLineAutoApprover.isCommandAutoApproved('git status', shell, os, undefined);
+			strictEqual(result.result, 'approved', 'git command should be approved');
+			ok(isAutoApproveRule(result.rule), 'result should have an auto-approve rule');
+			strictEqual(result.rule.sourceTarget, ConfigurationTarget.WORKSPACE_FOLDER, 'workspace-folder-scoped rule should have WORKSPACE_FOLDER source target');
+		});
 	});
 });

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -377,7 +377,7 @@ export class ThemeConfiguration {
 			return ConfigurationTarget.WORKSPACE_FOLDER;
 		} else if (!types.isUndefined(settings.workspaceValue)) {
 			return ConfigurationTarget.WORKSPACE;
-		} else if (!types.isUndefined(settings.userRemote)) {
+		} else if (!types.isUndefined(settings.userRemoteValue)) {
 			return ConfigurationTarget.USER_REMOTE;
 		}
 		return ConfigurationTarget.USER;


### PR DESCRIPTION
Fixes #301471

## Bug

Two `IConfigurationValue` property accesses introduced in bb18007f use the `IInspectValue<T>` object property instead of the scalar value property, causing incorrect scope detection.

### 1. `themeConfiguration.ts` - `findAutoConfigurationTarget()`

`settings.userRemote` is an `IInspectValue<T>` object (`{value?, override?, overrides?}`), not the scalar `T` value. It can be defined when only language-specific overrides exist in the remote config, even with no actual remote value set. This causes the function to incorrectly return `USER_REMOTE`, making theme settings target the wrong configuration scope.

**Fix:** `settings.userRemote` -> `settings.userRemoteValue`

### 2. `commandLineAutoApprover.ts` - source target detection

`configInspectValue.workspaceFolder` is an `IInspectValue<T>` object whose keys are `{value, override, overrides}`. The `checkTarget` function looks for tool-pattern keys (e.g., `"git*"`) via `hasOwnProperty`, which never matches on `IInspectValue`. Workspace-folder-scoped auto-approve rules are never detected and fall through to a lower-priority scope.

**Fix:** `configInspectValue.workspaceFolder` -> `configInspectValue.workspaceFolderValue`

### Root Cause

Both uses are from the same commit (bb18007f). The `IConfigurationValue<T>` interface exposes both scalar values (`userRemoteValue: T`) and inspect objects (`userRemote: IInspectValue<T>`). The similar naming makes it easy to use the wrong one.

### Testing

Added a regression test that stubs `configurationService.inspect` to return a `workspaceFolderValue` containing a rule key and asserts the matched rule reports `sourceTarget` as `ConfigurationTarget.WORKSPACE_FOLDER`.