### PR TITLE
Fix start marker recreation losing early terminal output

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -13,7 +13,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import { trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
-import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
+import { createAltBufferPromise, getPreferredOutputStartMarker, setupRecreatingStartMarker } from './strategyHelpers.js';
 
 /**
  * This strategy is used when shell integration is enabled, but rich command detection was not
@@ -168,7 +168,13 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			}
 			if (output === undefined) {
 				try {
-					output = xterm.getContentsAsText(this._startMarker.value, endMarker);
+					const outputStartMarker = getPreferredOutputStartMarker(
+						this._startMarker.value,
+						finishedCommand?.marker,
+						finishedCommand?.executedMarker,
+						(msg: string) => this._log(msg)
+					);
+					output = xterm.getContentsAsText(outputStartMarker, endMarker);
 					this._log('Fetched output via markers');
 				} catch {
 					this._log('Failed to fetch output via markers');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -13,7 +13,7 @@ import { ITerminalLogService } from '../../../../../../platform/terminal/common/
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
-import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
+import { createAltBufferPromise, getPreferredOutputStartMarker, setupRecreatingStartMarker } from './strategyHelpers.js';
 
 /**
  * This strategy is used when the terminal has rich shell integration/command detection is
@@ -114,7 +114,13 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			}
 			if (output === undefined) {
 				try {
-					output = xterm.getContentsAsText(this._startMarker.value, endMarker);
+					const outputStartMarker = getPreferredOutputStartMarker(
+						this._startMarker.value,
+						finishedCommand?.marker,
+						finishedCommand?.executedMarker,
+						(msg: string) => this._log(msg)
+					);
+					output = xterm.getContentsAsText(outputStartMarker, endMarker);
 					this._log('Fetched output via markers');
 				} catch {
 					this._log('Failed to fetch output via markers');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
@@ -8,8 +8,8 @@ import { DisposableStore, MutableDisposable, toDisposable, type IDisposable } fr
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
 /**
- * Picks the best start marker for output capture: prefer non-disposed over disposed,
- * then earliest line.
+ * Picks the best start marker for output capture: prefer non-disposed markers,
+ * then choose the earliest line.
  */
 export function getPreferredOutputStartMarker(
 	startMarker: IXtermMarker | undefined,
@@ -19,10 +19,10 @@ export function getPreferredOutputStartMarker(
 ): IXtermMarker | undefined {
 	let best: IXtermMarker | undefined;
 	for (const marker of [startMarker, commandMarker, executedMarker]) {
-		if (!marker || marker.line < 0) {
+		if (!marker || marker.isDisposed || marker.line < 0) {
 			continue;
 		}
-		if (!best || (!marker.isDisposed && best.isDisposed) || (!best.isDisposed === !marker.isDisposed && marker.line < best.line)) {
+		if (!best || marker.line < best.line) {
 			best = marker;
 		}
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
@@ -8,6 +8,31 @@ import { DisposableStore, MutableDisposable, toDisposable, type IDisposable } fr
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
 /**
+ * Picks the best start marker for output capture: prefer non-disposed over disposed,
+ * then earliest line.
+ */
+export function getPreferredOutputStartMarker(
+	startMarker: IXtermMarker | undefined,
+	commandMarker: IXtermMarker | undefined,
+	executedMarker: IXtermMarker | undefined,
+	log?: (message: string) => void,
+): IXtermMarker | undefined {
+	let best: IXtermMarker | undefined;
+	for (const marker of [startMarker, commandMarker, executedMarker]) {
+		if (!marker || marker.line < 0) {
+			continue;
+		}
+		if (!best || (!marker.isDisposed && best.isDisposed) || (!best.isDisposed === !marker.isDisposed && marker.line < best.line)) {
+			best = marker;
+		}
+	}
+	if (best && best !== startMarker) {
+		log?.(`Using ${best === commandMarker ? 'command' : 'executed'} marker as output start (line ${best.line})`);
+	}
+	return best ?? startMarker;
+}
+
+/**
  * Sets up a recreating start marker which is resilient to prompts that clear/re-render (eg. transient
  * or powerlevel10k style prompts). The marker is recreated at the cursor position whenever the
  * existing marker is disposed. The caller is responsible for adding the startMarker to the store.
@@ -20,17 +45,33 @@ export function setupRecreatingStartMarker(
 	log?: (message: string) => void,
 ): void {
 	const markerListener = new MutableDisposable<IDisposable>();
+	let earliestStartLine = startMarker.value && startMarker.value.line >= 0 ? startMarker.value.line : undefined;
 	const recreateStartMarker = () => {
 		if (store.isDisposed) {
 			return;
 		}
 		const marker = xterm.raw.registerMarker();
-		startMarker.value = marker ?? undefined;
-		fire(marker);
 		if (!marker) {
+			log?.('Failed to create start marker');
 			markerListener.clear();
+			if (!startMarker.value) {
+				fire(undefined);
+			}
 			return;
 		}
+
+		const candidateLine = marker.line >= 0 ? marker.line : undefined;
+		if (earliestStartLine !== undefined && candidateLine !== undefined && candidateLine > earliestStartLine) {
+			log?.(`Start marker recreation at line ${candidateLine} is past earliest known line ${earliestStartLine}, skipping`);
+		} else {
+			startMarker.value = marker;
+			fire(marker);
+			if (candidateLine !== undefined) {
+				earliestStartLine = earliestStartLine === undefined ? candidateLine : Math.min(earliestStartLine, candidateLine);
+			}
+		}
+
+		// Always listen even on rejected markers so the chain keeps running
 		markerListener.value = marker.onDispose(() => {
 			log?.('Start marker was disposed, recreating');
 			recreateStartMarker();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/strategyHelpers.ts
@@ -29,7 +29,7 @@ export function getPreferredOutputStartMarker(
 	if (best && best !== startMarker) {
 		log?.(`Using ${best === commandMarker ? 'command' : 'executed'} marker as output start (line ${best.line})`);
 	}
-	return best ?? startMarker;
+	return best;
 }
 
 /**
@@ -63,6 +63,10 @@ export function setupRecreatingStartMarker(
 		const candidateLine = marker.line >= 0 ? marker.line : undefined;
 		if (earliestStartLine !== undefined && candidateLine !== undefined && candidateLine > earliestStartLine) {
 			log?.(`Start marker recreation at line ${candidateLine} is past earliest known line ${earliestStartLine}, skipping`);
+			if (startMarker.value && (startMarker.value.isDisposed || startMarker.value.line < 0)) {
+				startMarker.clear();
+				fire(undefined);
+			}
 		} else {
 			startMarker.value = marker;
 			fire(marker);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/strategyHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/strategyHelpers.test.ts
@@ -15,13 +15,18 @@ class TestMarker implements IXtermMarker {
 	isDisposed = false;
 	private readonly _listeners = new Set<() => void>();
 
-	constructor(readonly line: number) { }
+	line: number;
+
+	constructor(line: number) {
+		this.line = line;
+	}
 
 	dispose(): void {
 		if (this.isDisposed) {
 			return;
 		}
 		this.isDisposed = true;
+		this.line = -1;
 		for (const listener of this._listeners) {
 			listener();
 		}
@@ -55,8 +60,9 @@ suite('Execute Strategy Helpers', () => {
 
 		strictEqual(startMarker.value, firstMarker);
 		firstMarker.dispose();
-		strictEqual(startMarker.value, firstMarker, 'Recreated marker should not replace an earlier boundary');
-		strictEqual(createdMarkers.length, 1, 'No new marker event should fire when a forward recreation is ignored');
+		strictEqual(startMarker.value, undefined, 'Disposed marker should be cleared when forward recreation is skipped');
+		strictEqual(createdMarkers.length, 2, 'Undefined marker event should fire when disposed marker is cleared');
+		strictEqual(createdMarkers[1], undefined, 'Cleared marker event should fire undefined');
 
 		store.dispose();
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/strategyHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/strategyHelpers.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import { type IDisposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import type { IMarker as IXtermMarker } from '@xterm/xterm';
+import { getPreferredOutputStartMarker, setupRecreatingStartMarker } from '../../browser/executeStrategy/strategyHelpers.js';
+
+class TestMarker implements IXtermMarker {
+	private static _idPool = 0;
+	readonly id = TestMarker._idPool++;
+	isDisposed = false;
+	private readonly _listeners = new Set<() => void>();
+
+	constructor(readonly line: number) { }
+
+	dispose(): void {
+		if (this.isDisposed) {
+			return;
+		}
+		this.isDisposed = true;
+		for (const listener of this._listeners) {
+			listener();
+		}
+	}
+
+	onDispose(listener: () => void): IDisposable {
+		this._listeners.add(listener);
+		return {
+			dispose: () => this._listeners.delete(listener)
+		};
+	}
+}
+
+suite('Execute Strategy Helpers', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('setupRecreatingStartMarker should preserve earliest boundary when recreation moves forward', () => {
+		const store = new DisposableStore();
+		const startMarker = new MutableDisposable<IXtermMarker>();
+		const firstMarker = new TestMarker(10);
+		const recreatedMarker = new TestMarker(50);
+		let markerFactoryCallCount = 0;
+		const createdMarkers: Array<IXtermMarker | undefined> = [];
+
+		setupRecreatingStartMarker(
+			{ raw: { registerMarker: () => markerFactoryCallCount++ === 0 ? firstMarker : recreatedMarker } },
+			startMarker,
+			marker => createdMarkers.push(marker),
+			store
+		);
+
+		strictEqual(startMarker.value, firstMarker);
+		firstMarker.dispose();
+		strictEqual(startMarker.value, firstMarker, 'Recreated marker should not replace an earlier boundary');
+		strictEqual(createdMarkers.length, 1, 'No new marker event should fire when a forward recreation is ignored');
+
+		store.dispose();
+	});
+
+	test('getPreferredOutputStartMarker should fall back to command marker over a later disposed start marker', () => {
+		const disposedStartMarker = new TestMarker(50);
+		disposedStartMarker.dispose();
+		const commandMarker = new TestMarker(20);
+
+		const selected = getPreferredOutputStartMarker(disposedStartMarker, commandMarker, undefined);
+
+		strictEqual(selected, commandMarker);
+	});
+
+	test('getPreferredOutputStartMarker should select earliest marker', () => {
+		const startMarker = new TestMarker(30);
+		const commandMarker = new TestMarker(25);
+		const executedMarker = new TestMarker(15);
+
+		const selected = getPreferredOutputStartMarker(startMarker, commandMarker, executedMarker);
+
+		strictEqual(selected, executedMarker);
+	});
+});


### PR DESCRIPTION
When a command produces enough output to overflow the scrollback the xterm start marker gets disposed and `setupRecreatingStartMarker` recreates it at the current cursor which is past the output that already scrolled out. This means `getContentsAsText` captures only the tail fragment.

This prevents start marker recreation from moving the boundary forward past where it originally was and adds a fallback that picks the earliest available marker (from command detection or the executed marker) when fetching output.
