### PR TITLE
SCM - Include stashes in the SCM history graph

### DIFF
--- a/extensions/git/src/historyProvider.ts
+++ b/extensions/git/src/historyProvider.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { CancellationToken, Disposable, Event, EventEmitter, FileDecoration, FileDecorationProvider, SourceControlHistoryItem, SourceControlHistoryItemChange, SourceControlHistoryOptions, SourceControlHistoryProvider, ThemeIcon, Uri, window, LogOutputChannel, SourceControlHistoryItemRef, l10n, SourceControlHistoryItemRefsChangeEvent, workspace, ConfigurationChangeEvent, Command, commands } from 'vscode';
+import { CancellationToken, Command, ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileDecoration, FileDecorationProvider, LogOutputChannel, SourceControlHistoryItem, SourceControlHistoryItemChange, SourceControlHistoryItemRef, SourceControlHistoryItemRefsChangeEvent, SourceControlHistoryOptions, SourceControlHistoryProvider, ThemeIcon, Uri, commands, l10n, window, workspace } from 'vscode';
 import { Repository, Resource } from './repository';
 import { IDisposable, deltaHistoryItemRefs, dispose, filterEvent, subject, truncate } from './util';
 import { toMultiFileDiffEditorUris } from './uri';
 import type { AvatarQuery, AvatarQueryCommit, Branch, LogOptions, Ref } from './api/git';
 import { RefType } from './api/git.constants';
 import { emojify, ensureEmojis } from './emoji';
-import { Commit } from './git';
+import { Commit, Stash } from './git';
 import { OperationKind, OperationResult } from './operation';
 import { ISourceControlHistoryItemDetailsProviderRegistry, provideSourceControlHistoryItemAvatar, provideSourceControlHistoryItemHoverCommands, provideSourceControlHistoryItemMessageLinks } from './historyItemDetailsProvider';
-import { throttle } from './decorators';
+import { sequentialize, throttle } from './decorators';
 import { getHistoryItemHover, getHoverCommitHashCommands, processHoverRemoteCommands } from './hover';
 
 function compareSourceControlHistoryItemRef(ref1: SourceControlHistoryItemRef, ref2: SourceControlHistoryItemRef): number {
@@ -25,6 +25,8 @@ function compareSourceControlHistoryItemRef(ref1: SourceControlHistoryItemRef, r
 			return 2;
 		} else if (ref.id.startsWith('refs/tags/')) {
 			return 3;
+		} else if (ref.id.startsWith('stash')) {
+			return 4;
 		}
 
 		return 99;
@@ -38,6 +40,14 @@ function compareSourceControlHistoryItemRef(ref1: SourceControlHistoryItemRef, r
 	}
 
 	return ref1.name.localeCompare(ref2.name);
+}
+
+function compareStashItemRef(ref1: SourceControlHistoryItemRef, ref2: SourceControlHistoryItemRef): number {
+	const getIndex = (id: string) => {
+		const match = id.match(/^stash@\{(\d+)\}$/);
+		return match ? parseInt(match[1], 10) : Number.MAX_SAFE_INTEGER;
+	};
+	return getIndex(ref1.id) - getIndex(ref2.id);
 }
 
 export class GitHistoryProvider implements SourceControlHistoryProvider, FileDecorationProvider, IDisposable {
@@ -61,6 +71,8 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 
 	private _HEAD: Branch | undefined;
 	private _historyItemRefs: SourceControlHistoryItemRef[] = [];
+	private _historyStashRefs: SourceControlHistoryItemRef[] = [];
+	private _stashRefsByHash = new Map<string, SourceControlHistoryItemRef>();
 
 	private commitShortHashLength = 7;
 	private historyItemDecorations = new Map<string, FileDecoration>();
@@ -104,9 +116,25 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 		const historyItemRefs = this.repository.refs
 			.map(ref => this.toSourceControlHistoryItemRef(ref))
 			.sort((a, b) => a.id.localeCompare(b.id));
-
-		const delta = deltaHistoryItemRefs(this._historyItemRefs, historyItemRefs);
+		const refDelta = deltaHistoryItemRefs(this._historyItemRefs, historyItemRefs);
 		this._historyItemRefs = historyItemRefs;
+
+		let historyStashRefs: SourceControlHistoryItemRef[] = this._historyStashRefs;
+		if (result.operation.kind === OperationKind.Stash) {
+			try {
+				historyStashRefs = await this.getAndSyncStashRefs();
+			} catch (err) {
+				this.logger.error(`[GitHistoryProvider][onDidRunWriteOperation] Failed to get stashes: ${err}`);
+			}
+		}
+		const stashDelta = deltaHistoryItemRefs(this._historyStashRefs, historyStashRefs);
+		this._historyStashRefs = historyStashRefs;
+
+		const delta = {
+			added: refDelta.added.concat(stashDelta.added),
+			modified: refDelta.modified.concat(stashDelta.modified),
+			removed: refDelta.removed.concat(stashDelta.removed)
+		};
 
 		let historyItemRefId = '';
 		let historyItemRefName = '';
@@ -243,7 +271,16 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 			}
 		}
 
-		return [...branches, ...remoteBranches, ...tags];
+		let stashes: SourceControlHistoryItemRef[] = this._historyStashRefs;
+		try {
+			stashes = await this.getAndSyncStashRefs();
+			this._historyStashRefs = stashes;
+		} catch (err) {
+			this.logger.error(`[GitHistoryProvider][provideHistoryItemRefs] Failed to get stashes: ${err}`);
+			stashes = this._historyStashRefs;
+		}
+
+		return [...branches, ...remoteBranches, ...tags, ...stashes];
 	}
 
 	async provideHistoryItems(options: SourceControlHistoryOptions, token: CancellationToken): Promise<SourceControlHistoryItem[]> {
@@ -271,9 +308,14 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 				logOptions = { ...logOptions, skip: options.skip };
 			}
 
-			const commits = typeof options.filterText === 'string' && options.filterText !== ''
+			const allCommits = typeof options.filterText === 'string' && options.filterText !== ''
 				? await this._searchHistoryItems(options.filterText.trim(), logOptions, token)
 				: await this.repository.log({ ...logOptions, silent: true }, token);
+
+			const gitStashIndexCommitFormat = /^index on .+: [a-f0-9]{7,} /;
+			const commits = allCommits.filter(commit => {
+				return !gitStashIndexCommitFormat.test(commit.message);
+			});
 
 			if (token.isCancellationRequested) {
 				return [];
@@ -535,6 +577,11 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 			}
 		}
 
+		const stashRef = this._stashRefsByHash.get(commit.hash);
+		if (stashRef) {
+			references.push(stashRef);
+		}
+
 		return references.sort(compareSourceControlHistoryItemRef);
 	}
 
@@ -574,6 +621,23 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 		return Array.from(commits.values()).slice(0, options.maxEntries ?? 50);
 	}
 
+	@sequentialize
+	private async getAndSyncStashRefs(): Promise<SourceControlHistoryItemRef[]> {
+		const gitStashes = await this.repository.getStashes();
+		this._stashRefsByHash.clear();
+
+		const stashRefs: SourceControlHistoryItemRef[] = [];
+		for (const stash of gitStashes) {
+			const stashRef = this.stashToSourceControlHistoryItemRef(stash);
+			this._stashRefsByHash.set(stash.hash, stashRef);
+			stashRefs.push(stashRef);
+		}
+
+		stashRefs.sort(compareStashItemRef);
+
+		return stashRefs;
+	}
+
 	private toSourceControlHistoryItemRef(ref: Ref): SourceControlHistoryItemRef {
 		switch (ref.type) {
 			case RefType.RemoteHead:
@@ -604,6 +668,17 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 					category: l10n.t('branches')
 				};
 		}
+	}
+
+	private stashToSourceControlHistoryItemRef(stash: Stash): SourceControlHistoryItemRef {
+		return {
+			id: `stash@{${stash.index}}`,
+			name: stash.description,
+			description: stash.branchName,
+			revision: stash.hash,
+			icon: new ThemeIcon('git-stash'),
+			category: l10n.t('stashes')
+		};
 	}
 
 	dispose(): void {

--- a/extensions/git/src/test/historyProvider.test.ts
+++ b/extensions/git/src/test/historyProvider.test.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import 'mocha';
+import * as sinon from 'sinon';
+import { CancellationToken, ConfigurationTarget, EventEmitter, LogOutputChannel, SourceControlHistoryItemRef, ThemeIcon, workspace } from 'vscode';
+import type { Branch, LogOptions, Ref, RefQuery } from '../api/git';
+import { RefType } from '../api/git.constants';
+import { Commit, Stash } from '../git';
+import { ISourceControlHistoryItemDetailsProviderRegistry } from '../historyItemDetailsProvider';
+import { OperationKind } from '../operation';
+import { GitHistoryProvider } from '../historyProvider';
+import { Repository } from '../repository';
+
+const mockLogger = {
+	trace: (_message: string, ..._args: any[]): void => { },
+	error: (_error: string | Error, ..._args: any[]): void => { }
+} as unknown as LogOutputChannel;
+
+const mockRegistry = {
+	getSourceControlHistoryItemDetailsProviders: () => [],
+	registerSourceControlHistoryItemDetailsProvider: () => ({ dispose: () => { } })
+} as unknown as ISourceControlHistoryItemDetailsProviderRegistry;
+
+type MockRepository = Repository & {
+	getStashes: sinon.SinonStub<[], Promise<Stash[]>>;
+	getRefs: sinon.SinonStub<[query?: RefQuery, cancellationToken?: CancellationToken], Promise<(Ref | Branch)[]>>;
+	log: sinon.SinonStub<[options?: LogOptions & { silent?: boolean }, cancellationToken?: CancellationToken], Promise<Commit[]>>;
+};
+
+suite(GitHistoryProvider.name, () => {
+	let mockRepository: MockRepository;
+	let gitHistoryProvider: GitHistoryProvider;
+	let onDidRunOperationEmitter: EventEmitter<any>;
+
+	setup(() => {
+		sinon.stub(workspace, 'getConfiguration').returns({
+			get: (_key: string, defaultValue?: any) => defaultValue,
+			has: (_: string) => { throw new Error('Not implemented.'); },
+			update: (_arg1: string, _arg2: any, _arg3?: ConfigurationTarget | boolean | null, _arg4?: boolean) => { throw new Error('Not implemented.'); },
+			inspect: (_: string) => { throw new Error('Not implemented.'); }
+		});
+
+		onDidRunOperationEmitter = new EventEmitter<any>();
+
+		mockRepository = {
+			refs: [{ name: 'main', type: RefType.Head, commit: 'abc1234' }],
+			root: '/test/repo',
+			HEAD: { name: 'main', type: RefType.Head, commit: 'abc1234' },
+			onDidRunOperation: onDidRunOperationEmitter.event,
+			getStashes: sinon.stub().resolves([]),
+			getRefs: sinon.stub().callsFake(() => Promise.resolve(mockRepository.refs)),
+			log: sinon.stub().resolves([])
+		} as MockRepository;
+
+		gitHistoryProvider = new GitHistoryProvider(mockRegistry, mockRepository, mockLogger);
+	});
+
+	teardown(() => {
+		gitHistoryProvider?.dispose();
+		sinon.restore();
+	});
+
+	suite('provideHistoryItemRefs', () => {
+		test('includes stashes', async () => {
+			const stashes = [
+				{ index: 0, hash: 'stash1', description: 'WIP: feature', branchName: 'main', parents: [] },
+				{ index: 1, hash: 'stash2', description: 'WIP: bugfix', branchName: 'main', parents: [] }
+			];
+			mockRepository.getStashes.resolves(stashes);
+
+			const historyItemRefs = await gitHistoryProvider.provideHistoryItemRefs(undefined);
+
+			const stashRefs = historyItemRefs.filter(ref => ref.id.startsWith('stash@{'));
+			assert.strictEqual(stashRefs.length, 2, 'Should have 2 stash refs');
+
+			const expectedStash0: SourceControlHistoryItemRef = {
+				id: 'stash@{0}',
+				name: 'WIP: feature',
+				description: 'main',
+				revision: 'stash1',
+				category: 'stashes',
+				icon: new ThemeIcon('git-stash')
+			};
+			const expectedStash1: SourceControlHistoryItemRef = {
+				id: 'stash@{1}',
+				name: 'WIP: bugfix',
+				description: 'main',
+				revision: 'stash2',
+				category: 'stashes',
+				icon: new ThemeIcon('git-stash')
+			};
+			assert.deepStrictEqual(stashRefs[0], expectedStash0);
+			assert.deepStrictEqual(stashRefs[1], expectedStash1);
+		});
+
+		test('stashes are sorted numerically by index', async () => {
+			const stashes = [
+				{ index: 12, hash: 'stash12', description: 'WIP: oldest', branchName: 'main', parents: [] },
+				{ index: 0, hash: 'stash0', description: 'WIP: newest', branchName: 'main', parents: [] },
+				{ index: 5, hash: 'stash5', description: 'WIP: middle', branchName: 'main', parents: [] },
+				{ index: 2, hash: 'stash2', description: 'WIP: recent', branchName: 'main', parents: [] }
+			];
+			mockRepository.getStashes.resolves(stashes);
+
+			const historyItemRefs = await gitHistoryProvider.provideHistoryItemRefs(undefined);
+			const stashRefs = historyItemRefs.filter(ref => ref.id.startsWith('stash@{'));
+
+			assert.strictEqual(stashRefs.length, 4);
+			assert.strictEqual(stashRefs[0].id, 'stash@{0}');
+			assert.strictEqual(stashRefs[1].id, 'stash@{2}');
+			assert.strictEqual(stashRefs[2].id, 'stash@{5}');
+			assert.strictEqual(stashRefs[3].id, 'stash@{12}');
+		});
+
+		test('handles stash errors', async () => {
+			mockRepository.getStashes.rejects(new Error('Git stash failed'));
+
+			const historyItemRefs = await gitHistoryProvider.provideHistoryItemRefs(undefined);
+
+			assert.ok(historyItemRefs.length > 0, 'Should still return results despite stash error');
+			const stashRefs = historyItemRefs.filter(ref => ref.id.startsWith('stash@{'));
+			assert.strictEqual(stashRefs.length, 0, 'Should have no stash refs on error with no previous state');
+		});
+
+		test('falls back to previous stash state on error', async () => {
+			const stashes = [{ index: 0, hash: 'stash1', description: 'WIP: feature', branchName: 'main', parents: [] }];
+			mockRepository.getStashes.resolves(stashes);
+
+			let historyItemRefs = await gitHistoryProvider.provideHistoryItemRefs(undefined);
+			let stashRefs = historyItemRefs.filter(ref => ref.id.startsWith('stash@{'));
+			assert.strictEqual(stashRefs.length, 1, 'First call should have stash');
+
+			mockRepository.getStashes.rejects(new Error('Git stash failed'));
+
+			historyItemRefs = await gitHistoryProvider.provideHistoryItemRefs(undefined);
+			stashRefs = historyItemRefs.filter(ref => ref.id.startsWith('stash@{'));
+			assert.strictEqual(stashRefs.length, 1, 'Should fall back to previous stash state on error');
+			assert.strictEqual(stashRefs[0].id, 'stash@{0}');
+		});
+	});
+
+	suite('provideHistoryItems', () => {
+		test('filters out git stash index commits', async () => {
+			const commits: Commit[] = [
+				{ hash: 'def5678', message: 'index on main: abc1234 feat: add feature', parents: [], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] },
+				{ hash: 'abc1234', message: 'feat: add feature', parents: [], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] },
+				{ hash: 'bbb3456', message: 'index on main: aaa9012 fix: bug fix', parents: [], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] },
+				{ hash: 'aaa9012', message: 'fix: bug fix', parents: [], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] }
+			];
+			mockRepository.log.resolves(commits);
+
+			const updateComplete = new Promise<void>(resolve => {
+				gitHistoryProvider.onDidChangeCurrentHistoryItemRefs(() => resolve(), { dispose: () => { } });
+			});
+			onDidRunOperationEmitter.fire({ operation: { kind: OperationKind.Commit, readOnly: false, showProgress: false } });
+			await updateComplete;
+
+			const historyItems = await gitHistoryProvider.provideHistoryItems({ historyItemRefs: ['refs/heads/main'] }, {} as CancellationToken);
+
+			assert.strictEqual(historyItems.length, 2, 'Should filter out stash index commits');
+			assert.strictEqual(historyItems[0].id, 'abc1234');
+			assert.strictEqual(historyItems[1].id, 'aaa9012');
+		});
+
+		test('attaches stash ref to history item with matching hash', async () => {
+			const stashes = [
+				{ index: 0, hash: 'stash1hash', description: 'WIP: feature', branchName: 'main', parents: [] }
+			];
+			mockRepository.getStashes.resolves(stashes);
+
+			const updateComplete = new Promise<void>(resolve => {
+				gitHistoryProvider.onDidChangeCurrentHistoryItemRefs(() => resolve(), { dispose: () => { } });
+			});
+			onDidRunOperationEmitter.fire({ operation: { kind: OperationKind.Stash, readOnly: false, showProgress: false } });
+			await updateComplete;
+
+			const commits: Commit[] = [
+				{ hash: 'stash1hash', message: 'WIP on main: abc1234 feat: add feature', parents: ['abc1234'], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] },
+				{ hash: 'abc1234', message: 'feat: add feature', parents: [], authorDate: new Date(), authorName: 'Author', authorEmail: 'author@example.com', commitDate: new Date(), refNames: [] }
+			];
+			mockRepository.log.resolves(commits);
+
+			const historyItems = await gitHistoryProvider.provideHistoryItems({ historyItemRefs: ['refs/heads/main'] }, {} as CancellationToken);
+
+			assert.strictEqual(historyItems.length, 2);
+
+			const stashItem = historyItems.find(item => item.id === 'stash1hash');
+			assert.ok(stashItem?.references, 'Stash commit should have references');
+			const stashRef = stashItem!.references!.find(ref => ref.id === 'stash@{0}');
+			assert.ok(stashRef, 'Stash commit should have stash@{0} reference');
+			assert.strictEqual(stashRef!.name, 'WIP: feature');
+			assert.deepStrictEqual(stashRef!.icon, new ThemeIcon('git-stash'));
+
+			const regularItem = historyItems.find(item => item.id === 'abc1234');
+			assert.strictEqual(regularItem?.references, undefined, 'Regular commit should not have references');
+		});
+	});
+});


### PR DESCRIPTION
For Issue https://github.com/microsoft/vscode/issues/280264

Behavior:
- Source Control Git graph now includes stashes in addition to remotes/branches and tags. 
- Stashes are displayed in the selector dropdown via historyProvider.provideHistoryItemRefs
- Selected stashes (but not their index commits) are displayed in the graph via historyProvider.provideHistoryItems
- onDidRunWriteOperation diff calculation includes change in stash history
- Avoids potential race-condition in stashRef with @sequentialize decorator

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
