### PR TITLE
build(next): include sessions built-in skills in desktop resources

### DIFF
--- a/build/next/index.ts
+++ b/build/next/index.ts
@@ -280,8 +280,9 @@ const desktopResourcePatterns = [
 	'vs/workbench/browser/parts/editor/media/*.png',
 	'vs/workbench/contrib/debug/browser/media/*.png',
 
-	// Sessions - built-in prompts
+	// Sessions - built-in prompts and skills
 	'vs/sessions/prompts/*.prompt.md',
+	'vs/sessions/skills/**/SKILL.md',
 ];
 
 // Resources for server target (minimal - no UI)


### PR DESCRIPTION
## Summary
Adds the missing sessions skills resource pattern to the next build pipeline so built-in `SKILL.md` files are copied into the desktop output.

## Problem
`AgenticPromptsService` resolves built-in skills from `vs/sessions/skills`, but `build/next/index.ts` only copied `vs/sessions/prompts/*.prompt.md`. This made built-in skills unavailable at runtime in next-build artifacts.

## Change
- add `vs/sessions/skills/**/SKILL.md` to `desktopResourcePatterns` in `build/next/index.ts`

## Validation
- `npm run compile-check-ts-native`
