### PR TITLE
chat: interpolate PLUGIN_ROOT and CLAUDE_PLUGIN_ROOT in MCP server definitions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -669,6 +669,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		const inputResizeObserver = questionRenderStore.add(new dom.DisposableResizeObserver(() => scheduleLayoutInputScrollable()));
 		questionRenderStore.add(inputResizeObserver.observe(inputScrollableNode));
 		questionRenderStore.add(inputResizeObserver.observe(inputContainer));
+		questionRenderStore.add(dom.addDisposableListener(dom.getWindow(this.domNode), dom.EventType.RESIZE, () => scheduleLayoutInputScrollable()));
 		scheduleLayoutInputScrollable();
 		questionRenderStore.add(dom.runAtThisOrScheduleAtNextAnimationFrame(dom.getWindow(this.domNode), () => {
 			inputContainer.scrollTop = 0;

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -26,7 +26,7 @@ import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } fr
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
-import { IMcpServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
+import { IMcpRemoteServerConfiguration, IMcpServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
@@ -55,6 +55,8 @@ interface IAgentPluginFormatAdapter {
 	readonly format: AgentPluginFormat;
 	readonly manifestPath: string;
 	readonly hookConfigPath: string;
+	readonly pluginRootToken: string | undefined;
+	readonly pluginRootEnvVar: string | undefined;
 	parseHooks(json: unknown, pluginUri: URI, userHome: string): IAgentPluginHook[];
 }
 
@@ -76,6 +78,8 @@ class CopilotPluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.Copilot;
 	readonly manifestPath = 'plugin.json';
 	readonly hookConfigPath = 'hooks.json';
+	readonly pluginRootToken = undefined;
+	readonly pluginRootEnvVar = undefined;
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -131,6 +135,57 @@ export function shellQuotePluginRootInCommand(command: string, fsPath: string, t
 		// Wrap in double quotes, escaping any embedded double-quote chars.
 		return '"' + fullPath.replace(/"/g, '\\"') + '"';
 	});
+}
+
+/**
+ * Replaces `${token}` references in MCP server definition string fields
+ * (command, args, cwd, env values, url, envFile, headers) with the plugin
+ * root filesystem path. No shell quoting is needed because args are already
+ * a string array.
+ */
+function interpolateMcpPluginRoot(
+	def: IAgentPluginMcpServerDefinition,
+	fsPath: string,
+	token: string,
+	envVar: string,
+): IAgentPluginMcpServerDefinition {
+	const replace = (s: string) => s.replaceAll(token, fsPath);
+
+	const config = def.configuration;
+	let interpolated: IMcpServerConfiguration;
+
+	if (config.type === McpServerType.LOCAL) {
+		const local: Mutable<IMcpStdioServerConfiguration> = { ...config };
+		local.command = replace(local.command);
+		if (local.args) {
+			local.args = local.args.map(replace);
+		}
+		if (local.cwd) {
+			local.cwd = replace(local.cwd);
+		}
+		local.env = { ...local.env };
+		for (const [k, v] of Object.entries(local.env)) {
+			if (typeof v === 'string') {
+				local.env[k] = replace(v);
+			}
+		}
+		local.env[envVar] = fsPath;
+		if (local.envFile) {
+			local.envFile = replace(local.envFile);
+		}
+		interpolated = local;
+	} else {
+		const remote: Mutable<IMcpRemoteServerConfiguration> = { ...config };
+		remote.url = replace(remote.url);
+		if (remote.headers) {
+			remote.headers = Object.fromEntries(
+				Object.entries(remote.headers).map(([k, v]) => [k, replace(v)])
+			);
+		}
+		interpolated = remote;
+	}
+
+	return { name: def.name, configuration: interpolated };
 }
 
 /**
@@ -201,6 +256,8 @@ class ClaudePluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.Claude;
 	readonly manifestPath = '.claude-plugin/plugin.json';
 	readonly hookConfigPath = 'hooks/hooks.json';
+	readonly pluginRootToken = '${CLAUDE_PLUGIN_ROOT}';
+	readonly pluginRootEnvVar = 'CLAUDE_PLUGIN_ROOT';
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -215,6 +272,8 @@ class OpenPluginFormatAdapter implements IAgentPluginFormatAdapter {
 	readonly format = AgentPluginFormat.OpenPlugin;
 	readonly manifestPath = '.plugin/plugin.json';
 	readonly hookConfigPath = 'hooks/hooks.json';
+	readonly pluginRootToken = '${PLUGIN_ROOT}';
+	readonly pluginRootEnvVar = 'PLUGIN_ROOT';
 
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
@@ -525,8 +584,8 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 
 		const mcpServerDefinitions = observeComponent(
 			'mcpServers',
-			paths => this._readMcpDefinitionsFromPaths(paths),
-			async section => this._parseMcpServerDefinitionMap({ mcpServers: section }),
+			paths => this._readMcpDefinitionsFromPaths(paths, uri.fsPath, adapter),
+			async section => this._parseMcpServerDefinitionMap({ mcpServers: section }, uri.fsPath, adapter),
 			'.mcp.json',
 		);
 
@@ -596,11 +655,11 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 	 * Definitions from all files are merged; the first definition for a given
 	 * server name wins.
 	 */
-	private async _readMcpDefinitionsFromPaths(paths: readonly URI[]): Promise<readonly IAgentPluginMcpServerDefinition[]> {
+	private async _readMcpDefinitionsFromPaths(paths: readonly URI[], pluginFsPath: string, adapter: IAgentPluginFormatAdapter): Promise<readonly IAgentPluginMcpServerDefinition[]> {
 		const merged = new Map<string, IMcpServerConfiguration>();
 		for (const mcpPath of paths) {
 			const json = await this._readJsonFile(mcpPath);
-			for (const def of this._parseMcpServerDefinitionMap(json)) {
+			for (const def of this._parseMcpServerDefinitionMap(json, pluginFsPath, adapter)) {
 				if (!merged.has(def.name)) {
 					merged.set(def.name, def.configuration);
 				}
@@ -611,7 +670,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			.sort((a, b) => a.name.localeCompare(b.name));
 	}
 
-	private _parseMcpServerDefinitionMap(raw: unknown): IAgentPluginMcpServerDefinition[] {
+	private _parseMcpServerDefinitionMap(raw: unknown, pluginFsPath: string, adapter: IAgentPluginFormatAdapter): IAgentPluginMcpServerDefinition[] {
 		if (!raw || typeof raw !== 'object' || !raw.hasOwnProperty('mcpServers')) {
 			return [];
 		}
@@ -623,7 +682,11 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 				continue;
 			}
 
-			definitions.push({ name, configuration });
+			let def: IAgentPluginMcpServerDefinition = { name, configuration };
+			if (adapter.pluginRootToken && adapter.pluginRootEnvVar) {
+				def = interpolateMcpPluginRoot(def, pluginFsPath, adapter.pluginRootToken, adapter.pluginRootEnvVar);
+			}
+			definitions.push(def);
 		}
 
 		return definitions;

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -872,4 +872,63 @@ suite('AgentPlugin format detection', () => {
 		assert.strictEqual(instruction.name, 'my-rule');
 		assert.ok(instruction.uri.path.endsWith('/rules/my-rule.mdc'));
 	}));
+
+	test('PLUGIN_ROOT expansion in inline MCP server definitions', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/mcp-root');
+		await writeFile('/plugins/mcp-root/.plugin/plugin.json', JSON.stringify({
+			name: 'mcp-root',
+			mcpServers: {
+				'my-server': {
+					command: '${PLUGIN_ROOT}/bin/server',
+					args: ['--config', '${PLUGIN_ROOT}/config.json'],
+					cwd: '${PLUGIN_ROOT}',
+					env: { 'CONFIG_DIR': '${PLUGIN_ROOT}/etc' },
+				},
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
+		const server = plugins[0].mcpServerDefinitions.get()[0];
+		assert.strictEqual(server.name, 'my-server');
+		const config = server.configuration as { command: string; args: string[]; cwd: string; env: Record<string, string> };
+		assert.ok(!config.command.includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in command, got: ${config.command}`);
+		assert.ok(!config.args[1].includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in args, got: ${config.args[1]}`);
+		assert.ok(!config.cwd.includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in cwd, got: ${config.cwd}`);
+		assert.ok(!config.env['CONFIG_DIR'].includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in env, got: ${config.env['CONFIG_DIR']}`);
+		assert.strictEqual(config.env['PLUGIN_ROOT'], uri.fsPath, 'Expected PLUGIN_ROOT env var to be set');
+	}));
+
+	test('CLAUDE_PLUGIN_ROOT expansion in MCP server definitions from .mcp.json', () => runWithFakedTimers({ useFakeTimers: true }, async () => {
+		const uri = pluginUri('/plugins/claude-mcp-root');
+		await writeFile('/plugins/claude-mcp-root/.claude-plugin/plugin.json', JSON.stringify({ name: 'claude-mcp-root' }));
+		await writeFile('/plugins/claude-mcp-root/.mcp.json', JSON.stringify({
+			mcpServers: {
+				'claude-server': {
+					command: '${CLAUDE_PLUGIN_ROOT}/run.sh',
+					args: ['--dir', '${CLAUDE_PLUGIN_ROOT}/data'],
+				},
+			},
+		}));
+
+		const discovery = createDiscovery();
+		discovery.start(mockEnablementModel);
+		await discovery.setSourcesAndRefresh([uri]);
+
+		const plugins = discovery.plugins.get();
+		assert.strictEqual(plugins.length, 1);
+
+		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
+		const server = plugins[0].mcpServerDefinitions.get()[0];
+		const config = server.configuration as { command: string; args: string[]; env: Record<string, string> };
+		assert.ok(!config.command.includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in command, got: ${config.command}`);
+		assert.ok(!config.args[1].includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in args, got: ${config.args[1]}`);
+		assert.strictEqual(config.env['CLAUDE_PLUGIN_ROOT'], uri.fsPath, 'Expected CLAUDE_PLUGIN_ROOT env var to be set');
+	}));
 });

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -897,7 +897,7 @@ suite('AgentPlugin format detection', () => {
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
 		const server = plugins[0].mcpServerDefinitions.get()[0];
 		assert.strictEqual(server.name, 'my-server');
-		const config = server.configuration as { command: string; args: string[]; cwd: string; env: Record<string, string> };
+		const config: any = server.configuration;
 		assert.ok(!config.command.includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in command, got: ${config.command}`);
 		assert.ok(!config.args[1].includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in args, got: ${config.args[1]}`);
 		assert.ok(!config.cwd.includes('${PLUGIN_ROOT}'), `Expected PLUGIN_ROOT to be expanded in cwd, got: ${config.cwd}`);
@@ -926,7 +926,7 @@ suite('AgentPlugin format detection', () => {
 
 		await waitForState(plugins[0].mcpServerDefinitions, d => d.length > 0);
 		const server = plugins[0].mcpServerDefinitions.get()[0];
-		const config = server.configuration as { command: string; args: string[]; env: Record<string, string> };
+		const config: any = server.configuration;
 		assert.ok(!config.command.includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in command, got: ${config.command}`);
 		assert.ok(!config.args[1].includes('${CLAUDE_PLUGIN_ROOT}'), `Expected CLAUDE_PLUGIN_ROOT to be expanded in args, got: ${config.args[1]}`);
 		assert.strictEqual(config.env['CLAUDE_PLUGIN_ROOT'], uri.fsPath, 'Expected CLAUDE_PLUGIN_ROOT env var to be set');


### PR DESCRIPTION
- Adds pluginRootToken and pluginRootEnvVar properties to IAgentPluginFormatAdapter
  to support format-specific token and environment variable injection
- Implements interpolateMcpPluginRoot() function to replace tokens in MCP server
  definition string fields (command, args, cwd, env values, url, envFile, headers)
- Automatically injects envVar with plugin filesystem path for LOCAL (stdio) servers
- Integrates interpolation into _parseMcpServerDefinitionMap() for both file-based
  and inline MCP definitions
- Adds tests for PLUGIN_ROOT expansion in inline definitions and CLAUDE_PLUGIN_ROOT
  expansion in .mcp.json file-based definitions

(Commit message generated by Copilot)