### PR TITLE
Fix delete action in AI Customizations editor

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -14,7 +14,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IEditorService } from '../../../../workbench/services/editor/common/editorService.js';
-import { IFileService } from '../../../../platform/files/common/files.js';
+import { IFileService, FileSystemProviderCapabilities } from '../../../../platform/files/common/files.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 
@@ -108,7 +108,8 @@ registerAction2(class extends Action2 {
 		});
 
 		if (confirmation.confirmed) {
-			await fileService.del(uri, { useTrash: true, recursive: true });
+			const useTrash = fileService.hasCapability(uri, FileSystemProviderCapabilities.Trash);
+			await fileService.del(uri, { useTrash, recursive: true });
 		}
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -22,7 +22,7 @@ import { IPromptsService, PromptsStorage, IPromptPath } from '../../common/promp
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { AGENT_MD_FILENAME } from '../../common/promptSyntax/config/promptFileLocations.js';
 import { agentIcon, instructionsIcon, promptIcon, skillIcon, hookIcon, userIcon, workspaceIcon, extensionIcon, pluginIcon, builtinIcon } from './aiCustomizationIcons.js';
-import { AICustomizationManagementItemMenuId, AICustomizationManagementSection, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
+import { AI_CUSTOMIZATION_ITEM_STORAGE_KEY, AI_CUSTOMIZATION_ITEM_TYPE_KEY, AI_CUSTOMIZATION_ITEM_URI_KEY, AICustomizationManagementItemMenuId, AICustomizationManagementSection, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
 import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { Delayer } from '../../../../../base/common/async.js';
@@ -353,8 +353,15 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			storage: element.storage,
 		};
 
+		// Create scoped context key service with item-specific keys for when-clause filtering
+		const overlay = this.contextKeyService.createOverlay([
+			[AI_CUSTOMIZATION_ITEM_TYPE_KEY, element.promptType],
+			[AI_CUSTOMIZATION_ITEM_STORAGE_KEY, element.storage],
+			[AI_CUSTOMIZATION_ITEM_URI_KEY, element.uri.toString()],
+		]);
+
 		const menu = templateData.elementDisposables.add(
-			this.menuService.createMenu(AICustomizationManagementItemMenuId, this.contextKeyService)
+			this.menuService.createMenu(AICustomizationManagementItemMenuId, overlay)
 		);
 
 		const updateActions = () => {
@@ -615,8 +622,15 @@ export class AICustomizationListWidget extends Disposable {
 			storage: item.storage,
 		};
 
+		// Create scoped context key service with item-specific keys for when-clause filtering
+		const overlay = this.contextKeyService.createOverlay([
+			[AI_CUSTOMIZATION_ITEM_TYPE_KEY, item.promptType],
+			[AI_CUSTOMIZATION_ITEM_STORAGE_KEY, item.storage],
+			[AI_CUSTOMIZATION_ITEM_URI_KEY, item.uri.toString()],
+		]);
+
 		// Get menu actions, excluding inline actions to avoid duplicates
-		const actions = this.menuService.getMenuActions(AICustomizationManagementItemMenuId, this.contextKeyService, {
+		const actions = this.menuService.getMenuActions(AICustomizationManagementItemMenuId, overlay, {
 			arg: context,
 			shouldForwardArgs: true,
 		});

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -37,7 +37,7 @@ import { PromptsStorage } from '../../common/promptSyntax/service/promptsService
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ChatConfiguration } from '../../common/constants.js';
-import { IFileService } from '../../../../../platform/files/common/files.js';
+import { IFileService, FileSystemProviderCapabilities } from '../../../../../platform/files/common/files.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { basename, dirname } from '../../../../../base/common/resources.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -252,16 +252,21 @@ registerAction2(class extends Action2 {
 		});
 
 		if (confirmation.confirmed) {
-			const telemetryService = accessor.get(ITelemetryService);
-			telemetryService.publicLog2<CustomizationEditorDeleteItemEvent, CustomizationEditorDeleteItemClassification>('chatCustomizationEditor.deleteItem', {
-				promptType: promptType ?? '',
-				storage: storage ?? '',
-			});
+			try {
+				const telemetryService = accessor.get(ITelemetryService);
+				telemetryService.publicLog2<CustomizationEditorDeleteItemEvent, CustomizationEditorDeleteItemClassification>('chatCustomizationEditor.deleteItem', {
+					promptType: promptType ?? '',
+					storage: storage ?? '',
+				});
+			} catch {
+				// Telemetry must not block deletion
+			}
 
 			// For skills, delete the parent folder (e.g. .github/skills/my-skill/)
 			// since each skill is a folder containing SKILL.md.
 			const deleteTarget = isSkill ? dirname(uri) : uri;
-			await fileService.del(deleteTarget, { useTrash: true, recursive: isSkill });
+			const useTrash = fileService.hasCapability(deleteTarget, FileSystemProviderCapabilities.Trash);
+			await fileService.del(deleteTarget, { useTrash, recursive: isSkill });
 
 			// Commit the deletion to git (sessions: main repo + worktree)
 			if (storage === PromptsStorage.local) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -20,9 +20,13 @@ import { AICustomizationManagementEditorInput } from './aiCustomizationManagemen
 import {
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID,
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID,
+	AI_CUSTOMIZATION_ITEM_STORAGE_KEY,
+	AI_CUSTOMIZATION_ITEM_TYPE_KEY,
+	AI_CUSTOMIZATION_ITEM_URI_KEY,
 	AICustomizationManagementCommands,
 	AICustomizationManagementItemMenuId,
 	AICustomizationManagementSection,
+	BUILTIN_STORAGE,
 } from './aiCustomizationManagement.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
@@ -227,8 +231,8 @@ registerAction2(class extends Action2 {
 		// For skills, use the parent folder name since skills are structured as <skillname>/SKILL.md.
 		const fileName = isSkill ? basename(dirname(uri)) : basename(uri);
 
-		// Extension and plugin files cannot be deleted
-		if (storage === PromptsStorage.extension || storage === PromptsStorage.plugin) {
+		// Extension, plugin, and built-in files cannot be deleted
+		if (storage === PromptsStorage.extension || storage === PromptsStorage.plugin || storage === BUILTIN_STORAGE) {
 			await dialogService.info(
 				localize('cannotDeleteExtension', "Cannot Delete Extension File"),
 				localize('cannotDeleteExtensionDetail', "Files provided by extensions cannot be deleted. You can disable the extension if you no longer want to use this customization.")
@@ -289,8 +293,14 @@ registerAction2(class extends Action2 {
 	}
 });
 
-// Context Key for prompt type to conditionally show "Run Prompt"
-const AI_CUSTOMIZATION_ITEM_TYPE_KEY = 'aiCustomizationManagementItemType';
+/**
+ * When clause that hides an action for read-only (extension, plugin, built-in) items.
+ */
+const WHEN_ITEM_IS_DELETABLE = ContextKeyExpr.and(
+	ContextKeyExpr.notEquals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.extension),
+	ContextKeyExpr.notEquals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.plugin),
+	ContextKeyExpr.notEquals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+);
 
 // Register context menu items
 
@@ -305,6 +315,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
 	group: 'inline',
 	order: 10,
+	when: WHEN_ITEM_IS_DELETABLE,
 });
 
 // Context menu items (shown on right-click)
@@ -326,8 +337,8 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	group: '3_file',
 	order: 1,
 	when: ContextKeyExpr.or(
-		ContextKeyExpr.regex('aiCustomizationManagementItemUri', new RegExp(`^${Schemas.file}:`)),
-		ContextKeyExpr.regex('aiCustomizationManagementItemUri', new RegExp(`^${Schemas.vscodeUserData}:`))
+		ContextKeyExpr.regex(AI_CUSTOMIZATION_ITEM_URI_KEY, new RegExp(`^${Schemas.file}:`)),
+		ContextKeyExpr.regex(AI_CUSTOMIZATION_ITEM_URI_KEY, new RegExp(`^${Schemas.vscodeUserData}:`))
 	),
 });
 
@@ -335,6 +346,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_ID, title: localize('delete', "Delete") },
 	group: '4_modify',
 	order: 1,
+	when: WHEN_ITEM_IS_DELETABLE,
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -73,6 +73,21 @@ export const AICustomizationManagementTitleMenuId = MenuId.for('AICustomizationM
 export const AICustomizationManagementItemMenuId = MenuId.for('AICustomizationManagementEditorItem');
 
 /**
+ * Context key for the item prompt type (e.g. 'prompt', 'agent') used in when-clause filtering.
+ */
+export const AI_CUSTOMIZATION_ITEM_TYPE_KEY = 'aiCustomizationManagementItemType';
+
+/**
+ * Context key for the item storage type (e.g. 'local', 'user', 'extension') used in when-clause filtering.
+ */
+export const AI_CUSTOMIZATION_ITEM_STORAGE_KEY = 'aiCustomizationManagementItemStorage';
+
+/**
+ * Context key for the item URI used in when-clause filtering.
+ */
+export const AI_CUSTOMIZATION_ITEM_URI_KEY = 'aiCustomizationManagementItemUri';
+
+/**
  * Storage key for persisting the selected section.
  */
 export const AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY = 'aiCustomizationManagement.selectedSection';


### PR DESCRIPTION
## Summary

Fixes two issues with the delete action in the AI Customizations editor:

### 1. Delete shows for read-only items (extension, plugin, built-in)
The delete button (inline hover + context menu) was visible for all items including read-only ones. Added `when`-clause filtering using context key overlays so delete is hidden for extension, plugin, and built-in storage types.

This also fixes "Run Prompt" and "Reveal in OS" actions which had `when`-clauses that were never evaluated because item-specific context keys were never set on the scoped context key service.

### 2. Delete action silently fails after confirmation
After clicking "Delete" in the confirmation dialog, nothing happened. Root cause: the `telemetryService.publicLog2()` call was throwing an exception (resolved via `accessor.get()` in the action's `run()` method), which propagated uncaught and prevented `fileService.del()` from executing. Wrapped telemetry in try/catch.

Additionally, `fileService.del()` was called with `useTrash: true` unconditionally, but some file system providers don't support trash. Now checks `hasCapability()` first.

### Files changed
- `aiCustomizationManagement.ts` — Added shared context key constants for item type/storage/URI
- `aiCustomizationManagement.contribution.ts` — Added `when`-clauses on delete menu items, wrapped telemetry in try/catch, check trash capability
- `aiCustomizationListWidget.ts` — Create context key overlays when rendering items and context menus
- `aiCustomizationTreeView.contribution.ts` (sessions) — Check trash capability