### PR TITLE
fix: clamp widthUntilLineNumberEnd to prevent negative Rect width

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/view/inlineEdits/components/gutterIndicatorView.ts
@@ -391,7 +391,7 @@ export class InlineEditsGutterIndicator extends Disposable {
 
 			let widthUntilLineNumberEnd;
 			if (layout.lineNumbersWidth === 0) {
-				widthUntilLineNumberEnd = Math.min(Math.max(layout.lineNumbersLeft - gutterViewPortWithStickyScroll.left, 0), pillRect.width - idealIconAreaWidth);
+				widthUntilLineNumberEnd = Math.max(0, Math.min(Math.max(layout.lineNumbersLeft - gutterViewPortWithStickyScroll.left, 0), pillRect.width - idealIconAreaWidth));
 			} else {
 				widthUntilLineNumberEnd = Math.max(layout.lineNumbersLeft + layout.lineNumbersWidth - gutterViewPortWithStickyScroll.left, 0);
 			}


### PR DESCRIPTION
When pillRect.width < idealIconAreaWidth (22px) and lineNumbersWidth is 0, the expression pillRect.width - idealIconAreaWidth produces a negative value. Math.min then selects this negative widthUntilLineNumberEnd, which causes pillRect.withWidth(negative) to create a Rect where left > right, throwing Invalid arguments: Horizontally offset by N.

Wrap the computation in Math.max(0, ...) so widthUntilLineNumberEnd is clamped to 0 when the pill is too narrow.

Fixes #301197