### PR TITLE
fix: stop event propagation on Enter key in find and replace inputs

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -894,10 +894,12 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		if (e.equals(ctrlKeyMod | KeyCode.Enter)) {
 			if (this._keybindingService.dispatchEvent(e, e.target)) {
 				e.preventDefault();
+				e.stopPropagation();
 				return;
 			} else {
 				this._findInput.inputBox.insertAtCursor('\n');
 				e.preventDefault();
+				e.stopPropagation();
 				return;
 			}
 		}
@@ -933,10 +935,12 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		if (e.equals(ctrlKeyMod | KeyCode.Enter)) {
 			if (this._keybindingService.dispatchEvent(e, e.target)) {
 				e.preventDefault();
+				e.stopPropagation();
 				return;
 			} else {
 				this._replaceInput.inputBox.insertAtCursor('\n');
 				e.preventDefault();
+				e.stopPropagation();
 				return;
 			}
 


### PR DESCRIPTION
fix: stop event propagation on Enter key in find and replace inputs. Fix #299353