### PR TITLE
fix: broken link for 'Learn more about agent plugins'

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -398,7 +398,7 @@ export class PluginListWidget extends Disposable {
 		this.sectionDescription.textContent = localize('pluginsDescription', "Extend your AI agent with plugins that add commands, skills, agents, hooks, and MCP servers from reusable packages.");
 		this.sectionLink = DOM.append(this.sectionHeader, $('a.section-footer-link')) as HTMLAnchorElement;
 		this.sectionLink.textContent = localize('learnMorePlugins', "Learn more about agent plugins");
-		this.sectionLink.href = 'https://code.visualstudio.com/docs/copilot/chat/agent-plugins';
+		this.sectionLink.href = 'https://code.visualstudio.com/docs/copilot/customization/agent-plugins';
 		this._register(DOM.addDisposableListener(this.sectionLink, 'click', (e) => {
 			e.preventDefault();
 			const href = this.sectionLink.href;


### PR DESCRIPTION
Fix broken link for 'Learn more about agent plugins'  in 'Chat Customizations' - 'Plugins'

<img width="1197" height="717" alt="image" src="https://github.com/user-attachments/assets/601ce266-3d8f-4f18-a6a1-d576ad5bd5b3" />

<img width="1062" height="766" alt="image" src="https://github.com/user-attachments/assets/0ac3fa5a-392a-4bc1-8254-f581dd7d21c7" />
