### PR TITLE
fix: prevent stale todo list from overwriting current state

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.ts
@@ -11,7 +11,6 @@ import { IInstantiationService } from '../../../../../../../platform/instantiati
 import { IMarkdownRenderer } from '../../../../../../../platform/markdown/browser/markdownRenderer.js';
 import { IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
 import { IChatRendererContent } from '../../../../common/model/chatViewModel.js';
-import { IChatTodoListService } from '../../../../common/tools/chatTodoListService.js';
 import { CodeBlockModelCollection } from '../../../../common/widget/codeBlockModelCollection.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, ToolInvocationPresentation } from '../../../../common/tools/languageModelToolsService.js';
 import { ChatTreeItem, IChatCodeBlockInfo } from '../../../chat.js';
@@ -64,28 +63,12 @@ export class ChatToolInvocationPart extends Disposable implements IChatContentPa
 		private readonly announcedToolProgressKeys: Set<string> | undefined,
 		private readonly codeBlockStartIndex: number,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IChatTodoListService private readonly chatTodoListService: IChatTodoListService,
 	) {
 		super();
 
 		this.domNode = dom.$('.chat-tool-invocation-part');
 		if (toolInvocation.presentation === 'hidden') {
 			return;
-		}
-
-		// Update the todo list service if this tool invocation contains todo data
-		if (toolInvocation.toolSpecificData?.kind === 'todoList') {
-			const sessionResource = context.element.sessionResource;
-			const todos = toolInvocation.toolSpecificData.todoList.map((todo, index) => {
-				const parsedId = parseInt(todo.id, 10);
-				const id = Number.isNaN(parsedId) ? index + 1 : parsedId;
-				return {
-					id,
-					title: todo.title,
-					status: todo.status as 'not-started' | 'in-progress' | 'completed'
-				};
-			});
-			this.chatTodoListService.setTodos(sessionResource, todos);
 		}
 
 		if (toolInvocation.kind === 'toolInvocation') {

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -29,10 +29,11 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatRequestToolReferenceEntry, IChatRequestVariableEntry, isImplicitVariableEntry, isStringImplicitContextValue, isStringVariableEntry } from '../attachments/chatVariableEntries.js';
 import { migrateLegacyTerminalToolSpecificData } from '../chat.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, isIUsedContext } from '../chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatTodoListContent, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, isIUsedContext } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ChatToolInvocation } from './chatProgressTypes/chatToolInvocation.js';
 import { ToolDataSource, IToolData } from '../tools/languageModelToolsService.js';
+import { IChatTodoListService } from '../tools/chatTodoListService.js';
 import { IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../editing/chatEditingService.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier } from '../languageModels.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, IChatAgentService, UserSelectedTools, reviveSerializedAgent } from '../participants/chatAgents.js';
@@ -2133,6 +2134,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IChatEditingService private readonly chatEditingService: IChatEditingService,
 		@IChatService private readonly chatService: IChatService,
+		@IChatTodoListService private readonly chatTodoListService: IChatTodoListService,
 	) {
 		super();
 
@@ -2335,15 +2337,24 @@ export class ChatModel extends Disposable implements IChatModel {
 				modelState = { value: ResponseModelState.Cancelled, completedAt: Date.now() };
 			}
 
-			// Mark question carousels as used after
-			// deserialization. After a reload, the extension is no longer listening for
-			// their responses, so they cannot be interacted with.
+			// Post-process deserialized response parts:
+			// - Mark question carousels as used (extension is no longer listening after reload)
+			// - Track the last todoList for hydration into the service
+			let lastTodoList: IChatTodoListContent['todoList'] | undefined;
 			if (raw.response) {
 				for (const part of raw.response) {
-					if (hasKey(part, { kind: true }) && (part.kind === 'questionCarousel')) {
-						part.isUsed = true;
+					if (hasKey(part, { kind: true })) {
+						if (part.kind === 'questionCarousel') {
+							part.isUsed = true;
+						}
+						if (part.kind === 'toolInvocationSerialized' && part.toolSpecificData?.kind === 'todoList') {
+							lastTodoList = part.toolSpecificData.todoList;
+						}
 					}
 				}
+			}
+			if (lastTodoList) {
+				this.chatTodoListService.setTodos(this._sessionResource, lastTodoList.map((t, i) => ({ id: Number(t.id) || i + 1, title: t.title, status: t.status })));
 			}
 
 			request.response = new ChatResponseModel({
@@ -2579,6 +2590,14 @@ export class ChatModel extends Disposable implements IChatModel {
 			this.logService.error(`Couldn't handle progress: ${JSON.stringify(progress)}`);
 		} else {
 			request.response.updateContent(progress, quiet);
+
+			// Hydrate todoList into the service when a serialized tool
+			// invocation arrives (e.g. from a background agent that did
+			// not run invoke() locally).
+			if (progress.kind === 'toolInvocationSerialized' && progress.toolSpecificData?.kind === 'todoList') {
+				const todoList = progress.toolSpecificData.todoList;
+				this.chatTodoListService.setTodos(this._sessionResource, todoList.map((t, i) => ({ id: Number(t.id) || i + 1, title: t.title, status: t.status })));
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -33,7 +33,7 @@ import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatRequestQueueKind, 
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ChatToolInvocation } from './chatProgressTypes/chatToolInvocation.js';
 import { ToolDataSource, IToolData } from '../tools/languageModelToolsService.js';
-import { IChatTodoListService } from '../tools/chatTodoListService.js';
+import { IChatTodo, IChatTodoListService } from '../tools/chatTodoListService.js';
 import { IChatEditingService, IChatEditingSession, ModifiedFileEntryState } from '../editing/chatEditingService.js';
 import { ILanguageModelChatMetadata, ILanguageModelChatMetadataAndIdentifier } from '../languageModels.js';
 import { IChatAgentCommand, IChatAgentData, IChatAgentResult, IChatAgentService, UserSelectedTools, reviveSerializedAgent } from '../participants/chatAgents.js';
@@ -2354,7 +2354,7 @@ export class ChatModel extends Disposable implements IChatModel {
 				}
 			}
 			if (lastTodoList) {
-				this.chatTodoListService.setTodos(this._sessionResource, lastTodoList.map((t, i) => ({ id: Number(t.id) || i + 1, title: t.title, status: t.status })));
+				this.chatTodoListService.setTodos(this._sessionResource, deserializeTodoList(lastTodoList));
 			}
 
 			request.response = new ChatResponseModel({
@@ -2595,8 +2595,7 @@ export class ChatModel extends Disposable implements IChatModel {
 			// invocation arrives (e.g. from a background agent that did
 			// not run invoke() locally).
 			if (progress.kind === 'toolInvocationSerialized' && progress.toolSpecificData?.kind === 'todoList') {
-				const todoList = progress.toolSpecificData.todoList;
-				this.chatTodoListService.setTodos(this._sessionResource, todoList.map((t, i) => ({ id: Number(t.id) || i + 1, title: t.title, status: t.status })));
+				this.chatTodoListService.setTodos(this._sessionResource, deserializeTodoList(progress.toolSpecificData.todoList));
 			}
 		}
 	}
@@ -2835,4 +2834,12 @@ export namespace ChatResponseResource {
 			index: Number(index),
 		};
 	}
+}
+
+/**
+ * Converts serialized todoList entries (string IDs) into {@link IChatTodo}
+ * objects (numeric IDs) suitable for {@link IChatTodoListService.setTodos}.
+ */
+function deserializeTodoList(todoList: IChatTodoListContent['todoList']): IChatTodo[] {
+	return todoList.map((t, i) => ({ id: Number(t.id) || i + 1, title: t.title, status: t.status }));
 }

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolInvocationPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatToolInvocationPart.test.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { Event } from '../../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { mainWindow } from '../../../../../../../base/browser/window.js';
+import { workbenchInstantiationService } from '../../../../../../test/browser/workbenchTestServices.js';
+import { ChatToolInvocationPart } from '../../../../browser/widget/chatContentParts/toolInvocationParts/chatToolInvocationPart.js';
+import { IChatToolInvocationSerialized, ToolConfirmKind } from '../../../../common/chatService/chatService.js';
+import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
+import { IChatResponseViewModel } from '../../../../common/model/chatViewModel.js';
+import { IMarkdownRenderer } from '../../../../../../../platform/markdown/browser/markdownRenderer.js';
+import { IRenderedMarkdown, MarkdownRenderOptions } from '../../../../../../../base/browser/markdownRenderer.js';
+import { IMarkdownString } from '../../../../../../../base/common/htmlContent.js';
+import { CodeBlockModelCollection } from '../../../../common/widget/codeBlockModelCollection.js';
+import { EditorPool, DiffEditorPool } from '../../../../browser/widget/chatContentParts/chatContentCodePools.js';
+import { CollapsibleListPool } from '../../../../browser/widget/chatContentParts/chatReferencesContentPart.js';
+import { observableValue } from '../../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { IChatTodo, IChatTodoListService } from '../../../../common/tools/chatTodoListService.js';
+import { ToolDataSource } from '../../../../common/tools/languageModelToolsService.js';
+import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
+
+const testSessionUri = URI.parse('chat-session://test/session1');
+
+/**
+ * Regression test for issue #299234.
+ *
+ * Before the fix, ChatToolInvocationPart's constructor called setTodos()
+ * from toolSpecificData every time a part was constructed. Parts can be
+ * constructed out of chronological order due to lazy rendering (collapsed
+ * thinking/subagent sections), session restore, or scroll virtualization.
+ *
+ * When an older tool invocation's part was constructed AFTER a newer one,
+ * its setTodos() call overwrote the correct state with stale data. The
+ * widget then showed incomplete state while the chat text claimed completion.
+ *
+ * The fix removes the setTodos() call from the constructor entirely.
+ */
+suite('ChatToolInvocationPart todo list side-effect (issue #299234)', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let disposables: DisposableStore;
+	let instantiationService: ReturnType<typeof workbenchInstantiationService>;
+	let mockMarkdownRenderer: IMarkdownRenderer;
+	let mockListPool: CollapsibleListPool;
+	let mockEditorPool: EditorPool;
+	let mockCodeBlockModelCollection: CodeBlockModelCollection;
+	let setTodosCalls: { sessionResource: URI; todos: IChatTodo[] }[];
+
+	function createMockRenderContext(): IChatContentPartRenderContext {
+		const mockElement: Partial<IChatResponseViewModel> = {
+			isComplete: true,
+			id: 'test-response-id',
+			sessionResource: testSessionUri,
+			get model() { return {} as IChatResponseViewModel['model']; }
+		};
+
+		return {
+			element: mockElement as IChatResponseViewModel,
+			inlineTextModels: {} as InlineTextModelCollection,
+			elementIndex: 0,
+			container: mainWindow.document.createElement('div'),
+			content: [],
+			contentIndex: 0,
+			editorPool: mockEditorPool,
+			codeBlockStartIndex: 0,
+			treeStartIndex: 0,
+			diffEditorPool: {} as DiffEditorPool,
+			codeBlockModelCollection: mockCodeBlockModelCollection,
+			currentWidth: observableValue('currentWidth', 500),
+			onDidChangeVisibility: Event.None
+		};
+	}
+
+	function createSerializedToolInvocationWithTodos(todoList: { id: string; title: string; status: 'not-started' | 'in-progress' | 'completed' }[]): IChatToolInvocationSerialized {
+		return {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'call-' + Math.random().toString(36).substring(7),
+			toolId: 'manage_todo_list',
+			invocationMessage: 'Updating TODO list',
+			originMessage: undefined,
+			pastTenseMessage: 'Updated TODO list',
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: true,
+			presentation: undefined,
+			source: ToolDataSource.Internal,
+			toolSpecificData: {
+				kind: 'todoList',
+				todoList
+			},
+		};
+	}
+
+	setup(() => {
+		disposables = store.add(new DisposableStore());
+		instantiationService = workbenchInstantiationService(undefined, store);
+		setTodosCalls = [];
+
+		instantiationService.stub(IChatTodoListService, {
+			_serviceBrand: undefined,
+			onDidUpdateTodos: Event.None,
+			getTodos: () => [],
+			setTodos: (sessionResource: URI, todos: IChatTodo[]) => {
+				setTodosCalls.push({ sessionResource, todos: [...todos] });
+			},
+			migrateTodos: () => { },
+		});
+
+		mockMarkdownRenderer = {
+			render: (_markdown: IMarkdownString, _options?: MarkdownRenderOptions, outElement?: HTMLElement): IRenderedMarkdown => {
+				const element = outElement ?? mainWindow.document.createElement('div');
+				const content = typeof _markdown === 'string' ? _markdown : (_markdown.value ?? '');
+				element.textContent = content;
+				return { element, dispose: () => { } };
+			}
+		};
+
+		instantiationService.stub(IHoverService, {
+			_serviceBrand: undefined,
+			showDelayedHover: () => undefined,
+			setupDelayedHover: () => ({ dispose: () => { } }),
+			setupDelayedHoverAtMouse: () => ({ dispose: () => { } }),
+			showInstantHover: () => undefined,
+			hideHover: () => { },
+			showAndFocusLastHover: () => { },
+			setupManagedHover: () => ({ dispose: () => { }, show: () => { }, hide: () => { }, update: () => { } }),
+			showManagedHover: () => { }
+		});
+
+		mockListPool = {} as CollapsibleListPool;
+		mockEditorPool = {} as EditorPool;
+		mockCodeBlockModelCollection = {} as CodeBlockModelCollection;
+	});
+
+	teardown(() => {
+		disposables.dispose();
+	});
+
+	function createPart(toolInvocation: IChatToolInvocationSerialized): ChatToolInvocationPart {
+		const context = createMockRenderContext();
+		const part = store.add(instantiationService.createInstance(
+			ChatToolInvocationPart,
+			toolInvocation,
+			context,
+			mockMarkdownRenderer,
+			mockListPool,
+			mockEditorPool,
+			() => 500,
+			mockCodeBlockModelCollection,
+			new Set<string>(),
+			0
+		));
+
+		mainWindow.document.body.appendChild(part.domNode);
+		disposables.add({ dispose: () => part.domNode.remove() });
+
+		return part;
+	}
+
+	test('constructing a part with stale todoList data must not call setTodos', () => {
+		const staleTodoData = createSerializedToolInvocationWithTodos([
+			{ id: '1', title: 'Task 1', status: 'not-started' },
+			{ id: '2', title: 'Task 2', status: 'not-started' },
+			{ id: '3', title: 'Task 3', status: 'not-started' },
+		]);
+
+		createPart(staleTodoData);
+
+		assert.strictEqual(
+			setTodosCalls.length, 0,
+			'ChatToolInvocationPart constructor must not call setTodos — ' +
+			'before the fix for #299234, this was 1'
+		);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -424,13 +424,65 @@ suite('ChatModel', () => {
 			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
 		));
 
-		// Each request with todoList data hydrates inline, so the last call wins
-		assert.ok(setTodosCalls.length >= 1, 'Should hydrate at least once');
-		assert.deepStrictEqual(setTodosCalls[setTodosCalls.length - 1].todos, [
+		// Each request with todoList data hydrates per-request, so two calls are expected
+		assert.strictEqual(setTodosCalls.length, 2, 'Should hydrate once per request containing todo data');
+		assert.deepStrictEqual(setTodosCalls[0].todos, [
+			{ id: 1, title: 'Task 1', status: 'not-started' },
+			{ id: 2, title: 'Task 2', status: 'not-started' },
+			{ id: 3, title: 'Task 3', status: 'not-started' },
+		], 'First hydration should use the older (not-started) state');
+		assert.deepStrictEqual(setTodosCalls[1].todos, [
 			{ id: 1, title: 'Task 1', status: 'completed' },
 			{ id: 2, title: 'Task 2', status: 'completed' },
 			{ id: 3, title: 'Task 3', status: 'completed' },
-		], 'Final hydration should use the latest (completed) todo state');
+		], 'Second hydration should use the latest (completed) state');
+	});
+
+	test('acceptResponseProgress hydrates todo list from serialized tool invocations at runtime', () => {
+		const setTodosCalls: { todos: IChatTodo[] }[] = [];
+		instantiationService.stub(IChatTodoListService, {
+			_serviceBrand: undefined,
+			onDidUpdateTodos: Event.None,
+			getTodos: () => [],
+			setTodos: (_sessionResource: URI, todos: IChatTodo[]) => { setTodosCalls.push({ todos: [...todos] }); },
+			migrateTodos: () => { },
+		});
+
+		const model = testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			undefined,
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+
+		const request = model.addRequest({ text: 'create todo list', parts: [] }, { variables: [] }, 0);
+
+		const todoProgress: IChatToolInvocationSerialized = {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'call-runtime-1',
+			toolId: 'manage_todo_list',
+			invocationMessage: 'Updating TODO list',
+			originMessage: undefined,
+			pastTenseMessage: 'Created TODO list',
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: true,
+			presentation: undefined,
+			source: undefined,
+			toolSpecificData: {
+				kind: 'todoList',
+				todoList: [
+					{ id: '1', title: 'Task A', status: 'not-started' },
+					{ id: '2', title: 'Task B', status: 'in-progress' },
+				]
+			},
+		};
+
+		model.acceptResponseProgress(request, todoProgress);
+
+		assert.strictEqual(setTodosCalls.length, 1, 'Should hydrate once from runtime progress');
+		assert.deepStrictEqual(setTodosCalls[0].todos, [
+			{ id: 1, title: 'Task A', status: 'not-started' },
+			{ id: 2, title: 'Task B', status: 'in-progress' },
+		]);
 	});
 
 	test('modeInfo roundtrips through serialization', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import * as sinon from 'sinon';
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { Event } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -27,8 +28,9 @@ import { IChatRequestImplicitVariableEntry, IChatRequestStringVariableEntry, ICh
 import { ChatAgentService, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatModel, ChatRequestModel, IChatRequestModeInfo, IExportableChatData, ISerializableChatData1, ISerializableChatData2, ISerializableChatData3, isExportableSessionData, isSerializableSessionData, normalizeSerializableChatData, Response } from '../../../common/model/chatModel.js';
 import { ChatRequestTextPart } from '../../../common/requestParser/chatParserTypes.js';
-import { ChatRequestQueueKind, IChatService, IChatToolInvocation } from '../../../common/chatService/chatService.js';
+import { ChatRequestQueueKind, IChatService, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind } from '../../../common/chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind } from '../../../common/constants.js';
+import { IChatTodo, IChatTodoListService } from '../../../common/tools/chatTodoListService.js';
 import { MockChatService } from '../chatService/mockChatService.js';
 
 suite('ChatModel', () => {
@@ -273,6 +275,162 @@ suite('ChatModel', () => {
 		// Should filter out string attachments and implicit attachments with StringChatContextValue
 		// Should keep file attachments and implicit attachments with URI values
 		assert.deepStrictEqual(serialized.attachments, [fileAttachment, implicitWithUri]);
+	});
+
+	test('deserialization hydrates todo list from serialized tool invocations', () => {
+		const setTodosCalls: { sessionResource: URI; todos: IChatTodo[] }[] = [];
+		instantiationService.stub(IChatTodoListService, {
+			_serviceBrand: undefined,
+			onDidUpdateTodos: Event.None,
+			getTodos: () => [],
+			setTodos: (sessionResource: URI, todos: IChatTodo[]) => { setTodosCalls.push({ sessionResource, todos: [...todos] }); },
+			migrateTodos: () => { },
+		});
+
+		const toolInvocationWithTodos: IChatToolInvocationSerialized = {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'call-1',
+			toolId: 'manage_todo_list',
+			invocationMessage: 'Updating TODO list',
+			originMessage: undefined,
+			pastTenseMessage: 'Updated TODO list (3/3 complete)',
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: true,
+			presentation: undefined,
+			source: undefined,
+			toolSpecificData: {
+				kind: 'todoList',
+				todoList: [
+					{ id: '1', title: 'Task 1', status: 'completed' },
+					{ id: '2', title: 'Task 2', status: 'completed' },
+					{ id: '3', title: 'Task 3', status: 'completed' },
+				]
+			},
+		};
+
+		const serializableData: ISerializableChatData3 = {
+			version: 3,
+			sessionId: 'test-todo-session',
+			creationDate: Date.now(),
+			customTitle: undefined,
+			initialLocation: ChatAgentLocation.Chat,
+			requests: [{
+				requestId: 'req1',
+				message: { text: 'create a todo list', parts: [] },
+				variableData: { variables: [] },
+				response: [
+					{ value: 'Created a todo list', isTrusted: false },
+					toolInvocationWithTodos,
+				],
+				modelState: { value: 1 /* ResponseModelState.Complete */, completedAt: Date.now() },
+			}],
+			responderUsername: 'bot',
+		};
+
+		testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			{ value: serializableData, serializer: undefined! },
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+
+		assert.strictEqual(setTodosCalls.length, 1, 'Should hydrate exactly once');
+		assert.deepStrictEqual(setTodosCalls[0].todos, [
+			{ id: 1, title: 'Task 1', status: 'completed' },
+			{ id: 2, title: 'Task 2', status: 'completed' },
+			{ id: 3, title: 'Task 3', status: 'completed' },
+		]);
+	});
+
+	test('deserialization hydrates latest todo list when multiple invocations exist', () => {
+		const setTodosCalls: { todos: IChatTodo[] }[] = [];
+		instantiationService.stub(IChatTodoListService, {
+			_serviceBrand: undefined,
+			onDidUpdateTodos: Event.None,
+			getTodos: () => [],
+			setTodos: (_sessionResource: URI, todos: IChatTodo[]) => { setTodosCalls.push({ todos: [...todos] }); },
+			migrateTodos: () => { },
+		});
+
+		const olderToolInvocation: IChatToolInvocationSerialized = {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'call-1',
+			toolId: 'manage_todo_list',
+			invocationMessage: 'Creating TODO list',
+			originMessage: undefined,
+			pastTenseMessage: 'Created TODO list with 3 items',
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: true,
+			presentation: undefined,
+			source: undefined,
+			toolSpecificData: {
+				kind: 'todoList',
+				todoList: [
+					{ id: '1', title: 'Task 1', status: 'not-started' },
+					{ id: '2', title: 'Task 2', status: 'not-started' },
+					{ id: '3', title: 'Task 3', status: 'not-started' },
+				]
+			},
+		};
+
+		const newerToolInvocation: IChatToolInvocationSerialized = {
+			kind: 'toolInvocationSerialized',
+			toolCallId: 'call-2',
+			toolId: 'manage_todo_list',
+			invocationMessage: 'Updating TODO list',
+			originMessage: undefined,
+			pastTenseMessage: 'All tasks complete (3/3)',
+			isConfirmed: { type: ToolConfirmKind.ConfirmationNotNeeded },
+			isComplete: true,
+			presentation: undefined,
+			source: undefined,
+			toolSpecificData: {
+				kind: 'todoList',
+				todoList: [
+					{ id: '1', title: 'Task 1', status: 'completed' },
+					{ id: '2', title: 'Task 2', status: 'completed' },
+					{ id: '3', title: 'Task 3', status: 'completed' },
+				]
+			},
+		};
+
+		const serializableData: ISerializableChatData3 = {
+			version: 3,
+			sessionId: 'test-todo-session-2',
+			creationDate: Date.now(),
+			customTitle: undefined,
+			initialLocation: ChatAgentLocation.Chat,
+			requests: [
+				{
+					requestId: 'req1',
+					message: { text: 'create a todo list', parts: [] },
+					variableData: { variables: [] },
+					response: [olderToolInvocation],
+					modelState: { value: 1, completedAt: Date.now() },
+				},
+				{
+					requestId: 'req2',
+					message: { text: 'complete all tasks', parts: [] },
+					variableData: { variables: [] },
+					response: [newerToolInvocation],
+					modelState: { value: 1, completedAt: Date.now() },
+				},
+			],
+			responderUsername: 'bot',
+		};
+
+		testDisposables.add(instantiationService.createInstance(
+			ChatModel,
+			{ value: serializableData, serializer: undefined! },
+			{ initialLocation: ChatAgentLocation.Chat, canUseTools: true }
+		));
+
+		// Each request with todoList data hydrates inline, so the last call wins
+		assert.ok(setTodosCalls.length >= 1, 'Should hydrate at least once');
+		assert.deepStrictEqual(setTodosCalls[setTodosCalls.length - 1].todos, [
+			{ id: 1, title: 'Task 1', status: 'completed' },
+			{ id: 2, title: 'Task 2', status: 'completed' },
+			{ id: 3, title: 'Task 3', status: 'completed' },
+		], 'Final hydration should use the latest (completed) todo state');
 	});
 
 	test('modeInfo roundtrips through serialization', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/manageTodoListTool.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/tools/builtinTools/manageTodoListTool.test.ts
@@ -4,10 +4,44 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { CancellationToken } from '../../../../../../../base/common/cancellation.js';
+import { Emitter, Event } from '../../../../../../../base/common/event.js';
+import { URI } from '../../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
-import { createManageTodoListToolData } from '../../../../common/tools/builtinTools/manageTodoListTool.js';
-import { IToolData } from '../../../../common/tools/languageModelToolsService.js';
+import { NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { NullTelemetryService } from '../../../../../../../platform/telemetry/common/telemetryUtils.js';
+import { IChatTodo, IChatTodoListService } from '../../../../common/tools/chatTodoListService.js';
+import { createManageTodoListToolData, ManageTodoListTool } from '../../../../common/tools/builtinTools/manageTodoListTool.js';
+import { IToolData, IToolInvocation } from '../../../../common/tools/languageModelToolsService.js';
 import { IJSONSchema } from '../../../../../../../base/common/jsonSchema.js';
+
+const testSessionUri = URI.parse('chat-session://test/session1');
+
+class MockChatTodoListService implements IChatTodoListService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _onDidUpdateTodos = new Emitter<URI>();
+	readonly onDidUpdateTodos: Event<URI> = this._onDidUpdateTodos.event;
+
+	private readonly _store = new Map<string, IChatTodo[]>();
+	readonly setTodosCalls: { sessionResource: URI; todos: IChatTodo[] }[] = [];
+
+	getTodos(sessionResource: URI): IChatTodo[] {
+		return this._store.get(sessionResource.toString()) ?? [];
+	}
+
+	setTodos(sessionResource: URI, todos: IChatTodo[]): void {
+		this.setTodosCalls.push({ sessionResource, todos: [...todos] });
+		this._store.set(sessionResource.toString(), [...todos]);
+		this._onDidUpdateTodos.fire(sessionResource);
+	}
+
+	migrateTodos(_oldSessionResource: URI, _newSessionResource: URI): void { }
+
+	dispose(): void {
+		this._onDidUpdateTodos.dispose();
+	}
+}
 
 suite('ManageTodoListTool Schema', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -57,5 +91,190 @@ suite('ManageTodoListTool Schema', () => {
 		const statusProperty = properties['status'];
 		assert.ok(statusProperty, 'Status property should exist');
 		assert.deepStrictEqual(statusProperty.enum, ['not-started', 'in-progress', 'completed'], 'Status should have correct enum values');
+	});
+});
+
+suite('ManageTodoListTool Invocation', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let tool: ManageTodoListTool;
+	let mockService: MockChatTodoListService;
+
+	setup(() => {
+		mockService = new MockChatTodoListService();
+		store.add({ dispose: () => mockService.dispose() });
+		tool = store.add(new ManageTodoListTool(
+			mockService,
+			new NullLogService(),
+			NullTelemetryService,
+		));
+	});
+
+	function createInvocation(parameters: Record<string, any>): IToolInvocation {
+		return {
+			parameters,
+			context: { sessionResource: testSessionUri },
+			callId: 'test-call-1',
+			toolId: 'manage_todo_list',
+		};
+	}
+
+	const noopCountTokens = async () => 0;
+	const noopProgress = { report() { } };
+
+	test('invoke write operation persists todos to service', async () => {
+		const todos = [
+			{ id: 1, title: 'Task 1', status: 'not-started' as const },
+			{ id: 2, title: 'Task 2', status: 'not-started' as const },
+			{ id: 3, title: 'Task 3', status: 'not-started' as const },
+		];
+
+		const result = await tool.invoke(
+			createInvocation({ todoList: todos }),
+			noopCountTokens, noopProgress, CancellationToken.None
+		);
+
+		assert.ok(result.content[0].kind === 'text');
+		assert.ok((result.content[0] as { kind: 'text'; value: string }).value.includes('Successfully wrote todo list'));
+		assert.deepStrictEqual(mockService.getTodos(testSessionUri), todos);
+	});
+
+	test('invoke read operation returns current state', async () => {
+		mockService.setTodos(testSessionUri, [
+			{ id: 1, title: 'Task 1', status: 'completed' },
+			{ id: 2, title: 'Task 2', status: 'in-progress' },
+		]);
+
+		const result = await tool.invoke(
+			createInvocation({ operation: 'read', todoList: [], chatSessionResource: testSessionUri.toString() }),
+			noopCountTokens, noopProgress, CancellationToken.None
+		);
+
+		assert.ok(result.content[0].kind === 'text');
+		const text = (result.content[0] as { kind: 'text'; value: string }).value;
+		assert.ok(text.includes('Task 1'), 'Read result should include task titles');
+		assert.ok(text.includes('[x]'), 'Read result should show completed status');
+		assert.ok(text.includes('[-]'), 'Read result should show in-progress status');
+	});
+
+	test('prepareToolInvocation generates correct pastTenseMessage for creating todos', async () => {
+		const result = await tool.prepareToolInvocation({
+			parameters: {
+				todoList: [
+					{ id: 1, title: 'Task 1', status: 'not-started' },
+					{ id: 2, title: 'Task 2', status: 'not-started' },
+					{ id: 3, title: 'Task 3', status: 'not-started' },
+				]
+			},
+			toolCallId: 'call-1',
+			chatSessionResource: testSessionUri,
+		}, CancellationToken.None);
+
+		assert.ok(result);
+		assert.ok(result.pastTenseMessage);
+		const message = typeof result.pastTenseMessage === 'string' ? result.pastTenseMessage : result.pastTenseMessage.value;
+		assert.ok(message.includes('3'), 'Should mention count of created todos');
+	});
+
+	test('prepareToolInvocation generates correct pastTenseMessage for starting a todo', async () => {
+		mockService.setTodos(testSessionUri, [
+			{ id: 1, title: 'Task 1', status: 'not-started' },
+			{ id: 2, title: 'Task 2', status: 'not-started' },
+		]);
+
+		const result = await tool.prepareToolInvocation({
+			parameters: {
+				todoList: [
+					{ id: 1, title: 'Task 1', status: 'in-progress' },
+					{ id: 2, title: 'Task 2', status: 'not-started' },
+				]
+			},
+			toolCallId: 'call-1',
+			chatSessionResource: testSessionUri,
+		}, CancellationToken.None);
+
+		assert.ok(result);
+		const message = typeof result.pastTenseMessage === 'string' ? result.pastTenseMessage : result.pastTenseMessage!.value;
+		assert.ok(message.includes('Task 1'), 'Should mention the started task');
+		assert.ok(message.includes('1/2'), 'Should show progress');
+	});
+
+	test('steering mid-task: service state and pastTenseMessage stay consistent after out-of-order rendering', async () => {
+		// Request 1: agent creates the TODO list and starts task 2
+		await tool.invoke(
+			createInvocation({
+				todoList: [
+					{ id: 1, title: 'Set up project', status: 'completed' },
+					{ id: 2, title: 'Add auth middleware', status: 'in-progress' },
+					{ id: 3, title: 'Write tests', status: 'not-started' },
+				]
+			}),
+			noopCountTokens, noopProgress, CancellationToken.None
+		);
+
+		// User steers: "skip auth, mark it done, jump to tests"
+		// Request 2: prepareToolInvocation runs first (service still has request 1 state)
+		const prepareResult = await tool.prepareToolInvocation({
+			parameters: {
+				todoList: [
+					{ id: 1, title: 'Set up project', status: 'completed' },
+					{ id: 2, title: 'Add auth middleware', status: 'completed' },
+					{ id: 3, title: 'Write tests', status: 'in-progress' },
+				]
+			},
+			toolCallId: 'call-steered',
+			chatSessionResource: testSessionUri,
+		}, CancellationToken.None);
+
+		// pastTenseMessage should reflect the transition (task 3 started)
+		const message = typeof prepareResult!.pastTenseMessage === 'string'
+			? prepareResult!.pastTenseMessage
+			: prepareResult!.pastTenseMessage!.value;
+		assert.ok(message.includes('Write tests'), 'pastTenseMessage should reference the newly started task');
+		assert.ok(message.includes('3/3'), 'pastTenseMessage should show position of started task');
+
+		// Request 2: then invoke() runs and updates the service
+		await tool.invoke(
+			createInvocation({
+				todoList: [
+					{ id: 1, title: 'Set up project', status: 'completed' },
+					{ id: 2, title: 'Add auth middleware', status: 'completed' },
+					{ id: 3, title: 'Write tests', status: 'in-progress' },
+				]
+			}),
+			noopCountTokens, noopProgress, CancellationToken.None
+		);
+
+		// Service now has the steered state
+		assert.deepStrictEqual(mockService.getTodos(testSessionUri), [
+			{ id: 1, title: 'Set up project', status: 'completed' },
+			{ id: 2, title: 'Add auth middleware', status: 'completed' },
+			{ id: 3, title: 'Write tests', status: 'in-progress' },
+		]);
+	});
+
+	test('prepareToolInvocation generates correct pastTenseMessage for completing a todo', async () => {
+		mockService.setTodos(testSessionUri, [
+			{ id: 1, title: 'Task 1', status: 'completed' },
+			{ id: 2, title: 'Task 2', status: 'in-progress' },
+			{ id: 3, title: 'Task 3', status: 'not-started' },
+		]);
+
+		const result = await tool.prepareToolInvocation({
+			parameters: {
+				todoList: [
+					{ id: 1, title: 'Task 1', status: 'completed' },
+					{ id: 2, title: 'Task 2', status: 'completed' },
+					{ id: 3, title: 'Task 3', status: 'not-started' },
+				]
+			},
+			toolCallId: 'call-1',
+			chatSessionResource: testSessionUri,
+		}, CancellationToken.None);
+
+		assert.ok(result);
+		const message = typeof result.pastTenseMessage === 'string' ? result.pastTenseMessage : result.pastTenseMessage!.value;
+		assert.ok(message.includes('Task 2'), 'Should mention the completed task');
+		assert.ok(message.includes('2/3'), 'Should show progress');
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #299234

- **Root cause**: `ChatToolInvocationPart`'s constructor called `setTodos()` from `toolSpecificData` on every render. When parts were constructed out of chronological order (lazy rendering, collapsed sections, scroll virtualization), an older invocation's data overwrote the current state.
- **Fix**: Remove the `setTodos()` side-effect from the UI constructor. Move todo list hydration to the two proper data entry points in `ChatModel`:
  - `_deserializeRequest()` — for session restore from storage (scans all parts, hydrates only the latest)
  - `acceptResponseProgress()` — for live background agent data arriving via `toolInvocationSerialized`

## Test plan

- [x] Regression test: `chatToolInvocationPart.test.ts` — instantiates real `ChatToolInvocationPart` with stale todoList data, asserts `setTodos` is not called. **Fails on main, passes on this branch.**
- [x] Hydration tests: `chatModel.test.ts` — verifies deserialization hydrates todo list correctly (single and multiple invocations, latest state wins)
- [x] Invocation tests: `manageTodoListTool.test.ts` — write/read operations, `pastTenseMessage` generation, steering mid-task consistency
- [x] All existing tests pass (17919 passing, 19 pre-existing failures)
- [x] TypeScript compilation clean