### PR TITLE
Fix SCM commit tooltip newline handling (#270925)

### DIFF
--- a/extensions/git/src/hover.ts
+++ b/extensions/git/src/hover.ts
@@ -122,8 +122,42 @@ function appendContent(markdownString: MarkdownString, authorAvatar: string | un
 	}
 
 	// Subject | Message (escape image syntax)
-	markdownString.appendMarkdown(`${emojify(message.replace(/!\[/g, '&#33;&#91;').replace(/\r\n|\r|\n/g, '\n\n'))}`);
+	markdownString.appendMarkdown(formatMessageForHoverMarkdown(emojify(message)));
 	markdownString.appendMarkdown(`\n\n---\n\n`);
+}
+
+export function formatMessageForHoverMarkdown(message: string): string {
+	const escapedMessage = message
+		.replace(/!\[/g, '&#33;&#91;')
+		.replace(/\r\n|\r/g, '\n');
+
+	return escapedMessage
+		.split(/\n\s*\n/g)
+		.map(paragraph => {
+			const lines = paragraph.split('\n');
+			const result: string[] = [];
+			let current = '';
+
+			for (const line of lines) {
+				if (/^\s*(?:[-*+]|\d+[.)])\s/.test(line)) {
+					if (current) {
+						result.push(current);
+					}
+					current = line.trimEnd();
+				} else {
+					current = current
+						? current + ' ' + line.trim()
+						: line.trimEnd();
+				}
+			}
+			if (current) {
+				result.push(current);
+			}
+
+			return result.join('\n').trim();
+		})
+		.filter(paragraph => paragraph.length > 0)
+		.join('\n\n');
 }
 
 function appendShortStats(markdownString: MarkdownString, shortStats: { files: number; insertions: number; deletions: number }): void {

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -5,6 +5,7 @@
 
 import 'mocha';
 import { GitStatusParser, parseGitCommits, parseGitmodules, parseLsTree, parseLsFiles, parseGitRemotes, parseCoAuthors } from '../git';
+import { formatMessageForHoverMarkdown } from '../hover';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -265,6 +266,64 @@ suite('git', () => {
 `;
 
 			assert.deepStrictEqual(parseGitRemotes(sample), []);
+		});
+	});
+
+	suite('formatMessageForHoverMarkdown', () => {
+		test('treats single newlines as soft wraps', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\nbody line 1\nbody line 2'),
+				'subject body line 1 body line 2'
+			);
+		});
+
+		test('treats double newlines as paragraph breaks', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\nbody line 1\n\nbody line 2'),
+				'subject body line 1\n\nbody line 2'
+			);
+		});
+
+		test('normalizes windows newlines and escapes image syntax', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\r\n![alt](image)\r\n\r\nbody'),
+				'subject &#33;&#91;alt](image)\n\nbody'
+			);
+		});
+
+		test('preserves list items separated by single newlines', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\n\n- item 1\n- item 2\n- item 3'),
+				'subject\n\n- item 1\n- item 2\n- item 3'
+			);
+		});
+
+		test('joins continuation lines within list items', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\n\n- item 1 that wraps\n  across lines\n- item 2'),
+				'subject\n\n- item 1 that wraps across lines\n- item 2'
+			);
+		});
+
+		test('preserves list items with asterisk and plus markers', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\n\n* item 1\n+ item 2'),
+				'subject\n\n* item 1\n+ item 2'
+			);
+		});
+
+		test('preserves numbered list items', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\n\n1. first\n2. second'),
+				'subject\n\n1. first\n2. second'
+			);
+		});
+
+		test('handles prose followed by list items in same paragraph', () => {
+			assert.strictEqual(
+				formatMessageForHoverMarkdown('subject\n\nDuring compilation:\n- step 1\n- step 2'),
+				'subject\n\nDuring compilation:\n- step 1\n- step 2'
+			);
 		});
 	});
 

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -636,7 +636,8 @@
 	margin-bottom: 4px;
 }
 
-.monaco-hover.history-item-hover .history-item-hover-container > .rendered-markdown > p {
+.monaco-hover.history-item-hover .history-item-hover-container > .rendered-markdown > p,
+.monaco-hover.history-item-hover .history-item-hover-container > .rendered-markdown > ul {
 	margin: 4px 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #270925

The commit message tooltip in the SCM history view had two issues with how newlines were handled:

1. **Hard-wrapped prose appeared choppy** — Single newlines in 72-column wrapped commit messages were converted to `\n\n` (double newlines), rendering each original line as a separate paragraph with excessive spacing.
2. **Markdown list items were destroyed** — List items (`- `, `* `, `1. `) separated by single newlines got merged into a single run-on paragraph, losing all list formatting.

### Changes

- **`extensions/git/src/hover.ts`** — Extract `formatMessageForHoverMarkdown()` function that intelligently handles newlines: joins continuation lines within paragraphs (soft wraps → spaces), preserves newlines before markdown list markers, and keeps double newlines as paragraph breaks.
- **`src/vs/workbench/contrib/scm/browser/media/scm.css`** — Extend the `margin: 4px 0` override to `<ul>` elements (previously only `<p>` was overridden, so lists inherited the default `8px` margin).
- **`extensions/git/src/test/git.test.ts`** — Add 8 test cases covering soft wraps, paragraph breaks, list items, continuation lines, mixed markers, numbered lists, and prose-then-list patterns.

### Before / After

Hard-wrapped prose commit (before — each 72-col line break shown as paragraph break):

<img width="542" height="559" alt="main #2" src="https://github.com/user-attachments/assets/48232f11-c620-48ac-89c0-805852da39aa" />

After (prose reflows naturally into paragraphs):

<img width="540" height="546" alt="octopus #2" src="https://github.com/user-attachments/assets/32dc3df9-8257-4fd2-9d03-098d68723219" />

## Test plan

- [x] Existing `formatMessageForHoverMarkdown` tests pass
- [x] New test cases for list items, continuation lines, numbered lists
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Layer validation passes (`npm run valid-layers-check`)
- [ ] Manual: hover over commits with 72-col wrapped prose — text reflows as paragraphs
- [ ] Manual: hover over commits with `- ` bullet lists — items render as proper list
- [ ] Manual: hover over commits with long bullet items that wrap — continuation lines join within the bullet