### PR TITLE
sessions: collapse sidebar Customizations by default

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -50,6 +50,14 @@ src/vs/sessions/contrib/sessions/browser/
 └── customizationsToolbar.contribution.ts       # Sidebar customization links
 ```
 
+### Sessions Sidebar Customizations Section
+
+The Sessions sidebar includes a collapsible **Customizations** shortcuts section rendered by `AICustomizationShortcutsWidget` (`contrib/sessions/browser/aiCustomizationShortcutsWidget.ts`).
+
+- The section is **collapsed by default**
+- Collapse state is persisted in profile storage under `agentSessions.customizationsCollapsed`
+- The persisted preference overrides the default on subsequent launches
+
 ### IAICustomizationWorkspaceService
 
 The `IAICustomizationWorkspaceService` interface controls per-window behavior:

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -54,9 +54,11 @@ src/vs/sessions/contrib/sessions/browser/
 
 The Sessions sidebar includes a collapsible **Customizations** shortcuts section rendered by `AICustomizationShortcutsWidget` (`contrib/sessions/browser/aiCustomizationShortcutsWidget.ts`).
 
-- The section is **collapsed by default**
-- Collapse state is persisted in profile storage under `agentSessions.customizationsCollapsed`
-- The persisted preference overrides the default on subsequent launches
+- The initial state is read from `IStorageService.getBoolean('agentSessions.customizationsCollapsed', StorageScope.PROFILE, true)`.
+- The fallback is `true`, so users with no stored value see the section collapsed by default.
+- The toggle writes back with `StorageTarget.USER`, so the preference persists across Sessions window launches.
+- If a stored value exists, it takes precedence over the fallback: previously expanded sections remain expanded, and previously collapsed sections remain collapsed.
+- This behavior only affects the Sessions sidebar shortcuts widget and does not change data discovery or counts.
 
 ### IAICustomizationWorkspaceService
 

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -473,6 +473,7 @@ The Sessions view is registered in `contrib/sessions/browser/sessions.contributi
 - **Container**: Sessions container in `ViewContainerLocation.Sidebar` (default)
 - **View**: `SessionsViewId` with `AgenticSessionsViewPane`
 - **Window visibility**: `WindowVisibility.Sessions`
+- **Customizations shortcuts**: The Customizations section at the bottom of the view is collapsed by default and persists its collapse state using `agentSessions.customizationsCollapsed`
 
 ---
 
@@ -640,6 +641,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-03-16 | Changed Sessions sidebar Customizations shortcuts section to be collapsed by default by changing the fallback for `agentSessions.customizationsCollapsed` to `true`; documented persisted collapse behavior in the layout and AI customizations specs |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |
 | 2026-02-17 | Added `-webkit-app-region: drag` to sidebar title area so it can be used to drag the window; interactive children (actions, composite bar, labels) marked `no-drag`; CSS rules scoped to `.agent-sessions-workbench` in `parts/media/sidebarPart.css` |

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -52,7 +52,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
 		// Get initial collapsed state
-		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, false);
+		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
 		if (isCollapsed) {

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -216,14 +216,15 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 	}
 
 	// Override storage to set initial collapsed state
-	if (options?.collapsed) {
+	if (options?.collapsed !== undefined) {
+		const collapsed = options.collapsed;
 		const storageService = instantiationService.get(IStorageService);
 		instantiationService.set(IStorageService, new class extends mock<IStorageService>() {
-			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean) {
+			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean): boolean {
 				if (key === 'agentSessions.customizationsCollapsed') {
-					return true;
+					return collapsed;
 				}
-				return storageService.getBoolean(key, scope, fallbackValue!);
+				return storageService.getBoolean(key, scope, fallbackValue ?? false) ?? false;
 			}
 			override store() { }
 		}());
@@ -243,7 +244,7 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
 	Expanded: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx),
+		render: (ctx) => renderWidget(ctx, { collapsed: false }),
 	}),
 
 	Collapsed: defineComponentFixture({
@@ -253,7 +254,7 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
 	WithMcpServers: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3 }),
+		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3, collapsed: false }),
 	}),
 
 	CollapsedWithMcpServers: defineComponentFixture({
@@ -265,6 +266,7 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 		labels: { kind: 'screenshot' },
 		render: (ctx) => renderWidget(ctx, {
 			mcpServerCount: 2,
+			collapsed: false,
 			counts: { agents: 2, skills: 30, instructions: 16, prompts: 17, hooks: 4 },
 		}),
 	}),

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -215,16 +215,18 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 		}));
 	}
 
-	// Override storage to set initial collapsed state
+	// Override storage to set initial collapsed state.
+	// The mock is self-contained: it intercepts the one key the widget reads and
+	// falls back to the provided fallback value for all other keys, avoiding any
+	// dependency on the underlying storage instance.
 	if (options?.collapsed !== undefined) {
 		const collapsed = options.collapsed;
-		const storageService = instantiationService.get(IStorageService);
 		instantiationService.set(IStorageService, new class extends mock<IStorageService>() {
-			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean): boolean {
+			override getBoolean(key: string, _scope: StorageScope, fallbackValue?: boolean): boolean {
 				if (key === 'agentSessions.customizationsCollapsed') {
 					return collapsed;
 				}
-				return storageService.getBoolean(key, scope, fallbackValue ?? false) ?? false;
+				return fallbackValue ?? false;
 			}
 			override store() { }
 		}());

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -242,6 +242,13 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 
 export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
+	// Verifies default behavior from storage fallback (collapsed by default).
+	DefaultCollapsed: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: (ctx) => renderWidget(ctx),
+	}),
+
+	// Explicitly force expanded to keep visual coverage of the expanded layout.
 	Expanded: defineComponentFixture({
 		labels: { kind: 'screenshot' },
 		render: (ctx) => renderWidget(ctx, { collapsed: false }),


### PR DESCRIPTION
## Summary
- collapse the Sessions sidebar **Customizations** shortcuts section by default by changing the `agentSessions.customizationsCollapsed` fallback to `true`
- keep persisted user preference authoritative for subsequent launches
- update sessions docs (`AI_CUSTOMIZATIONS.md`, `LAYOUT.md`) to document exact storage/default behavior
- update `aiCustomizationShortcutsWidget` fixture coverage by adding explicit default-collapsed coverage and preserving explicit expanded coverage

## Validation
- `npm run -s compile-check-ts-native`
- `npm run -s valid-layers-check`
