### PR TITLE
fix: enrich notebook model index error diagnostics and fix sort comparator (#301207)

### DIFF
--- a/.github/prompts/fix-error.prompt.md
+++ b/.github/prompts/fix-error.prompt.md
@@ -15,3 +15,23 @@ Follow the `fix-errors` skill guidelines to fix this error. Key principles:
 4. **If the producer is identifiable**, fix it directly.
 
 After making changes, check for compilation errors via the build task and run relevant unit tests.
+
+## Submitting the Fix
+
+After the fix is validated (compilation clean, tests pass):
+
+1. **Create a branch**: `git checkout -b <github-username>/<short-description>` (e.g., `bryanchen-d/fix-notebook-index-error`).
+2. **Commit**: Stage changed files and commit with a message like `fix: <brief description> (#<issue-number>)`.
+3. **Push**: `git push -u origin <branch-name>`.
+4. **Create a draft PR** with a description that includes:
+   - A summary of the change.
+   - What scenarios may trigger the error.
+   - The code flow explaining why the error gets thrown and goes unhandled.
+   - Steps a user can follow to manually validate the fix.
+   - How the fix addresses the issue, with a brief note per changed file.
+5. **Monitor the PR** for Copilot review comments. Wait 1-2 minutes after each push for Copilot to leave its review, then check for new comments. Evaluate each comment:
+   - If valid, apply the fix, amend the commit, and force-push.
+   - If not applicable, leave a reply explaining why.
+   - After addressing comments, update the PR description if the changes affect the summary, code flow explanation, or per-file notes.
+6. **Repeat monitoring** after each force-push: wait 1-2 minutes, check for new Copilot comments, and address them. Continue this loop until no new comments appear.
+7. **Re-run tests** after addressing review comments to confirm nothing regressed.

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -679,7 +679,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 				cellIndex = edit.index;
 			} else if (hasKey(edit, { handle: true })) {
 				cellIndex = this._getCellIndexByHandle(edit.handle);
-				this._assertIndex(cellIndex);
+				this._assertIndex(cellIndex, `editType: ${edit.editType}, key: handle`);
 			} else if (hasKey(edit, { outputId: true })) {
 				cellIndex = this._getCellIndexWithOutputIdHandle(edit.outputId);
 				if (this._indexIsInvalid(cellIndex)) {
@@ -714,7 +714,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 				}
 
 				if (b.end === undefined) {
-					return -1;
+					return 1;
 				}
 
 				return b.end - a.end || b.originalIndex - a.originalIndex;
@@ -1298,9 +1298,9 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return true;
 	}
 
-	private _assertIndex(index: number) {
+	private _assertIndex(index: number, context?: string) {
 		if (this._indexIsInvalid(index)) {
-			throw new Error(`model index out of range ${index}`);
+			throw new Error(`model index out of range ${index} (cellCount: ${this._cells.length}${context ? `, ${context}` : ''})`);
 		}
 	}
 


### PR DESCRIPTION
Fixes #301207

## Problem

Unhandled error `model index out of range 11` in `NotebookTextModel._assertIndex` provides no diagnostic context — no cell count, no edit type, no indication of which lookup key produced the invalid index — making it difficult to determine the root cause from telemetry alone.

Additionally, the sort comparator in `_doApplyEdits` returned `-1` when `b.end === undefined` (DocumentMetadata edits), which incorrectly sorted them *after* cell-referencing edits instead of before them.

## Changes

1. **Enrich `_assertIndex` error message** — include `cellCount` and an optional `context` string so telemetry reports show the cell count and which edit type / lookup key triggered the failure.

2. **Pass context to `_assertIndex` in the handle-lookup branch** — so handle-based lookups also report diagnostic details.

3. **Fix sort comparator** — change `return -1` to `return 1` for the `b.end === undefined` case so DocumentMetadata edits (which have no cell index) sort before cell-referencing edits, matching the existing `a.end === undefined` branch.