### PR TITLE
Refactor session handling in ChatService to capture session options before loading remote sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -826,14 +826,9 @@ export class ChatService extends Disposable implements IChatService {
 			const newItem = await this.chatSessionService.createNewChatSessionItem(getChatSessionType(sessionResource), { prompt: requestText, command: commandPart?.text }, CancellationToken.None);
 			if (newItem) {
 
-				// Update the model's contributed session with the resolved resource
-				// so subsequent requests don't re-invoke newChatSessionItemHandler
-				// and getChatSessionFromInternalUri returns the real resource.
+				// Capture session options before loading the remote session,
+				// since the alias registration below may change the lookup.
 				const sessionOptions = this.chatSessionService.getSessionOptions(sessionResource);
-				model?.setContributedChatSession({
-					chatSessionResource: sessionResource,
-					initialSessionOptions: sessionOptions ? [...sessionOptions].map(([optionId, value]) => ({ optionId, value })) : undefined,
-				});
 
 				model = (await this.loadRemoteSession(newItem.resource, model.initialLocation, CancellationToken.None))?.object as ChatModel | undefined;
 				if (!model) {
@@ -842,6 +837,13 @@ export class ChatService extends Disposable implements IChatService {
 
 				// Register alias so session-option lookups work with the new resource
 				this.chatSessionService.registerSessionResourceAlias(sessionResource, newItem.resource);
+
+				// Update the new model's contributed session with initialSessionOptions
+				// so that the agent receives them when invoked.
+				model.setContributedChatSession({
+					chatSessionResource: newItem.resource,
+					initialSessionOptions: sessionOptions ? [...sessionOptions].map(([optionId, value]) => ({ optionId, value })) : undefined,
+				});
 
 				sessionResource = newItem.resource;
 				newSessionResource = newItem.resource;

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -55,6 +55,8 @@ import { ChatDebugServiceImpl } from '../../../common/chatDebugServiceImpl.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { MockLanguageModelToolsService } from '../tools/mockLanguageModelToolsService.js';
+import { IChatSessionsService } from '../../../common/chatSessionsService.js';
+import { MockChatSessionsService } from '../mockChatSessionsService.js';
 
 const chatAgentWithUsedContextId = 'ChatProviderWithUsedContext';
 const chatAgentWithUsedContext: IChatAgent = {
@@ -770,6 +772,73 @@ suite('ChatService', () => {
 		assert.ok(lastThree[0].includes('queued-1'));
 		assert.ok(lastThree[1].includes('queued-2'));
 		assert.ok(lastThree[2].includes('queued-3'));
+	});
+
+	test('sendRequest on untitled remote session propagates initialSessionOptions to new model', async () => {
+		const remoteScheme = 'remoteProvider';
+		const untitledResource = URI.from({ scheme: remoteScheme, path: '/untitled-test-session' });
+		const realResource = URI.from({ scheme: remoteScheme, path: '/real-session-123' });
+
+		// Set up the mock chat sessions service
+		const mockSessionsService = new MockChatSessionsService();
+
+		// Register a content provider so loadRemoteSession can resolve sessions
+		testDisposables.add(mockSessionsService.registerChatSessionContentProvider(remoteScheme, {
+			provideChatSessionContent: (_resource: URI, _token: CancellationToken) => {
+				return Promise.resolve({
+					sessionResource: _resource,
+					history: [],
+					onWillDispose: Event.None,
+					dispose: () => { },
+				});
+			},
+		}));
+
+		// Set session options for the untitled resource
+		mockSessionsService.setSessionOption(untitledResource, 'model', 'claude-3.5-sonnet');
+		mockSessionsService.setSessionOption(untitledResource, 'repo', 'my-repo');
+
+		// Override createNewChatSessionItem to return a real resource
+		mockSessionsService.createNewChatSessionItem = async () => ({
+			resource: realResource,
+			label: 'Test Session',
+			timing: { created: Date.now(), lastRequestStarted: undefined, lastRequestEnded: undefined },
+		});
+
+		instantiationService.stub(IChatSessionsService, mockSessionsService);
+
+		// Register the remote agent
+		const remoteAgent: IChatAgentImplementation = {
+			async invoke(request, progress, history, token) {
+				return {};
+			},
+		};
+		testDisposables.add(chatAgentService.registerAgent(remoteScheme, { ...getAgentData(remoteScheme), isDefault: true }));
+		testDisposables.add(chatAgentService.registerAgentImplementation(remoteScheme, remoteAgent));
+
+		const testService = createChatService();
+
+		// Load the untitled session to create the initial model
+		const untitledRef = await testService.acquireOrLoadSession(untitledResource, ChatAgentLocation.Chat, CancellationToken.None);
+		assert.ok(untitledRef, 'Should load untitled session');
+		testDisposables.add(untitledRef);
+
+		// Send a request - this triggers the untitled → real session conversion
+		const response = await testService.sendRequest(untitledResource, 'hello', { agentId: remoteScheme });
+		ChatSendResult.assertSent(response);
+		await response.data.responseCompletePromise;
+
+		// The new model (with real resource) should have initialSessionOptions set
+		const newModel = testService.getSession(realResource) as ChatModel;
+		assert.ok(newModel, 'New model should exist at the real resource');
+		assert.ok(newModel.contributedChatSession, 'New model should have contributedChatSession');
+		assert.deepStrictEqual(
+			newModel.contributedChatSession?.initialSessionOptions?.map(o => ({ optionId: o.optionId, value: o.value })),
+			[
+				{ optionId: 'model', value: 'claude-3.5-sonnet' },
+				{ optionId: 'repo', value: 'my-repo' },
+			]
+		);
 	});
 });
 


### PR DESCRIPTION
This makes sure `initialSessionOptions` is defined during the request handler.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
