### PR TITLE
Implement image carousel service and integrate with chat attachments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -18,7 +18,6 @@ import { IMarkdownString, MarkdownString } from '../../../../../base/common/html
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../../../base/common/lifecycle.js';
-import { getMediaMime } from '../../../../../base/common/mime.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { basename, dirname } from '../../../../../base/common/path.js';
 import { ScrollbarVisibility } from '../../../../../base/common/scrollable.js';
@@ -69,11 +68,7 @@ import { IChatEntitlementService } from '../../../../services/chat/common/chatEn
 import { ILanguageModelToolsService, isToolSet } from '../../common/tools/languageModelToolsService.js';
 import { getCleanPromptName } from '../../common/promptSyntax/config/promptFileLocations.js';
 import { IChatContextService } from '../contextContrib/chatContextService.js';
-import { IChatWidgetService } from '../chat.js';
-import { isEqual } from '../../../../../base/common/resources.js';
-import { IChatResponseViewModel, isResponseVM } from '../../common/model/chatViewModel.js';
-import { VSBuffer } from '../../../../../base/common/buffer.js';
-import { extractImagesFromChatResponse, IChatExtractedImage } from '../../common/chatImageExtraction.js';
+import { IChatImageCarouselService } from '../chatImageCarouselService.js';
 
 const commonHoverOptions: Partial<IHoverOptions> = {
 	style: HoverStyle.Pointer,
@@ -427,7 +422,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService private readonly labelService: ILabelService,
 		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
-		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@IChatImageCarouselService private readonly chatImageCarouselService: IChatImageCarouselService,
 	) {
 		super(attachment, options, container, contextResourceLabels, currentLanguageModel, commandService, openerService, configurationService);
 
@@ -473,54 +468,8 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 	}
 
 	private async openInCarousel(name: string, data: Uint8Array, referenceUri: URI | undefined): Promise<void> {
-		// Try to find all images from the focused chat widget's responses
-		const widget = this.chatWidgetService.lastFocusedWidget;
-		if (widget?.viewModel) {
-			const responses = widget.viewModel.getItems().filter((item): item is IChatResponseViewModel => isResponseVM(item));
-
-			// Collect all responses that have images, one section per response.
-			// The loop continues after finding the clicked image to gather all sections for the carousel.
-			const sections: { title: string; images: IChatExtractedImage[] }[] = [];
-			let clickedGlobalIndex = -1;
-			let globalOffset = 0;
-
-			// Use session-level ID so the same carousel is reused regardless of which image is clicked
-			const collectionId = widget.viewModel.sessionResource.toString() + '_carousel';
-
-			for (const response of responses) {
-				const extracted = extractImagesFromChatResponse(response);
-				if (extracted && extracted.images.length > 0) {
-					sections.push({ title: extracted.title, images: extracted.images });
-
-					if (clickedGlobalIndex === -1) {
-						const localIndex = referenceUri
-							? extracted.images.findIndex(img => isEqual(img.uri, referenceUri))
-							: extracted.images.findIndex(img => img.data.equals(VSBuffer.wrap(data)));
-						if (localIndex !== -1) {
-							clickedGlobalIndex = globalOffset + localIndex;
-						}
-					}
-
-					globalOffset += extracted.images.length;
-				}
-			}
-
-			if (clickedGlobalIndex !== -1 && sections.length > 0) {
-				await this.commandService.executeCommand('workbench.action.chat.openImageInCarousel', {
-					collection: {
-						id: collectionId,
-						title: sections.length === 1 ? sections[0].title : localize('chat.imageCarousel.allImages', "Chat Images"),
-						sections,
-					},
-					startIndex: clickedGlobalIndex,
-				});
-				return;
-			}
-		}
-
-		// Fallback: open just the single clicked image
-		const mimeType = getMediaMime(name) ?? 'image/png';
-		await this.commandService.executeCommand('workbench.action.chat.openImageInCarousel', { name, mimeType, data, title: name });
+		const resource = referenceUri ?? URI.from({ scheme: 'data', path: name });
+		await this.chatImageCarouselService.openCarouselAtResource(resource, data);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -97,6 +97,7 @@ import { ChatTransferContribution } from './actions/chatTransfer.js';
 import { registerChatOpenAgentDebugPanelAction } from './actions/chatOpenAgentDebugPanelAction.js';
 import { IChatDebugService } from '../common/chatDebugService.js';
 import { ChatDebugServiceImpl } from '../common/chatDebugServiceImpl.js';
+import { ChatImageCarouselService, IChatImageCarouselService } from './chatImageCarouselService.js';
 import { ChatDebugEditor } from './chatDebug/chatDebugEditor.js';
 import { PromptsDebugContribution } from './promptsDebugContribution.js';
 import { ChatDebugEditorInput, ChatDebugEditorInputSerializer } from './chatDebug/chatDebugEditorInput.js';
@@ -1863,5 +1864,6 @@ registerSingleton(IChatOutputRendererService, ChatOutputRendererService, Instant
 registerSingleton(IChatLayoutService, ChatLayoutService, InstantiationType.Delayed);
 registerSingleton(IChatTipService, ChatTipService, InstantiationType.Delayed);
 registerSingleton(IChatDebugService, ChatDebugServiceImpl, InstantiationType.Delayed);
+registerSingleton(IChatImageCarouselService, ChatImageCarouselService, InstantiationType.Delayed);
 
 ChatWidget.CONTRIBS.push(ChatDynamicVariableModel);

--- a/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
@@ -1,0 +1,221 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getMediaMime } from '../../../../base/common/mime.js';
+import { isEqual } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { localize } from '../../../../nls.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { extractImagesFromChatResponse } from '../common/chatImageExtraction.js';
+import { IChatResponseViewModel, isResponseVM } from '../common/model/chatViewModel.js';
+import { IChatWidgetService } from './chat.js';
+
+export const IChatImageCarouselService = createDecorator<IChatImageCarouselService>('chatImageCarouselService');
+
+export interface IChatImageCarouselService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Opens the image carousel for the given resource URI, collecting all images
+	 * from the focused chat widget's responses to populate the carousel.
+	 *
+	 * @param resource The URI of the clicked image to start the carousel at.
+	 * @param data Optional raw image data (e.g. for input attachment images that are Uint8Arrays).
+	 */
+	openCarouselAtResource(resource: URI, data?: Uint8Array): Promise<void>;
+}
+
+//#region Carousel data types
+
+export interface ICarouselImage {
+	readonly id: string;
+	readonly name: string;
+	readonly mimeType: string;
+	readonly data: Uint8Array;
+}
+
+export interface ICarouselSection {
+	readonly title: string;
+	readonly images: ICarouselImage[];
+}
+
+export interface ICarouselCollectionArgs {
+	readonly collection: {
+		readonly id: string;
+		readonly title: string;
+		readonly sections: ICarouselSection[];
+	};
+	readonly startIndex: number;
+}
+
+export interface ICarouselSingleImageArgs {
+	readonly name: string;
+	readonly mimeType: string;
+	readonly data: Uint8Array;
+	readonly title: string;
+}
+
+//#endregion
+
+//#region Testable helper functions
+
+/**
+ * Collects all carousel image sections from chat response items.
+ * Each response with images becomes one section containing both
+ * tool invocation images and inline reference images (file URIs).
+ */
+export async function collectCarouselSections(
+	responses: IChatResponseViewModel[],
+	readFile: (uri: URI) => Promise<Uint8Array>,
+): Promise<ICarouselSection[]> {
+	const sections: ICarouselSection[] = [];
+
+	for (const response of responses) {
+		const { title, images } = await extractImagesFromChatResponse(response, async uri => VSBuffer.wrap(await readFile(uri)));
+
+		if (images.length > 0) {
+			sections.push({
+				title,
+				images: images.map(({ id, name, mimeType, data }) => ({ id, name, mimeType, data: data.buffer }))
+			});
+		}
+	}
+
+	return sections;
+}
+
+/**
+ * Finds the global index of the clicked image across all carousel sections.
+ * Tries URI string match, then parsed URI equality, then data buffer equality.
+ */
+export function findClickedImageIndex(
+	sections: ICarouselSection[],
+	resource: URI,
+	data?: Uint8Array,
+): number {
+	let globalOffset = 0;
+
+	for (const section of sections) {
+		const localIndex = findImageInList(section.images, resource, data);
+		if (localIndex >= 0) {
+			return globalOffset + localIndex;
+		}
+		globalOffset += section.images.length;
+	}
+
+	return -1;
+}
+
+function findImageInList(
+	images: ICarouselImage[],
+	resource: URI,
+	data?: Uint8Array,
+): number {
+	// Try matching by URI string (for inline references and tool images with URIs)
+	const uriStr = resource.toString();
+	const byUri = images.findIndex(img => img.id === uriStr);
+	if (byUri >= 0) {
+		return byUri;
+	}
+
+	// Try matching by parsed URI equality (for tool invocation images with generated URIs)
+	const byParsedUri = images.findIndex(img => {
+		try {
+			return isEqual(URI.parse(img.id), resource);
+		} catch {
+			return false;
+		}
+	});
+	if (byParsedUri >= 0) {
+		return byParsedUri;
+	}
+
+	// Fall back to matching by data buffer equality
+	if (data) {
+		const wrapped = VSBuffer.wrap(data);
+		return images.findIndex(img => VSBuffer.wrap(img.data).equals(wrapped));
+	}
+
+	return -1;
+}
+
+/**
+ * Builds the collection arguments for the carousel command.
+ */
+export function buildCollectionArgs(
+	sections: ICarouselSection[],
+	clickedGlobalIndex: number,
+	sessionResource: URI,
+): ICarouselCollectionArgs {
+	const collectionId = sessionResource.toString() + '_carousel';
+	return {
+		collection: {
+			id: collectionId,
+			title: sections.length === 1
+				? sections[0].title
+				: localize('chatImageCarousel.allImages', "Conversation Images"),
+			sections,
+		},
+		startIndex: clickedGlobalIndex,
+	};
+}
+
+/**
+ * Builds the single-image arguments for the carousel command.
+ */
+export function buildSingleImageArgs(resource: URI, data: Uint8Array): ICarouselSingleImageArgs {
+	const name = resource.path.split('/').pop() ?? 'image';
+	const mimeType = getMediaMime(resource.path) ?? getMediaMime(name) ?? 'image/png';
+	return { name, mimeType, data, title: name };
+}
+
+//#endregion
+
+const CAROUSEL_COMMAND = 'workbench.action.chat.openImageInCarousel';
+
+export class ChatImageCarouselService implements IChatImageCarouselService {
+
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
+		@ICommandService private readonly commandService: ICommandService,
+		@IFileService private readonly fileService: IFileService,
+	) { }
+
+	async openCarouselAtResource(resource: URI, data?: Uint8Array): Promise<void> {
+		const widget = this.chatWidgetService.lastFocusedWidget;
+		if (!widget?.viewModel) {
+			await this.openSingleImage(resource, data);
+			return;
+		}
+
+		const responses = widget.viewModel.getItems().filter((item): item is IChatResponseViewModel => isResponseVM(item));
+		const readFile = async (uri: URI) => (await this.fileService.readFile(uri)).value.buffer;
+		const sections = await collectCarouselSections(responses, readFile);
+		const clickedGlobalIndex = findClickedImageIndex(sections, resource, data);
+
+		if (clickedGlobalIndex === -1 || sections.length === 0) {
+			await this.openSingleImage(resource, data);
+			return;
+		}
+
+		const args = buildCollectionArgs(sections, clickedGlobalIndex, widget.viewModel.sessionResource);
+		await this.commandService.executeCommand(CAROUSEL_COMMAND, args);
+	}
+
+	private async openSingleImage(resource: URI, data?: Uint8Array): Promise<void> {
+		if (!data) {
+			const content = await this.fileService.readFile(resource);
+			data = content.value.buffer;
+		}
+
+		const args = buildSingleImageArgs(resource, data);
+		await this.commandService.executeCommand(CAROUSEL_COMMAND, args);
+	}
+}

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -44,10 +44,12 @@ import { ExplorerFolderContext } from '../../../../files/common/files.js';
 import { IWorkspaceSymbol } from '../../../../search/common/search.js';
 import { IChatContentInlineReference } from '../../../common/chatService/chatService.js';
 import { IChatWidgetService } from '../../chat.js';
+import { IChatImageCarouselService } from '../../chatImageCarouselService.js';
 import { chatAttachmentResourceContextKey, hookUpSymbolAttachmentDragAndContextMenu } from '../../attachments/chatAttachmentWidgets.js';
 import { IChatMarkdownAnchorService } from './chatMarkdownAnchorService.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { ChatConfiguration } from '../../../common/constants.js';
+import { getMediaMime } from '../../../../../../base/common/mime.js';
 
 /**
  * Returns the editor ID to use when opening a resource from chat pills (inline anchors), based on the
@@ -136,6 +138,7 @@ export class InlineAnchorWidget extends Disposable {
 		private readonly element: HTMLAnchorElement | HTMLElement,
 		public readonly inlineReference: IChatContentInlineReference,
 		private readonly metadata: InlineAnchorWidgetMetadata | undefined,
+		@IChatImageCarouselService private readonly chatImageCarouselService: IChatImageCarouselService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IContextKeyService originalContextKeyService: IContextKeyService,
 		@IContextMenuService contextMenuService: IContextMenuService,
@@ -303,6 +306,14 @@ export class InlineAnchorWidget extends Disposable {
 		// Click handler to open with custom editor association from chat.editorAssociations setting
 		this._register(dom.addDisposableListener(element, 'click', async (e) => {
 			dom.EventHelper.stop(e, true);
+
+			// If the reference is an image file and the carousel is enabled, open the carousel
+			const mimeType = getMediaMime(location.uri.path);
+			if (mimeType?.startsWith('image/') && this.configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled)) {
+				await this.chatImageCarouselService.openCarouselAtResource(location.uri);
+				return;
+			}
+
 			const editorOverride = getEditorOverrideForChatResource(location.uri, this.configurationService);
 			const editorOptions: { override: string | undefined; selection?: IRange } = {
 				override: editorOverride,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -20,7 +20,7 @@ import { ChatProgressSubPart } from '../chatProgressContentPart.js';
 import { ChatResourceGroupWidget } from '../chatResourceGroupWidget.js';
 import { IChatCollapsibleIODataPart } from '../chatToolInputOutputContentPart.js';
 import { BaseChatToolInvocationSubPart } from './chatToolInvocationSubPart.js';
-import { extractImagesFromToolInvocation } from '../../../../common/chatImageExtraction.js';
+import { extractImagesFromToolInvocationOutputDetails } from '../../../../common/chatImageExtraction.js';
 import { TerminalToolAutoExpand } from './terminalToolAutoExpand.js';
 import { ChatCollapsibleContentPart } from '../chatCollapsibleContentPart.js';
 import { IChatRendererContent } from '../../../../common/model/chatViewModel.js';
@@ -449,7 +449,7 @@ export class ChatTerminalToolProgressPart extends BaseChatToolInvocationSubPart 
 	 */
 	private _renderImagePills(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, context: IChatContentPartRenderContext, innerContainer: HTMLElement): void {
 		const renderImages = () => {
-			const extracted = extractImagesFromToolInvocation(toolInvocation, context.element.sessionResource);
+			const extracted = extractImagesFromToolInvocationOutputDetails(toolInvocation, context.element.sessionResource);
 			const imageParts: IChatCollapsibleIODataPart[] = extracted.map(img => ({
 				kind: 'data',
 				value: img.data.buffer,

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -31,8 +31,8 @@ export interface IChatExtractedImageCollection {
 
 /**
  * Extract all images from a chat response's tool invocations and inline references.
- * When a {@link readFile} callback is provided, inline reference images (file URIs)
- * are also extracted; otherwise only tool invocation images are returned.
+ * Tool invocation images are extracted from output details and message URIs.
+ * Inline reference images (file URIs) are read via the provided {@link readFile} callback.
  */
 export async function extractImagesFromChatResponse(
 	response: IChatResponseViewModel,
@@ -112,12 +112,14 @@ export async function extractImagesFromToolInvocationMessages(
 	toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
 	readFile: (uri: URI) => Promise<VSBuffer>
 ): Promise<IChatExtractedImage[]> {
+	// Use pastTenseMessage if available, otherwise fall back to invocationMessage.
+	// When pastTenseMessage exists it visually replaces invocationMessage in the UI,
+	// so we only look at its URIs — we don't fall back to invocationMessage URIs.
 	const message = toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage;
 	if (!message || typeof message === 'string' || !message.uris || Object.keys(message.uris).length === 0) {
 		return [];
 	}
 
-	// Prefer past tense message for caption, but fall back to invocation message if past tense not yet available (e.g. for streaming responses)
 	const images: IChatExtractedImage[] = [];
 	for (const uriComponents of Object.values(message.uris)) {
 		const uri = URI.revive(uriComponents);
@@ -167,7 +169,12 @@ async function extractImageFromInlineReference(
 		return undefined;
 	}
 
-	const data = await readFile(refUri);
+	let data: VSBuffer;
+	try {
+		data = await readFile(refUri);
+	} catch {
+		return undefined;
+	}
 	const name = part.name ?? refUri.path.split('/').pop() ?? 'image';
 	return {
 		id: refUri.toString(),

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
-import { getExtensionForMimeType } from '../../../../base/common/mime.js';
+import { getExtensionForMimeType, getMediaMime } from '../../../../base/common/mime.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
+import { isLocation } from '../../../../editor/common/languages.js';
 import { IChatResponseViewModel, IChatRequestViewModel, isRequestVM } from './model/chatViewModel.js';
 import { ChatResponseResource } from './model/chatModel.js';
-import { IChatToolInvocation, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from './chatService/chatService.js';
+import { IChatContentInlineReference, IChatToolInvocation, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from './chatService/chatService.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, IToolResultOutputDetails } from './tools/languageModelToolsService.js';
 
 export interface IChatExtractedImage {
@@ -29,20 +30,26 @@ export interface IChatExtractedImageCollection {
 }
 
 /**
- * Extract all images from a chat response's tool invocations.
+ * Extract all images from a chat response's tool invocations and inline references.
+ * When a {@link readFile} callback is provided, inline reference images (file URIs)
+ * are also extracted; otherwise only tool invocation images are returned.
  */
-export function extractImagesFromChatResponse(response: IChatResponseViewModel): IChatExtractedImageCollection | undefined {
+export async function extractImagesFromChatResponse(
+	response: IChatResponseViewModel,
+	readFile?: (uri: URI) => Promise<VSBuffer>,
+): Promise<IChatExtractedImageCollection> {
 	const allImages: IChatExtractedImage[] = [];
 
 	for (const item of response.response.value) {
 		if (item.kind === 'toolInvocation' || item.kind === 'toolInvocationSerialized') {
 			const images = extractImagesFromToolInvocation(item, response.sessionResource);
 			allImages.push(...images);
+		} else if (item.kind === 'inlineReference' && readFile) {
+			const image = await extractImageFromInlineReference(item, readFile);
+			if (image) {
+				allImages.push(image);
+			}
 		}
-	}
-
-	if (allImages.length === 0) {
-		return undefined;
 	}
 
 	// Use the corresponding user request as the carousel title
@@ -109,4 +116,28 @@ function getImageDataFromOutputDetails(resultDetails: IToolResultOutputDetails, 
 	} else {
 		return resultDetails.output.value;
 	}
+}
+
+async function extractImageFromInlineReference(
+	part: IChatContentInlineReference,
+	readFile: (uri: URI) => Promise<VSBuffer>,
+): Promise<IChatExtractedImage | undefined> {
+	const ref = part.inlineReference;
+	const refUri = URI.isUri(ref) ? ref : isLocation(ref) ? ref.uri : ref.location.uri;
+	const mime = getMediaMime(refUri.path);
+	if (!mime?.startsWith('image/')) {
+		return undefined;
+	}
+
+	const data = await readFile(refUri);
+	const name = part.name ?? refUri.path.split('/').pop() ?? 'image';
+	return {
+		id: refUri.toString(),
+		uri: refUri,
+		name,
+		mimeType: mime,
+		data,
+		source: localize('chatImageExtraction.inlineReference', "File"),
+		caption: undefined,
+	};
 }

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -36,15 +36,17 @@ export interface IChatExtractedImageCollection {
  */
 export async function extractImagesFromChatResponse(
 	response: IChatResponseViewModel,
-	readFile?: (uri: URI) => Promise<VSBuffer>,
+	readFile: (uri: URI) => Promise<VSBuffer>,
 ): Promise<IChatExtractedImageCollection> {
 	const allImages: IChatExtractedImage[] = [];
 
 	for (const item of response.response.value) {
 		if (item.kind === 'toolInvocation' || item.kind === 'toolInvocationSerialized') {
-			const images = extractImagesFromToolInvocation(item, response.sessionResource);
+			const images = extractImagesFromToolInvocationOutputDetails(item, response.sessionResource);
 			allImages.push(...images);
-		} else if (item.kind === 'inlineReference' && readFile) {
+			const messageImages = await extractImagesFromToolInvocationMessages(item, readFile);
+			allImages.push(...messageImages);
+		} else if (item.kind === 'inlineReference') {
 			const image = await extractImageFromInlineReference(item, readFile);
 			if (image) {
 				allImages.push(image);
@@ -63,7 +65,7 @@ export async function extractImagesFromChatResponse(
 	};
 }
 
-export function extractImagesFromToolInvocation(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, sessionResource: URI): IChatExtractedImage[] {
+export function extractImagesFromToolInvocationOutputDetails(toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized, sessionResource: URI): IChatExtractedImage[] {
 	const images: IChatExtractedImage[] = [];
 
 	const resultDetails = IChatToolInvocation.resultDetails(toolInvocation);
@@ -103,6 +105,42 @@ export function extractImagesFromToolInvocation(toolInvocation: IChatToolInvocat
 		}
 	}
 
+	return images;
+}
+
+export async function extractImagesFromToolInvocationMessages(
+	toolInvocation: IChatToolInvocation | IChatToolInvocationSerialized,
+	readFile: (uri: URI) => Promise<VSBuffer>
+): Promise<IChatExtractedImage[]> {
+	const message = toolInvocation.pastTenseMessage ?? toolInvocation.invocationMessage;
+	if (!message || typeof message === 'string' || !message.uris || Object.keys(message.uris).length === 0) {
+		return [];
+	}
+
+	// Prefer past tense message for caption, but fall back to invocation message if past tense not yet available (e.g. for streaming responses)
+	const images: IChatExtractedImage[] = [];
+	for (const uriComponents of Object.values(message.uris)) {
+		const uri = URI.revive(uriComponents);
+		const mimeType = getMediaMime(uri.path);
+		if (mimeType?.startsWith('image/')) {
+			let data: VSBuffer;
+			try {
+				data = await readFile(uri);
+			} catch {
+				continue;
+			}
+			const name = uri.path.split('/').pop() ?? 'image';
+			images.push({
+				id: uri.toString(),
+				uri,
+				name,
+				mimeType,
+				data,
+				source: localize('chatImageExtraction.toolSource', "Tool: {0}", toolInvocation.toolId),
+				caption: message.value,
+			});
+		}
+	}
 	return images;
 }
 

--- a/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { buildCollectionArgs, buildSingleImageArgs, findClickedImageIndex, ICarouselSection } from '../../browser/chatImageCarouselService.js';
+
+suite('ChatImageCarouselService helpers', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeImage(id: string, name: string = 'img.png', mimeType: string = 'image/png'): { id: string; name: string; mimeType: string; data: Uint8Array } {
+		return { id, name, mimeType, data: new Uint8Array([1, 2, 3]) };
+	}
+
+	function makeSections(...imageCounts: number[]): ICarouselSection[] {
+		return imageCounts.map((count, sectionIdx) => ({
+			title: `Section ${sectionIdx}`,
+			images: Array.from({ length: count }, (_, imgIdx) =>
+				makeImage(URI.file(`/image_s${sectionIdx}_i${imgIdx}.png`).toString(), `image_s${sectionIdx}_i${imgIdx}.png`)
+			),
+		}));
+	}
+
+	suite('findClickedImageIndex', () => {
+
+		test('finds image by URI string match in first section', () => {
+			const sections = makeSections(3);
+			const targetUri = URI.parse(sections[0].images[1].id);
+			assert.strictEqual(findClickedImageIndex(sections, targetUri), 1);
+		});
+
+		test('finds image by URI string match in second section', () => {
+			const sections = makeSections(2, 3);
+			const targetUri = URI.parse(sections[1].images[2].id);
+			// globalOffset = 2 (first section) + 2 (third in second section) = 4
+			assert.strictEqual(findClickedImageIndex(sections, targetUri), 4);
+		});
+
+		test('returns -1 when no match found', () => {
+			const sections = makeSections(2, 2);
+			const unknownUri = URI.file('/nonexistent.png');
+			assert.strictEqual(findClickedImageIndex(sections, unknownUri), -1);
+		});
+
+		test('falls back to data buffer match', () => {
+			const sections: ICarouselSection[] = [{
+				title: 'Section',
+				images: [
+					{ id: 'custom-id-1', name: 'a.png', mimeType: 'image/png', data: new Uint8Array([10, 20]) },
+					{ id: 'custom-id-2', name: 'b.png', mimeType: 'image/png', data: new Uint8Array([30, 40]) },
+				],
+			}];
+			const unknownUri = URI.from({ scheme: 'data', path: 'b.png' });
+			assert.strictEqual(findClickedImageIndex(sections, unknownUri, new Uint8Array([30, 40])), 1);
+		});
+
+		test('returns -1 for empty sections', () => {
+			assert.strictEqual(findClickedImageIndex([], URI.file('/x.png')), -1);
+		});
+	});
+
+	suite('buildCollectionArgs', () => {
+
+		test('uses section title when single section', () => {
+			const sections = makeSections(2);
+			const result = buildCollectionArgs(sections, 0, URI.file('/session'));
+			assert.deepStrictEqual(result, {
+				collection: {
+					id: URI.file('/session').toString() + '_carousel',
+					title: 'Section 0',
+					sections,
+				},
+				startIndex: 0,
+			});
+		});
+
+		test('uses generic title for multiple sections', () => {
+			const sections = makeSections(1, 1);
+			const result = buildCollectionArgs(sections, 1, URI.file('/session'));
+			assert.strictEqual(result.collection.title, 'Conversation Images');
+			assert.strictEqual(result.startIndex, 1);
+		});
+	});
+
+	suite('buildSingleImageArgs', () => {
+
+		test('extracts name and mime from URI path', () => {
+			const uri = URI.file('/path/to/photo.jpg');
+			const data = new Uint8Array([1, 2, 3]);
+			assert.deepStrictEqual(buildSingleImageArgs(uri, data), {
+				name: 'photo.jpg',
+				mimeType: 'image/jpg',
+				data,
+				title: 'photo.jpg',
+			});
+		});
+
+		test('defaults mime to image/png for unknown extension', () => {
+			const uri = URI.file('/path/to/file.xyz');
+			const data = new Uint8Array([1]);
+			assert.strictEqual(buildSingleImageArgs(uri, data).mimeType, 'image/png');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -11,7 +11,7 @@ import { IChatProgressResponseContent } from '../../common/model/chatModel.js';
 import { IChatResponseViewModel } from '../../common/model/chatViewModel.js';
 import { IChatContentInlineReference, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from '../../common/chatService/chatService.js';
 import { IToolResultInputOutputDetails } from '../../common/tools/languageModelToolsService.js';
-import { extractImagesFromChatResponse } from '../../common/chatImageExtraction.js';
+import { extractImagesFromChatResponse, extractImagesFromToolInvocationMessages } from '../../common/chatImageExtraction.js';
 
 function makeToolInvocation(overrides: Partial<IChatToolInvocationSerialized> = {}): IChatToolInvocationSerialized {
 	return {
@@ -72,7 +72,7 @@ suite('extractImagesFromChatResponse', () => {
 
 	test('returns empty images when response has no items', async () => {
 		const response = makeResponse([]);
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 		assert.deepStrictEqual(result, {
 			id: response.sessionResource.toString() + '_' + response.id,
 			title: 'Show me images',
@@ -82,7 +82,7 @@ suite('extractImagesFromChatResponse', () => {
 
 	test('uses default title when no matching request is found', async () => {
 		const response = makeResponse([], { noMatchingRequest: true });
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 		assert.strictEqual(result.title, 'Images');
 	});
 
@@ -98,7 +98,7 @@ suite('extractImagesFromChatResponse', () => {
 		});
 
 		const response = makeResponse([toolInvocation]);
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 
 		assert.strictEqual(result.images.length, 1);
 		assert.strictEqual(result.images[0].id, 'call_img_0');
@@ -124,7 +124,7 @@ suite('extractImagesFromChatResponse', () => {
 		});
 
 		const response = makeResponse([toolInvocation]);
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 
 		assert.strictEqual(result.images.length, 2);
 		assert.strictEqual(result.images[0].id, 'call_multi_0');
@@ -140,7 +140,7 @@ suite('extractImagesFromChatResponse', () => {
 		const toolInvocation = makeToolInvocation({ resultDetails });
 
 		const response = makeResponse([toolInvocation]);
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 		assert.strictEqual(result.images.length, 0);
 	});
 
@@ -170,15 +170,6 @@ suite('extractImagesFromChatResponse', () => {
 
 		assert.strictEqual(result.images.length, 1);
 		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
-	});
-
-	test('skips inline references without readFile callback', async () => {
-		const imageUri = URI.file('/photos/cat.png');
-		const inlineRef = makeInlineReference(imageUri);
-
-		const response = makeResponse([inlineRef]);
-		const result = await extractImagesFromChatResponse(response);
-		assert.strictEqual(result.images.length, 0);
 	});
 
 	test('skips non-image inline references', async () => {
@@ -232,7 +223,162 @@ suite('extractImagesFromChatResponse', () => {
 	test('collection id combines sessionResource and response id', async () => {
 		const sessionResource = URI.parse('chat-session://test/my-session');
 		const response = makeResponse([], { sessionResource, id: 'response-42' });
-		const result = await extractImagesFromChatResponse(response);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
 		assert.strictEqual(result.id, sessionResource.toString() + '_response-42');
+	});
+
+	test('extracts images from tool invocation message URIs', async () => {
+		const imageUri = URI.file('/screenshots/result.png');
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_msg',
+			toolId: 'screenshot-tool',
+			pastTenseMessage: { value: 'Took a screenshot', isTrusted: false, uris: { '0': imageUri.toJSON() } },
+		});
+
+		const response = makeResponse([toolInvocation]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 1);
+		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
+		assert.strictEqual(result.images[0].name, 'result.png');
+		assert.strictEqual(result.images[0].mimeType, 'image/png');
+		assert.strictEqual(result.images[0].caption, 'Took a screenshot');
+	});
+
+	test('combines output details images and message URI images', async () => {
+		const imageUri = URI.file('/screenshots/msg-image.jpg');
+		const resultDetails: IToolResultOutputDetailsSerialized = {
+			output: { type: 'data', mimeType: 'image/png', base64Data: 'AQID' },
+		};
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_both',
+			toolId: 'combo-tool',
+			pastTenseMessage: { value: 'Ran combo tool', isTrusted: false, uris: { '0': imageUri.toJSON() } },
+			resultDetails,
+		});
+
+		const response = makeResponse([toolInvocation]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 2);
+		assert.strictEqual(result.images[0].id, 'call_both_0');
+		assert.strictEqual(result.images[1].uri.toString(), imageUri.toString());
+	});
+});
+
+suite('extractImagesFromToolInvocationMessages', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns empty when message is undefined', async () => {
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: undefined,
+			invocationMessage: undefined,
+		});
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('returns empty when message is a string', async () => {
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: 'some string message',
+		});
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('returns empty when message has no uris', async () => {
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: { value: 'No URIs here', isTrusted: false },
+		});
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('returns empty when message uris are empty', async () => {
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: { value: 'Empty URIs', isTrusted: false, uris: {} },
+		});
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('skips non-image URIs', async () => {
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: { value: 'Code file', isTrusted: false, uris: { '0': URI.file('/src/main.ts').toJSON() } },
+		});
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('extracts image from message URI', async () => {
+		const imageUri = URI.file('/screenshots/capture.png');
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_uri',
+			toolId: 'screenshot-tool',
+			pastTenseMessage: { value: 'Captured screenshot', isTrusted: false, uris: { '0': imageUri.toJSON() } },
+		});
+
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].uri.toString(), imageUri.toString());
+		assert.strictEqual(result[0].name, 'capture.png');
+		assert.strictEqual(result[0].mimeType, 'image/png');
+		assert.strictEqual(result[0].caption, 'Captured screenshot');
+		assert.ok(result[0].source.includes('screenshot-tool'));
+	});
+
+	test('extracts multiple images from message URIs', async () => {
+		const uri1 = URI.file('/img/a.png');
+		const uri2 = URI.file('/img/b.jpg');
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: {
+				value: 'Generated images',
+				isTrusted: false,
+				uris: { '0': uri1.toJSON(), '1': uri2.toJSON() },
+			},
+		});
+
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+
+		assert.strictEqual(result.length, 2);
+		assert.strictEqual(result[0].mimeType, 'image/png');
+		assert.strictEqual(result[1].mimeType, 'image/jpg');
+	});
+
+	test('continues when readFile fails for one URI', async () => {
+		const goodUri = URI.file('/img/good.png');
+		const badUri = URI.file('/img/bad.png');
+		const failingReadFile = (uri: URI) => {
+			if (uri.path.includes('bad')) {
+				return Promise.reject(new Error('File not found'));
+			}
+			return Promise.resolve(VSBuffer.fromString('image-data'));
+		};
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: {
+				value: 'Mixed results',
+				isTrusted: false,
+				uris: { '0': badUri.toJSON(), '1': goodUri.toJSON() },
+			},
+		});
+
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, failingReadFile);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].uri.toString(), goodUri.toString());
+	});
+
+	test('falls back to invocationMessage when pastTenseMessage is undefined', async () => {
+		const imageUri = URI.file('/img/fallback.png');
+		const toolInvocation = makeToolInvocation({
+			pastTenseMessage: undefined,
+			invocationMessage: { value: 'Running tool', isTrusted: false, uris: { '0': imageUri.toJSON() } },
+		});
+
+		const result = await extractImagesFromToolInvocationMessages(toolInvocation, fakeReadFile);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].caption, 'Running tool');
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IChatProgressResponseContent } from '../../common/model/chatModel.js';
+import { IChatResponseViewModel } from '../../common/model/chatViewModel.js';
+import { IChatContentInlineReference, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from '../../common/chatService/chatService.js';
+import { IToolResultInputOutputDetails } from '../../common/tools/languageModelToolsService.js';
+import { extractImagesFromChatResponse } from '../../common/chatImageExtraction.js';
+
+function makeToolInvocation(overrides: Partial<IChatToolInvocationSerialized> = {}): IChatToolInvocationSerialized {
+	return {
+		kind: 'toolInvocationSerialized',
+		toolCallId: 'call_1',
+		toolId: 'test-tool',
+		invocationMessage: 'Running tool',
+		originMessage: undefined,
+		pastTenseMessage: 'Ran tool',
+		isConfirmed: true,
+		isComplete: true,
+		source: undefined,
+		presentation: undefined,
+		resultDetails: undefined,
+		...overrides,
+	};
+}
+
+function makeInlineReference(uri: URI, name?: string): IChatContentInlineReference {
+	return {
+		kind: 'inlineReference',
+		inlineReference: uri,
+		name,
+	};
+}
+
+function makeResponse(items: ReadonlyArray<IChatProgressResponseContent>, opts: {
+	sessionResource?: URI;
+	requestId?: string;
+	id?: string;
+	requestMessageText?: string;
+	noMatchingRequest?: boolean;
+} = {}): IChatResponseViewModel {
+	const sessionResource = opts.sessionResource ?? URI.parse('chat-session://test/session');
+	const requestId = opts.requestId ?? 'req-1';
+	const responseId = opts.id ?? 'resp-1';
+	const requestMessageText = opts.requestMessageText ?? 'Show me images';
+
+	return {
+		id: responseId,
+		requestId,
+		sessionResource,
+		response: { value: items },
+		session: {
+			getItems: () => opts.noMatchingRequest ? [] : [{
+				id: requestId,
+				messageText: requestMessageText,
+				message: { parts: [], text: requestMessageText },
+			}],
+		},
+	} as unknown as IChatResponseViewModel;
+}
+
+const fakeReadFile = (uri: URI) => Promise.resolve(VSBuffer.fromString(`data-for-${uri.path}`));
+
+suite('extractImagesFromChatResponse', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('returns empty images when response has no items', async () => {
+		const response = makeResponse([]);
+		const result = await extractImagesFromChatResponse(response);
+		assert.deepStrictEqual(result, {
+			id: response.sessionResource.toString() + '_' + response.id,
+			title: 'Show me images',
+			images: [],
+		});
+	});
+
+	test('uses default title when no matching request is found', async () => {
+		const response = makeResponse([], { noMatchingRequest: true });
+		const result = await extractImagesFromChatResponse(response);
+		assert.strictEqual(result.title, 'Images');
+	});
+
+	test('extracts image from tool invocation with IToolResultOutputDetails', async () => {
+		const resultDetails: IToolResultOutputDetailsSerialized = {
+			output: { type: 'data', mimeType: 'image/png', base64Data: 'AQID' },
+		};
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_img',
+			toolId: 'screenshot-tool',
+			pastTenseMessage: 'Took a screenshot',
+			resultDetails,
+		});
+
+		const response = makeResponse([toolInvocation]);
+		const result = await extractImagesFromChatResponse(response);
+
+		assert.strictEqual(result.images.length, 1);
+		assert.strictEqual(result.images[0].id, 'call_img_0');
+		assert.strictEqual(result.images[0].mimeType, 'image/png');
+		assert.ok(result.images[0].source.includes('screenshot-tool'));
+		assert.strictEqual(result.images[0].caption, 'Took a screenshot');
+	});
+
+	test('extracts multiple images from tool invocation with IToolResultInputOutputDetails', async () => {
+		const resultDetails: IToolResultInputOutputDetails = {
+			input: '',
+			output: [
+				{ type: 'embed', mimeType: 'image/png', value: 'AQID', isText: false },
+				{ type: 'embed', mimeType: 'text/plain', value: 'text', isText: true },
+				{ type: 'embed', mimeType: 'image/jpeg', value: 'BAUG', isText: false },
+			],
+		};
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_multi',
+			toolId: 'multi-tool',
+			pastTenseMessage: 'Generated images',
+			resultDetails,
+		});
+
+		const response = makeResponse([toolInvocation]);
+		const result = await extractImagesFromChatResponse(response);
+
+		assert.strictEqual(result.images.length, 2);
+		assert.strictEqual(result.images[0].id, 'call_multi_0');
+		assert.strictEqual(result.images[0].mimeType, 'image/png');
+		assert.strictEqual(result.images[1].id, 'call_multi_2');
+		assert.strictEqual(result.images[1].mimeType, 'image/jpeg');
+	});
+
+	test('skips tool invocations without image results', async () => {
+		const resultDetails: IToolResultOutputDetailsSerialized = {
+			output: { type: 'data', mimeType: 'text/plain', base64Data: 'aGVsbG8=' },
+		};
+		const toolInvocation = makeToolInvocation({ resultDetails });
+
+		const response = makeResponse([toolInvocation]);
+		const result = await extractImagesFromChatResponse(response);
+		assert.strictEqual(result.images.length, 0);
+	});
+
+	test('extracts image from inline reference URI when readFile is provided', async () => {
+		const imageUri = URI.file('/photos/cat.png');
+		const inlineRef = makeInlineReference(imageUri, 'cat.png');
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 1);
+		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
+		assert.strictEqual(result.images[0].name, 'cat.png');
+		assert.strictEqual(result.images[0].mimeType, 'image/png');
+		assert.strictEqual(result.images[0].source, 'File');
+	});
+
+	test('extracts image from inline reference Location', async () => {
+		const imageUri = URI.file('/photos/dog.jpg');
+		const inlineRef: IChatContentInlineReference = {
+			kind: 'inlineReference',
+			inlineReference: { uri: imageUri, range: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 } },
+		};
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 1);
+		assert.strictEqual(result.images[0].uri.toString(), imageUri.toString());
+	});
+
+	test('skips inline references without readFile callback', async () => {
+		const imageUri = URI.file('/photos/cat.png');
+		const inlineRef = makeInlineReference(imageUri);
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response);
+		assert.strictEqual(result.images.length, 0);
+	});
+
+	test('skips non-image inline references', async () => {
+		const codeUri = URI.file('/src/main.ts');
+		const inlineRef = makeInlineReference(codeUri);
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+		assert.strictEqual(result.images.length, 0);
+	});
+
+	test('uses filename from URI path when name is not provided', async () => {
+		const imageUri = URI.file('/assets/banner.gif');
+		const inlineRef = makeInlineReference(imageUri);
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 1);
+		assert.strictEqual(result.images[0].name, 'banner.gif');
+	});
+
+	test('preserves interleaved order of tool and inline reference images', async () => {
+		const toolInvocation = makeToolInvocation({
+			toolCallId: 'call_first',
+			toolId: 'tool-1',
+			resultDetails: {
+				output: { type: 'data', mimeType: 'image/png', base64Data: 'AQID' },
+			} satisfies IToolResultOutputDetailsSerialized,
+		});
+
+		const inlineRef = makeInlineReference(URI.file('/middle.png'), 'middle.png');
+
+		const toolInvocation2 = makeToolInvocation({
+			toolCallId: 'call_last',
+			toolId: 'tool-2',
+			resultDetails: {
+				output: { type: 'data', mimeType: 'image/jpeg', base64Data: 'BAUG' },
+			} satisfies IToolResultOutputDetailsSerialized,
+		});
+
+		const response = makeResponse([toolInvocation, inlineRef, toolInvocation2]);
+		const result = await extractImagesFromChatResponse(response, fakeReadFile);
+
+		assert.strictEqual(result.images.length, 3);
+		assert.strictEqual(result.images[0].id, 'call_first_0');
+		assert.strictEqual(result.images[1].name, 'middle.png');
+		assert.strictEqual(result.images[2].id, 'call_last_0');
+	});
+
+	test('collection id combines sessionResource and response id', async () => {
+		const sessionResource = URI.parse('chat-session://test/my-session');
+		const response = makeResponse([], { sessionResource, id: 'response-42' });
+		const result = await extractImagesFromChatResponse(response);
+		assert.strictEqual(result.id, sessionResource.toString() + '_response-42');
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -227,6 +227,16 @@ suite('extractImagesFromChatResponse', () => {
 		assert.strictEqual(result.id, sessionResource.toString() + '_response-42');
 	});
 
+	test('skips inline reference when readFile fails', async () => {
+		const imageUri = URI.file('/photos/missing.png');
+		const inlineRef = makeInlineReference(imageUri, 'missing.png');
+		const failingReadFile = (_uri: URI) => Promise.reject(new Error('File not found'));
+
+		const response = makeResponse([inlineRef]);
+		const result = await extractImagesFromChatResponse(response, failingReadFile);
+		assert.strictEqual(result.images.length, 0);
+	});
+
 	test('extracts images from tool invocation message URIs', async () => {
 		const imageUri = URI.file('/screenshots/result.png');
 		const toolInvocation = makeToolInvocation({


### PR DESCRIPTION
- Introduced `ChatImageCarouselService` to manage image carousels in chat.
- Updated `ImageAttachmentWidget` to utilize the new carousel service for image display.
- Enhanced image extraction logic to support inline references and tool invocations.
- Added tests for carousel service functionality and image extraction.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
