### PR TITLE
fix: resolve custom mode handoffs by URI to bypass getCustomModes gate

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1195,11 +1195,19 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// Fall back to the current mode picker for old sessions where modeInfo was not persisted.
 		const modeInfo = lastItem.model.request?.modeInfo;
 		let responseMode: IChatMode | undefined;
-		if (modeInfo?.modeInstructions?.name) {
+		if (modeInfo?.modeInstructions?.uri) {
+			// URI is the authoritative identifier for custom modes — findModeById does
+			// a direct map lookup, avoiding the getCustomModes() visibility gate.
+			// URI.revive handles both live URI instances and deserialized UriComponents.
+			responseMode = this.chatModeService.findModeById(URI.revive(modeInfo.modeInstructions.uri).toString());
+		}
+		if (!responseMode && modeInfo?.modeInstructions?.name) {
 			responseMode = this.chatModeService.findModeByName(modeInfo.modeInstructions.name);
-		} else if (modeInfo?.modeId) {
+		}
+		if (!responseMode && modeInfo?.modeId) {
 			responseMode = this.chatModeService.findModeById(modeInfo.modeId);
-		} else {
+		}
+		if (!responseMode) {
 			responseMode = this.input.currentModeObs.get();
 		}
 


### PR DESCRIPTION
## Problem

The handoff widget for custom modes (e.g. Plan) fails to appear after a response completes. This is a regression from #298867.

`renderChatSuggestNextWidget` resolves the response's mode via `findModeByName()`, which routes through `getCustomModes()` — gated by `hasToolsAgent`. Even when the gate passes, name-based lookup is fragile: a custom mode whose name collides with a builtin mode resolves to the wrong mode (or none), hiding handoffs entirely.

## Root Cause

`findModeByName` → `getCustomModes()` → gated by `hasToolsAgent`

Meanwhile, `findModeById` does a **direct** `_customModeInstances.get(id)` lookup — ungated. The mode's URI (its authoritative identifier) is already persisted in `modeInfo.modeInstructions.uri` and matches the `_customModeInstances` map key.

## Fix

Add a URI-first lookup in the handoff widget's mode resolution cascade:

1. **URI lookup** via `findModeById(URI.revive(uri).toString())` — exact, ungated, no collision risk
2. **Name fallback** via `findModeByName` — for older sessions without URI
3. **Mode ID fallback** via `findModeById(modeId)` — for builtins (`ask`, `agent`, `edit`)
4. **Current mode fallback** — for sessions without any modeInfo

`URI.revive()` handles both live `URI` instances and deserialized `UriComponents` from session restore.

No changes to `chatModes.ts` — the `getCustomModes()` gate and `findModeByName` behavior are preserved, addressing the [review feedback from #298867](https://github.com/microsoft/vscode/pull/298867) that the gate should not be circumvented.