### PR TITLE
build: bump js-debug to 1.112.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -52,8 +52,8 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.110.0",
-			"sha256": "ad3f7d935b64f4ee123853c464b47b3cba13e5018edef831770ae9c3eb218f5b",
+			"version": "1.112.0",
+			"sha256": "c24322931434940938f8cf76ebc3dac1e95a5539b9625b165b6672d7f7eafea8",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
- Updates js-debug extension from version 1.110.0 to 1.112.0
- Updates corresponding sha256 hash for verification

(Commit message generated by Copilot)