### PR TITLE
Update color settings in 2026 Dark theme for improved visibility

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -281,7 +281,7 @@
 				"string.comment"
 			],
 			"settings": {
-				"foreground": "#768390"
+				"foreground": "#8b949e"
 			}
 		},
 		{
@@ -290,7 +290,7 @@
 				"constant.character"
 			],
 			"settings": {
-				"foreground": "#F47067"
+				"foreground": "#ff7b72"
 			}
 		},
 		{
@@ -303,7 +303,7 @@
 				"entity"
 			],
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
@@ -313,7 +313,7 @@
 				"meta.definition.variable"
 			],
 			"settings": {
-				"foreground": "#F69D50"
+				"foreground": "#ffa657"
 			}
 		},
 		{
@@ -327,13 +327,13 @@
 				"meta.embedded.expression"
 			],
 			"settings": {
-				"foreground": "#ADBAC7"
+				"foreground": "#c9d1d9"
 			}
 		},
 		{
 			"scope": "entity.name.function",
 			"settings": {
-				"foreground": "#DCBDFB"
+				"foreground": "#d2a8ff"
 			}
 		},
 		{
@@ -342,13 +342,13 @@
 				"support.class.component"
 			],
 			"settings": {
-				"foreground": "#8DDB8C"
+				"foreground": "#7ee787"
 			}
 		},
 		{
 			"scope": "keyword",
 			"settings": {
-				"foreground": "#F47067"
+				"foreground": "#ff7b72"
 			}
 		},
 		{
@@ -357,7 +357,7 @@
 				"storage.type"
 			],
 			"settings": {
-				"foreground": "#F47067"
+				"foreground": "#ff7b72"
 			}
 		},
 		{
@@ -367,7 +367,7 @@
 				"storage.type.java"
 			],
 			"settings": {
-				"foreground": "#ADBAC7"
+				"foreground": "#c9d1d9"
 			}
 		},
 		{
@@ -376,66 +376,66 @@
 				"string punctuation.section.embedded source"
 			],
 			"settings": {
-				"foreground": "#96D0FF"
+				"foreground": "#a5d6ff"
 			}
 		},
 		{
 			"scope": "support",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "meta.property-name",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "variable",
 			"settings": {
-				"foreground": "#F69D50"
+				"foreground": "#ffa657"
 			}
 		},
 		{
 			"scope": "variable.other",
 			"settings": {
-				"foreground": "#ADBAC7"
+				"foreground": "#c9d1d9"
 			}
 		},
 		{
 			"scope": "invalid.broken",
 			"settings": {
-				"foreground": "#FF938A",
+				"foreground": "#ffa198",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "invalid.deprecated",
 			"settings": {
-				"foreground": "#FF938A",
+				"foreground": "#ffa198",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "invalid.illegal",
 			"settings": {
-				"foreground": "#FF938A",
+				"foreground": "#ffa198",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "invalid.unimplemented",
 			"settings": {
-				"foreground": "#FF938A",
+				"foreground": "#ffa198",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "carriage-return",
 			"settings": {
-				"foreground": "#CDD9E5",
-				"background": "#F47067",
+				"foreground": "#f0f6fc",
+				"background": "#ff7b72",
 				"fontStyle": "italic underline",
 				"content": "^M"
 			}
@@ -443,13 +443,13 @@
 		{
 			"scope": "message.error",
 			"settings": {
-				"foreground": "#FF938A"
+				"foreground": "#ffa198"
 			}
 		},
 		{
 			"scope": "string variable",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
@@ -458,7 +458,7 @@
 				"string.regexp"
 			],
 			"settings": {
-				"foreground": "#96D0FF"
+				"foreground": "#a5d6ff"
 			}
 		},
 		{
@@ -469,44 +469,44 @@
 				"string.regexp string.regexp.arbitrary-repitition"
 			],
 			"settings": {
-				"foreground": "#96D0FF"
+				"foreground": "#a5d6ff"
 			}
 		},
 		{
 			"scope": "string.regexp constant.character.escape",
 			"settings": {
-				"foreground": "#8DDB8C",
+				"foreground": "#7ee787",
 				"fontStyle": "bold"
 			}
 		},
 		{
 			"scope": "support.constant",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "support.variable",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "support.type.property-name.json",
 			"settings": {
-				"foreground": "#8DDB8C"
+				"foreground": "#7ee787"
 			}
 		},
 		{
 			"scope": "meta.module-reference",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "punctuation.definition.list.begin.markdown",
 			"settings": {
-				"foreground": "#F69D50"
+				"foreground": "#ffa657"
 			}
 		},
 		{
@@ -515,27 +515,27 @@
 				"markup.heading entity.name"
 			],
 			"settings": {
-				"foreground": "#6CB6FF",
+				"foreground": "#79c0ff",
 				"fontStyle": "bold"
 			}
 		},
 		{
 			"scope": "markup.quote",
 			"settings": {
-				"foreground": "#8DDB8C"
+				"foreground": "#7ee787"
 			}
 		},
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"foreground": "#ADBAC7",
+				"foreground": "#c9d1d9",
 				"fontStyle": "italic"
 			}
 		},
 		{
 			"scope": "markup.bold",
 			"settings": {
-				"foreground": "#ADBAC7",
+				"foreground": "#c9d1d9",
 				"fontStyle": "bold"
 			}
 		},
@@ -558,7 +558,7 @@
 		{
 			"scope": "markup.inline.raw",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
@@ -568,8 +568,8 @@
 				"punctuation.definition.deleted"
 			],
 			"settings": {
-				"foreground": "#FF938A",
-				"background": "#5D0F12"
+				"foreground": "#ffa198",
+				"background": "#490202"
 			}
 		},
 		{
@@ -577,7 +577,7 @@
 				"punctuation.section.embedded"
 			],
 			"settings": {
-				"foreground": "#F47067"
+				"foreground": "#ff7b72"
 			}
 		},
 		{
@@ -587,8 +587,8 @@
 				"punctuation.definition.inserted"
 			],
 			"settings": {
-				"foreground": "#8DDB8C",
-				"background": "#113417"
+				"foreground": "#7ee787",
+				"background": "#04260f"
 			}
 		},
 		{
@@ -597,8 +597,8 @@
 				"punctuation.definition.changed"
 			],
 			"settings": {
-				"foreground": "#F69D50",
-				"background": "#682D0F"
+				"foreground": "#ffa657",
+				"background": "#5a1e02"
 			}
 		},
 		{
@@ -607,34 +607,34 @@
 				"markup.untracked"
 			],
 			"settings": {
-				"foreground": "#2D333B",
-				"background": "#6CB6FF"
+				"foreground": "#0d1117",
+				"background": "#79c0ff"
 			}
 		},
 		{
 			"scope": "meta.diff.range",
 			"settings": {
-				"foreground": "#DCBDFB",
+				"foreground": "#d2a8ff",
 				"fontStyle": "bold"
 			}
 		},
 		{
 			"scope": "meta.diff.header",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
 			"scope": "meta.separator",
 			"settings": {
-				"foreground": "#6CB6FF",
+				"foreground": "#79c0ff",
 				"fontStyle": "bold"
 			}
 		},
 		{
 			"scope": "meta.output",
 			"settings": {
-				"foreground": "#6CB6FF"
+				"foreground": "#79c0ff"
 			}
 		},
 		{
@@ -647,13 +647,13 @@
 				"brackethighlighter.quote"
 			],
 			"settings": {
-				"foreground": "#768390"
+				"foreground": "#8b949e"
 			}
 		},
 		{
 			"scope": "brackethighlighter.unmatched",
 			"settings": {
-				"foreground": "#FF938A"
+				"foreground": "#ffa198"
 			}
 		},
 		{
@@ -662,7 +662,7 @@
 				"string.other.link"
 			],
 			"settings": {
-				"foreground": "#96D0FF"
+				"foreground": "#a5d6ff"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -435,7 +435,7 @@
 			"scope": "carriage-return",
 			"settings": {
 				"foreground": "#f0f6fc",
-				"background": "#ff7b72",
+				"background": "#8b1111",
 				"fontStyle": "italic underline",
 				"content": "^M"
 			}

--- a/extensions/vscode-colorize-tests/test/colorize-results/12750_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/12750_html.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/13448_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/13448_html.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/14119_less.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/14119_less.json
@@ -59,7 +59,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/25920_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/25920_html.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/COMMIT_EDITMSG.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/COMMIT_EDITMSG.json
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "markup.deleted: #CE9178",
 			"hc_light": "markup.deleted: #5A5A5A",
 			"light_modern": "markup.deleted: #A31515",
-			"2026-dark": "markup.deleted: #FF938A",
+			"2026-dark": "markup.deleted: #FFA198",
 			"2026-light": "markup.deleted: #82071E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "markup.changed: #569CD6",
 			"hc_light": "markup.changed: #0451A5",
 			"light_modern": "markup.changed: #0451A5",
-			"2026-dark": "markup.changed: #F69D50",
+			"2026-dark": "markup.changed: #FFA657",
 			"2026-light": "markup.changed: #953800"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "markup.inserted: #B5CEA8",
 			"hc_light": "markup.inserted: #096D48",
 			"light_modern": "markup.inserted: #098658",
-			"2026-dark": "markup.inserted: #8DDB8C",
+			"2026-dark": "markup.inserted: #7EE787",
 			"2026-light": "markup.inserted: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/Dockerfile.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/Dockerfile.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/basic_java.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/basic_java.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "storage.type.java: #4EC9B0",
 			"hc_light": "storage.type.java: #185E73",
 			"light_modern": "storage.type.java: #267F99",
-			"2026-dark": "storage.type.java: #ADBAC7",
+			"2026-dark": "storage.type.java: #C9D1D9",
 			"2026-light": "storage.type.java: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "storage.type.java: #4EC9B0",
 			"hc_light": "storage.type.java: #185E73",
 			"light_modern": "storage.type.java: #267F99",
-			"2026-dark": "storage.type.java: #ADBAC7",
+			"2026-dark": "storage.type.java: #C9D1D9",
 			"2026-light": "storage.type.java: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/git-rebase-todo.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/git-rebase-todo.json
@@ -571,7 +571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-1550_yaml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-1550_yaml.json
@@ -11,7 +11,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-224862_yaml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-224862_yaml.json
@@ -11,7 +11,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-28354_php.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-28354_php.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-4008_yaml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-4008_yaml.json
@@ -11,7 +11,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-6303_yaml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-6303_yaml.json
@@ -11,7 +11,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.yaml: #0F4A85",
 			"light_modern": "string.quoted.single.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.yaml: #0000FF"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/issue-76997_php.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/issue-76997_php.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/makefile.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/makefile.json
@@ -59,7 +59,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4667,7 +4667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5003,7 +5003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5019,7 +5019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5083,7 +5083,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5147,7 +5147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5275,7 +5275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5291,7 +5291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5323,7 +5323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5387,7 +5387,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5579,7 +5579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5595,7 +5595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5627,7 +5627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/md-math_md.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/md-math_md.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4795,7 +4795,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -5035,7 +5035,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5131,7 +5131,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5179,7 +5179,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5275,7 +5275,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5291,7 +5291,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5339,7 +5339,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5355,7 +5355,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5467,7 +5467,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5627,7 +5627,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5643,7 +5643,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5659,7 +5659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5691,7 +5691,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5707,7 +5707,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5723,7 +5723,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5739,7 +5739,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5755,7 +5755,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5771,7 +5771,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5947,7 +5947,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5963,7 +5963,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5979,7 +5979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5995,7 +5995,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -6059,7 +6059,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6075,7 +6075,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6091,7 +6091,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6155,7 +6155,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6171,7 +6171,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6267,7 +6267,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6283,7 +6283,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6427,7 +6427,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6443,7 +6443,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6555,7 +6555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6667,7 +6667,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6683,7 +6683,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6699,7 +6699,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -6715,7 +6715,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6731,7 +6731,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -6747,7 +6747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6779,7 +6779,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6795,7 +6795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6859,7 +6859,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6875,7 +6875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6971,7 +6971,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6987,7 +6987,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7003,7 +7003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7067,7 +7067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7083,7 +7083,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7099,7 +7099,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7147,7 +7147,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7163,7 +7163,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7227,7 +7227,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7243,7 +7243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7307,7 +7307,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7323,7 +7323,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7419,7 +7419,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7435,7 +7435,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7451,7 +7451,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7499,7 +7499,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7515,7 +7515,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7579,7 +7579,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7595,7 +7595,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7659,7 +7659,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7675,7 +7675,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7787,7 +7787,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7803,7 +7803,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7851,7 +7851,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -7915,7 +7915,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7931,7 +7931,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8011,7 +8011,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8171,7 +8171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8187,7 +8187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8203,7 +8203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8235,7 +8235,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8251,7 +8251,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8267,7 +8267,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8379,7 +8379,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8395,7 +8395,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8411,7 +8411,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8443,7 +8443,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8459,7 +8459,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8475,7 +8475,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8539,7 +8539,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8555,7 +8555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8715,7 +8715,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8731,7 +8731,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8747,7 +8747,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8763,7 +8763,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8779,7 +8779,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8795,7 +8795,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8827,7 +8827,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8843,7 +8843,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8859,7 +8859,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -8923,7 +8923,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8939,7 +8939,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9099,7 +9099,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -9115,7 +9115,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -9131,7 +9131,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -9147,7 +9147,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9163,7 +9163,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9179,7 +9179,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9227,7 +9227,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9243,7 +9243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9419,7 +9419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9435,7 +9435,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9451,7 +9451,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9515,7 +9515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9531,7 +9531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9547,7 +9547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-13777_go.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-13777_go.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-166781_rs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-166781_rs.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-173216_sh.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-173216_sh.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-173224_sh.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-173224_sh.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-173336_sh.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-173336_sh.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-241001_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-241001_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-33886_md.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-33886_md.json
@@ -11,7 +11,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-4287_pug.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-4287_pug.json
@@ -27,7 +27,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.comment.buffered.block.pug: #0F4A85",
 			"light_modern": "string.comment.buffered.block.pug: #0000FF",
-			"2026-dark": "string.comment: #768390",
+			"2026-dark": "string.comment: #8B949E",
 			"2026-light": "string.comment.buffered.block.pug: #0000FF"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-6611_rs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-6611_rs.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-7115_xml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-7115_xml.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-78769_cpp.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-78769_cpp.json
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-80644_cpp.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-80644_cpp.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-brackets_tsx.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-brackets_tsx.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-embedding_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-embedding_html.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.html: #0F4A85",
 			"light_modern": "string.unquoted.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.html: #0000FF"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.html: #0F4A85",
 			"light_modern": "string.unquoted.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.html: #0000FF"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-freeze-56377_py.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-freeze-56377_py.json
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-freeze-56476_ps1.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-freeze-56476_ps1.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-function-inv_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-function-inv_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-issue11_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-issue11_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-issue241715_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-issue241715_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "variable.other.enummember: #4FC1FF",
 			"hc_light": "variable.other.enummember: #02715D",
 			"light_modern": "variable.other.enummember: #0070C1",
-			"2026-dark": "variable.other.enummember: #6CB6FF",
+			"2026-dark": "variable.other.enummember: #79C0FF",
 			"2026-light": "variable.other.enummember: #0550AE"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5787,7 +5787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5899,7 +5899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5915,7 +5915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5931,7 +5931,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5963,7 +5963,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5995,7 +5995,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6139,7 +6139,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6171,7 +6171,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6203,7 +6203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6299,7 +6299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6395,7 +6395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6571,7 +6571,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6603,7 +6603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6699,7 +6699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6971,7 +6971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6987,7 +6987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7003,7 +7003,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7291,7 +7291,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7579,7 +7579,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7899,7 +7899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7963,7 +7963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7979,7 +7979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8043,7 +8043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-issue5431_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-issue5431_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-issue5465_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-issue5465_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-issue5566_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-issue5566_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-jsdoc-multiline-type_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-jsdoc-multiline-type_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-keywords_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-keywords_ts.json
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-members_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-members_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-object-literals_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-object-literals_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-regex_coffee.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-regex_coffee.json
@@ -11,7 +11,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-strings_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-strings_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test-this_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test-this_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test2_pl.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test2_pl.json
@@ -43,7 +43,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test6916_js.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test6916_js.json
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_bat.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_bat.json
@@ -27,7 +27,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_bib.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_bib.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_c.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_c.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cc.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cc.json
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_clj.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_clj.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "storage: #569CD6",
 			"hc_light": "storage: #0F4A85",
 			"light_modern": "storage: #0000FF",
-			"2026-dark": "storage: #F47067",
+			"2026-dark": "storage: #FF7B72",
 			"2026-light": "storage: #CF222E"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4667,7 +4667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4827,7 +4827,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_code-snippets.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_code-snippets.json
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_coffee.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_coffee.json
@@ -11,7 +11,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cpp.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cpp.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cs.json
@@ -75,7 +75,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cshtml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cshtml.json
@@ -59,7 +59,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5019,7 +5019,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_css.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_css.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.deprecated: #FF938A",
+			"2026-dark": "invalid.deprecated: #FFA198",
 			"2026-light": "invalid.deprecated: #82071E"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.deprecated: #FF938A",
+			"2026-dark": "invalid.deprecated: #FFA198",
 			"2026-light": "invalid.deprecated: #82071E"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.deprecated: #FF938A",
+			"2026-dark": "invalid.deprecated: #FFA198",
 			"2026-light": "invalid.deprecated: #82071E"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.deprecated: #FF938A",
+			"2026-dark": "invalid.deprecated: #FFA198",
 			"2026-light": "invalid.deprecated: #82071E"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.deprecated: #FF938A",
+			"2026-dark": "invalid.deprecated: #FFA198",
 			"2026-light": "invalid.deprecated: #82071E"
 		}
 	},
@@ -5787,7 +5787,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -5851,7 +5851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5867,7 +5867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5883,7 +5883,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -12667,7 +12667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12683,7 +12683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12699,7 +12699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12923,7 +12923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -13275,7 +13275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -14459,7 +14459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14475,7 +14475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14491,7 +14491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14683,7 +14683,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -15067,7 +15067,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -15323,7 +15323,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -15387,7 +15387,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -15563,7 +15563,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_cu.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_cu.json
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "meta.preprocessor: #569CD6",
 			"hc_light": "meta.preprocessor: #0F4A85",
 			"light_modern": "meta.preprocessor: #0000FF",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4667,7 +4667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4795,7 +4795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4891,7 +4891,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5003,7 +5003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5019,7 +5019,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5035,7 +5035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5083,7 +5083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5131,7 +5131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5179,7 +5179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5259,7 +5259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5291,7 +5291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5323,7 +5323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5339,7 +5339,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5355,7 +5355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5387,7 +5387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5659,7 +5659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5723,7 +5723,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5787,7 +5787,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5883,7 +5883,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6075,7 +6075,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6219,7 +6219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6251,7 +6251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6283,7 +6283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6315,7 +6315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6443,7 +6443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6475,7 +6475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6507,7 +6507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6667,7 +6667,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6843,7 +6843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6875,7 +6875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6987,7 +6987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7003,7 +7003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7035,7 +7035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7051,7 +7051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7067,7 +7067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7083,7 +7083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7099,7 +7099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7115,7 +7115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7131,7 +7131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7147,7 +7147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7179,7 +7179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7195,7 +7195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7211,7 +7211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7227,7 +7227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7291,7 +7291,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7467,7 +7467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7499,7 +7499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7611,7 +7611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7627,7 +7627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7659,7 +7659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7707,7 +7707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7755,7 +7755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7787,7 +7787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7803,7 +7803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7819,7 +7819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7851,7 +7851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7883,7 +7883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7915,7 +7915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7931,7 +7931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7947,7 +7947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7963,7 +7963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7979,7 +7979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8011,7 +8011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8043,7 +8043,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8123,7 +8123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8267,7 +8267,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8299,7 +8299,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8379,7 +8379,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8443,7 +8443,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8475,7 +8475,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8587,7 +8587,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8731,7 +8731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8763,7 +8763,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8923,7 +8923,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9003,7 +9003,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9035,7 +9035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9291,7 +9291,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9451,7 +9451,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9675,7 +9675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9691,7 +9691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9707,7 +9707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9723,7 +9723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9739,7 +9739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9755,7 +9755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9771,7 +9771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9787,7 +9787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9803,7 +9803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9819,7 +9819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9835,7 +9835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9851,7 +9851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9867,7 +9867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9899,7 +9899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9931,7 +9931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9963,7 +9963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9979,7 +9979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9995,7 +9995,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10011,7 +10011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10027,7 +10027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10043,7 +10043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10059,7 +10059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10075,7 +10075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10091,7 +10091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10107,7 +10107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10123,7 +10123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10139,7 +10139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10155,7 +10155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10187,7 +10187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10219,7 +10219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10251,7 +10251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10267,7 +10267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10299,7 +10299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10315,7 +10315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -10331,7 +10331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10363,7 +10363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10395,7 +10395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10411,7 +10411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10443,7 +10443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10459,7 +10459,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -10475,7 +10475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10491,7 +10491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10507,7 +10507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10523,7 +10523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10539,7 +10539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10555,7 +10555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10571,7 +10571,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10587,7 +10587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10603,7 +10603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10619,7 +10619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10651,7 +10651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10667,7 +10667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10683,7 +10683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10699,7 +10699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10715,7 +10715,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10731,7 +10731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10747,7 +10747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10763,7 +10763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10779,7 +10779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10795,7 +10795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10811,7 +10811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10827,7 +10827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10843,7 +10843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10859,7 +10859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10891,7 +10891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10923,7 +10923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10955,7 +10955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10987,7 +10987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11003,7 +11003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11019,7 +11019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11035,7 +11035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11067,7 +11067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11083,7 +11083,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11099,7 +11099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11131,7 +11131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11163,7 +11163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11179,7 +11179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11211,7 +11211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11243,7 +11243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11259,7 +11259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11275,7 +11275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11291,7 +11291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11307,7 +11307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11323,7 +11323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11339,7 +11339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11355,7 +11355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11371,7 +11371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11387,7 +11387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11419,7 +11419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11435,7 +11435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11451,7 +11451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11467,7 +11467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11515,7 +11515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11563,7 +11563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11579,7 +11579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11595,7 +11595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11611,7 +11611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11627,7 +11627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11643,7 +11643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11659,7 +11659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11675,7 +11675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11691,7 +11691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11707,7 +11707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11723,7 +11723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11739,7 +11739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11771,7 +11771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11787,7 +11787,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11803,7 +11803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11819,7 +11819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11835,7 +11835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11867,7 +11867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11915,7 +11915,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11947,7 +11947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11963,7 +11963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11979,7 +11979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12011,7 +12011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12027,7 +12027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12043,7 +12043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12075,7 +12075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12107,7 +12107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12123,7 +12123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12139,7 +12139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12155,7 +12155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12171,7 +12171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12187,7 +12187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12203,7 +12203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12219,7 +12219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12235,7 +12235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12251,7 +12251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12267,7 +12267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12283,7 +12283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12315,7 +12315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12331,7 +12331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12363,7 +12363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12395,7 +12395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12427,7 +12427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12443,7 +12443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12459,7 +12459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12475,7 +12475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12491,7 +12491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12507,7 +12507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12523,7 +12523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12539,7 +12539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12555,7 +12555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12587,7 +12587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12603,7 +12603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12635,7 +12635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12651,7 +12651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12667,7 +12667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12683,7 +12683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12699,7 +12699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12715,7 +12715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12731,7 +12731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12747,7 +12747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12779,7 +12779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12795,7 +12795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12827,7 +12827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12859,7 +12859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12875,7 +12875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12891,7 +12891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12907,7 +12907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12923,7 +12923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12939,7 +12939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12955,7 +12955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12971,7 +12971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12987,7 +12987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13019,7 +13019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13035,7 +13035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13051,7 +13051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13067,7 +13067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13083,7 +13083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13099,7 +13099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13115,7 +13115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13131,7 +13131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13163,7 +13163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13179,7 +13179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13211,7 +13211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13243,7 +13243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13259,7 +13259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13275,7 +13275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13307,7 +13307,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13339,7 +13339,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13403,7 +13403,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -13595,7 +13595,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -13723,7 +13723,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13867,7 +13867,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -14219,7 +14219,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14251,7 +14251,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14363,7 +14363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -14555,7 +14555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14587,7 +14587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14667,7 +14667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14763,7 +14763,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14795,7 +14795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14875,7 +14875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15099,7 +15099,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -15131,7 +15131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15211,7 +15211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15387,7 +15387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15467,7 +15467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15595,7 +15595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15675,7 +15675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15931,7 +15931,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -16155,7 +16155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16171,7 +16171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16203,7 +16203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16219,7 +16219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16235,7 +16235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16251,7 +16251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16267,7 +16267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16283,7 +16283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16299,7 +16299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16331,7 +16331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16347,7 +16347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16363,7 +16363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16379,7 +16379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16395,7 +16395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -16411,7 +16411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16427,7 +16427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16443,7 +16443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16459,7 +16459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16475,7 +16475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16491,7 +16491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16507,7 +16507,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -16523,7 +16523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16539,7 +16539,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -16555,7 +16555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16571,7 +16571,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -16603,7 +16603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16619,7 +16619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16635,7 +16635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16651,7 +16651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16667,7 +16667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16683,7 +16683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16699,7 +16699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16715,7 +16715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16731,7 +16731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16747,7 +16747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16763,7 +16763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16779,7 +16779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16795,7 +16795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16811,7 +16811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16827,7 +16827,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -16843,7 +16843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16875,7 +16875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16891,7 +16891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16907,7 +16907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16923,7 +16923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16939,7 +16939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16955,7 +16955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16987,7 +16987,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -17019,7 +17019,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -17115,7 +17115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -17147,7 +17147,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -17243,7 +17243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -17323,7 +17323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -17339,7 +17339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -17371,7 +17371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -17435,7 +17435,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_dart.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_dart.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_diff.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_diff.json
@@ -11,7 +11,7 @@
 			"dark_modern": "meta.diff.header: #569CD6",
 			"hc_light": "meta.diff.header: #062F4A",
 			"light_modern": "meta.diff.header: #000080",
-			"2026-dark": "meta.diff.header: #6CB6FF",
+			"2026-dark": "meta.diff.header: #79C0FF",
 			"2026-light": "meta.diff.header: #0550AE"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "meta.diff.header: #569CD6",
 			"hc_light": "meta.diff.header: #062F4A",
 			"light_modern": "meta.diff.header: #000080",
-			"2026-dark": "meta.diff.header.from-file: #FF938A",
+			"2026-dark": "meta.diff.header.from-file: #FFA198",
 			"2026-light": "meta.diff.header.from-file: #82071E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "meta.diff.header: #569CD6",
 			"hc_light": "meta.diff.header: #062F4A",
 			"light_modern": "meta.diff.header: #000080",
-			"2026-dark": "meta.diff.header.from-file: #FF938A",
+			"2026-dark": "meta.diff.header.from-file: #FFA198",
 			"2026-light": "meta.diff.header.from-file: #82071E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "meta.diff.header: #569CD6",
 			"hc_light": "meta.diff.header: #062F4A",
 			"light_modern": "meta.diff.header: #000080",
-			"2026-dark": "meta.diff.header.to-file: #8DDB8C",
+			"2026-dark": "meta.diff.header.to-file: #7EE787",
 			"2026-light": "meta.diff.header.to-file: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "meta.diff.header: #569CD6",
 			"hc_light": "meta.diff.header: #062F4A",
 			"light_modern": "meta.diff.header: #000080",
-			"2026-dark": "meta.diff.header.to-file: #8DDB8C",
+			"2026-dark": "meta.diff.header.to-file: #7EE787",
 			"2026-light": "meta.diff.header.to-file: #116329"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.diff.range: #DCBDFB",
+			"2026-dark": "meta.diff.range: #D2A8FF",
 			"2026-light": "meta.diff.range: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.diff.range: #DCBDFB",
+			"2026-dark": "meta.diff.range: #D2A8FF",
 			"2026-light": "meta.diff.range: #8250DF"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.diff.range: #DCBDFB",
+			"2026-dark": "meta.diff.range: #D2A8FF",
 			"2026-light": "meta.diff.range: #8250DF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.diff.range: #DCBDFB",
+			"2026-dark": "meta.diff.range: #D2A8FF",
 			"2026-light": "meta.diff.range: #8250DF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.diff.range: #DCBDFB",
+			"2026-dark": "meta.diff.range: #D2A8FF",
 			"2026-light": "meta.diff.range: #8250DF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "markup.deleted: #CE9178",
 			"hc_light": "markup.deleted: #5A5A5A",
 			"light_modern": "markup.deleted: #A31515",
-			"2026-dark": "punctuation.definition.deleted: #FF938A",
+			"2026-dark": "punctuation.definition.deleted: #FFA198",
 			"2026-light": "punctuation.definition.deleted: #82071E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "markup.deleted: #CE9178",
 			"hc_light": "markup.deleted: #5A5A5A",
 			"light_modern": "markup.deleted: #A31515",
-			"2026-dark": "markup.deleted: #FF938A",
+			"2026-dark": "markup.deleted: #FFA198",
 			"2026-light": "markup.deleted: #82071E"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "markup.inserted: #B5CEA8",
 			"hc_light": "markup.inserted: #096D48",
 			"light_modern": "markup.inserted: #098658",
-			"2026-dark": "punctuation.definition.inserted: #8DDB8C",
+			"2026-dark": "punctuation.definition.inserted: #7EE787",
 			"2026-light": "punctuation.definition.inserted: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "markup.inserted: #B5CEA8",
 			"hc_light": "markup.inserted: #096D48",
 			"light_modern": "markup.inserted: #098658",
-			"2026-dark": "markup.inserted: #8DDB8C",
+			"2026-dark": "markup.inserted: #7EE787",
 			"2026-light": "markup.inserted: #116329"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_env.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_env.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_fs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_fs.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_go.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_go.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "constant.other.placeholder: #9CDCFE",
 			"hc_light": "constant.other.placeholder: #001080",
 			"light_modern": "constant.other.placeholder: #001080",
-			"2026-dark": "constant.other.placeholder: #F47067",
+			"2026-dark": "constant.other.placeholder: #FF7B72",
 			"2026-light": "constant.other.placeholder: #CF222E"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_groovy.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_groovy.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4795,7 +4795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4827,7 +4827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4891,7 +4891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5259,7 +5259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5275,7 +5275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5323,7 +5323,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5707,7 +5707,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5723,7 +5723,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5771,7 +5771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5803,7 +5803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5835,7 +5835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5867,7 +5867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5883,7 +5883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5899,7 +5899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5915,7 +5915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5947,7 +5947,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5963,7 +5963,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -6011,7 +6011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -6123,7 +6123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6187,7 +6187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6251,7 +6251,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6363,7 +6363,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6379,7 +6379,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -6411,7 +6411,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6427,7 +6427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -6475,7 +6475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6491,7 +6491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -6507,7 +6507,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6523,7 +6523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -6555,7 +6555,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6571,7 +6571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -6603,7 +6603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -6635,7 +6635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -6795,7 +6795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6827,7 +6827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7019,7 +7019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7035,7 +7035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7051,7 +7051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7163,7 +7163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7179,7 +7179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7195,7 +7195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7227,7 +7227,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7243,7 +7243,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7259,7 +7259,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7275,7 +7275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7307,7 +7307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7339,7 +7339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7371,7 +7371,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7387,7 +7387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7419,7 +7419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7451,7 +7451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7483,7 +7483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7515,7 +7515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7547,7 +7547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7563,7 +7563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7579,7 +7579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7595,7 +7595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7611,7 +7611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7643,7 +7643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7659,7 +7659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7675,7 +7675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7691,7 +7691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7787,7 +7787,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7803,7 +7803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7819,7 +7819,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7851,7 +7851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8059,7 +8059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8075,7 +8075,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8091,7 +8091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8107,7 +8107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8123,7 +8123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8251,7 +8251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8267,7 +8267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8283,7 +8283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8299,7 +8299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8315,7 +8315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8331,7 +8331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8347,7 +8347,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8363,7 +8363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8379,7 +8379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -8411,7 +8411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -8443,7 +8443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -8715,7 +8715,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8731,7 +8731,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9115,7 +9115,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9131,7 +9131,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9531,7 +9531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9547,7 +9547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9563,7 +9563,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9579,7 +9579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9611,7 +9611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9643,7 +9643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9659,7 +9659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9675,7 +9675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9691,7 +9691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9707,7 +9707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9723,7 +9723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9739,7 +9739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9755,7 +9755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9771,7 +9771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9787,7 +9787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9803,7 +9803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9819,7 +9819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9835,7 +9835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9851,7 +9851,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9867,7 +9867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9883,7 +9883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9899,7 +9899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9915,7 +9915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9931,7 +9931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9947,7 +9947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9963,7 +9963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9979,7 +9979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9995,7 +9995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10011,7 +10011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10027,7 +10027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10043,7 +10043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10059,7 +10059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10075,7 +10075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10331,7 +10331,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -10347,7 +10347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10379,7 +10379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10411,7 +10411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10427,7 +10427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10443,7 +10443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10459,7 +10459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10475,7 +10475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10491,7 +10491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10507,7 +10507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10523,7 +10523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10539,7 +10539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10555,7 +10555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10571,7 +10571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10587,7 +10587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10603,7 +10603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10619,7 +10619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10747,7 +10747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -10763,7 +10763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -10779,7 +10779,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -10795,7 +10795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10827,7 +10827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10859,7 +10859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10907,7 +10907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10923,7 +10923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10955,7 +10955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -10971,7 +10971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -10987,7 +10987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11019,7 +11019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11051,7 +11051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11083,7 +11083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11099,7 +11099,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11115,7 +11115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11147,7 +11147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11179,7 +11179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11211,7 +11211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11227,7 +11227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11243,7 +11243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11259,7 +11259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -11275,7 +11275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11291,7 +11291,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11307,7 +11307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11339,7 +11339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11371,7 +11371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11387,7 +11387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11403,7 +11403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11419,7 +11419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11435,7 +11435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11451,7 +11451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11467,7 +11467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11499,7 +11499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11531,7 +11531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11563,7 +11563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11675,7 +11675,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11691,7 +11691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11723,7 +11723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11755,7 +11755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11787,7 +11787,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11803,7 +11803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11835,7 +11835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11867,7 +11867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11883,7 +11883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11899,7 +11899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11915,7 +11915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11947,7 +11947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -11979,7 +11979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12091,7 +12091,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12107,7 +12107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12139,7 +12139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12171,7 +12171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12203,7 +12203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12267,7 +12267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12283,7 +12283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12299,7 +12299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12347,7 +12347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12363,7 +12363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12395,7 +12395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12427,7 +12427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12443,7 +12443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -12459,7 +12459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12475,7 +12475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12491,7 +12491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -12507,7 +12507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12539,7 +12539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12555,7 +12555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12571,7 +12571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12603,7 +12603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12619,7 +12619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12635,7 +12635,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -12651,7 +12651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -12667,7 +12667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12699,7 +12699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12715,7 +12715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -12843,7 +12843,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12875,7 +12875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -12907,7 +12907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -12955,7 +12955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -13035,7 +13035,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -13339,7 +13339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13355,7 +13355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13371,7 +13371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13387,7 +13387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13403,7 +13403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13419,7 +13419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13435,7 +13435,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -13467,7 +13467,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -13483,7 +13483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13499,7 +13499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13643,7 +13643,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -13659,7 +13659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -13675,7 +13675,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -13707,7 +13707,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -13723,7 +13723,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -13739,7 +13739,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -13755,7 +13755,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -13771,7 +13771,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -13835,7 +13835,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13979,7 +13979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13995,7 +13995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14011,7 +14011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14459,7 +14459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14475,7 +14475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14491,7 +14491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -14523,7 +14523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -14539,7 +14539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -14555,7 +14555,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -14587,7 +14587,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -14603,7 +14603,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -14619,7 +14619,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -14635,7 +14635,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -14651,7 +14651,7 @@
 			"dark_modern": "storage.modifier: #569CD6",
 			"hc_light": "storage.modifier: #0F4A85",
 			"light_modern": "storage.modifier: #0000FF",
-			"2026-dark": "storage.modifier.import: #ADBAC7",
+			"2026-dark": "storage.modifier.import: #C9D1D9",
 			"2026-light": "storage.modifier.import: #1F2328"
 		}
 	},
@@ -14715,7 +14715,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14779,7 +14779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -14859,7 +14859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_handlebars.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_handlebars.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_hbs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_hbs.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.handlebars: #0F4A85",
 			"light_modern": "string.quoted.double.handlebars: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.handlebars: #0000FF"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_hlsl.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_hlsl.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_html.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_html.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.html: #0F4A85",
 			"light_modern": "string.unquoted.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.html: #0000FF"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_ini.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_ini.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_jl.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_jl.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_js.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_js.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4667,7 +4667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4795,7 +4795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4891,7 +4891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5003,7 +5003,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -5019,7 +5019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5035,7 +5035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5131,7 +5131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5147,7 +5147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5259,7 +5259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5275,7 +5275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5291,7 +5291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5323,7 +5323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5355,7 +5355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5387,7 +5387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5467,7 +5467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5515,7 +5515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5579,7 +5579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5595,7 +5595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_json.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_json.json
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_jsx.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_jsx.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.tag.attributes: #ADBAC7",
+			"2026-dark": "meta.tag.attributes: #C9D1D9",
 			"2026-light": "meta.tag.attributes: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.tag.attributes: #ADBAC7",
+			"2026-dark": "meta.tag.attributes: #C9D1D9",
 			"2026-light": "meta.tag.attributes: #1F2328"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "meta.embedded: #D4D4D4",
 			"hc_light": "meta.embedded: #292929",
 			"light_modern": "meta.embedded: #000000",
-			"2026-dark": "meta.embedded.expression: #ADBAC7",
+			"2026-dark": "meta.embedded.expression: #C9D1D9",
 			"2026-light": "meta.embedded.expression: #1F2328"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.jsx.children: #ADBAC7",
+			"2026-dark": "meta.jsx.children: #C9D1D9",
 			"2026-light": "meta.jsx.children: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "support.class: #4EC9B0",
 			"hc_light": "support.class: #185E73",
 			"light_modern": "support.class: #267F99",
-			"2026-dark": "support.class.component: #8DDB8C",
+			"2026-dark": "support.class.component: #7EE787",
 			"2026-light": "support.class.component: #116329"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.tag.attributes: #ADBAC7",
+			"2026-dark": "meta.tag.attributes: #C9D1D9",
 			"2026-light": "meta.tag.attributes: #1F2328"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.tag.attributes: #ADBAC7",
+			"2026-dark": "meta.tag.attributes: #C9D1D9",
 			"2026-light": "meta.tag.attributes: #1F2328"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.tag.attributes: #ADBAC7",
+			"2026-dark": "meta.tag.attributes: #C9D1D9",
 			"2026-light": "meta.tag.attributes: #1F2328"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_less.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_less.json
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5003,7 +5003,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "source.css variable: #9CDCFE",
 			"hc_light": "source.css variable: #264F78",
 			"light_modern": "source.css variable: #E50000",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_log.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_log.json
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_lua.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_lua.json
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_m.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_m.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_md.json
@@ -11,7 +11,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.single.html: #0F4A85",
 			"light_modern": "string.quoted.single.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.single.html: #0000FF"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.html: #0F4A85",
 			"light_modern": "string.quoted.double.html: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.html: #0000FF"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "markup.italic: #C586C0",
 			"hc_light": "markup.italic: #800080",
 			"light_modern": "markup.italic: #800080",
-			"2026-dark": "markup.italic: #ADBAC7",
+			"2026-dark": "markup.italic: #C9D1D9",
 			"2026-light": "markup.italic: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "markup.italic: #C586C0",
 			"hc_light": "markup.italic: #800080",
 			"light_modern": "markup.italic: #800080",
-			"2026-dark": "markup.italic: #ADBAC7",
+			"2026-dark": "markup.italic: #C9D1D9",
 			"2026-light": "markup.italic: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "markup.italic: #C586C0",
 			"hc_light": "markup.italic: #800080",
 			"light_modern": "markup.italic: #800080",
-			"2026-dark": "markup.italic: #ADBAC7",
+			"2026-dark": "markup.italic: #C9D1D9",
 			"2026-light": "markup.italic: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "markup.inline.raw: #CE9178",
 			"hc_light": "markup.inline.raw: #0F4A85",
 			"light_modern": "markup.inline.raw: #800000",
-			"2026-dark": "markup.inline.raw: #6CB6FF",
+			"2026-dark": "markup.inline.raw: #79C0FF",
 			"2026-light": "markup.inline.raw: #0550AE"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "markup.inline.raw: #CE9178",
 			"hc_light": "markup.inline.raw: #0F4A85",
 			"light_modern": "markup.inline.raw: #800000",
-			"2026-dark": "markup.inline.raw: #6CB6FF",
+			"2026-dark": "markup.inline.raw: #79C0FF",
 			"2026-light": "markup.inline.raw: #0550AE"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "markup.inline.raw: #CE9178",
 			"hc_light": "markup.inline.raw: #0F4A85",
 			"light_modern": "markup.inline.raw: #800000",
-			"2026-dark": "markup.inline.raw: #6CB6FF",
+			"2026-dark": "markup.inline.raw: #79C0FF",
 			"2026-light": "markup.inline.raw: #0550AE"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "markup.quote: #8DDB8C",
+			"2026-dark": "markup.quote: #7EE787",
 			"2026-light": "markup.quote: #116329"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.separator: #6CB6FF",
+			"2026-dark": "meta.separator: #79C0FF",
 			"2026-light": "meta.separator: #0550AE"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.separator: #6CB6FF",
+			"2026-dark": "meta.separator: #79C0FF",
 			"2026-light": "meta.separator: #0550AE"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.separator: #6CB6FF",
+			"2026-dark": "meta.separator: #79C0FF",
 			"2026-light": "meta.separator: #0550AE"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading entity.name: #6CB6FF",
+			"2026-dark": "markup.heading entity.name: #79C0FF",
 			"2026-light": "markup.heading entity.name: #0550AE"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "punctuation.definition.list.begin.markdown: #6796E6",
 			"hc_light": "punctuation.definition.list.begin.markdown: #0451A5",
 			"light_modern": "punctuation.definition.list.begin.markdown: #0451A5",
-			"2026-dark": "punctuation.definition.list.begin.markdown: #F69D50",
+			"2026-dark": "punctuation.definition.list.begin.markdown: #FFA657",
 			"2026-light": "punctuation.definition.list.begin.markdown: #953800"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string.other.link: #96D0FF",
+			"2026-dark": "string.other.link: #A5D6FF",
 			"2026-light": "string.other.link: #0A3069"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_mm.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_mm.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_p6.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_p6.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_php.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_php.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4763,7 +4763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4795,7 +4795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4827,7 +4827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5083,7 +5083,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -5259,7 +5259,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_pl.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_pl.json
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_ps1.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_ps1.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_pug.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_pug.json
@@ -11,7 +11,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.comment.buffered.block.pug: #0F4A85",
 			"light_modern": "string.comment.buffered.block.pug: #0000FF",
-			"2026-dark": "string.comment: #768390",
+			"2026-dark": "string.comment: #8B949E",
 			"2026-light": "string.comment.buffered.block.pug: #0000FF"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.comment.buffered.block.pug: #0F4A85",
 			"light_modern": "string.comment.buffered.block.pug: #0000FF",
-			"2026-dark": "string.comment: #768390",
+			"2026-dark": "string.comment: #8B949E",
 			"2026-light": "string.comment.buffered.block.pug: #0000FF"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.comment.buffered.block.pug: #0F4A85",
 			"light_modern": "string.comment.buffered.block.pug: #0000FF",
-			"2026-dark": "string.comment: #768390",
+			"2026-dark": "string.comment: #8B949E",
 			"2026-light": "string.comment.buffered.block.pug: #0000FF"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.object.member: #ADBAC7",
+			"2026-dark": "meta.object.member: #C9D1D9",
 			"2026-light": "meta.object.member: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.comment.buffered.block.pug: #0F4A85",
 			"light_modern": "string.comment.buffered.block.pug: #0000FF",
-			"2026-dark": "string.comment: #768390",
+			"2026-dark": "string.comment: #8B949E",
 			"2026-light": "string.comment.buffered.block.pug: #0000FF"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.interpolated.pug: #0F4A85",
 			"light_modern": "string.interpolated.pug: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.interpolated.pug: #0000FF"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.interpolated.pug: #0F4A85",
 			"light_modern": "string.interpolated.pug: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.interpolated.pug: #0000FF"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.interpolated.pug: #0F4A85",
 			"light_modern": "string.interpolated.pug: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.interpolated.pug: #0000FF"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_py.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_py.json
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3403,7 +3403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5083,7 +5083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -5355,7 +5355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5739,7 +5739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -5803,7 +5803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -5963,7 +5963,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6043,7 +6043,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6187,7 +6187,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6347,7 +6347,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6555,7 +6555,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -6587,7 +6587,7 @@
 			"dark_modern": "punctuation.character.set.begin.regexp: #CE9178",
 			"hc_light": "punctuation.character.set.begin.regexp: #D16969",
 			"light_modern": "punctuation.character.set.begin.regexp: #D16969",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -6619,7 +6619,7 @@
 			"dark_modern": "punctuation.character.set.end.regexp: #CE9178",
 			"hc_light": "punctuation.character.set.end.regexp: #D16969",
 			"light_modern": "punctuation.character.set.end.regexp: #D16969",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -6667,7 +6667,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -6715,7 +6715,7 @@
 			"dark_modern": "punctuation.character.set.begin.regexp: #CE9178",
 			"hc_light": "punctuation.character.set.begin.regexp: #D16969",
 			"light_modern": "punctuation.character.set.begin.regexp: #D16969",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -6747,7 +6747,7 @@
 			"dark_modern": "punctuation.character.set.end.regexp: #CE9178",
 			"hc_light": "punctuation.character.set.end.regexp: #D16969",
 			"light_modern": "punctuation.character.set.end.regexp: #D16969",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -6795,7 +6795,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -6859,7 +6859,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "support: #6CB6FF",
+			"2026-dark": "support: #79C0FF",
 			"2026-light": "support: #0550AE"
 		}
 	},
@@ -6907,7 +6907,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -7163,7 +7163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7179,7 +7179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7195,7 +7195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7499,7 +7499,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7515,7 +7515,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7531,7 +7531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7627,7 +7627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -7691,7 +7691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -7739,7 +7739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -7755,7 +7755,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7883,7 +7883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7899,7 +7899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7979,7 +7979,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8027,7 +8027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8043,7 +8043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8059,7 +8059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8091,7 +8091,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8107,7 +8107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8123,7 +8123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8155,7 +8155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8171,7 +8171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8203,7 +8203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8219,7 +8219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8283,7 +8283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8299,7 +8299,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -8315,7 +8315,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -8331,7 +8331,7 @@
 			"dark_modern": "punctuation.character.set.begin.regexp: #CE9178",
 			"hc_light": "punctuation.character.set.begin.regexp: #D16969",
 			"light_modern": "punctuation.character.set.begin.regexp: #D16969",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -8363,7 +8363,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -8443,7 +8443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8459,7 +8459,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8475,7 +8475,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8491,7 +8491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8507,7 +8507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8523,7 +8523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8539,7 +8539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8571,7 +8571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8587,7 +8587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8619,7 +8619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8635,7 +8635,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8667,7 +8667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8683,7 +8683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8699,7 +8699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8715,7 +8715,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_r.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_r.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_rb.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_rb.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3227,7 +3227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "punctuation.section.embedded: #569CD6",
 			"hc_light": "punctuation.section.embedded: #0F4A85",
 			"light_modern": "punctuation.section.embedded: #0000FF",
-			"2026-dark": "punctuation.section.embedded: #F47067",
+			"2026-dark": "punctuation.section.embedded: #FF7B72",
 			"2026-light": "punctuation.section.embedded: #CF222E"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4603,7 +4603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_regexp.ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_regexp.ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "constant.other.character-class.set.regexp: #D16969",
 			"hc_light": "constant.other.character-class.set.regexp: #811F3F",
 			"light_modern": "constant.other.character-class.set.regexp: #811F3F",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "constant.character: #569CD6",
 			"hc_light": "constant.character: #0F4A85",
 			"light_modern": "constant.character: #0000FF",
-			"2026-dark": "constant.character: #F47067",
+			"2026-dark": "constant.character: #FF7B72",
 			"2026-light": "constant.character: #CF222E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "variable.other.constant: #4FC1FF",
 			"hc_light": "variable.other.constant: #02715D",
 			"light_modern": "variable.other.constant: #0070C1",
-			"2026-dark": "variable.other.constant: #6CB6FF",
+			"2026-dark": "variable.other.constant: #79C0FF",
 			"2026-light": "variable.other.constant: #0550AE"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "constant.other.character-class.set.regexp: #D16969",
 			"hc_light": "constant.other.character-class.set.regexp: #811F3F",
 			"light_modern": "constant.other.character-class.set.regexp: #811F3F",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "constant.other.character-class.set.regexp: #D16969",
 			"hc_light": "constant.other.character-class.set.regexp: #811F3F",
 			"light_modern": "constant.other.character-class.set.regexp: #811F3F",
-			"2026-dark": "constant: #6CB6FF",
+			"2026-dark": "constant: #79C0FF",
 			"2026-light": "constant: #0550AE"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "constant.character.escape: #D7BA7D",
 			"hc_light": "constant.character.escape: #EE0000",
 			"light_modern": "constant.character.escape: #EE0000",
-			"2026-dark": "string.regexp constant.character.escape: #8DDB8C",
+			"2026-dark": "string.regexp constant.character.escape: #7EE787",
 			"2026-light": "string.regexp constant.character.escape: #116329"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_rs.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_rs.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_rst.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_rst.json
@@ -11,7 +11,7 @@
 			"dark_modern": "markup.italic: #C586C0",
 			"hc_light": "markup.italic: #800080",
 			"light_modern": "markup.italic: #800080",
-			"2026-dark": "markup.italic: #ADBAC7",
+			"2026-dark": "markup.italic: #C9D1D9",
 			"2026-light": "markup.italic: #1F2328"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "markup.bold: #569CD6",
 			"hc_light": "markup.bold: #000080",
 			"light_modern": "markup.bold: #000080",
-			"2026-dark": "markup.bold: #ADBAC7",
+			"2026-dark": "markup.bold: #C9D1D9",
 			"2026-light": "markup.bold: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "markup.heading: #569CD6",
 			"hc_light": "markup.heading: #0F4A85",
 			"light_modern": "markup.heading: #800000",
-			"2026-dark": "markup.heading: #6CB6FF",
+			"2026-dark": "markup.heading: #79C0FF",
 			"2026-light": "markup.heading: #0550AE"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_scss.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_scss.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "support.constant: #6CB6FF",
+			"2026-dark": "support.constant: #79C0FF",
 			"2026-light": "support.constant: #0550AE"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2619,7 +2619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2651,7 +2651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3579,7 +3579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4107,7 +4107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5179,7 +5179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5515,7 +5515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5547,7 +5547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5595,7 +5595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5627,7 +5627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5659,7 +5659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5691,7 +5691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5707,7 +5707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5739,7 +5739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5755,7 +5755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5787,7 +5787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5803,7 +5803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5835,7 +5835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5851,7 +5851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -5867,7 +5867,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -5899,7 +5899,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -5915,7 +5915,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -5931,7 +5931,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -6587,7 +6587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6603,7 +6603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6619,7 +6619,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6939,7 +6939,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -6955,7 +6955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7083,7 +7083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7099,7 +7099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7851,7 +7851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -7899,7 +7899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7915,7 +7915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -8011,7 +8011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -8859,7 +8859,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8875,7 +8875,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -8891,7 +8891,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -8955,7 +8955,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8971,7 +8971,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8987,7 +8987,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9035,7 +9035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9051,7 +9051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9083,7 +9083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9099,7 +9099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9115,7 +9115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9131,7 +9131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9147,7 +9147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -9227,7 +9227,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9243,7 +9243,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9259,7 +9259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9323,7 +9323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9339,7 +9339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9403,7 +9403,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9579,7 +9579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9595,7 +9595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9611,7 +9611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9659,7 +9659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -9675,7 +9675,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -9691,7 +9691,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -10299,7 +10299,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -10315,7 +10315,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -10331,7 +10331,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -11611,7 +11611,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -11659,7 +11659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -11675,7 +11675,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -11691,7 +11691,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -11819,7 +11819,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -12171,7 +12171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12187,7 +12187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12251,7 +12251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12267,7 +12267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12731,7 +12731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12747,7 +12747,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12811,7 +12811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -12827,7 +12827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -13371,7 +13371,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -13387,7 +13387,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -13403,7 +13403,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -13419,7 +13419,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -13435,7 +13435,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -13451,7 +13451,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -14555,7 +14555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -14571,7 +14571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -14587,7 +14587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -14619,7 +14619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -14635,7 +14635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.definition.variable: #F69D50",
+			"2026-dark": "meta.definition.variable: #FFA657",
 			"2026-light": "meta.definition.variable: #953800"
 		}
 	},
@@ -15195,7 +15195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -15211,7 +15211,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -15227,7 +15227,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -15819,7 +15819,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -15835,7 +15835,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -15851,7 +15851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -15979,7 +15979,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -16251,7 +16251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16267,7 +16267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16331,7 +16331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16347,7 +16347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -16443,7 +16443,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -16459,7 +16459,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -16475,7 +16475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -17227,7 +17227,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -17243,7 +17243,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -17259,7 +17259,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -17867,7 +17867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -17883,7 +17883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -17899,7 +17899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -18347,7 +18347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -18363,7 +18363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -18379,7 +18379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -18587,7 +18587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -18603,7 +18603,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -18619,7 +18619,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -18683,7 +18683,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -19387,7 +19387,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -19547,7 +19547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -19563,7 +19563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -19579,7 +19579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -19643,7 +19643,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -20347,7 +20347,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -20459,7 +20459,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -20475,7 +20475,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -20491,7 +20491,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -20555,7 +20555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -21099,7 +21099,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -21547,7 +21547,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -21563,7 +21563,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -21579,7 +21579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -21643,7 +21643,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -22411,7 +22411,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -22523,7 +22523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -22539,7 +22539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -22555,7 +22555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -22619,7 +22619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -22683,7 +22683,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -22907,7 +22907,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -23403,7 +23403,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -23499,7 +23499,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -23515,7 +23515,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -23531,7 +23531,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -23595,7 +23595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -23627,7 +23627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -23787,7 +23787,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -23803,7 +23803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -23819,7 +23819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -23867,7 +23867,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -23883,7 +23883,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -23899,7 +23899,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -23963,7 +23963,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -24251,7 +24251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -24267,7 +24267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -24283,7 +24283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -24395,7 +24395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -24619,7 +24619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -24683,7 +24683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -24811,7 +24811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -25099,7 +25099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -25115,7 +25115,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -25131,7 +25131,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -25227,7 +25227,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -25291,7 +25291,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -25643,7 +25643,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -25659,7 +25659,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -25675,7 +25675,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -25739,7 +25739,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -26507,7 +26507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -26619,7 +26619,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -26651,7 +26651,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -26667,7 +26667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -26683,7 +26683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -26747,7 +26747,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -26763,7 +26763,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -26779,7 +26779,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27051,7 +27051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -27067,7 +27067,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -27083,7 +27083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -27163,7 +27163,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27179,7 +27179,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27195,7 +27195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27403,7 +27403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -27499,7 +27499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -27691,7 +27691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -27835,7 +27835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -27899,7 +27899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.property-name: #6CB6FF",
+			"2026-dark": "meta.property-name: #79C0FF",
 			"2026-light": "meta.property-name: #0550AE"
 		}
 	},
@@ -27995,7 +27995,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -28011,7 +28011,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -28027,7 +28027,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -29019,7 +29019,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -29451,7 +29451,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -29899,7 +29899,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -29915,7 +29915,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -29931,7 +29931,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -29995,7 +29995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30027,7 +30027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30171,7 +30171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30203,7 +30203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30251,7 +30251,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -30267,7 +30267,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -30283,7 +30283,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -30347,7 +30347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30379,7 +30379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30459,7 +30459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30491,7 +30491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -30523,7 +30523,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -30539,7 +30539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -30555,7 +30555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_sh.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_sh.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2939,7 +2939,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3083,7 +3083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3787,7 +3787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_shader.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_shader.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "support.variable: #9CDCFE",
 			"hc_light": "support.variable: #001080",
 			"light_modern": "support.variable: #001080",
-			"2026-dark": "support.variable: #6CB6FF",
+			"2026-dark": "support.variable: #79C0FF",
 			"2026-light": "support.variable: #0550AE"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_sql.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_sql.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_sty.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_sty.json
@@ -1579,7 +1579,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_swift.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_swift.json
@@ -11,7 +11,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_tex.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_tex.json
@@ -59,7 +59,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.parameter.function: #ADBAC7",
+			"2026-dark": "variable.parameter.function: #C9D1D9",
 			"2026-light": "variable.parameter.function: #1F2328"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2171,7 +2171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2331,7 +2331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2731,7 +2731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2747,7 +2747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2779,7 +2779,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2811,7 +2811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2827,7 +2827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2859,7 +2859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2923,7 +2923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3019,7 +3019,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3035,7 +3035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3099,7 +3099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3131,7 +3131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3259,7 +3259,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3275,7 +3275,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3291,7 +3291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3323,7 +3323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3355,7 +3355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3371,7 +3371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3419,7 +3419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3467,7 +3467,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3483,7 +3483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3531,7 +3531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3547,7 +3547,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3563,7 +3563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3611,7 +3611,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3675,7 +3675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3707,7 +3707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3723,7 +3723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3771,7 +3771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3851,7 +3851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3883,7 +3883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3979,7 +3979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -3995,7 +3995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4027,7 +4027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4059,7 +4059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4139,7 +4139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4171,7 +4171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4203,7 +4203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4235,7 +4235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4267,7 +4267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4299,7 +4299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4315,7 +4315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4331,7 +4331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4347,7 +4347,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4395,7 +4395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4427,7 +4427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4459,7 +4459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4491,7 +4491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4523,7 +4523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4539,7 +4539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4571,7 +4571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4635,7 +4635,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4651,7 +4651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4667,7 +4667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4683,7 +4683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4715,7 +4715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4747,7 +4747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4779,7 +4779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4827,7 +4827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4843,7 +4843,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4875,7 +4875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4891,7 +4891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4907,7 +4907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4939,7 +4939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4955,7 +4955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5003,7 +5003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5019,7 +5019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5035,7 +5035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5051,7 +5051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5115,7 +5115,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5131,7 +5131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5147,7 +5147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5179,7 +5179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5211,7 +5211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5243,7 +5243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5259,7 +5259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5275,7 +5275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5291,7 +5291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5323,7 +5323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5339,7 +5339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5355,7 +5355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5387,7 +5387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5403,7 +5403,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5483,7 +5483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5515,7 +5515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5531,7 +5531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5547,7 +5547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5563,7 +5563,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5579,7 +5579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5595,7 +5595,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5611,7 +5611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5643,7 +5643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5659,7 +5659,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5691,7 +5691,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5707,7 +5707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5723,7 +5723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5739,7 +5739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5755,7 +5755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5787,7 +5787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5819,7 +5819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5835,7 +5835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5851,7 +5851,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5867,7 +5867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5883,7 +5883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5899,7 +5899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5915,7 +5915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5931,7 +5931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5963,7 +5963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -5979,7 +5979,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -5995,7 +5995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6011,7 +6011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6027,7 +6027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6043,7 +6043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6059,7 +6059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6075,7 +6075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6091,7 +6091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6107,7 +6107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6123,7 +6123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6139,7 +6139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6155,7 +6155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6171,7 +6171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6187,7 +6187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6203,7 +6203,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6219,7 +6219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6235,7 +6235,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6251,7 +6251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6267,7 +6267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6283,7 +6283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6299,7 +6299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6315,7 +6315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6347,7 +6347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6363,7 +6363,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6379,7 +6379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6395,7 +6395,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6411,7 +6411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6427,7 +6427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6443,7 +6443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6459,7 +6459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6475,7 +6475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6491,7 +6491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6507,7 +6507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6523,7 +6523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6539,7 +6539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6555,7 +6555,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6571,7 +6571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6587,7 +6587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6603,7 +6603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6619,7 +6619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6635,7 +6635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6651,7 +6651,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6667,7 +6667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6683,7 +6683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6699,7 +6699,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6715,7 +6715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6731,7 +6731,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6747,7 +6747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6763,7 +6763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6779,7 +6779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6795,7 +6795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6827,7 +6827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6843,7 +6843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6859,7 +6859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6875,7 +6875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6891,7 +6891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6907,7 +6907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6923,7 +6923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6955,7 +6955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -6971,7 +6971,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6987,7 +6987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7003,7 +7003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7019,7 +7019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7051,7 +7051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7083,7 +7083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7099,7 +7099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7115,7 +7115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7131,7 +7131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7147,7 +7147,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7163,7 +7163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7179,7 +7179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7195,7 +7195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7227,7 +7227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7243,7 +7243,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -7259,7 +7259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7275,7 +7275,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7291,7 +7291,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7307,7 +7307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7323,7 +7323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7339,7 +7339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7355,7 +7355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7371,7 +7371,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -7387,7 +7387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7403,7 +7403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7419,7 +7419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7451,7 +7451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7483,7 +7483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7499,7 +7499,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7515,7 +7515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7531,7 +7531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7547,7 +7547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7563,7 +7563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7579,7 +7579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7595,7 +7595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7611,7 +7611,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7627,7 +7627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7643,7 +7643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7659,7 +7659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7675,7 +7675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7691,7 +7691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7707,7 +7707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7723,7 +7723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7739,7 +7739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7755,7 +7755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7803,7 +7803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7819,7 +7819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7899,7 +7899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7931,7 +7931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7947,7 +7947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -7963,7 +7963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -7995,7 +7995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8027,7 +8027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8043,7 +8043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8059,7 +8059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8075,7 +8075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8091,7 +8091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8107,7 +8107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8139,7 +8139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8171,7 +8171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8187,7 +8187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8219,7 +8219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8251,7 +8251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8267,7 +8267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8283,7 +8283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8315,7 +8315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8347,7 +8347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8363,7 +8363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8379,7 +8379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8395,7 +8395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8411,7 +8411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8427,7 +8427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8459,7 +8459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8491,7 +8491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8507,7 +8507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8539,7 +8539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8555,7 +8555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8571,7 +8571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8587,7 +8587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8603,7 +8603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8619,7 +8619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8651,7 +8651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8667,7 +8667,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8683,7 +8683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8699,7 +8699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8715,7 +8715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8747,7 +8747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8779,7 +8779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8795,7 +8795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8811,7 +8811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8827,7 +8827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8843,7 +8843,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8859,7 +8859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8875,7 +8875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8891,7 +8891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8923,7 +8923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8955,7 +8955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -8971,7 +8971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9003,7 +9003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9019,7 +9019,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9035,7 +9035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9051,7 +9051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9067,7 +9067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9099,7 +9099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9147,7 +9147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9163,7 +9163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9179,7 +9179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9195,7 +9195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9243,7 +9243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9259,7 +9259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9275,7 +9275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9307,7 +9307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9323,7 +9323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9339,7 +9339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9355,7 +9355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9387,7 +9387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9403,7 +9403,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -9419,7 +9419,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9435,7 +9435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9451,7 +9451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9483,7 +9483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9531,7 +9531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9547,7 +9547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9563,7 +9563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9579,7 +9579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9611,7 +9611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9643,7 +9643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9659,7 +9659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9675,7 +9675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9707,7 +9707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9723,7 +9723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9739,7 +9739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9755,7 +9755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9787,7 +9787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9803,7 +9803,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9819,7 +9819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9851,7 +9851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9883,7 +9883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9915,7 +9915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9931,7 +9931,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9947,7 +9947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -9979,7 +9979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10011,7 +10011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10027,7 +10027,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10059,7 +10059,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10075,7 +10075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10107,7 +10107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10123,7 +10123,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10139,7 +10139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10155,7 +10155,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -10171,7 +10171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10187,7 +10187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10203,7 +10203,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10219,7 +10219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10235,7 +10235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10267,7 +10267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10283,7 +10283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10299,7 +10299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10315,7 +10315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10331,7 +10331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10347,7 +10347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10363,7 +10363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10379,7 +10379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10411,7 +10411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10427,7 +10427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10443,7 +10443,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10459,7 +10459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10475,7 +10475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10491,7 +10491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10507,7 +10507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10539,7 +10539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10555,7 +10555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10571,7 +10571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10587,7 +10587,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10603,7 +10603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10619,7 +10619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10635,7 +10635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10651,7 +10651,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10683,7 +10683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10699,7 +10699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10715,7 +10715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10731,7 +10731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10747,7 +10747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10763,7 +10763,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10795,7 +10795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10811,7 +10811,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -10827,7 +10827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10843,7 +10843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10859,7 +10859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10891,7 +10891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10923,7 +10923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10939,7 +10939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -10955,7 +10955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10971,7 +10971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11003,7 +11003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11035,7 +11035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11051,7 +11051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11067,7 +11067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11083,7 +11083,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11115,7 +11115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11131,7 +11131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11147,7 +11147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11179,7 +11179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11211,7 +11211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11243,7 +11243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11259,7 +11259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11275,7 +11275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11307,7 +11307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11339,7 +11339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11371,7 +11371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11387,7 +11387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11403,7 +11403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11435,7 +11435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11451,7 +11451,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11467,7 +11467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11483,7 +11483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11499,7 +11499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11531,7 +11531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11547,7 +11547,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11563,7 +11563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11595,7 +11595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11611,7 +11611,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11627,7 +11627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11643,7 +11643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11659,7 +11659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11675,7 +11675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11707,7 +11707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11739,7 +11739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11755,7 +11755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11787,7 +11787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11803,7 +11803,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11819,7 +11819,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11835,7 +11835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11851,7 +11851,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11867,7 +11867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11883,7 +11883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11899,7 +11899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11915,7 +11915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11931,7 +11931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11947,7 +11947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11963,7 +11963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11979,7 +11979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -11995,7 +11995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12011,7 +12011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12043,7 +12043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12059,7 +12059,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -12075,7 +12075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12091,7 +12091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -12107,7 +12107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12123,7 +12123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12139,7 +12139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12155,7 +12155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12171,7 +12171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12187,7 +12187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12203,7 +12203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12219,7 +12219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12251,7 +12251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12267,7 +12267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12283,7 +12283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12299,7 +12299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12331,7 +12331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12347,7 +12347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12363,7 +12363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12379,7 +12379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12395,7 +12395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12427,7 +12427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12459,7 +12459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12475,7 +12475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12491,7 +12491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12507,7 +12507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12539,7 +12539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12555,7 +12555,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -12571,7 +12571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12587,7 +12587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12603,7 +12603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12619,7 +12619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12635,7 +12635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12667,7 +12667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12683,7 +12683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12699,7 +12699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12715,7 +12715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12731,7 +12731,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12747,7 +12747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12763,7 +12763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12779,7 +12779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12811,7 +12811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12827,7 +12827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12843,7 +12843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12859,7 +12859,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12891,7 +12891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12907,7 +12907,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -12923,7 +12923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12939,7 +12939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -12955,7 +12955,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -12987,7 +12987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13019,7 +13019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13035,7 +13035,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13051,7 +13051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13067,7 +13067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13099,7 +13099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13115,7 +13115,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -13131,7 +13131,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13147,7 +13147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13163,7 +13163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13179,7 +13179,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13195,7 +13195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13227,7 +13227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13243,7 +13243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13259,7 +13259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13275,7 +13275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13291,7 +13291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13307,7 +13307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13323,7 +13323,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13339,7 +13339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13355,7 +13355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13371,7 +13371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13403,7 +13403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13419,7 +13419,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13435,7 +13435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13451,7 +13451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13467,7 +13467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13483,7 +13483,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13499,7 +13499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13515,7 +13515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13531,7 +13531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13563,7 +13563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13579,7 +13579,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13595,7 +13595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13611,7 +13611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13627,7 +13627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13643,7 +13643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13659,7 +13659,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13675,7 +13675,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13691,7 +13691,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13707,7 +13707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13723,7 +13723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13739,7 +13739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13755,7 +13755,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13771,7 +13771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13787,7 +13787,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13803,7 +13803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13835,7 +13835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13851,7 +13851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -13867,7 +13867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13883,7 +13883,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13899,7 +13899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13915,7 +13915,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13947,7 +13947,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13963,7 +13963,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -13979,7 +13979,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -13995,7 +13995,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -14011,7 +14011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14043,7 +14043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14075,7 +14075,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14091,7 +14091,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14107,7 +14107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14123,7 +14123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14155,7 +14155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14171,7 +14171,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14187,7 +14187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14203,7 +14203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14219,7 +14219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14251,7 +14251,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14283,7 +14283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14299,7 +14299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14315,7 +14315,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14331,7 +14331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14347,7 +14347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14363,7 +14363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14395,7 +14395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14411,7 +14411,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14427,7 +14427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14443,7 +14443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14475,7 +14475,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14491,7 +14491,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14507,7 +14507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14523,7 +14523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14539,7 +14539,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14555,7 +14555,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14571,7 +14571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14587,7 +14587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14603,7 +14603,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14619,7 +14619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14635,7 +14635,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14667,7 +14667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14683,7 +14683,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14699,7 +14699,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14715,7 +14715,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14731,7 +14731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14747,7 +14747,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14763,7 +14763,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14779,7 +14779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14795,7 +14795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14811,7 +14811,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14827,7 +14827,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -14843,7 +14843,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14859,7 +14859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14875,7 +14875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14891,7 +14891,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -14907,7 +14907,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14939,7 +14939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14955,7 +14955,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -14971,7 +14971,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -14987,7 +14987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15003,7 +15003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15019,7 +15019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15035,7 +15035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15051,7 +15051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15067,7 +15067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15099,7 +15099,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15115,7 +15115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15131,7 +15131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15147,7 +15147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15163,7 +15163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15179,7 +15179,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15195,7 +15195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15211,7 +15211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15227,7 +15227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15243,7 +15243,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15259,7 +15259,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15275,7 +15275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15291,7 +15291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15307,7 +15307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15323,7 +15323,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15339,7 +15339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15355,7 +15355,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15371,7 +15371,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15387,7 +15387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15403,7 +15403,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15419,7 +15419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15435,7 +15435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15467,7 +15467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15483,7 +15483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15499,7 +15499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15515,7 +15515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15531,7 +15531,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15563,7 +15563,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15579,7 +15579,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15595,7 +15595,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15611,7 +15611,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15627,7 +15627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15659,7 +15659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15675,7 +15675,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15691,7 +15691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15707,7 +15707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15723,7 +15723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15739,7 +15739,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15755,7 +15755,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15771,7 +15771,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15787,7 +15787,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15803,7 +15803,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15819,7 +15819,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -15835,7 +15835,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15851,7 +15851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15867,7 +15867,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15883,7 +15883,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15899,7 +15899,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15931,7 +15931,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15947,7 +15947,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -15963,7 +15963,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -15979,7 +15979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -15995,7 +15995,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16011,7 +16011,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16027,7 +16027,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16043,7 +16043,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16059,7 +16059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16091,7 +16091,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -16107,7 +16107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16123,7 +16123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16139,7 +16139,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16155,7 +16155,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16171,7 +16171,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -16187,7 +16187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16203,7 +16203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16219,7 +16219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16235,7 +16235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16251,7 +16251,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -16267,7 +16267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16283,7 +16283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16299,7 +16299,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16315,7 +16315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16331,7 +16331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16347,7 +16347,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16363,7 +16363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16379,7 +16379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16395,7 +16395,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -16411,7 +16411,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -16443,7 +16443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16539,7 +16539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -16571,7 +16571,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_vb.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_vb.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2571,7 +2571,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -2587,7 +2587,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -2907,7 +2907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2955,7 +2955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3163,7 +3163,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_xml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_xml.json
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1915,7 +1915,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2107,7 +2107,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2203,7 +2203,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2235,7 +2235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2363,7 +2363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2395,7 +2395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2459,7 +2459,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2475,7 +2475,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2491,7 +2491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.quoted.double.xml: #0F4A85",
 			"light_modern": "string.quoted.double.xml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.quoted.double.xml: #0000FF"
 		}
 	},
@@ -2555,7 +2555,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_yaml.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_yaml.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity: #6CB6FF",
+			"2026-dark": "entity: #79C0FF",
 			"2026-light": "entity: #0550AE"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "punctuation.definition.comment: #768390",
+			"2026-dark": "punctuation.definition.comment: #8B949E",
 			"2026-light": "punctuation.definition.comment: #6E7781"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -667,7 +667,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -907,7 +907,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -923,7 +923,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1019,7 +1019,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1035,7 +1035,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.in.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.in.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.in.yaml: #0000FF"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1131,7 +1131,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1147,7 +1147,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1227,7 +1227,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1259,7 +1259,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1291,7 +1291,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -1307,7 +1307,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1355,7 +1355,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -1419,7 +1419,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1435,7 +1435,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1467,7 +1467,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.in.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.in.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.in.yaml: #0000FF"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.in.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.in.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.in.yaml: #0000FF"
 		}
 	},
@@ -1547,7 +1547,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "invalid: #F44747",
 			"hc_light": "invalid: #B5200D",
 			"light_modern": "invalid: #CD3131",
-			"2026-dark": "invalid.illegal: #FF938A",
+			"2026-dark": "invalid.illegal: #FFA198",
 			"2026-light": "invalid.illegal: #82071E"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -1611,7 +1611,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "meta.block: #ADBAC7",
+			"2026-dark": "meta.block: #C9D1D9",
 			"2026-light": "meta.block: #1F2328"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string.unquoted.plain.out.yaml: #0F4A85",
 			"light_modern": "string.unquoted.plain.out.yaml: #0000FF",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string.unquoted.plain.out.yaml: #0000FF"
 		}
 	}

--- a/extensions/vscode-colorize-tests/test/colorize-results/tsconfig_off_json.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/tsconfig_off_json.json
@@ -43,7 +43,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "support.type.property-name: #9CDCFE",
 			"hc_light": "support.type.property-name.json: #0451A5",
 			"light_modern": "support.type.property-name.json: #0451A5",
-			"2026-dark": "support.type.property-name.json: #8DDB8C",
+			"2026-dark": "support.type.property-name.json: #7EE787",
 			"2026-light": "support.type.property-name.json: #116329"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-241001_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-241001_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -955,7 +955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1099,7 +1099,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1211,7 +1211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1275,7 +1275,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1339,7 +1339,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1451,7 +1451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1659,7 +1659,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1755,7 +1755,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1803,7 +1803,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1883,7 +1883,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1899,7 +1899,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1947,7 +1947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2299,7 +2299,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-function-inv_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-function-inv_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue11_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue11_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -795,7 +795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -971,7 +971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1051,7 +1051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1115,7 +1115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1387,7 +1387,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1515,7 +1515,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1707,7 +1707,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1723,7 +1723,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2379,7 +2379,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2523,7 +2523,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2715,7 +2715,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2875,7 +2875,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2987,7 +2987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3515,7 +3515,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue241715_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue241715_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -603,7 +603,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -827,7 +827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -859,7 +859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -987,7 +987,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1179,7 +1179,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1195,7 +1195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1371,7 +1371,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1499,7 +1499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -1531,7 +1531,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1579,7 +1579,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1595,7 +1595,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -1627,7 +1627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1691,7 +1691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1787,7 +1787,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -1819,7 +1819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1851,7 +1851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1979,7 +1979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2043,7 +2043,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2075,7 +2075,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2427,7 +2427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -2683,7 +2683,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2843,7 +2843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3067,7 +3067,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3195,7 +3195,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3435,7 +3435,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3451,7 +3451,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3643,7 +3643,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3755,7 +3755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3819,7 +3819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4075,7 +4075,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4187,7 +4187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4363,7 +4363,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4411,7 +4411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4555,7 +4555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5147,7 +5147,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5387,7 +5387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5419,7 +5419,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5451,7 +5451,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -5499,7 +5499,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5431_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5431_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -443,7 +443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5465_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5465_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5566_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-issue5566_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-jsdoc-multiline-type_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-jsdoc-multiline-type_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-keywords_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-keywords_ts.json
@@ -27,7 +27,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-members_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-members_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-object-literals_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-object-literals_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-strings_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-strings_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -491,7 +491,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -555,7 +555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "string variable: #6CB6FF",
+			"2026-dark": "string variable: #79C0FF",
 			"2026-light": "string variable: #0550AE"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-this_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-this_ts.json
@@ -27,7 +27,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-variables_css.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test-variables_css.json
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_css.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_css.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -107,7 +107,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -267,7 +267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -891,7 +891,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -1067,7 +1067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3915,7 +3915,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -3947,7 +3947,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7771,7 +7771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8411,7 +8411,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8427,7 +8427,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -8443,7 +8443,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9147,7 +9147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9691,7 +9691,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9707,7 +9707,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -9723,7 +9723,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -10315,7 +10315,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -10347,7 +10347,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},
@@ -10459,7 +10459,7 @@
 			"dark_modern": "entity.name.tag: #569CD6",
 			"hc_light": "entity.name.tag: #0F4A85",
 			"light_modern": "entity.name.tag: #800000",
-			"2026-dark": "entity.name.tag: #8DDB8C",
+			"2026-dark": "entity.name.tag: #7EE787",
 			"2026-light": "entity.name.tag: #116329"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_ini.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_ini.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "default: #CCCCCC",
 			"hc_light": "default: #292929",
 			"light_modern": "default: #3B3B3B",
-			"2026-dark": "entity.name: #F69D50",
+			"2026-dark": "entity.name: #FFA657",
 			"2026-light": "entity.name: #953800"
 		}
 	},
@@ -219,7 +219,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -331,7 +331,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_regexp.ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_regexp.ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -59,7 +59,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -75,7 +75,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -123,7 +123,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -139,7 +139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -171,7 +171,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -187,7 +187,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -203,7 +203,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -251,7 +251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -283,7 +283,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -299,7 +299,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -347,7 +347,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -363,7 +363,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -395,7 +395,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -427,7 +427,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -459,7 +459,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -507,7 +507,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -523,7 +523,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -571,7 +571,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -587,7 +587,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -635,7 +635,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -699,7 +699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -731,7 +731,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -763,7 +763,7 @@
 			"dark_modern": "string.regexp: #D16969",
 			"hc_light": "string.regexp: #811F3F",
 			"light_modern": "string.regexp: #811F3F",
-			"2026-dark": "string.regexp: #96D0FF",
+			"2026-dark": "string.regexp: #A5D6FF",
 			"2026-light": "string.regexp: #0A3069"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "keyword: #569CD6",
 			"hc_light": "keyword: #0F4A85",
 			"light_modern": "keyword: #0000FF",
-			"2026-dark": "keyword: #F47067",
+			"2026-dark": "keyword: #FF7B72",
 			"2026-light": "keyword: #CF222E"
 		}
 	},

--- a/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_ts.json
+++ b/extensions/vscode-colorize-tests/test/colorize-tree-sitter-results/test_ts.json
@@ -11,7 +11,7 @@
 			"dark_modern": "comment: #6A9955",
 			"hc_light": "comment: #515151",
 			"light_modern": "comment: #008000",
-			"2026-dark": "comment: #768390",
+			"2026-dark": "comment: #8B949E",
 			"2026-light": "comment: #6E7781"
 		}
 	},
@@ -27,7 +27,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -43,7 +43,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -91,7 +91,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -155,7 +155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -235,7 +235,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -315,7 +315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -379,7 +379,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -411,7 +411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -475,7 +475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -539,7 +539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -619,7 +619,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -651,7 +651,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -683,7 +683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -715,7 +715,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -747,7 +747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -779,7 +779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -811,7 +811,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -843,7 +843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -875,7 +875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -939,7 +939,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1003,7 +1003,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1083,7 +1083,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1163,7 +1163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1243,7 +1243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1323,7 +1323,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1403,7 +1403,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1483,7 +1483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1563,7 +1563,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1643,7 +1643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1675,7 +1675,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -1739,7 +1739,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1771,7 +1771,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1835,7 +1835,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1867,7 +1867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1931,7 +1931,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -1963,7 +1963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -1995,7 +1995,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2011,7 +2011,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2027,7 +2027,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2059,7 +2059,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2091,7 +2091,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2123,7 +2123,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2139,7 +2139,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2155,7 +2155,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2187,7 +2187,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2219,7 +2219,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2251,7 +2251,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2267,7 +2267,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2283,7 +2283,7 @@
 			"dark_modern": "string: #CE9178",
 			"hc_light": "string: #0F4A85",
 			"light_modern": "string: #A31515",
-			"2026-dark": "string: #96D0FF",
+			"2026-dark": "string: #A5D6FF",
 			"2026-light": "string: #0A3069"
 		}
 	},
@@ -2315,7 +2315,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2347,7 +2347,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2411,7 +2411,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2443,7 +2443,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2507,7 +2507,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2539,7 +2539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2603,7 +2603,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2635,7 +2635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -2667,7 +2667,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2699,7 +2699,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2763,7 +2763,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -2795,7 +2795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2891,7 +2891,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -2971,7 +2971,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3003,7 +3003,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3051,7 +3051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3115,7 +3115,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3147,7 +3147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3179,7 +3179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3211,7 +3211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3243,7 +3243,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3307,7 +3307,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3339,7 +3339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3387,7 +3387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3499,7 +3499,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3595,7 +3595,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3627,7 +3627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3659,7 +3659,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3691,7 +3691,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -3739,7 +3739,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3803,7 +3803,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -3835,7 +3835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3867,7 +3867,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -3899,7 +3899,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -3931,7 +3931,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -3963,7 +3963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4011,7 +4011,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -4043,7 +4043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4091,7 +4091,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4123,7 +4123,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4155,7 +4155,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4219,7 +4219,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4251,7 +4251,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4283,7 +4283,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4379,7 +4379,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4443,7 +4443,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4475,7 +4475,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4507,7 +4507,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4587,7 +4587,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4619,7 +4619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4699,7 +4699,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4731,7 +4731,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4811,7 +4811,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4827,7 +4827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4859,7 +4859,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -4891,7 +4891,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -4923,7 +4923,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -4971,7 +4971,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -4987,7 +4987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5035,7 +5035,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5067,7 +5067,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5099,7 +5099,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5131,7 +5131,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5163,7 +5163,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5195,7 +5195,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5227,7 +5227,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5307,7 +5307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5371,7 +5371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5435,7 +5435,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5467,7 +5467,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5579,7 +5579,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5643,7 +5643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -5675,7 +5675,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5755,7 +5755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5819,7 +5819,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -5851,7 +5851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -5931,7 +5931,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -5947,7 +5947,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6043,7 +6043,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6059,7 +6059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6139,7 +6139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6203,7 +6203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6299,7 +6299,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -6315,7 +6315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6395,7 +6395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6459,7 +6459,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6555,7 +6555,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6619,7 +6619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6747,7 +6747,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -6779,7 +6779,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -6811,7 +6811,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6843,7 +6843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6875,7 +6875,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6907,7 +6907,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -6939,7 +6939,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -6971,7 +6971,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7035,7 +7035,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7147,7 +7147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7211,7 +7211,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -7243,7 +7243,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7307,7 +7307,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7419,7 +7419,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7483,7 +7483,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7547,7 +7547,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7579,7 +7579,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -7611,7 +7611,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7643,7 +7643,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7675,7 +7675,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -7707,7 +7707,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7803,7 +7803,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -7835,7 +7835,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7867,7 +7867,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7915,7 +7915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -7963,7 +7963,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8027,7 +8027,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8059,7 +8059,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8107,7 +8107,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8123,7 +8123,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8235,7 +8235,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8251,7 +8251,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8315,7 +8315,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8347,7 +8347,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -8379,7 +8379,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8411,7 +8411,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8475,7 +8475,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8491,7 +8491,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8603,7 +8603,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -8619,7 +8619,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8683,7 +8683,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8715,7 +8715,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -8747,7 +8747,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8779,7 +8779,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -8843,7 +8843,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -8875,7 +8875,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8907,7 +8907,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8955,7 +8955,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -8987,7 +8987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9019,7 +9019,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9147,7 +9147,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -9179,7 +9179,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9211,7 +9211,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9291,7 +9291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9355,7 +9355,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -9387,7 +9387,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9499,7 +9499,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9531,7 +9531,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9595,7 +9595,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9627,7 +9627,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9659,7 +9659,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9691,7 +9691,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9723,7 +9723,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9755,7 +9755,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9787,7 +9787,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9819,7 +9819,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9851,7 +9851,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9883,7 +9883,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9915,7 +9915,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -9947,7 +9947,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -9979,7 +9979,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10011,7 +10011,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -10043,7 +10043,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10075,7 +10075,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10107,7 +10107,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10139,7 +10139,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10171,7 +10171,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10203,7 +10203,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10235,7 +10235,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10267,7 +10267,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10299,7 +10299,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10331,7 +10331,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10363,7 +10363,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10395,7 +10395,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10443,7 +10443,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10475,7 +10475,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10507,7 +10507,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10539,7 +10539,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10571,7 +10571,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10603,7 +10603,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10635,7 +10635,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10667,7 +10667,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10699,7 +10699,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10731,7 +10731,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10763,7 +10763,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10795,7 +10795,7 @@
 			"dark_modern": "entity.name.function: #DCDCAA",
 			"hc_light": "entity.name.function: #5E2CBC",
 			"light_modern": "entity.name.function: #795E26",
-			"2026-dark": "entity.name.function: #DCBDFB",
+			"2026-dark": "entity.name.function: #D2A8FF",
 			"2026-light": "entity.name.function: #8250DF"
 		}
 	},
@@ -10827,7 +10827,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10859,7 +10859,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10891,7 +10891,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -10923,7 +10923,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -10955,7 +10955,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -10987,7 +10987,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11019,7 +11019,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11051,7 +11051,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11083,7 +11083,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11115,7 +11115,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11147,7 +11147,7 @@
 			"dark_modern": "variable.language: #569CD6",
 			"hc_light": "variable.language: #0F4A85",
 			"light_modern": "variable.language: #0000FF",
-			"2026-dark": "variable.language: #6CB6FF",
+			"2026-dark": "variable.language: #79C0FF",
 			"2026-light": "variable.language: #0550AE"
 		}
 	},
@@ -11179,7 +11179,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11275,7 +11275,7 @@
 			"dark_modern": "storage.type: #569CD6",
 			"hc_light": "storage.type: #0F4A85",
 			"light_modern": "storage.type: #0000FF",
-			"2026-dark": "storage.type: #F47067",
+			"2026-dark": "storage.type: #FF7B72",
 			"2026-light": "storage.type: #CF222E"
 		}
 	},
@@ -11291,7 +11291,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},
@@ -11339,7 +11339,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable.other: #ADBAC7",
+			"2026-dark": "variable.other: #C9D1D9",
 			"2026-light": "variable.other: #1F2328"
 		}
 	},
@@ -11371,7 +11371,7 @@
 			"dark_modern": "variable: #9CDCFE",
 			"hc_light": "variable: #001080",
 			"light_modern": "variable: #001080",
-			"2026-dark": "variable: #F69D50",
+			"2026-dark": "variable: #FFA657",
 			"2026-light": "variable: #953800"
 		}
 	},


### PR DESCRIPTION
Enhance the visibility of various elements in the 2026 Dark theme by updating color settings. Adjustments improve readability and user experience. Testing involves reviewing the theme in the editor to ensure colors are distinct and accessible.

