### PR TITLE
fix: improve text selection contrast in Solarized Light

### DIFF
--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -372,7 +372,7 @@
 		"editorCursor.foreground": "#657B83",
 		"editorWhitespace.foreground": "#586E7580",
 		"editor.lineHighlightBackground": "#EEE8D5",
-		"editor.selectionBackground": "#EEE8D5",
+		"editor.selectionBackground": "#878b9180",
 		"minimap.selectionHighlight": "#EEE8D5",
 		"editorIndentGuide.background": "#586E7580",
 		"editorIndentGuide.activeBackground": "#081E2580",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -373,7 +373,7 @@
 		"editorWhitespace.foreground": "#586E7580",
 		"editor.lineHighlightBackground": "#EEE8D5",
 		"editor.selectionBackground": "#878b9180",
-		"minimap.selectionHighlight": "#EEE8D5",
+		"minimap.selectionHighlight": "#878b9180",
 		"editorIndentGuide.background": "#586E7580",
 		"editorIndentGuide.activeBackground": "#081E2580",
 		"editorHoverWidget.background": "#CCC4B0",


### PR DESCRIPTION
Fixes #297509 

# Solution 
Update `editor.selectionBackground` from **#EEE8D5** to **#878b9180**. The
previous color lacked sufficient contrast, making it difficult to
distinguish selected text from the background. The new color matches
existing selection background logic used in other parts of the theme,
ensuring visual consistency and better accessibility.

# Result
### Before Fix
<img width="480" height="238" alt="Screenshot from 2026-03-13 18-46-13" src="https://github.com/user-attachments/assets/12147792-b2f5-421b-8d5b-bbd747b69d89" />

### After Fix
<img width="480" height="238" alt="Screenshot from 2026-03-13 18-49-29" src="https://github.com/user-attachments/assets/ab105ba2-49ff-4438-90b1-5a23104be31f" />