### PR TITLE
editor: suppress root folder description in short label mode

### DIFF
--- a/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/modalEditorPart.ts
@@ -26,7 +26,7 @@ import { EditorPart } from './editorPart.js';
 import { GroupDirection, GroupsOrder, IModalEditorPart, GroupActivationReason } from '../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { EditorPartModalContext, EditorPartModalMaximizedContext, EditorPartModalNavigationContext } from '../../../common/contextkeys.js';
-import { EditorResourceAccessor, SideBySideEditor, Verbosity } from '../../../common/editor.js';
+import { EditorInputCapabilities, EditorResourceAccessor, SideBySideEditor, Verbosity } from '../../../common/editor.js';
 import { ResourceLabel } from '../../labels.js';
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
@@ -285,12 +285,13 @@ export class ModalEditorPart {
 			const activeEditor = editorPart.activeGroup.activeEditor;
 			if (activeEditor) {
 				const { labelFormat } = editorPart.partOptions;
+				const forceDescription = activeEditor.hasCapability(EditorInputCapabilities.ForceDescription);
 
 				label.element.setResource(
 					{
 						resource: EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.BOTH }),
 						name: activeEditor.getName(),
-						description: activeEditor.getDescription(labelFormat === 'short' ? Verbosity.SHORT : labelFormat === 'long' ? Verbosity.LONG : Verbosity.MEDIUM) || ''
+						description: labelFormat === 'short' && !forceDescription ? '' : activeEditor.getDescription(labelFormat === 'short' ? Verbosity.SHORT : labelFormat === 'long' ? Verbosity.LONG : Verbosity.MEDIUM) || ''
 					},
 					{
 						icon: activeEditor.getIcon(),

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1385,11 +1385,12 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		const labels: IEditorInputLabel[] = [];
 		let activeEditorTabIndex = -1;
 		this.tabsModel.getEditors(EditorsOrder.SEQUENTIAL).forEach((editor: EditorInput, tabIndex: number) => {
+			const forceDescription = editor.hasCapability(EditorInputCapabilities.ForceDescription);
 			labels.push({
 				editor,
 				name: editor.getName(),
-				description: editor.getDescription(verbosity),
-				forceDescription: editor.hasCapability(EditorInputCapabilities.ForceDescription),
+				description: labelFormat === 'short' && !forceDescription ? '' : editor.getDescription(verbosity),
+				forceDescription,
 				title: editor.getTitle(Verbosity.LONG),
 				ariaLabel: computeEditorAriaLabel(editor, tabIndex, this.groupView, this.editorPartsView.count)
 			});

--- a/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/singleEditorTabsControl.ts
@@ -300,6 +300,8 @@ export class SingleEditorTabsControl extends EditorTabsControl {
 				description = ''; // hide description when showing breadcrumbs
 			} else if (labelFormat === 'default' && !isGroupActive) {
 				description = ''; // hide description when group is not active and style is 'default'
+			} else if (labelFormat === 'short' && !editor.hasCapability(EditorInputCapabilities.ForceDescription)) {
+				description = ''; // hide description in short mode to suppress root folder name
 			} else {
 				description = editor.getDescription(this.getVerbosity(labelFormat)) || '';
 			}


### PR DESCRIPTION
When `workbench.editor.labelFormat` is set to `short`, tabs and single-tab controls still render the root folder name via `getDescription(Verbosity.SHORT)`. This is redundant because the short format already implies a compact display.

Suppress the description in short mode across all three editor tab surfaces unless the editor has `ForceDescription` capability.

Changed files:
- `multiEditorTabsControl.ts`
- `singleEditorTabsControl.ts`
- `modalEditorPart.ts`