### PR TITLE
Center agent feedback widget header on start line

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -413,9 +413,10 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 
 		const widgetWidth = getTotalWidth(this._domNode) || 280;
 		const widgetHeight = this._domNode.offsetHeight || 0;
+		const headerHeight = this._headerNode.offsetHeight || lineHeight;
 
-		// Compute content-relative top and clamp to keep the widget within the editor content area
-		const contentRelativeTop = this._editor.getTopForLineNumber(startLineNumber) - lineHeight;
+		// Align the header center with the start line center before clamping within the editor content area.
+		const contentRelativeTop = this._editor.getTopForLineNumber(startLineNumber) + (lineHeight - headerHeight) / 2;
 		const scrollHeight = this._editor.getScrollHeight();
 		const clampedContentTop = Math.min(Math.max(0, contentRelativeTop), Math.max(0, scrollHeight - widgetHeight));
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
+++ b/src/vs/sessions/contrib/agentFeedback/browser/media/agentFeedbackEditorWidget.css
@@ -36,7 +36,7 @@
 .agent-feedback-widget-arrow {
 	position: absolute;
 	left: -8px;
-	top: 12px;
+	top: 9px;
 	width: 0;
 	height: 0;
 	border-top: 8px solid transparent;


### PR DESCRIPTION
## Summary

Fixes the vertical positioning of the agent feedback editor widget so the **center of the header** aligns with the **center of the start line**, instead of placing the widget top one full line above.

## Changes

**`agentFeedbackEditorWidgetContribution.ts`** — Updated `layout()` positioning math:
- Old: `getTopForLineNumber(startLineNumber) - lineHeight` (shifted widget up by one line)
- New: `getTopForLineNumber(startLineNumber) + (lineHeight - headerHeight) / 2` (centers the header on the line)
- Measures actual `_headerNode.offsetHeight` for accuracy

**`agentFeedbackEditorWidget.css`** — Adjusted the arrow pointer `top` from `12px` → `9px` to match the updated header alignment.