### PR TITLE
feat(git): add "Copy Branch Name" to branch context menus

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -492,6 +492,11 @@
         "enablement": "!operationInProgress"
       },
       {
+        "command": "git.graph.copyBranchName",
+        "title": "%command.artifactCopyBranchName%",
+        "category": "Git"
+      },
+      {
         "command": "git.checkoutDetached",
         "title": "%command.checkoutDetached%",
         "category": "Git",
@@ -2749,6 +2754,11 @@
           "command": "git.graph.deleteTag",
           "when": "scmProvider == git && scmHistoryItemRef =~ /^refs\\/tags\\//",
           "group": "3_tag@2"
+        },
+        {
+          "command": "git.graph.copyBranchName",
+          "when": "scmProvider == git && scmHistoryItemRef =~ /^refs\\/heads\\/|^refs\\/remotes\\//",
+          "group": "9_copy@1"
         }
       ],
       "editor/title": [
@@ -3129,6 +3139,10 @@
         {
           "command": "git.publish",
           "group": "4_publish@1"
+        },
+        {
+          "command": "git.graph.copyBranchName",
+          "group": "5_copy@1"
         }
       ],
       "git.remotes": [

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3179,6 +3179,16 @@ export class CommandCenter {
 		await this._deleteBranch(repository, remoteName, refName, { remote: true });
 	}
 
+	@command('git.graph.copyBranchName', { repository: true })
+	async graphCopyBranchName(_repository: Repository, historyItem?: SourceControlHistoryItem, historyItemRefId?: string): Promise<void> {
+		const historyItemRef = historyItem?.references?.find(r => r.id === historyItemRefId);
+		if (!historyItemRef?.name) {
+			return;
+		}
+
+		env.clipboard.writeText(historyItemRef.name);
+	}
+
 	@command('git.graph.compareWithRemote', { repository: true })
 	async compareWithRemote(repository: Repository, historyItem?: SourceControlHistoryItem): Promise<void> {
 		if (!historyItem || !repository.historyProvider.currentHistoryItemRemoteRef) {


### PR DESCRIPTION
Adds a new `git.graph.copyBranchName` command to:
- `git.branch` submenu (SCM panel Branch menu)
- `scm/historyItemRef/context` (right-click on branch refs in graph)

Related to #148069.

Successfully tested both touchpoints locally:

<img width="1068" height="1089" alt="image" src="https://github.com/user-attachments/assets/1c715702-8784-40aa-8416-9cc2d5c5ff66" />

<img width="1002" height="1088" alt="image" src="https://github.com/user-attachments/assets/2fdda0a8-b9ad-40b8-974e-2f1b038919fa" />
