### PR TITLE
fix: wait for file system provider in McpResourceManagementService.initialize()

### DIFF
--- a/src/vs/platform/mcp/common/mcpManagementService.ts
+++ b/src/vs/platform/mcp/common/mcpManagementService.ts
@@ -16,7 +16,7 @@ import { URI } from '../../../base/common/uri.js';
 import { localize } from '../../../nls.js';
 import { ConfigurationTarget } from '../../configuration/common/configuration.js';
 import { IEnvironmentService } from '../../environment/common/environment.js';
-import { IFileService } from '../../files/common/files.js';
+import { IFileService, whenProviderRegistered } from '../../files/common/files.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
 import { ILogService } from '../../log/common/log.js';
 import { IUriIdentityService } from '../../uriIdentity/common/uriIdentity.js';
@@ -341,6 +341,7 @@ export abstract class AbstractMcpResourceManagementService extends AbstractCommo
 	private initialize(): Promise<void> {
 		if (!this.initializePromise) {
 			this.initializePromise = (async () => {
+				await whenProviderRegistered(this.mcpResource, this.fileService);
 				try {
 					this.local = await this.populateLocalServers();
 				} finally {

--- a/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
+++ b/src/vs/platform/mcp/test/common/mcpManagementService.test.ts
@@ -1189,4 +1189,39 @@ suite('McpResourceManagementService', () => {
 		assert.strictEqual(updateCount, 1);
 		assert.deepStrictEqual(updated[0].rootSandbox, updatedSandbox);
 	});
+
+	test('waits for file system provider before reading servers', async () => {
+		const customScheme = 'test-remote';
+		const remoteMcpResource = URI.from({ scheme: customScheme, path: '/workspace/.vscode/mcp.json' });
+
+		const remoteFileService = disposables.add(new FileService(new NullLogService()));
+		const uriIdentityService = disposables.add(new UriIdentityService(remoteFileService));
+		const scannerService = disposables.add(new McpResourceScannerService(remoteFileService, uriIdentityService));
+		const remoteService = disposables.add(new TestMcpResourceManagementService(remoteMcpResource, remoteFileService, uriIdentityService, scannerService));
+
+		// Call getInstalled() before the provider is registered - it should wait
+		const getInstalledPromise = remoteService.getInstalled();
+
+		// Write the config file to the provider before registering it,
+		// so data is available when whenProviderRegistered resolves
+		const provider = disposables.add(new InMemoryFileSystemProvider());
+		await provider.mkdir(URI.from({ scheme: customScheme, path: '/workspace' }));
+		await provider.mkdir(URI.from({ scheme: customScheme, path: '/workspace/.vscode' }));
+		await provider.writeFile(remoteMcpResource, VSBuffer.fromString(JSON.stringify({
+			servers: {
+				'remote-server': {
+					type: 'stdio',
+					command: 'node',
+					args: ['server.js']
+				}
+			}
+		}, null, '\t')).buffer, { create: true, overwrite: true, unlock: false, atomic: false });
+
+		// Register the provider - this unblocks whenProviderRegistered and populateLocalServers
+		disposables.add(remoteFileService.registerProvider(customScheme, provider));
+
+		const servers = await getInstalledPromise;
+		assert.strictEqual(servers.length, 1);
+		assert.strictEqual(servers[0].name, 'remote-server');
+	});
 });


### PR DESCRIPTION
AbstractMcpResourceManagementService.initialize() calls populateLocalServers() which reads the mcp.json config file. In remote scenarios, the file system provider for the resource's scheme may not yet be registered, causing an ENOPRO error.

Add await whenProviderRegistered() before reading to ensure the provider is available. Add a test that verifies getInstalled() waits for the provider.

Fixes #302287 
