### PR TITLE
Add "Workbench > Browser" settings category

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -156,6 +156,11 @@ export const tocData: ITOCEntry<string> = {
 					id: 'workbench/screencastmode',
 					label: localize('screencastMode', "Screencast Mode"),
 					settings: ['screencastMode.*']
+				},
+				{
+					id: 'workbench/browser',
+					label: localize('browser', "Browser"),
+					settings: ['workbench.browser.*']
 				}
 			]
 		},


### PR DESCRIPTION
Move workbench.browser.* settings into their own sub-category in the Settings panel table of contents.

Before:
<img width="1387" height="793" alt="image" src="https://github.com/user-attachments/assets/d30b1b72-8749-4974-8092-7cbb8fc35be7" />


After:
<img width="1396" height="805" alt="image" src="https://github.com/user-attachments/assets/c16bc5a7-8b2d-48f0-a96b-e171ff33de56" />
