### PR TITLE
Add `terminal.integrated.editor.inheritBackground` setting

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -123,6 +123,7 @@ export const enum TerminalSettingId {
 	EnableKittyKeyboardProtocol = 'terminal.integrated.enableKittyKeyboardProtocol',
 	EnableWin32InputMode = 'terminal.integrated.enableWin32InputMode',
 	AllowInUntrustedWorkspace = 'terminal.integrated.allowInUntrustedWorkspace',
+	EditorInheritBackground = 'terminal.integrated.editor.inheritBackground',
 
 	// Developer/debug settings
 

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -65,6 +65,9 @@
 .monaco-workbench .terminal-editor .terminal-wrapper {
 	background-color: var(--vscode-terminal-background, var(--vscode-editorPane-background));
 }
+.monaco-workbench .terminal-editor .terminal-wrapper.inherit-editor-bg {
+	background-color: var(--vscode-editor-background);
+}
 .monaco-workbench .terminal-editor .terminal-wrapper,
 .monaco-workbench .pane-body.integrated-terminal .terminal-wrapper {
 	display: block;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -580,6 +580,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			if (e.affectsConfiguration('terminal.integrated')) {
 				this.updateConfig();
 				this.setVisible(this._isVisible);
+				this._updateInheritEditorBgClass();
 			}
 			const layoutSettings: string[] = [
 				TerminalSettingId.FontSize,
@@ -608,6 +609,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}));
 		this._register(this._workspaceContextService.onDidChangeWorkspaceFolders(() => this._labelComputer?.refreshLabel(this)));
+		this._register(this._onDidChangeTarget.event(() => this._updateInheritEditorBgClass()));
 
 		// Clear out initial data events after 10 seconds, hopefully extension hosts are up and
 		// running at that point.
@@ -1083,6 +1085,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		// Attach the xterm object to the DOM, exposing it to the smoke tests
 		this._wrapperElement.xterm = xterm.raw;
+		this._updateInheritEditorBgClass();
 
 		const screenElement = xterm.attachToElement(xtermHost);
 
@@ -1916,6 +1919,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	updateConfig(): void {
 		this._setCommandsToSkipShell(this._terminalConfigurationService.config.commandsToSkipShell);
 		this._refreshEnvironmentVariableInfoWidgetState(this._processManager.environmentVariableInfo);
+	}
+
+	private _updateInheritEditorBgClass(): void {
+		const shouldInheritBg = this._targetRef.object === TerminalLocation.Editor
+			&& !!this._terminalConfigurationService.config.editor?.inheritBackground;
+		this._wrapperElement.classList.toggle('inherit-editor-bg', shouldInheritBg);
 	}
 
 	private async _updateUnicodeVersion(): Promise<void> {
@@ -2813,16 +2822,20 @@ export class TerminalInstanceColorProvider implements IXtermColorProvider {
 	constructor(
 		private readonly _target: IReference<TerminalLocation | undefined>,
 		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
+		@ITerminalConfigurationService private readonly _terminalConfigurationService: ITerminalConfigurationService,
 	) {
 	}
 
 	getBackgroundColor(theme: IColorTheme) {
 		const terminalBackground = theme.getColor(TERMINAL_BACKGROUND_COLOR);
+		if (this._target.object === TerminalLocation.Editor) {
+			if (this._terminalConfigurationService.config.editor?.inheritBackground) {
+				return theme.getColor(editorBackground);
+			}
+			return terminalBackground ?? theme.getColor(editorBackground);
+		}
 		if (terminalBackground) {
 			return terminalBackground;
-		}
-		if (this._target.object === TerminalLocation.Editor) {
-			return theme.getColor(editorBackground);
 		}
 		const location = this._viewDescriptorService.getViewLocationById(TERMINAL_VIEW_ID)!;
 		if (location === ViewContainerLocation.Panel) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -281,7 +281,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 			if (e.affectsConfiguration(TerminalSettingId.UnicodeVersion)) {
 				this._updateUnicodeVersion();
 			}
-			if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled)) {
+			if (e.affectsConfiguration(TerminalSettingId.ShellIntegrationDecorationsEnabled) || e.affectsConfiguration(TerminalSettingId.EditorInheritBackground)) {
 				this._updateTheme();
 			}
 		}));

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -216,6 +216,9 @@ export interface ITerminalConfiguration {
 		fallbackLigatures: string[];
 	};
 	hideOnLastClosed: boolean;
+	editor?: {
+		inheritBackground: boolean;
+	};
 }
 
 export interface ITerminalFont {

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -669,6 +669,11 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 			localize('terminal.integrated.focusAfterRun.none', "Do nothing."),
 		]
 	},
+	[TerminalSettingId.EditorInheritBackground]: {
+		description: localize('terminal.integrated.editor.inheritBackground', "Controls whether terminals opened in the editor area use the editor's background color instead of the terminal background color."),
+		type: 'boolean',
+		default: false
+	},
 	[TerminalSettingId.AllowInUntrustedWorkspace]: {
 		restricted: true,
 		markdownDescription: localize('terminal.integrated.allowInUntrustedWorkspace', "Controls whether terminals can be created in an untrusted workspace.\n\n**This feature bypasses a security protection that prevents terminals from launching in untrusted workspaces. The reason this is a security risk is because shells are often set up to potentially execute code automatically based on the contents of the current working directory. This should be safe to use provided your shell is set up in such a way that code execution in the folder never happens.**"),

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { deepStrictEqual, strictEqual } from 'assert';
+import { Color } from '../../../../../base/common/color.js';
 import { Event } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, ImmortalReference } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, type IProcessEnvironment } from '../../../../../base/common/platform.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -16,15 +17,19 @@ import { TestInstantiationService } from '../../../../../platform/instantiation/
 import { ResultKind } from '../../../../../platform/keybinding/common/keybindingResolver.js';
 import { TerminalCapability, type ICwdDetectionCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
-import { GeneralShellType, ITerminalChildProcess, ITerminalProfile, TitleEventSource, type IShellLaunchConfig, type ITerminalBackend, type ITerminalProcessOptions } from '../../../../../platform/terminal/common/terminal.js';
+import { GeneralShellType, ITerminalChildProcess, ITerminalProfile, TerminalLocation, TitleEventSource, type IShellLaunchConfig, type ITerminalBackend, type ITerminalProcessOptions } from '../../../../../platform/terminal/common/terminal.js';
 import { IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
-import { IViewDescriptorService } from '../../../../common/views.js';
+import { editorBackground } from '../../../../../platform/theme/common/colorRegistry.js';
+import { TestColorTheme } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND } from '../../../../common/theme.js';
+import { IViewDescriptorService, ViewContainerLocation } from '../../../../common/views.js';
 import { ITerminalConfigurationService, ITerminalInstance, ITerminalInstanceService, ITerminalService } from '../../browser/terminal.js';
 import { TerminalConfigurationService } from '../../browser/terminalConfigurationService.js';
-import { parseExitResult, TerminalInstance, TerminalLabelComputer } from '../../browser/terminalInstance.js';
+import { parseExitResult, TerminalInstance, TerminalInstanceColorProvider, TerminalLabelComputer } from '../../browser/terminalInstance.js';
 import { IEnvironmentVariableService } from '../../common/environmentVariable.js';
 import { EnvironmentVariableService } from '../../common/environmentVariableService.js';
 import { ITerminalProfileResolverService, ProcessState, DEFAULT_COMMANDS_TO_SKIP_SHELL } from '../../common/terminal.js';
+import { TERMINAL_BACKGROUND_COLOR } from '../../common/terminalColorRegistry.js';
 import { TestViewDescriptorService } from './xterm/xtermTerminal.test.js';
 import { fixPath } from '../../../../services/search/test/browser/queryBuilder.test.js';
 import { TestTerminalProfileResolverService, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
@@ -629,5 +634,112 @@ suite('Workbench - TerminalInstance', () => {
 			const result = await instance.getCwdResource();
 			strictEqual(result, undefined);
 		});
+	});
+});
+
+suite('TerminalInstanceColorProvider', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let configurationService: TestConfigurationService;
+	let viewDescriptorService: TestViewDescriptorService;
+
+	function createColorProvider(location: TerminalLocation | undefined): TerminalInstanceColorProvider {
+		const instantiationService = workbenchInstantiationService({
+			configurationService: () => configurationService,
+		}, store);
+		viewDescriptorService = new TestViewDescriptorService();
+		instantiationService.stub(IViewDescriptorService, viewDescriptorService as Partial<IViewDescriptorService>);
+		return instantiationService.createInstance(TerminalInstanceColorProvider, new ImmortalReference(location));
+	}
+
+	setup(() => {
+		configurationService = new TestConfigurationService({
+			terminal: {
+				integrated: {
+					editor: {
+						inheritBackground: false
+					}
+				}
+			}
+		});
+	});
+
+	test('editor terminal with inheritBackground=true returns editor background', () => {
+		configurationService = new TestConfigurationService({
+			terminal: {
+				integrated: {
+					editor: {
+						inheritBackground: true
+					}
+				}
+			}
+		});
+		const provider = createColorProvider(TerminalLocation.Editor);
+		const theme = new TestColorTheme({
+			[editorBackground]: '#1e1e1e',
+			[TERMINAL_BACKGROUND_COLOR]: '#ff0000',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#1e1e1e'));
+	});
+
+	test('editor terminal with inheritBackground=false and terminal.background set returns terminal background', () => {
+		const provider = createColorProvider(TerminalLocation.Editor);
+		const theme = new TestColorTheme({
+			[editorBackground]: '#1e1e1e',
+			[TERMINAL_BACKGROUND_COLOR]: '#ff0000',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#ff0000'));
+	});
+
+	test('editor terminal with inheritBackground=false and no terminal.background falls back to editor background', () => {
+		const provider = createColorProvider(TerminalLocation.Editor);
+		const theme = new TestColorTheme({
+			[editorBackground]: '#1e1e1e',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#1e1e1e'));
+	});
+
+	test('panel terminal ignores inheritBackground and uses terminal.background', () => {
+		configurationService = new TestConfigurationService({
+			terminal: {
+				integrated: {
+					editor: {
+						inheritBackground: true
+					}
+				}
+			}
+		});
+		const provider = createColorProvider(TerminalLocation.Panel);
+		const theme = new TestColorTheme({
+			[editorBackground]: '#1e1e1e',
+			[TERMINAL_BACKGROUND_COLOR]: '#ff0000',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#ff0000'));
+	});
+
+	test('panel terminal without terminal.background falls back to panel background', () => {
+		const provider = createColorProvider(TerminalLocation.Panel);
+		viewDescriptorService.moveTerminalToLocation(ViewContainerLocation.Panel);
+		const theme = new TestColorTheme({
+			[PANEL_BACKGROUND]: '#00ff00',
+			[SIDE_BAR_BACKGROUND]: '#0000ff',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#00ff00'));
+	});
+
+	test('sidebar terminal without terminal.background falls back to sidebar background', () => {
+		const provider = createColorProvider(TerminalLocation.Panel);
+		viewDescriptorService.moveTerminalToLocation(ViewContainerLocation.Sidebar);
+		const theme = new TestColorTheme({
+			[PANEL_BACKGROUND]: '#00ff00',
+			[SIDE_BAR_BACKGROUND]: '#0000ff',
+		});
+		const result = provider.getBackgroundColor(theme);
+		deepStrictEqual(result, Color.fromHex('#0000ff'));
 	});
 });


### PR DESCRIPTION
Adds a new `terminal.integrated.editor.inheritBackground` setting that lets users opt in to having editor-area terminals use `editor.background` instead of `terminal.background`.

Related: https://github.com/microsoft/vscode/issues/300295, https://github.com/microsoft/vscode/issues/300335

The regressions from #298688 were reverted in #305782. This PR builds on the reverted state by adding the opt-in setting that was discussed in #302139.

### Changes

**1. Add `terminal.integrated.editor.inheritBackground` setting**
- New boolean setting (default: `false`)
- When `true`, editor terminals use `editor.background` even when `terminal.background` is set
- Panel and sidebar terminals are unaffected regardless of this setting
- Files changed:
  - `src/vs/platform/terminal/common/terminal.ts` — `TerminalSettingId` enum entry
  - `src/vs/workbench/contrib/terminal/common/terminal.ts` — `ITerminalConfiguration` interface
  - `src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts` — setting registration

**2. Update `getBackgroundColor` priority for editor terminals**
- Editor terminals now check `terminal.background` first (matching panel/sidebar behavior)
- Fall back to `editor.background` when `terminal.background` is unset, or when `inheritBackground` is enabled
- Inject `ITerminalConfigurationService` into `TerminalInstanceColorProvider`

**3. CSS class toggle for wrapper background sync**
- Add `.terminal-wrapper.inherit-editor-bg` CSS rule that forces `var(--vscode-editor-background)`
- Add `_updateInheritEditorBgClass()` helper in `TerminalInstance` that toggles the class based on target location and setting value
- Wire the helper to config changes, target changes (`onDidChangeTarget`), and initial open
- Listen for `EditorInheritBackground` config changes in `XtermTerminal` to refresh the xterm theme

**4. Tests**
- 6 tests for `TerminalInstanceColorProvider` in `terminalInstance.test.ts`
- Covers editor terminal with `inheritBackground` on/off, `terminal.background` priority, and panel/sidebar fallback behavior

### How to test

1. Open a terminal in the editor area
2. Set a custom `terminal.background` via `workbench.colorCustomizations` (e.g., `"terminal.background": "#1a0000"`)
3. Verify the editor terminal respects the custom color (default behavior, `inheritBackground: false`)
4. Set `terminal.integrated.editor.inheritBackground` to `true`
5. Verify editor terminals now use `editor.background` instead, with no color mismatch between wrapper and canvas
6. Verify terminals in the bottom panel and sidebar always respect `terminal.background` regardless of this setting
7. Toggle the setting at runtime — background should update immediately
8. Drag a terminal from panel to editor and back — background should update correctly