### PR TITLE
Fix session badge visibility when grouped by repository

### DIFF
--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string>;
+		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5263,7 +5263,7 @@ declare namespace monaco.editor {
 	export const EditorOptions: {
 		acceptSuggestionOnCommitCharacter: IEditorOption<EditorOption.acceptSuggestionOnCommitCharacter, boolean>;
 		acceptSuggestionOnEnter: IEditorOption<EditorOption.acceptSuggestionOnEnter, 'on' | 'off' | 'smart'>;
-		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, any>;
+		accessibilitySupport: IEditorOption<EditorOption.accessibilitySupport, AccessibilitySupport>;
 		accessibilityPageSize: IEditorOption<EditorOption.accessibilityPageSize, number>;
 		allowOverflow: IEditorOption<EditorOption.allowOverflow, boolean>;
 		allowVariableLineHeights: IEditorOption<EditorOption.allowVariableLineHeights, boolean>;
@@ -5326,7 +5326,7 @@ declare namespace monaco.editor {
 		foldingMaximumRegions: IEditorOption<EditorOption.foldingMaximumRegions, number>;
 		unfoldOnClickAfterEndOfLine: IEditorOption<EditorOption.unfoldOnClickAfterEndOfLine, boolean>;
 		fontFamily: IEditorOption<EditorOption.fontFamily, string>;
-		fontInfo: IEditorOption<EditorOption.fontInfo, any>;
+		fontInfo: IEditorOption<EditorOption.fontInfo, FontInfo>;
 		fontLigatures2: IEditorOption<EditorOption.fontLigatures, string>;
 		fontSize: IEditorOption<EditorOption.fontSize, number>;
 		fontWeight: IEditorOption<EditorOption.fontWeight, string>;
@@ -5366,7 +5366,7 @@ declare namespace monaco.editor {
 		pasteAs: IEditorOption<EditorOption.pasteAs, Readonly<Required<IPasteAsOptions>>>;
 		parameterHints: IEditorOption<EditorOption.parameterHints, Readonly<Required<IEditorParameterHintOptions>>>;
 		peekWidgetDefaultFocus: IEditorOption<EditorOption.peekWidgetDefaultFocus, 'tree' | 'editor'>;
-		placeholder: IEditorOption<EditorOption.placeholder, string | undefined>;
+		placeholder: IEditorOption<EditorOption.placeholder, string>;
 		definitionLinkOpensInPeek: IEditorOption<EditorOption.definitionLinkOpensInPeek, boolean>;
 		quickSuggestions: IEditorOption<EditorOption.quickSuggestions, InternalQuickSuggestionsOptions>;
 		quickSuggestionsDelay: IEditorOption<EditorOption.quickSuggestionsDelay, number>;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -42,6 +42,7 @@ import { ChatEditorInput } from '../widgetHosts/editor/chatEditorInput.js';
 import { IMouseEvent } from '../../../../../base/browser/mouseEvent.js';
 import { IChatWidget } from '../chat.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 
 export interface IAgentSessionsControlOptions extends IAgentSessionsSorterOptions {
 	readonly overrideStyles: IStyleOverride<IListStyles>;
@@ -108,6 +109,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IStorageService private readonly storageService: IStorageService,
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -248,7 +250,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			...this.options,
 			isGroupedByRepository: () => this.options.filter.groupResults?.() === AgentSessionsGrouping.Repository,
 		}, approvalModel, activeSessionResource));
-		const sessionFilter = this._register(new AgentSessionsDataSource(this.options.filter, sorter));
+		const sessionFilter = this._register(new AgentSessionsDataSource(this.options.filter, sorter, this.logService));
 		const list = this.sessionsList = this._register(this.instantiationService.createInstance(WorkbenchCompressibleAsyncDataTree,
 			'AgentSessionsView',
 			container,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -889,12 +889,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 			const repoName = this.getRepositoryName(session);
 			if (!repoName) {
-				this.logService?.warn(
-					'[AgentSessions] Could not determine repository name for session, categorizing as "Other"',
-					`resource=${session.resource.toString()}`,
-					`badge=${session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : 'none'}`,
-					`metadata=${JSON.stringify(session.metadata)}`,
-				);
+				this.logService?.warn('[AgentSessions] Could not determine repository name for session, categorizing as "Other"', JSON.stringify(session));
 			}
 			const repoId = repoName || unknownKey;
 			const repoLabel = repoName || unknownLabel;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -277,12 +277,18 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			return false;
 		}
 
-		// When grouped by repository, hide the badge if it only shows the repo name
-		// (since the section header already displays it)
+		// When grouped by repository, hide the badge only if the name it shows
+		// matches the section header (i.e. the repository name for this session).
+		// Badges with a different name (e.g. worktree name) are still shown.
 		if (this.options.isGroupedByRepository?.()) {
 			const raw = typeof badge === 'string' ? badge : badge.value;
-			if (/^\$\((?:repo|folder|worktree)\)\s*.+/.test(raw)) {
-				return false;
+			const match = raw.match(/^\$\((?:repo|folder|worktree)\)\s*(.+)/);
+			if (match) {
+				const badgeName = match[1].trim();
+				const repoName = getRepositoryName(session.element);
+				if (badgeName === repoName) {
+					return false;
+				}
 			}
 		}
 
@@ -910,142 +916,151 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	}
 
 	private getRepositoryName(session: IAgentSession): string | undefined {
-		const metadata = session.metadata;
-		if (metadata) {
-			// Cloud sessions: metadata.owner + metadata.name
-			const owner = metadata.owner as string | undefined;
-			const name = metadata.name as string | undefined;
-			if (owner && name) {
-				return name;
-			}
+		return getRepositoryName(session);
+	}
+}
 
-			// repositoryNwo: "owner/repo"
-			const nwo = metadata.repositoryNwo as string | undefined;
-			if (nwo && nwo.includes('/')) {
-				return nwo.split('/').pop()!;
-			}
+/**
+ * Extracts the repository name for an agent session from its metadata or badge.
+ * Used for grouping sessions by repository and for determining whether a badge
+ * is redundant with the section header.
+ */
+export function getRepositoryName(session: IAgentSession): string | undefined {
+	const metadata = session.metadata;
+	if (metadata) {
+		// Cloud sessions: metadata.owner + metadata.name
+		const owner = metadata.owner as string | undefined;
+		const name = metadata.name as string | undefined;
+		if (owner && name) {
+			return name;
+		}
 
-			// repository: could be "owner/repo", a URL, or git@host:owner/repo.git
-			const repository = metadata.repository as string | undefined;
-			if (repository) {
-				const repoName = this.parseRepositoryName(repository);
-				if (repoName) {
-					return repoName;
-				}
-			}
+		// repositoryNwo: "owner/repo"
+		const nwo = metadata.repositoryNwo as string | undefined;
+		if (nwo && nwo.includes('/')) {
+			return nwo.split('/').pop()!;
+		}
 
-			// repositoryUrl: "https://github.com/owner/repo"
-			const repositoryUrl = metadata.repositoryUrl as string | undefined;
-			if (repositoryUrl) {
-				const repoName = this.parseRepositoryName(repositoryUrl);
-				if (repoName) {
-					return repoName;
-				}
-			}
-
-			// repositoryPath: extract repo name from the directory path basename
-			const repositoryPath = metadata.repositoryPath as string | undefined;
-			if (repositoryPath) {
-				const repoName = this.extractRepoNameFromPath(repositoryPath);
-				if (repoName) {
-					return repoName;
-				}
-			}
-
-			// worktreePath: extract repo name from the worktree path
-			const worktreePath = metadata.worktreePath as string | undefined;
-			if (worktreePath) {
-				const repoName = this.extractRepoNameFromPath(worktreePath);
-				if (repoName) {
-					return repoName;
-				}
-			}
-
-			// workingDirectoryPath: fallback to extract name from the working directory
-			const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
-			if (workingDirectoryPath) {
-				const repoName = this.extractRepoNameFromPath(workingDirectoryPath);
-				if (repoName) {
-					return repoName;
-				}
+		// repository: could be "owner/repo", a URL, or git@host:owner/repo.git
+		const repository = metadata.repository as string | undefined;
+		if (repository) {
+			const repoName = parseRepositoryName(repository);
+			if (repoName) {
+				return repoName;
 			}
 		}
 
-		// Fallback: extract repo/folder name from badge
-		const badge = session.badge;
-		if (badge) {
-			const raw = typeof badge === 'string' ? badge : badge.value;
-			const badgeMatch = raw.match(/\$\((?:repo|folder|worktree)\)\s*(.+)/);
-			if (badgeMatch) {
-				return badgeMatch[1].trim();
+		// repositoryUrl: "https://github.com/owner/repo"
+		const repositoryUrl = metadata.repositoryUrl as string | undefined;
+		if (repositoryUrl) {
+			const repoName = parseRepositoryName(repositoryUrl);
+			if (repoName) {
+				return repoName;
 			}
 		}
 
-		return undefined;
+		// repositoryPath: extract repo name from the directory path basename
+		const repositoryPath = metadata.repositoryPath as string | undefined;
+		if (repositoryPath) {
+			const repoName = extractRepoNameFromPath(repositoryPath);
+			if (repoName) {
+				return repoName;
+			}
+		}
+
+		// worktreePath: extract repo name from the worktree path
+		const worktreePath = metadata.worktreePath as string | undefined;
+		if (worktreePath) {
+			const repoName = extractRepoNameFromPath(worktreePath);
+			if (repoName) {
+				return repoName;
+			}
+		}
+
+		// workingDirectoryPath: fallback to extract name from the working directory
+		const workingDirectoryPath = metadata.workingDirectoryPath as string | undefined;
+		if (workingDirectoryPath) {
+			const repoName = extractRepoNameFromPath(workingDirectoryPath);
+			if (repoName) {
+				return repoName;
+			}
+		}
 	}
 
-	/**
-	 * Parses a repository name from various formats: "owner/repo", URLs,
-	 * and git@host:owner/repo.git style references.
-	 */
-	private parseRepositoryName(value: string): string | undefined {
-		// Direct "owner/repo" style (no scheme, no git@ prefix)
-		if (value.includes('/') && !value.includes('://') && !value.startsWith('git@')) {
-			let repoSegment = value.split('/').filter(Boolean).pop();
+	// Fallback: extract repo/folder name from badge
+	const badge = session.badge;
+	if (badge) {
+		const raw = typeof badge === 'string' ? badge : badge.value;
+		const badgeMatch = raw.match(/\$\((?:repo|folder|worktree)\)\s*(.+)/);
+		if (badgeMatch) {
+			return badgeMatch[1].trim();
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Parses a repository name from various formats: "owner/repo", URLs,
+ * and git@host:owner/repo.git style references.
+ */
+function parseRepositoryName(value: string): string | undefined {
+	// Direct "owner/repo" style (no scheme, no git@ prefix)
+	if (value.includes('/') && !value.includes('://') && !value.startsWith('git@')) {
+		let repoSegment = value.split('/').filter(Boolean).pop();
+		if (repoSegment?.endsWith('.git')) {
+			repoSegment = repoSegment.slice(0, -4);
+		}
+		return repoSegment || undefined;
+	}
+
+	// Standard URL formats (https://..., ssh://..., etc.)
+	try {
+		const url = new URL(value);
+		const parts = url.pathname.split('/').filter(Boolean);
+		if (parts.length >= 2) {
+			let repoSegment = parts[1];
+			if (repoSegment.endsWith('.git')) {
+				repoSegment = repoSegment.slice(0, -4);
+			}
+			return repoSegment || undefined;
+		}
+	} catch {
+		// not a standard URL
+	}
+
+	// git@host:owner/repo(.git) style URLs
+	if (value.startsWith('git@')) {
+		const colonIndex = value.indexOf(':');
+		if (colonIndex !== -1 && colonIndex < value.length - 1) {
+			const pathPart = value.substring(colonIndex + 1);
+			let repoSegment = pathPart.split('/').filter(Boolean).pop();
 			if (repoSegment?.endsWith('.git')) {
 				repoSegment = repoSegment.slice(0, -4);
 			}
 			return repoSegment || undefined;
 		}
-
-		// Standard URL formats (https://..., ssh://..., etc.)
-		try {
-			const url = new URL(value);
-			const parts = url.pathname.split('/').filter(Boolean);
-			if (parts.length >= 2) {
-				let repoSegment = parts[1];
-				if (repoSegment.endsWith('.git')) {
-					repoSegment = repoSegment.slice(0, -4);
-				}
-				return repoSegment || undefined;
-			}
-		} catch {
-			// not a standard URL
-		}
-
-		// git@host:owner/repo(.git) style URLs
-		if (value.startsWith('git@')) {
-			const colonIndex = value.indexOf(':');
-			if (colonIndex !== -1 && colonIndex < value.length - 1) {
-				const pathPart = value.substring(colonIndex + 1);
-				let repoSegment = pathPart.split('/').filter(Boolean).pop();
-				if (repoSegment?.endsWith('.git')) {
-					repoSegment = repoSegment.slice(0, -4);
-				}
-				return repoSegment || undefined;
-			}
-		}
-
-		return undefined;
 	}
 
-	/**
-	 * Extracts the repository name from a filesystem path, handling git worktree
-	 * conventions where paths follow `<repo>.worktrees/<worktree-name>`.
-	 */
-	private extractRepoNameFromPath(dirPath: string): string | undefined {
-		const segments = dirPath.split(/[/\\]/).filter(Boolean);
-		if (segments.length < 2) {
-			return segments[0];
-		}
+	return undefined;
+}
 
-		const parent = segments[segments.length - 2];
-		if (parent.endsWith('.worktrees')) {
-			return parent.slice(0, -'.worktrees'.length) || undefined;
-		}
-
-		return segments[segments.length - 1];
+/**
+ * Extracts the repository name from a filesystem path, handling git worktree
+ * conventions where paths follow `<repo>.worktrees/<worktree-name>`.
+ */
+function extractRepoNameFromPath(dirPath: string): string | undefined {
+	const segments = dirPath.split(/[/\\]/).filter(Boolean);
+	if (segments.length < 2) {
+		return segments[0];
 	}
+
+	const parent = segments[segments.length - 2];
+	if (parent.endsWith('.worktrees')) {
+		return parent.slice(0, -'.worktrees'.length) || undefined;
+	}
+
+	return segments[segments.length - 1];
 }
 
 export const AgentSessionSectionLabels = {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -281,7 +281,9 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		// When grouped by repository, hide the badge only if the name it shows
 		// matches the section header (i.e. the repository name for this session).
 		// Badges with a different name (e.g. worktree name) are still shown.
-		if (this.options.isGroupedByRepository?.()) {
+		// Archived sessions always keep their badge since they are grouped under
+		// the "Archived" section, not a repository section.
+		if (this.options.isGroupedByRepository?.() && !session.element.isArchived()) {
 			const raw = typeof badge === 'string' ? badge : badge.value;
 			const match = raw.match(/^\$\((?:repo|folder|worktree)\)\s*(.+)/);
 			if (match) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -49,6 +49,7 @@ import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 
 
 export type AgentSessionListItem = IAgentSession | IAgentSessionSection;
@@ -751,6 +752,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 	constructor(
 		private readonly filter: IAgentSessionsFilter | undefined,
 		private readonly sorter: ITreeSorter<IAgentSession>,
+		private readonly logService?: ILogService,
 	) {
 		super();
 	}
@@ -884,6 +886,13 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			}
 
 			const repoName = this.getRepositoryName(session);
+			if (!repoName) {
+				this.logService?.warn('[AgentSessions] Could not determine repository name for session, categorizing as "Other"', {
+					resource: session.resource.toString(),
+					badge: session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : undefined,
+					metadata: session.metadata,
+				});
+			}
 			const repoId = repoName || unknownKey;
 			const repoLabel = repoName || unknownLabel;
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -889,11 +889,12 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 			const repoName = this.getRepositoryName(session);
 			if (!repoName) {
-				this.logService?.warn('[AgentSessions] Could not determine repository name for session, categorizing as "Other"', {
-					resource: session.resource.toString(),
-					badge: session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : undefined,
-					metadata: session.metadata,
-				});
+				this.logService?.warn(
+					'[AgentSessions] Could not determine repository name for session, categorizing as "Other"',
+					`resource=${session.resource.toString()}`,
+					`badge=${session.badge ? (typeof session.badge === 'string' ? session.badge : session.badge.value) : 'none'}`,
+					`metadata=${JSON.stringify(session.metadata)}`,
+				);
 			}
 			const repoId = repoName || unknownKey;
 			const repoLabel = repoName || unknownLabel;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -859,5 +859,18 @@ suite('AgentSessionsDataSource', () => {
 			assert.strictEqual(getRepositoryName(session), 'vscode');
 			// Badge text shows a different name than the repo — renderer should NOT hide it
 		});
+
+		test('archived session still returns repo name from metadata', () => {
+			// Archived sessions are grouped under "Archived", not under a repo section,
+			// so the renderer must keep their badge visible even when the badge name
+			// matches the repo name. getRepositoryName still resolves normally.
+			const session = createMockSession({
+				id: '1',
+				isArchived: true,
+				metadata: { repositoryPath: '/Users/user/Projects/vscode' },
+				badge: '$(repo) vscode',
+			});
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName } from '../../../browser/agentSessions/agentSessionsViewer.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSessionSection } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -797,6 +797,67 @@ suite('AgentSessionsDataSource', () => {
 			const result = getSectionsFromResult(dataSource.getChildren(createMockModel(sessions)));
 
 			assert.deepStrictEqual(result.map(s => s.label), ['vscode']);
+		});
+	});
+
+	suite('getRepositoryName', () => {
+
+		test('returns metadata.name when owner and name are present', () => {
+			const session = createMockSession({ id: '1', metadata: { owner: 'microsoft', name: 'vscode' } });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns repo from repositoryNwo', () => {
+			const session = createMockSession({ id: '1', metadata: { repositoryNwo: 'microsoft/vscode' } });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns repo from repository URL', () => {
+			const session = createMockSession({ id: '1', metadata: { repository: 'https://github.com/microsoft/vscode' } });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns repo from repositoryPath basename', () => {
+			const session = createMockSession({ id: '1', metadata: { repositoryPath: '/Users/user/Projects/vscode' } });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns parent repo name from worktree path', () => {
+			const session = createMockSession({ id: '1', metadata: { worktreePath: '/Users/user/Projects/vscode.worktrees/my-branch' } });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns name from badge with $(repo) prefix', () => {
+			const session = createMockSession({ id: '1', badge: '$(repo) vscode' });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns name from badge with $(folder) prefix', () => {
+			const session = createMockSession({ id: '1', badge: '$(folder) my-project' });
+			assert.strictEqual(getRepositoryName(session), 'my-project');
+		});
+
+		test('metadata repo name takes priority over badge name', () => {
+			const session = createMockSession({ id: '1', metadata: { owner: 'microsoft', name: 'vscode' }, badge: '$(folder) copilot-worktree-branch' });
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('returns undefined when no repo info is available', () => {
+			const session = createMockSession({ id: '1' });
+			assert.strictEqual(getRepositoryName(session), undefined);
+		});
+
+		test('badge name can differ from metadata repo name (worktree scenario)', () => {
+			// This is the key scenario: a session in a worktree where the badge shows
+			// the worktree folder name but the repo name (from metadata) is different.
+			// The renderer uses this to decide whether to hide the badge when grouped by repo.
+			const session = createMockSession({
+				id: '1',
+				metadata: { repositoryPath: '/Users/user/Projects/vscode' },
+				badge: '$(folder) copilot-worktree-2026-03-13T00-27-32',
+			});
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+			// Badge text shows a different name than the repo — renderer should NOT hide it
 		});
 	});
 });


### PR DESCRIPTION
## Problem

When sessions are grouped by repository in the Agent Sessions window, the badge (showing repo/folder name) was **always hidden** for any session with a `$(repo)`, `$(folder)`, or `$(worktree)` badge — even when the badge name differed from the group header label. For example, a worktree session with badge `$(folder) copilot-worktree-2026-03-13T00-27-32` under the `vscode` group would incorrectly have its badge hidden.

## Fix

### Badge visibility logic (`renderBadge`)
- **Before**: Hid ALL badges matching `$(repo|folder|worktree) <name>` when grouped by repo.
- **After**: Only hides the badge when its name **matches** the section header (repo name). Badges with different names (e.g., worktree folder names) remain visible.
- **Archived sessions**: Always keep their badge visible since they're grouped under "Archived", not a repository section.

### Code refactoring
- Extracted `getRepositoryName`, `parseRepositoryName`, and `extractRepoNameFromPath` from `AgentSessionsDataSource` into module-level functions so both the data source (for grouping) and the renderer (for badge comparison) can reuse the same logic.

### Logging
- Added a warning log when a session can't be matched to a repository and falls into "Other", including the session's resource, badge, and metadata for diagnosis.

### Tests
- Added `getRepositoryName` test suite covering all metadata extraction paths, priority ordering, the worktree badge mismatch scenario, and archived sessions.

## Files changed
- `agentSessionsViewer.ts` — Badge visibility fix, function extraction, `ILogService` support
- `agentSessionsControl.ts` — Pass `ILogService` to `AgentSessionsDataSource`
- `agentSessionsDataSource.test.ts` — New tests for `getRepositoryName`