### PR TITLE
Rename chat debug to agent debug logs

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -237,7 +237,7 @@ type ChatDebugExportEvent = {
 type ChatDebugExportClassification = {
 	fileSizeBytes: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Size of the exported chat debug log file in bytes.' };
 	owner: 'vijayu';
-	comment: 'Tracks usage of the debug panel export feature.';
+	comment: 'Tracks usage of the Agent Debug Logs export feature.';
 };
 
 type ChatDebugImportEvent = {
@@ -249,5 +249,5 @@ type ChatDebugImportClassification = {
 	fileSizeBytes: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Size of the imported chat debug log file in bytes.' };
 	result: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Outcome of the chat debug file import: success, fileTooLarge, or providerFailed.' };
 	owner: 'vijayu';
-	comment: 'Tracks usage of the debug panel import feature and failure modes.';
+	comment: 'Tracks usage of the Agent Debug Logs import feature and failure modes.';
 };

--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -27,14 +27,14 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { IChatDebugEditorOptions } from '../chatDebug/chatDebugTypes.js';
 
 /**
- * Registers the Open Agent Debug Panel and Show Agent Logs actions.
+ * Registers the Open Agent Debug Logs and Show Agent Debug Logs actions.
  */
 export function registerChatOpenAgentDebugPanelAction() {
 	registerAction2(class OpenAgentDebugPanelAction extends Action2 {
 		constructor() {
 			super({
 				id: 'workbench.action.chat.openAgentDebugPanel',
-				title: localize2('chat.openAgentDebugPanel.label', "Open Agent Debug Panel"),
+				title: localize2('chat.openAgentDebugPanel.label', "Open Agent Debug Logs"),
 				f1: true,
 				category: Categories.Developer,
 				precondition: ChatContextKeys.enabled,
@@ -57,7 +57,7 @@ export function registerChatOpenAgentDebugPanelAction() {
 		constructor() {
 			super({
 				id: 'workbench.action.chat.openAgentDebugPanelForSession',
-				title: localize2('chat.openAgentDebugPanelForSession.label', "Show Agent Logs"),
+				title: localize2('chat.openAgentDebugPanelForSession.label', "Show Agent Debug Logs"),
 				f1: false,
 				category: CHAT_CATEGORY,
 				precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatSessionHasDebugData),

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
@@ -44,7 +44,7 @@ type ChatDebugViewSwitchedEvent = {
 type ChatDebugViewSwitchedClassification = {
 	viewState: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The view the user navigated to (home, overview, logs, flowchart).' };
 	owner: 'vijayu';
-	comment: 'Tracks which views users navigate to in the debug panel.';
+	comment: 'Tracks which views users navigate to in the Agent Debug Logs.';
 };
 
 export class ChatDebugEditor extends EditorPane {
@@ -172,7 +172,7 @@ export class ChatDebugEditor extends EditorPane {
 
 		this._register(this.chatService.onDidCreateModel(model => {
 			if (this.viewState === ViewState.Home) {
-				// Auto-navigate to the new session when the debug panel is
+				// Auto-navigate to the new session when the Agent Debug Logs is
 				// already open on the home view.  This avoids the user having to
 				// wait for the title to resolve and manually clicking the session.
 				this.navigateToSession(model.sessionResource);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditor.ts
@@ -34,7 +34,7 @@ const $ = DOM.$;
 
 type ChatDebugPanelOpenedClassification = {
 	owner: 'vijayu';
-	comment: 'Event fired when the agent debug panel is opened';
+	comment: 'Event fired when the agent debug logs panel is opened';
 };
 
 type ChatDebugViewSwitchedEvent = {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditorInput.ts
@@ -41,7 +41,7 @@ export class ChatDebugEditorInput extends EditorInput {
 	readonly resource = ChatDebugEditorInput.RESOURCE;
 
 	override getName(): string {
-		return localize('chatDebugInputName', "Agent Debug Panel");
+		return localize('chatDebugInputName', "Agent Debug Logs");
 	}
 
 	override getIcon(): ThemeIcon {

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFilters.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFilters.ts
@@ -19,7 +19,7 @@ import {
 } from './chatDebugTypes.js';
 
 /**
- * Shared filter state for the Agent Debug Panel.
+ * Shared filter state for the Agent Debug Logs.
  *
  * Both the Logs view and the Flow Chart view read from this single source of
  * truth. Toggle commands modify the state and fire `onDidChange` so every

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowChartView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugFlowChartView.ts
@@ -205,7 +205,7 @@ export class ChatDebugFlowChartView extends Disposable {
 		}
 		const sessionTitle = this.chatService.getSessionTitle(this.currentSessionResource) || LocalChatSessionUri.parseLocalSessionId(this.currentSessionResource) || this.currentSessionResource.toString();
 		this.breadcrumbWidget.setItems([
-			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Panel"), true),
+			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Logs"), true),
 			new TextBreadcrumbItem(sessionTitle, true),
 			new TextBreadcrumbItem(localize('chatDebug.flowChart', "Agent Flow Chart")),
 		]);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -51,7 +51,7 @@ export class ChatDebugHomeView extends Disposable {
 		DOM.clearNode(this.scrollContent);
 		this.renderDisposables.clear();
 
-		DOM.append(this.scrollContent, $('h2.chat-debug-home-title', undefined, localize('chatDebug.title', "Agent Debug Panel")));
+		DOM.append(this.scrollContent, $('h2.chat-debug-home-title', undefined, localize('chatDebug.title', "Agent Debug Logs")));
 
 		// Determine the active session resource
 		const activeWidget = this.chatWidgetService.lastFocusedWidget;

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView.ts
@@ -292,7 +292,7 @@ export class ChatDebugLogsView extends Disposable {
 		}
 		const sessionTitle = this.chatService.getSessionTitle(this.currentSessionResource) || LocalChatSessionUri.parseLocalSessionId(this.currentSessionResource) || this.currentSessionResource.toString();
 		this.breadcrumbWidget.setItems([
-			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Panel"), true),
+			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Logs"), true),
 			new TextBreadcrumbItem(sessionTitle, true),
 			new TextBreadcrumbItem(localize('chatDebug.logs', "Logs")),
 		]);

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView.ts
@@ -117,7 +117,7 @@ export class ChatDebugOverviewView extends Disposable {
 		}
 		const sessionTitle = this.chatService.getSessionTitle(this.currentSessionResource) || LocalChatSessionUri.parseLocalSessionId(this.currentSessionResource) || this.currentSessionResource.toString();
 		this.breadcrumbWidget.setItems([
-			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Panel"), true),
+			new TextBreadcrumbItem(localize('chatDebug.title', "Agent Debug Logs"), true),
 			new TextBreadcrumbItem(sessionTitle),
 		]);
 	}

--- a/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptsDebugContribution.ts
@@ -14,7 +14,7 @@ import { IPromptDiscoveryInfo, IPromptsService } from '../common/promptSyntax/se
  *
  * This contribution listens for discovery events emitted by the prompts service
  * and forwards them as debug log entries. It also registers a resolve provider
- * so expanding a discovery event in the debug panel shows the full file list.
+ * so expanding a discovery event in the Agent Debug Logs shows the full file list.
  */
 export class PromptsDebugContribution extends Disposable implements IWorkbenchContribution {
 
@@ -81,7 +81,7 @@ export class PromptsDebugContribution extends Disposable implements IWorkbenchCo
 		}));
 
 		// Register a resolve provider so expanding a discovery event
-		// in the debug panel shows the full file list.
+		// in the Agent Debug Logs shows the full file list.
 		this._register(chatDebugService.registerProvider({
 			provideChatDebugLog: async () => undefined,
 			resolveChatDebugLogEvent: async (eventId) => {


### PR DESCRIPTION
"Open Agent Debug Panel" → "Open Agent Debug Logs" (command palette title)
"Show Agent Logs" → "Show Agent Debug Logs" (menu item)
"Agent Debug Panel" → "Agent Debug Logs" (editor tab name, page title, breadcrumbs in overview/logs/flow chart views, and comments)