### PR TITLE
Fix listener leak in chat inline anchor widgets

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -277,14 +277,6 @@ export class InlineAnchorWidget extends Disposable {
 		const relativeLabel = labelService.getUriLabel(location.uri, { relative: true });
 		this._register(hoverService.setupManagedHover(getDefaultHoverDelegate('element'), element, relativeLabel));
 
-		// Apply link-style if configured
-		this.updateAppearance();
-		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ChatConfiguration.InlineReferencesStyle)) {
-				this.updateAppearance();
-			}
-		}));
-
 		// Drag and drop
 		if (this.data.kind !== 'symbol') {
 			element.draggable = true;
@@ -319,12 +311,6 @@ export class InlineAnchorWidget extends Disposable {
 
 	getHTMLElement(): HTMLElement {
 		return this.element;
-	}
-
-	private updateAppearance(): void {
-		const style = this.configurationService.getValue<string>(ChatConfiguration.InlineReferencesStyle);
-		const useLinkStyle = style === 'link';
-		this.element.classList.toggle('link-style', useLinkStyle);
 	}
 
 	private getCellIndex(location: URI) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatInlineAnchorWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/media/chatInlineAnchorWidget.css
@@ -60,9 +60,9 @@
 	flex-shrink: 0;
 }
 
-/* Link-style appearance - no box, no icon */
-.chat-inline-anchor-widget.link-style,
-.interactive-item-container .value .rendered-markdown .chat-inline-anchor-widget.link-style {
+/* Link-style appearance - no box, no icon (controlled by parent container class) */
+.chat-inline-references-link-style .chat-inline-anchor-widget,
+.chat-inline-references-link-style .interactive-item-container .value .rendered-markdown .chat-inline-anchor-widget {
 	border: none;
 	background-color: transparent;
 	padding: 0;
@@ -70,15 +70,15 @@
 	color: var(--vscode-textLink-foreground);
 }
 
-.chat-inline-anchor-widget.link-style:hover {
+.chat-inline-references-link-style .chat-inline-anchor-widget:hover {
 	background-color: transparent;
 	text-decoration: underline;
 }
 
-.chat-inline-anchor-widget.link-style .icon {
+.chat-inline-references-link-style .chat-inline-anchor-widget .icon {
 	display: none;
 }
 
-.chat-inline-anchor-widget.link-style .icon-label {
+.chat-inline-references-link-style .chat-inline-anchor-widget .icon-label {
 	padding: 0;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListWidget.ts
@@ -271,6 +271,18 @@ export class ChatListWidget extends Disposable {
 		this._lastItemIdContextKey = ChatContextKeys.lastItemId.bindTo(this.contextKeyService);
 		this._container = container;
 
+		// Toggle link-style for inline reference widgets based on configuration (single listener for all widgets)
+		const updateInlineReferencesStyle = () => {
+			const style = this.configurationService.getValue<string>(ChatConfiguration.InlineReferencesStyle);
+			this._container.classList.toggle('chat-inline-references-link-style', style === 'link');
+		};
+		updateInlineReferencesStyle();
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.InlineReferencesStyle)) {
+				updateInlineReferencesStyle();
+			}
+		}));
+
 		const scopedInstantiationService = this._register(this.instantiationService.createChild(
 			new ServiceCollection([IContextKeyService, this.contextKeyService])
 		));


### PR DESCRIPTION
Move per-widget `configurationService.onDidChangeConfiguration` listener to a single listener on the `ChatListWidget` container. Each `InlineAnchorWidget` previously registered its own listener to toggle a link-style CSS class, causing a listener leak warning when 175+ widgets existed in a session.

The fix uses a parent container class (`chat-inline-references-link-style`) toggled by a single listener, with CSS descendant selectors to style all child widgets.

Fixes #301185