### PR TITLE
fix: clear copy-on-selection override before re-setting to prevent double-set error

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -114,6 +114,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 
 		// Disable copy-on-selection during search to prevent search result from overriding clipboard
 		this._register(xterm.onBeforeSearch(() => {
+			this._overrideCopyOnSelectionDisposable.clear();
 			this._overrideCopyOnSelectionDisposable.value = TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection(false);
 		}));
 
@@ -182,9 +183,8 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	}
 
 	protected _onFocusTrackerFocus() {
-		if (TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection) {
-			this._overrideCopyOnSelectionDisposable.value = TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection(false);
-		}
+		this._overrideCopyOnSelectionDisposable.clear();
+		this._overrideCopyOnSelectionDisposable.value = TerminalClipboardContribution.get(this._instance)?.overrideCopyOnSelection(false);
 		this._findWidgetFocused.set(true);
 	}
 


### PR DESCRIPTION
Fixes #301201

The find widget's `onBeforeSearch` and `_onFocusTrackerFocus` both call `overrideCopyOnSelection(false)` which throws if the override is already set. The `MutableDisposable.value` setter evaluates the RHS (which calls `overrideCopyOnSelection`) before the setter can dispose the old value, so the override is still active when the new call is made.

Fix: call `this._overrideCopyOnSelectionDisposable.clear()` before calling `overrideCopyOnSelection(false)` in both locations to ensure the previous override is always disposed first.