### PR TITLE
prevent question carousel scrollbar overflow in split editors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart.ts
@@ -395,6 +395,12 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 			scrollableContent.style.height = constrainedScrollableHeightPx;
 			scrollableContent.style.maxHeight = constrainedScrollableHeightPx;
 		}
+		inputScrollable.setScrollDimensions({
+			width: scrollableContent.clientWidth,
+			scrollWidth: scrollableContent.scrollWidth,
+			height: constrainedScrollableHeight,
+			scrollHeight: contentScrollableHeight
+		});
 		inputScrollable.scanDomNode();
 	}
 
@@ -628,7 +634,7 @@ export class ChatQuestionCarouselPart extends Disposable implements IChatContent
 		this.renderInput(inputContainer, question);
 
 		const inputScrollable = questionRenderStore.add(new DomScrollableElement(inputContainer, {
-			vertical: ScrollbarVisibility.Visible,
+			vertical: ScrollbarVisibility.Auto,
 			horizontal: ScrollbarVisibility.Hidden,
 			consumeMouseWheelIfScrollbarIsNeeded: true,
 		}));


### PR DESCRIPTION
fixes #301249

Changed my mind, don't think this is a candidate.

https://github.com/user-attachments/assets/20979552-d752-46eb-a885-d85a6b598d90

