### PR TITLE
WIP - Allow installPluginFromSource command to accept source and sha programmatically

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -60,11 +60,11 @@ class InstallFromSourceAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
+	async run(accessor: ServicesAccessor, args?: { source?: string; sha?: string }): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
 		const pluginInstallService = accessor.get(IPluginInstallService);
 
-		const source = await quickInputService.input({
+		const source = args?.source ?? await quickInputService.input({
 			placeHolder: localize('pluginSourcePlaceholder', "owner/repo or git clone URL"),
 			prompt: localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from"),
 		});
@@ -73,7 +73,7 @@ class InstallFromSourceAction extends Action2 {
 			return;
 		}
 
-		await pluginInstallService.installPluginFromSource(source.trim());
+		await pluginInstallService.installPluginFromSource(source.trim(), args?.sha);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -55,7 +55,7 @@ export class PluginInstallService implements IPluginInstallService {
 		return this._installGitPlugin(plugin);
 	}
 
-	async installPluginFromSource(source: string): Promise<void> {
+	async installPluginFromSource(source: string, sha?: string): Promise<void> {
 		const reference = parseMarketplaceReference(source);
 		if (!reference) {
 			this._notificationService.notify({
@@ -75,8 +75,8 @@ export class PluginInstallService implements IPluginInstallService {
 
 		// Build a source descriptor for the git clone.
 		const sourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
-			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo! }
-			: { kind: PluginSourceKind.GitUrl as const, url: reference.cloneUrl };
+			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo!, sha }
+			: { kind: PluginSourceKind.GitUrl as const, url: reference.cloneUrl, sha };
 
 		// Build a temporary plugin object for the trust gate and clone step.
 		const tempPlugin: IMarketplacePlugin = {

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
@@ -47,8 +47,11 @@ export interface IPluginInstallService {
 	 * GitHub shorthand (`owner/repo`) or a full git clone URL. Clones the
 	 * repository, reads marketplace metadata to discover plugins, and
 	 * registers the selected plugin.
+	 *
+	 * @param source A GitHub shorthand (`owner/repo`) or full git clone URL.
+	 * @param sha Optional commit SHA to pin the installation to a specific revision.
 	 */
-	installPluginFromSource(source: string): Promise<void>;
+	installPluginFromSource(source: string, sha?: string): Promise<void>;
 
 	/**
 	 * Pulls the latest changes for an already-cloned marketplace repository.


### PR DESCRIPTION
## Summary

The `workbench.action.chat.installPluginFromSource` command currently always prompts the user interactively. This PR adds an optional `args` parameter so extensions can invoke it programmatically with a specific source and commit SHA.

## Motivation

Extensions like C# Dev Kit want to programmatically install agent plugins (e.g. from `dotnet/skills`) at a known-good revision. Today there's no way to do this — the command always opens a quick input prompt, and the `installPluginFromSource` service method doesn't accept a SHA.

The underlying infrastructure already supports `ref` and `sha` on `IGitHubPluginSource` / `IGitUrlPluginSource`, and `_checkoutRevision` in `pluginSources.ts` already handles checking out to a specific commit. This PR simply threads that capability up to the command layer.

## Changes

- **`chatPluginActions.ts`**: `InstallFromSourceAction.run()` now accepts an optional `{ source?: string; sha?: string }` argument. When `source` is provided, it skips the interactive prompt. The `sha` is forwarded to the install service.
- **`pluginInstallService.ts` (common)**: Added optional `sha` parameter to the `installPluginFromSource` interface method.
- **`pluginInstallService.ts` (browser)**: Threads `sha` into the `sourceDescriptor` built for GitHub and GitUrl sources.

## Usage

```typescript
// Programmatic — install at a specific commit
await vscode.commands.executeCommand(
  'workbench.action.chat.installPluginFromSource',
  { source: 'dotnet/skills', sha: 'abc123def456' }
);

// Programmatic — install latest (no sha)
await vscode.commands.executeCommand(
  'workbench.action.chat.installPluginFromSource',
  { source: 'dotnet/skills' }
);

// Interactive — unchanged behavior (no args)
await vscode.commands.executeCommand(
  'workbench.action.chat.installPluginFromSource'
);
```

## Testing

- Without args: interactive prompt still appears (no regression)
- With `{ source }`: clones and installs without prompting
- With `{ source, sha }`: clones and checks out the specified commit
