### PR TITLE
Increase opacity of inactive titlebar elements for improved visibility

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -148,7 +148,7 @@
 }
 
 .monaco-workbench .part.titlebar.inactive > * {
-	opacity: 0.3;
+	opacity: 0.6;
 }
 
 .monaco-workbench .part.titlebar > .titlebar-container > .titlebar-center > .window-title > .command-center > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item > .action-label,


### PR DESCRIPTION
Enhance the visibility of inactive titlebar elements by increasing their opacity from 0.3 to 0.6. This change improves the overall user experience by making inactive elements more distinguishable.

