### PR TITLE
Enhance image handling in chat attachments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -454,7 +454,8 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
 		// Wire up click + keyboard (Enter/Space) open handlers
-		if (resource || imageData) {
+		const canOpenCarousel = attachment.value instanceof Uint8Array && configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled);
+		if ((imageData && canOpenCarousel) || resource) {
 			this.element.style.cursor = 'pointer';
 			this._register(registerOpenEditorListeners(this.element, async () => {
 				await clickHandler();

--- a/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets.ts
@@ -61,6 +61,7 @@ import { toHistoryItemHoverContent } from '../../../scm/browser/scmHistory.js';
 import { getHistoryItemEditorTitle } from '../../../scm/browser/util.js';
 import { ITerminalService } from '../../../terminal/browser/terminal.js';
 import { IChatContentReference } from '../../common/chatService/chatService.js';
+import { coerceImageBuffer } from '../../common/chatImageExtraction.js';
 import { ChatConfiguration } from '../../common/constants.js';
 import { IChatRequestPasteVariableEntry, IChatRequestVariableEntry, IElementVariableEntry, INotebookOutputVariableEntry, IPromptFileVariableEntry, IPromptTextVariableEntry, ISCMHistoryItemVariableEntry, OmittedState, PromptFileVariableKind, ChatRequestToolReferenceEntry, ISCMHistoryItemChangeVariableEntry, ISCMHistoryItemChangeRangeVariableEntry, ITerminalVariableEntry, isStringVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../common/languageModels.js';
@@ -437,9 +438,10 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 
 		const ref = attachment.references?.[0]?.reference;
 		resource = ref && URI.isUri(ref) ? ref : undefined;
+		const imageData = coerceImageBuffer(attachment.value);
 		const clickHandler = async () => {
-			if (attachment.value instanceof Uint8Array && configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled)) {
-				await this.openInCarousel(attachment.name, attachment.value, resource);
+			if ((resource || imageData) && configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled)) {
+				await this.openInCarousel(attachment.name, imageData, resource);
 			} else if (resource) {
 				await this.openResource(resource, { editorOptions: { preserveFocus: true } }, false, undefined);
 			}
@@ -448,12 +450,11 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		const currentLanguageModelName = this.currentLanguageModel ? this.languageModelsService.lookupLanguageModel(this.currentLanguageModel.identifier)?.name ?? this.currentLanguageModel.identifier : 'Current model';
 
 		const fullName = resource ? this.labelService.getUriLabel(resource) : (attachment.fullName || attachment.name);
-		this._register(createImageElements(resource, attachment.name, fullName, this.element, attachment.value as Uint8Array, this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, attachment.omittedState, this.chatEntitlementService.previewFeaturesDisabled));
+		this._register(createImageElements(resource, attachment.name, fullName, this.element, imageData ?? (attachment.value as Uint8Array), this.hoverService, ariaLabel, currentLanguageModelName, clickHandler, this.currentLanguageModel, attachment.omittedState, this.chatEntitlementService.previewFeaturesDisabled));
 		this.element.ariaLabel = this.appendDeletionHint(ariaLabel);
 
 		// Wire up click + keyboard (Enter/Space) open handlers
-		const canOpenCarousel = attachment.value instanceof Uint8Array && configurationService.getValue<boolean>(ChatConfiguration.ImageCarouselEnabled);
-		if (canOpenCarousel || resource) {
+		if (resource || imageData) {
 			this.element.style.cursor = 'pointer';
 			this._register(registerOpenEditorListeners(this.element, async () => {
 				await clickHandler();
@@ -467,7 +468,7 @@ export class ImageAttachmentWidget extends AbstractChatAttachmentWidget {
 		}
 	}
 
-	private async openInCarousel(name: string, data: Uint8Array, referenceUri: URI | undefined): Promise<void> {
+	private async openInCarousel(name: string, data: Uint8Array | undefined, referenceUri: URI | undefined): Promise<void> {
 		const resource = referenceUri ?? URI.from({ scheme: 'data', path: name });
 		await this.chatImageCarouselService.openCarouselAtResource(resource, data);
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
@@ -11,8 +11,8 @@ import { localize } from '../../../../nls.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { extractImagesFromChatResponse } from '../common/chatImageExtraction.js';
-import { IChatResponseViewModel, isResponseVM } from '../common/model/chatViewModel.js';
+import { extractImagesFromChatRequest, extractImagesFromChatResponse } from '../common/chatImageExtraction.js';
+import { IChatRequestViewModel, IChatResponseViewModel, isRequestVM, isResponseVM } from '../common/model/chatViewModel.js';
 import { IChatWidgetService } from './chat.js';
 
 export const IChatImageCarouselService = createDecorator<IChatImageCarouselService>('chatImageCarouselService');
@@ -65,23 +65,57 @@ export interface ICarouselSingleImageArgs {
 //#region Testable helper functions
 
 /**
- * Collects all carousel image sections from chat response items.
- * Each response with images becomes one section containing both
- * tool invocation images and inline reference images (file URIs).
+ * Collects all carousel image sections from chat items.
+ * Each request/response pair with images becomes one section containing
+ * user attachment images, tool invocation images, and inline reference images.
  */
 export async function collectCarouselSections(
-	responses: IChatResponseViewModel[],
+	items: (IChatRequestViewModel | IChatResponseViewModel)[],
 	readFile: (uri: URI) => Promise<Uint8Array>,
 ): Promise<ICarouselSection[]> {
 	const sections: ICarouselSection[] = [];
 
-	for (const response of responses) {
-		const { title, images } = await extractImagesFromChatResponse(response, async uri => VSBuffer.wrap(await readFile(uri)));
+	// Build a map from request id to request VM for pairing
+	const requestMap = new Map<string, IChatRequestViewModel>();
+	for (const item of items) {
+		if (isRequestVM(item)) {
+			requestMap.set(item.id, item);
+		}
+	}
 
-		if (images.length > 0) {
+	for (const item of items) {
+		if (!isResponseVM(item)) {
+			continue;
+		}
+
+		const { title, images: responseImages } = await extractImagesFromChatResponse(item, async uri => VSBuffer.wrap(await readFile(uri)));
+
+		// Also collect images from the corresponding user request
+		const request = requestMap.get(item.requestId);
+		const requestImages = request ? extractImagesFromChatRequest(request) : [];
+
+		const allImages = [...requestImages, ...responseImages];
+		if (allImages.length > 0) {
 			sections.push({
 				title,
-				images: images.map(({ id, name, mimeType, data }) => ({ id, name, mimeType, data: data.buffer }))
+				images: allImages.map(({ id, name, mimeType, data }) => ({ id, name, mimeType, data: data.buffer }))
+			});
+		}
+	}
+
+	// Handle requests that have no response yet (e.g. pending requests with image attachments)
+	const respondedRequestIds = new Set(
+		items.filter(isResponseVM).map(r => r.requestId)
+	);
+	for (const item of items) {
+		if (!isRequestVM(item) || respondedRequestIds.has(item.id)) {
+			continue;
+		}
+		const requestImages = extractImagesFromChatRequest(item);
+		if (requestImages.length > 0) {
+			sections.push({
+				title: item.messageText,
+				images: requestImages.map(({ id, name, mimeType, data }) => ({ id, name, mimeType, data: data.buffer }))
 			});
 		}
 	}
@@ -195,9 +229,11 @@ export class ChatImageCarouselService implements IChatImageCarouselService {
 			return;
 		}
 
-		const responses = widget.viewModel.getItems().filter((item): item is IChatResponseViewModel => isResponseVM(item));
+		const items = widget.viewModel.getItems().filter(
+			(item): item is IChatRequestViewModel | IChatResponseViewModel => isRequestVM(item) || isResponseVM(item)
+		);
 		const readFile = async (uri: URI) => (await this.fileService.readFile(uri)).value.buffer;
-		const sections = await collectCarouselSections(responses, readFile);
+		const sections = await collectCarouselSections(items, readFile);
 		const clickedGlobalIndex = findClickedImageIndex(sections, resource, data);
 
 		if (clickedGlobalIndex === -1 || sections.length === 0) {

--- a/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatImageCarouselService.ts
@@ -88,7 +88,7 @@ export async function collectCarouselSections(
 			continue;
 		}
 
-		const { title, images: responseImages } = await extractImagesFromChatResponse(item, async uri => VSBuffer.wrap(await readFile(uri)));
+		const { title: extractedTitle, images: responseImages } = await extractImagesFromChatResponse(item, async uri => VSBuffer.wrap(await readFile(uri)));
 
 		// Also collect images from the corresponding user request
 		const request = requestMap.get(item.requestId);
@@ -97,7 +97,7 @@ export async function collectCarouselSections(
 		const allImages = [...requestImages, ...responseImages];
 		if (allImages.length > 0) {
 			sections.push({
-				title,
+				title: request?.messageText ?? extractedTitle,
 				images: allImages.map(({ id, name, mimeType, data }) => ({ id, name, mimeType, data: data.buffer }))
 			});
 		}

--- a/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
+++ b/src/vs/workbench/contrib/chat/common/chatImageExtraction.ts
@@ -12,6 +12,7 @@ import { IChatResponseViewModel, IChatRequestViewModel, isRequestVM } from './mo
 import { ChatResponseResource } from './model/chatModel.js';
 import { IChatContentInlineReference, IChatToolInvocation, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from './chatService/chatService.js';
 import { isToolResultInputOutputDetails, isToolResultOutputDetails, IToolResultOutputDetails } from './tools/languageModelToolsService.js';
+import { isImageVariableEntry } from './attachments/chatVariableEntries.js';
 
 export interface IChatExtractedImage {
 	readonly id: string;
@@ -185,4 +186,49 @@ async function extractImageFromInlineReference(
 		source: localize('chatImageExtraction.inlineReference', "File"),
 		caption: undefined,
 	};
+}
+
+export function coerceImageBuffer(value: unknown): Uint8Array | undefined {
+	return value instanceof Uint8Array
+		? value
+		: value instanceof ArrayBuffer
+			? new Uint8Array(value)
+			: (value && typeof value === 'object' && !Array.isArray(value))
+				? new Uint8Array(
+					Object.keys(value as Record<string, number>)
+						.sort((a, b) => Number(a) - Number(b))
+						.map(key => (value as Record<string, number>)[key])
+				)
+				: undefined;
+}
+
+/**
+ * Extract images from a chat request's variable attachments (user-attached images).
+ */
+export function extractImagesFromChatRequest(
+	request: IChatRequestViewModel,
+): IChatExtractedImage[] {
+	const images: IChatExtractedImage[] = [];
+	for (const variable of request.variables) {
+		if (!isImageVariableEntry(variable)) {
+			continue;
+		}
+		const buffer = coerceImageBuffer(variable.value);
+		if (!buffer) {
+			continue;
+		}
+		const mimeType = variable.mimeType ?? getMediaMime(variable.name) ?? 'image/png';
+		const uri = variable.references?.[0]?.reference;
+		const imageUri = URI.isUri(uri) ? uri : URI.from({ scheme: 'data', path: variable.name });
+		images.push({
+			id: imageUri.toString(),
+			uri: imageUri,
+			name: variable.name,
+			mimeType,
+			data: VSBuffer.wrap(buffer),
+			source: localize('chatImageExtraction.userAttachment', "Attachment"),
+			caption: undefined,
+		});
+	}
+	return images;
 }

--- a/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
@@ -200,6 +200,18 @@ suite('ChatImageCarouselService helpers', () => {
 			assert.strictEqual(result[0].images[0].name, 'cat.png');
 		});
 
+		test('prefers paired request message text over extracted response title', async () => {
+			const request = makeRequest('req-1', [
+				makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),
+			], 'Request title wins');
+			const response = makeResponse('req-1');
+
+			const result = await collectCarouselSections([request, response], async () => new Uint8Array());
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].title, 'Request title wins');
+		});
+
 		test('does not duplicate request images when response exists', async () => {
 			const request = makeRequest('req-1', [
 				makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),

--- a/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatImageCarouselService.test.ts
@@ -4,12 +4,58 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { buildCollectionArgs, buildSingleImageArgs, findClickedImageIndex, ICarouselSection } from '../../browser/chatImageCarouselService.js';
+import { buildCollectionArgs, buildSingleImageArgs, collectCarouselSections, findClickedImageIndex, ICarouselSection } from '../../browser/chatImageCarouselService.js';
+import { IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
+import { IChatRequestViewModel, IChatResponseViewModel } from '../../common/model/chatViewModel.js';
 
 suite('ChatImageCarouselService helpers', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function makeRequest(id: string, variables: IChatRequestViewModel['variables'], messageText: string = 'Request'): IChatRequestViewModel {
+		return {
+			id,
+			sessionResource: URI.parse('chat-session://test/session'),
+			dataId: `data-${id}`,
+			username: 'test-user',
+			message: { text: messageText, parts: [] },
+			messageText,
+			attempt: 0,
+			variables,
+			currentRenderedHeight: undefined,
+			shouldBeRemovedOnSend: undefined,
+			isComplete: true,
+			isCompleteAddedRequest: true,
+			slashCommand: undefined,
+			agentOrSlashCommandDetected: false,
+			shouldBeBlocked: undefined!,
+			timestamp: 0,
+		} as unknown as IChatRequestViewModel;
+	}
+
+	function makeResponse(requestId: string, id: string = 'resp-1'): IChatResponseViewModel {
+		return {
+			id,
+			requestId,
+			sessionResource: URI.parse('chat-session://test/session'),
+			response: { value: [] },
+			session: { getItems: () => [] },
+		} as unknown as IChatResponseViewModel;
+	}
+
+	function makeImageVariableEntry(overrides: Partial<IImageVariableEntry> & Pick<IImageVariableEntry, 'value'>): IImageVariableEntry {
+		const { value, ...rest } = overrides;
+		return {
+			id: 'img-1',
+			kind: 'image',
+			name: 'cat.png',
+			value,
+			mimeType: 'image/png',
+			...rest,
+		};
+	}
 
 	function makeImage(id: string, name: string = 'img.png', mimeType: string = 'image/png'): { id: string; name: string; mimeType: string; data: Uint8Array } {
 		return { id, name, mimeType, data: new Uint8Array([1, 2, 3]) };
@@ -104,4 +150,67 @@ suite('ChatImageCarouselService helpers', () => {
 			assert.strictEqual(buildSingleImageArgs(uri, data).mimeType, 'image/png');
 		});
 	});
+
+	suite('collectCarouselSections', () => {
+
+		test('collects request attachment images for pending requests', async () => {
+			const request = makeRequest('req-1', [
+				makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),
+			], 'Pending request');
+
+			const result = await collectCarouselSections([request], async () => new Uint8Array());
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].title, 'Pending request');
+			assert.strictEqual(result[0].images.length, 1);
+			assert.deepStrictEqual({
+				id: result[0].images[0].id,
+				name: result[0].images[0].name,
+				mimeType: result[0].images[0].mimeType,
+				data: [...result[0].images[0].data],
+			}, {
+				id: URI.from({ scheme: 'data', path: 'cat.png' }).toString(),
+				name: 'cat.png',
+				mimeType: 'image/png',
+				data: [1, 2, 3],
+			});
+		});
+
+		test('collects request attachment images restored as plain objects', async () => {
+			const request = makeRequest('req-1', [
+				makeImageVariableEntry({ value: { 0: 4, 1: 5, 2: 6 } }),
+			], 'Pending request');
+
+			const result = await collectCarouselSections([request], async () => new Uint8Array());
+
+			assert.deepStrictEqual([...result[0].images[0].data], [4, 5, 6]);
+		});
+
+		test('merges request images into matching response section', async () => {
+			const request = makeRequest('req-1', [
+				makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),
+			], 'Show me images');
+			const response = makeResponse('req-1');
+
+			const result = await collectCarouselSections([request, response], async uri => VSBuffer.fromString(`data-for-${uri.path}`).buffer);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].title, 'Show me images');
+			assert.strictEqual(result[0].images.length, 1);
+			assert.strictEqual(result[0].images[0].name, 'cat.png');
+		});
+
+		test('does not duplicate request images when response exists', async () => {
+			const request = makeRequest('req-1', [
+				makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),
+			], 'Show me images');
+			const response = makeResponse('req-1');
+
+			const result = await collectCarouselSections([request, response], async () => new Uint8Array());
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].images.length, 1);
+		});
+	});
+
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatImageExtraction.test.ts
@@ -7,11 +7,12 @@ import assert from 'assert';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IImageVariableEntry } from '../../common/attachments/chatVariableEntries.js';
 import { IChatProgressResponseContent } from '../../common/model/chatModel.js';
-import { IChatResponseViewModel } from '../../common/model/chatViewModel.js';
+import { IChatRequestViewModel, IChatResponseViewModel } from '../../common/model/chatViewModel.js';
 import { IChatContentInlineReference, IChatToolInvocationSerialized, IToolResultOutputDetailsSerialized } from '../../common/chatService/chatService.js';
 import { IToolResultInputOutputDetails } from '../../common/tools/languageModelToolsService.js';
-import { extractImagesFromChatResponse, extractImagesFromToolInvocationMessages } from '../../common/chatImageExtraction.js';
+import { extractImagesFromChatRequest, extractImagesFromChatResponse, extractImagesFromToolInvocationMessages } from '../../common/chatImageExtraction.js';
 
 function makeToolInvocation(overrides: Partial<IChatToolInvocationSerialized> = {}): IChatToolInvocationSerialized {
 	return {
@@ -66,6 +67,39 @@ function makeResponse(items: ReadonlyArray<IChatProgressResponseContent>, opts: 
 }
 
 const fakeReadFile = (uri: URI) => Promise.resolve(VSBuffer.fromString(`data-for-${uri.path}`));
+
+function makeRequest(variables: IChatRequestViewModel['variables'], opts: { id?: string; messageText?: string } = {}): IChatRequestViewModel {
+	return {
+		id: opts.id ?? 'req-1',
+		sessionResource: URI.parse('chat-session://test/session'),
+		dataId: 'data-1',
+		username: 'test-user',
+		message: { text: opts.messageText ?? 'Show me images', parts: [] },
+		messageText: opts.messageText ?? 'Show me images',
+		attempt: 0,
+		variables,
+		currentRenderedHeight: undefined,
+		shouldBeRemovedOnSend: undefined,
+		isComplete: true,
+		isCompleteAddedRequest: true,
+		slashCommand: undefined,
+		agentOrSlashCommandDetected: false,
+		shouldBeBlocked: undefined!,
+		timestamp: 0,
+	} as unknown as IChatRequestViewModel;
+}
+
+function makeImageVariableEntry(overrides: Partial<IImageVariableEntry> & Pick<IImageVariableEntry, 'value'>): IImageVariableEntry {
+	const { value, ...rest } = overrides;
+	return {
+		id: 'img-1',
+		kind: 'image',
+		name: 'cat.png',
+		value,
+		mimeType: 'image/png',
+		...rest,
+	};
+}
 
 suite('extractImagesFromChatResponse', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -390,5 +424,67 @@ suite('extractImagesFromToolInvocationMessages', () => {
 
 		assert.strictEqual(result.length, 1);
 		assert.strictEqual(result[0].caption, 'Running tool');
+	});
+});
+
+suite('extractImagesFromChatRequest', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('extracts image attachment from Uint8Array', () => {
+		const request = makeRequest([
+			makeImageVariableEntry({ value: new Uint8Array([1, 2, 3]) }),
+		]);
+
+		const result = extractImagesFromChatRequest(request);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].name, 'cat.png');
+		assert.strictEqual(result[0].mimeType, 'image/png');
+		assert.deepStrictEqual([...result[0].data.buffer], [1, 2, 3]);
+	});
+
+	test('extracts image attachment from ArrayBuffer', () => {
+		const request = makeRequest([
+			makeImageVariableEntry({ value: new Uint8Array([4, 5, 6]).buffer }),
+		]);
+
+		const result = extractImagesFromChatRequest(request);
+
+		assert.strictEqual(result.length, 1);
+		assert.deepStrictEqual([...result[0].data.buffer], [4, 5, 6]);
+	});
+
+	test('extracts restored image attachment from plain object bytes', () => {
+		const request = makeRequest([
+			makeImageVariableEntry({ value: { 0: 7, 1: 8, 2: 9 } }),
+		]);
+
+		const result = extractImagesFromChatRequest(request);
+
+		assert.strictEqual(result.length, 1);
+		assert.deepStrictEqual([...result[0].data.buffer], [7, 8, 9]);
+	});
+
+	test('extracts restored image attachment from reordered plain object bytes', () => {
+		const request = makeRequest([
+			makeImageVariableEntry({ value: { 2: 9, 0: 7, 1: 8 } }),
+		]);
+
+		const result = extractImagesFromChatRequest(request);
+
+		assert.strictEqual(result.length, 1);
+		assert.deepStrictEqual([...result[0].data.buffer], [7, 8, 9]);
+	});
+
+	test('uses attachment resource URI when available', () => {
+		const uri = URI.file('/tmp/cat.png');
+		const request = makeRequest([
+			makeImageVariableEntry({ value: new Uint8Array([1]), references: [{ kind: 'reference', reference: uri }] }),
+		]);
+
+		const result = extractImagesFromChatRequest(request);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].uri.toString(), uri.toString());
 	});
 });

--- a/src/vs/workbench/contrib/imageCarousel/AGENTS.md
+++ b/src/vs/workbench/contrib/imageCarousel/AGENTS.md
@@ -8,7 +8,7 @@ The image carousel is a self-contained workbench contribution that follows the *
 
 - **URI scheme**: `vscode-image-carousel` (registered in `Schemas` in `src/vs/base/common/network.ts`) — used for `EditorInput.resource` identity.
 - **Direct editor input**: Callers create `ImageCarouselEditorInput` with a collection and open it directly via `IEditorService.openEditor()`.
-- **Image extraction**: `IImageCarouselService.extractImagesFromResponse()` extracts images from chat response tool invocations into a **sections-based** collection. All images from a single response are grouped into one section. The collection title is the user's chat request message. Each image caption is derived from the tool's `pastTenseMessage` (preferred) or `invocationMessage`.
+- **Image extraction**: Chat integration builds a **sections-based** collection from chat request/response items. A section can include user-attached request images alongside response-derived images (tool invocations and inline references). For paired request/response items, the section title prefers the user's chat request message; pending requests with image attachments form their own section.
 
 ## How to open the carousel
 
@@ -22,7 +22,7 @@ await editorService.openEditor(input, { pinned: true }, MODAL_GROUP);
 
 ### From chat (via click handler)
 
-Clicking an image attachment pill in chat (when `chat.imageCarousel.enabled` is true) executes the `workbench.action.chat.openImageInCarousel` command, which extracts all images from the chat response and opens them in the carousel. MIME types are resolved via `getMediaMime()` from `src/vs/base/common/mime.ts`.
+Clicking an image attachment pill in chat (when `chat.imageCarousel.enabled` is true) executes the `workbench.action.chat.openImageInCarousel` command, which collects request attachment images together with response-derived images for the current chat session and opens them in the carousel. MIME types are resolved via `getMediaMime()` from `src/vs/base/common/mime.ts`.
 
 ## Key design decisions
 
@@ -30,9 +30,9 @@ Clicking an image attachment pill in chat (when `chat.imageCarousel.enabled` is 
 
 - **Modal editor**: Opens in `MODAL_GROUP` (-4) as an overlay.
 - **Not restorable**: `canSerialize()` returns `false` — image data is in-memory only.
-- **Collection ID = chat response identity**: `sessionResource + '_' + responseId` for stable dedup via `EditorInput.matches()`.
+- **Collection ID = chat session identity**: `sessionResource + '_carousel'` for stable dedup via `EditorInput.matches()`.
 - **Preview-gated**: `chat.imageCarousel.enabled` (default `false`, tagged `preview`). When off, clicks fall through to `openResource()`.
-- **Exact image matching**: Scans responses in reverse, only opens a collection if the clicked image bytes are found in it (`findIndex` + `VSBuffer.equals`).
+- **Exact image matching**: Finds the clicked image within the constructed collection by URI first, then falls back to byte equality when needed.
 
 ### DOM & rendering
 


### PR DESCRIPTION
- Introduced coerceImageBuffer function to standardize image data handling.
- Updated ImageAttachmentWidget to utilize coerced image data for carousel display.
- Enhanced collectCarouselSections to merge request and response images.
- Added extractImagesFromChatRequest function for extracting user-attached images.
- Expanded test coverage for image extraction and carousel section collection.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Support image attachments in chat request in Image Carousel.