### PR TITLE
only show `bypass approvals` for worktree CLI

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/newChatPermissionPicker.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatPermissionPicker.ts
@@ -38,6 +38,7 @@ export class NewChatPermissionPicker extends Disposable {
 	readonly onDidChangeLevel: Event<ChatPermissionLevel> = this._onDidChangeLevel.event;
 
 	private _currentLevel: ChatPermissionLevel = ChatPermissionLevel.Default;
+	private _worktreeIsolated = false;
 	private _triggerElement: HTMLElement | undefined;
 	private _container: HTMLElement | undefined;
 	private readonly _renderDisposables = this._register(new DisposableStore());
@@ -89,6 +90,21 @@ export class NewChatPermissionPicker extends Disposable {
 		}
 	}
 
+	setWorktreeIsolated(isolated: boolean): void {
+		if (this._worktreeIsolated === isolated) {
+			return;
+		}
+		this._worktreeIsolated = isolated;
+		if (isolated) {
+			this._currentLevel = ChatPermissionLevel.AutoApprove;
+			this._onDidChangeLevel.fire(this._currentLevel);
+		} else {
+			this._currentLevel = ChatPermissionLevel.Default;
+			this._onDidChangeLevel.fire(this._currentLevel);
+		}
+		this._updateTriggerLabel(this._triggerElement);
+	}
+
 	showPicker(): void {
 		if (!this._triggerElement || this.actionWidgetService.isVisible) {
 			return;
@@ -96,6 +112,8 @@ export class NewChatPermissionPicker extends Disposable {
 
 		const policyRestricted = this.configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
 		const isAutopilotEnabled = this.configurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
+		const worktreeIsolated = this._worktreeIsolated;
+		const worktreeTooltip = localize('permissions.worktreeIsolated', "Worktrees are isolated and don't require approvals");
 
 		const items: IActionListItem<IPermissionItem>[] = [
 			{
@@ -105,11 +123,12 @@ export class NewChatPermissionPicker extends Disposable {
 					level: ChatPermissionLevel.Default,
 					label: localize('permissions.default', "Default Approvals"),
 					icon: Codicon.shield,
-					checked: this._currentLevel === ChatPermissionLevel.Default,
+					checked: !worktreeIsolated && this._currentLevel === ChatPermissionLevel.Default,
 				},
 				label: localize('permissions.default', "Default Approvals"),
 				description: localize('permissions.default.subtext', "Copilot uses your configured settings"),
-				disabled: false,
+				disabled: worktreeIsolated,
+				tooltip: worktreeIsolated ? worktreeTooltip : undefined,
 			},
 			{
 				kind: ActionListItemKind.Action,
@@ -118,10 +137,12 @@ export class NewChatPermissionPicker extends Disposable {
 					level: ChatPermissionLevel.AutoApprove,
 					label: localize('permissions.autoApprove', "Bypass Approvals"),
 					icon: Codicon.warning,
-					checked: this._currentLevel === ChatPermissionLevel.AutoApprove,
+					checked: worktreeIsolated || this._currentLevel === ChatPermissionLevel.AutoApprove,
 				},
 				label: localize('permissions.autoApprove', "Bypass Approvals"),
-				description: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
+				description: worktreeIsolated
+					? localize('permissions.autoApprove.worktreeSubtext', "Worktrees run in an isolated Git branch")
+					: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
 				disabled: policyRestricted,
 			},
 		];
@@ -134,11 +155,12 @@ export class NewChatPermissionPicker extends Disposable {
 					level: ChatPermissionLevel.Autopilot,
 					label: localize('permissions.autopilot', "Autopilot (Preview)"),
 					icon: Codicon.rocket,
-					checked: this._currentLevel === ChatPermissionLevel.Autopilot,
+					checked: !worktreeIsolated && this._currentLevel === ChatPermissionLevel.Autopilot,
 				},
 				label: localize('permissions.autopilot', "Autopilot (Preview)"),
 				description: localize('permissions.autopilot.subtext', "Autonomously iterates from start to finish"),
-				disabled: policyRestricted,
+				disabled: policyRestricted || worktreeIsolated,
+				tooltip: worktreeIsolated ? worktreeTooltip : undefined,
 			});
 		}
 
@@ -167,7 +189,12 @@ export class NewChatPermissionPicker extends Disposable {
 	}
 
 	private async _selectLevel(level: ChatPermissionLevel): Promise<void> {
-		if (level === ChatPermissionLevel.AutoApprove && !shownWarnings.has(ChatPermissionLevel.AutoApprove)) {
+		// When worktree isolated, only bypass approvals is allowed
+		if (this._worktreeIsolated && level !== ChatPermissionLevel.AutoApprove) {
+			return;
+		}
+
+		if (level === ChatPermissionLevel.AutoApprove && !this._worktreeIsolated && !shownWarnings.has(ChatPermissionLevel.AutoApprove)) {
 			const result = await this.dialogService.prompt({
 				type: Severity.Warning,
 				message: localize('permissions.autoApprove.warning.title', "Enable Bypass Approvals?"),
@@ -234,19 +261,24 @@ export class NewChatPermissionPicker extends Disposable {
 		dom.clearNode(trigger);
 		let icon: ThemeIcon;
 		let label: string;
-		switch (this._currentLevel) {
-			case ChatPermissionLevel.Autopilot:
-				icon = Codicon.rocket;
-				label = localize('permissions.autopilot.label', "Autopilot (Preview)");
-				break;
-			case ChatPermissionLevel.AutoApprove:
-				icon = Codicon.warning;
-				label = localize('permissions.autoApprove.label', "Bypass Approvals");
-				break;
-			default:
-				icon = Codicon.shield;
-				label = localize('permissions.default.label', "Default Approvals");
-				break;
+		if (this._worktreeIsolated) {
+			icon = Codicon.warning;
+			label = localize('permissions.autoApprove.label', "Bypass Approvals");
+		} else {
+			switch (this._currentLevel) {
+				case ChatPermissionLevel.Autopilot:
+					icon = Codicon.rocket;
+					label = localize('permissions.autopilot.label', "Autopilot (Preview)");
+					break;
+				case ChatPermissionLevel.AutoApprove:
+					icon = Codicon.warning;
+					label = localize('permissions.autoApprove.label', "Bypass Approvals");
+					break;
+				default:
+					icon = Codicon.shield;
+					label = localize('permissions.default.label', "Default Approvals");
+					break;
+			}
 		}
 
 		dom.append(trigger, renderIcon(icon));

--- a/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
+++ b/src/vs/sessions/contrib/chat/browser/newChatViewPane.ts
@@ -213,6 +213,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			const isLocal = target === AgentSessionProviders.Background;
 			this._updateIsolationPickerVisibility();
 			this._permissionPicker.setVisible(isLocal);
+			this._permissionPicker.setWorktreeIsolated(isLocal && this._isolationModePicker.isolationMode === 'worktree');
 			this._branchPicker.setVisible(isLocal);
 			this._syncIndicator.setVisible(isLocal);
 			this._updateDraftState();
@@ -244,6 +245,7 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 			this._newSession.value?.setIsolationMode(mode);
 			this._branchPicker.setVisible(mode === 'worktree');
 			this._syncIndicator.setVisible(mode === 'worktree');
+			this._permissionPicker.setWorktreeIsolated(mode === 'worktree');
 			this._updateDraftState();
 			this._focusEditor();
 		}));
@@ -350,6 +352,9 @@ class NewChatWidget extends Disposable implements IHistoryNavigationWidget {
 		const isWorktree = this._isolationModePicker.isolationMode === 'worktree';
 		this._branchPicker.setVisible(isLocal && isWorktree);
 		this._syncIndicator.setVisible(isLocal && isWorktree);
+		if (isLocal) {
+			this._permissionPicker.setWorktreeIsolated(isWorktree);
+		}
 
 		// Render target buttons & extension pickers
 		this._renderOptionGroupPickers();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -575,6 +575,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				const delegateSessionType = this.options.sessionTypePickerDelegate?.getActiveSessionProvider?.();
 				if (ctx && (getChatSessionType(ctx.chatSessionResource) === chatSessionType) || delegateSessionType === chatSessionType) {
 					this.refreshChatSessionPickers();
+					this.updateWorktreeIsolationState(sessionResource);
 				}
 			}
 		}));
@@ -586,6 +587,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.agentSessionTypeKey.set(newSessionType);
 				this.updateWidgetLockStateFromSessionType(newSessionType);
 				this.refreshChatSessionPickers();
+				// Re-evaluate worktree isolation — the new session type may have
+				// a different isolation option than the previous one.
+				const sessionResource = this._widget?.viewModel?.model.sessionResource;
+				if (sessionResource) {
+					this.updateWorktreeIsolationState(sessionResource);
+				} else {
+					this._isWorktreeIsolated.set(false, undefined);
+				}
 			}));
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -413,6 +413,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private readonly _currentModeObservable: ISettableObservable<IChatMode>;
 	private readonly _currentPermissionLevel: ISettableObservable<ChatPermissionLevel>;
+	private readonly _isWorktreeIsolated: ISettableObservable<boolean>;
 	private permissionLevelKey: IContextKey<ChatPermissionLevel>;
 
 	public get currentModeKind(): ChatModeKind {
@@ -551,6 +552,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._contextResourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this._onDidChangeVisibility.event }));
 		this._currentModeObservable = observableValue<IChatMode>('currentMode', this.options.defaultMode ?? ChatMode.Agent);
 		this._currentPermissionLevel = observableValue<ChatPermissionLevel>('permissionLevel', ChatPermissionLevel.Default);
+		this._isWorktreeIsolated = observableValue<boolean>('isWorktreeIsolated', false);
 		this._register(this.editorService.onDidActiveEditorChange(() => {
 			this._indexOfLastOpenedContext = -1;
 			this.refreshChatSessionPickers();
@@ -562,6 +564,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (sessionResource && isEqual(sessionResource, e)) {
 				// Options changed for our current session - refresh pickers
 				this.refreshChatSessionPickers();
+				this.updateWorktreeIsolationState(sessionResource);
 			}
 		}));
 
@@ -823,6 +826,30 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.permissionWidget?.refresh();
 	}
 
+	private updateWorktreeIsolationState(sessionResource: URI): void {
+		const ctx = this.chatService.getChatSessionFromInternalUri(sessionResource);
+		if (!ctx) {
+			return;
+		}
+		const isolationOption = this.chatSessionsService.getSessionOption(ctx.chatSessionResource, 'isolation');
+		const isWorktree = typeof isolationOption === 'string'
+			? isolationOption === 'worktree'
+			: isolationOption?.id === 'worktree';
+		const wasWorktree = this._isWorktreeIsolated.get();
+		this._isWorktreeIsolated.set(isWorktree, undefined);
+		if (isWorktree && !wasWorktree) {
+			// Switching to worktree: force bypass approvals
+			this._currentPermissionLevel.set(ChatPermissionLevel.AutoApprove, undefined);
+			this.permissionLevelKey.set(ChatPermissionLevel.AutoApprove);
+			this.permissionWidget?.refresh();
+		} else if (!isWorktree && wasWorktree) {
+			// Switching away from worktree: reset to default
+			this._currentPermissionLevel.set(ChatPermissionLevel.Default, undefined);
+			this.permissionLevelKey.set(ChatPermissionLevel.Default);
+			this.permissionWidget?.refresh();
+		}
+	}
+
 	public openSessionTargetPicker(): void {
 		this.sessionTargetWidget?.show();
 	}
@@ -916,6 +943,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this._currentPermissionLevel.set(ChatPermissionLevel.Default, undefined);
 			this.permissionLevelKey.set(ChatPermissionLevel.Default);
 			this.permissionWidget?.refresh();
+		}
+
+		// Update worktree isolation state for the new session
+		const sessionResource = this._widget?.viewModel?.model.sessionResource;
+		if (sessionResource) {
+			this.updateWorktreeIsolationState(sessionResource);
+		} else {
+			this._isWorktreeIsolated.set(false, undefined);
 		}
 
 		// TODO@roblourens This is for an experiment which will be obsolete in a month or two and can then be removed.
@@ -2383,6 +2418,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							this._currentPermissionLevel.set(level, undefined);
 							this.permissionLevelKey.set(level);
 						},
+						isWorktreeIsolated: this._isWorktreeIsolated,
 					};
 					return this.permissionWidget = this.instantiationService.createInstance(PermissionPickerActionItem, action, delegate, pickerOptions);
 				}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -414,6 +414,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private readonly _currentModeObservable: ISettableObservable<IChatMode>;
 	private readonly _currentPermissionLevel: ISettableObservable<ChatPermissionLevel>;
 	private readonly _isWorktreeIsolated: ISettableObservable<boolean>;
+	private _lastIsolationOptionId: string | undefined;
 	private permissionLevelKey: IContextKey<ChatPermissionLevel>;
 
 	public get currentModeKind(): ChatModeKind {
@@ -589,12 +590,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.refreshChatSessionPickers();
 				// Re-evaluate worktree isolation — the new session type may have
 				// a different isolation option than the previous one.
-				const sessionResource = this._widget?.viewModel?.model.sessionResource;
-				if (sessionResource) {
-					this.updateWorktreeIsolationState(sessionResource);
-				} else {
-					this._isWorktreeIsolated.set(false, undefined);
-				}
+				this.updateWorktreeIsolationState(this._widget?.viewModel?.model.sessionResource);
 			}));
 		}
 
@@ -835,15 +831,29 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.permissionWidget?.refresh();
 	}
 
-	private updateWorktreeIsolationState(sessionResource: URI): void {
-		const ctx = this.chatService.getChatSessionFromInternalUri(sessionResource);
-		if (!ctx) {
-			return;
+	private updateWorktreeIsolationState(sessionResource?: URI): void {
+		let isolationOptionId: string | undefined;
+
+		// Try session-based lookup first (existing session)
+		if (sessionResource) {
+			const ctx = this.chatService.getChatSessionFromInternalUri(sessionResource);
+			if (ctx) {
+				const isolationOption = this.chatSessionsService.getSessionOption(ctx.chatSessionResource, 'isolation');
+				isolationOptionId = typeof isolationOption === 'string'
+					? isolationOption
+					: isolationOption?.id;
+			}
 		}
-		const isolationOption = this.chatSessionsService.getSessionOption(ctx.chatSessionResource, 'isolation');
-		const isWorktree = typeof isolationOption === 'string'
-			? isolationOption === 'worktree'
-			: isolationOption?.id === 'worktree';
+
+		// Fall back to the last known isolation option value (welcome view / no session yet)
+		if (isolationOptionId === undefined) {
+			isolationOptionId = this._lastIsolationOptionId;
+		}
+
+		this.applyWorktreeIsolation(isolationOptionId === 'worktree');
+	}
+
+	private applyWorktreeIsolation(isWorktree: boolean): void {
 		const wasWorktree = this._isWorktreeIsolated.get();
 		this._isWorktreeIsolated.set(isWorktree, undefined);
 		if (isWorktree && !wasWorktree) {
@@ -889,6 +899,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		// Clear existing widgets
 		this.disposeSessionPickerWidgets();
 
+		// Reset isolation tracking if the isolation option is no longer visible
+		if (!visibleGroupIds.has('isolation')) {
+			this._lastIsolationOptionId = undefined;
+		}
+
 		const widgets: (ChatSessionPickerActionItem | SearchableOptionPickerActionItem)[] = [];
 		for (const optionGroup of optionGroups) {
 			if (!visibleGroupIds.has(optionGroup.id)) {
@@ -898,6 +913,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			const initialItem = this.getCurrentOptionForGroup(optionGroup.id);
 			const initialState = { group: optionGroup, item: initialItem };
 
+			// Track the initial isolation option value for welcome view fallback
+			if (optionGroup.id === 'isolation' && initialItem) {
+				this._lastIsolationOptionId = initialItem.id;
+			}
+
 			// Create delegate for this option group
 			const itemDelegate: IChatSessionPickerDelegate = {
 				getCurrentOption: () => this.getCurrentOptionForGroup(optionGroup.id),
@@ -906,6 +926,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					// Update context key for this option group
 					this.updateOptionContextKey(optionGroup.id, option.id);
 					this.getOrCreateOptionEmitter(optionGroup.id).fire(option);
+
+					// Track isolation option changes for worktree isolation state
+					if (optionGroup.id === 'isolation') {
+						this._lastIsolationOptionId = option.id;
+						this.applyWorktreeIsolation(option.id === 'worktree');
+					}
 
 					// Notify session if we have one (not in welcome view before session creation)
 					const sessionResource = this._widget?.viewModel?.model.sessionResource;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -41,6 +41,7 @@ function hasShownElevatedWarning(level: ChatPermissionLevel): boolean {
 export interface IPermissionPickerDelegate {
 	readonly currentPermissionLevel: IObservable<ChatPermissionLevel>;
 	readonly setPermissionLevel: (level: ChatPermissionLevel) => void;
+	readonly isWorktreeIsolated: IObservable<boolean>;
 }
 
 export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
@@ -57,10 +58,12 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 	) {
 		const isAutoApprovePolicyRestricted = () => configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove).policyValue === false;
 		const isAutopilotEnabled = () => configurationService.getValue<boolean>(ChatConfiguration.AutopilotEnabled) !== false;
+		const worktreeIsolatedTooltip = localize('permissions.worktreeIsolated', "Worktrees are isolated and don't require approvals");
 		const actionProvider: IActionWidgetDropdownActionProvider = {
 			getActions: () => {
 				const currentLevel = delegate.currentPermissionLevel.get();
 				const policyRestricted = isAutoApprovePolicyRestricted();
+				const worktreeIsolated = delegate.isWorktreeIsolated.get();
 				const actions: IActionWidgetDropdownAction[] = [
 					{
 						...action,
@@ -68,13 +71,19 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						label: localize('permissions.default', "Default Approvals"),
 						description: localize('permissions.default.subtext', "Copilot uses your configured settings"),
 						icon: ThemeIcon.fromId(Codicon.shield.id),
-						checked: currentLevel === ChatPermissionLevel.Default,
-						tooltip: '',
+						checked: !worktreeIsolated && currentLevel === ChatPermissionLevel.Default,
+						enabled: !worktreeIsolated,
+						tooltip: worktreeIsolated ? worktreeIsolatedTooltip : '',
 						hover: {
-							content: localize('permissions.default.description', "Use configured approval settings"),
+							content: worktreeIsolated
+								? worktreeIsolatedTooltip
+								: localize('permissions.default.description', "Use configured approval settings"),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
+							if (worktreeIsolated) {
+								return;
+							}
 							delegate.setPermissionLevel(ChatPermissionLevel.Default);
 							if (this.element) {
 								this.renderLabel(this.element);
@@ -85,18 +94,25 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						...action,
 						id: 'chat.permissions.autoApprove',
 						label: localize('permissions.autoApprove', "Bypass Approvals"),
-						description: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
+						description: worktreeIsolated
+							? localize('permissions.autoApprove.worktreeSubtext', "Worktrees run in an isolated Git branch")
+							: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
 						icon: ThemeIcon.fromId(Codicon.warning.id),
-						checked: currentLevel === ChatPermissionLevel.AutoApprove,
+						checked: worktreeIsolated || currentLevel === ChatPermissionLevel.AutoApprove,
 						enabled: !policyRestricted,
 						tooltip: policyRestricted ? localize('permissions.autoApprove.policyDisabled', "Disabled by enterprise policy") : '',
 						hover: {
 							content: policyRestricted
 								? localize('permissions.autoApprove.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors"),
+								: worktreeIsolated
+									? localize('permissions.autoApprove.worktreeDescription', "Worktrees run in an isolated Git branch. All tool calls are auto-approved because changes don't affect your main workspace.")
+									: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors"),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
+							if (worktreeIsolated) {
+								return;
+							}
 							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
@@ -137,16 +153,21 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						label: localize('permissions.autopilot', "Autopilot (Preview)"),
 						description: localize('permissions.autopilot.subtext', "Autonomously iterates from start to finish"),
 						icon: ThemeIcon.fromId(Codicon.rocket.id),
-						checked: currentLevel === ChatPermissionLevel.Autopilot,
-						enabled: !policyRestricted,
-						tooltip: policyRestricted ? localize('permissions.autopilot.policyDisabled', "Disabled by enterprise policy") : '',
+						checked: !worktreeIsolated && currentLevel === ChatPermissionLevel.Autopilot,
+						enabled: !policyRestricted && !worktreeIsolated,
+						tooltip: worktreeIsolated ? worktreeIsolatedTooltip : policyRestricted ? localize('permissions.autopilot.policyDisabled', "Disabled by enterprise policy") : '',
 						hover: {
-							content: policyRestricted
-								? localize('permissions.autopilot.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done"),
+							content: worktreeIsolated
+								? worktreeIsolatedTooltip
+								: policyRestricted
+									? localize('permissions.autopilot.policyDescription', "Disabled by enterprise policy")
+									: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done"),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
+							if (worktreeIsolated) {
+								return;
+							}
 							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
@@ -194,22 +215,28 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
 		this.setAriaLabelAttributes(element);
 
+		const worktreeIsolated = this.delegate.isWorktreeIsolated.get();
 		const level = this.delegate.currentPermissionLevel.get();
 		let icon: ThemeIcon;
 		let label: string;
-		switch (level) {
-			case ChatPermissionLevel.Autopilot:
-				icon = Codicon.rocket;
-				label = localize('permissions.autopilot.label', "Autopilot (Preview)");
-				break;
-			case ChatPermissionLevel.AutoApprove:
-				icon = Codicon.warning;
-				label = localize('permissions.autoApprove.label', "Bypass Approvals");
-				break;
-			default:
-				icon = Codicon.shield;
-				label = localize('permissions.default.label', "Default Approvals");
-				break;
+		if (worktreeIsolated) {
+			icon = Codicon.warning;
+			label = localize('permissions.autoApprove.label', "Bypass Approvals");
+		} else {
+			switch (level) {
+				case ChatPermissionLevel.Autopilot:
+					icon = Codicon.rocket;
+					label = localize('permissions.autopilot.label', "Autopilot (Preview)");
+					break;
+				case ChatPermissionLevel.AutoApprove:
+					icon = Codicon.warning;
+					label = localize('permissions.autoApprove.label', "Bypass Approvals");
+					break;
+				default:
+					icon = Codicon.shield;
+					label = localize('permissions.default.label', "Default Approvals");
+					break;
+			}
 		}
 
 		const labelElements = [];
@@ -218,8 +245,8 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 		labelElements.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...labelElements);
-		element.classList.toggle('warning', level === ChatPermissionLevel.Autopilot);
-		element.classList.toggle('info', level === ChatPermissionLevel.AutoApprove);
+		element.classList.toggle('warning', !worktreeIsolated && level === ChatPermissionLevel.Autopilot);
+		element.classList.toggle('info', worktreeIsolated || level === ChatPermissionLevel.AutoApprove);
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -81,7 +81,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
-							if (worktreeIsolated) {
+							if (delegate.isWorktreeIsolated.get()) {
 								return;
 							}
 							delegate.setPermissionLevel(ChatPermissionLevel.Default);
@@ -110,7 +110,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
-							if (worktreeIsolated) {
+							if (delegate.isWorktreeIsolated.get()) {
 								return;
 							}
 							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove)) {
@@ -165,7 +165,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
-							if (worktreeIsolated) {
+							if (delegate.isWorktreeIsolated.get()) {
 								return;
 							}
 							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix https://github.com/microsoft/vscode/issues/300480


CLI runs in isolated worktrees - bypass approvals is always on there

<img width="755" height="269" alt="Screenshot 2026-03-15 at 5 36 50 PM" src="https://github.com/user-attachments/assets/eacafe26-f4f8-4095-a27f-c6db189b2b4f" />
