### PR TITLE
Fix SCM repository resolution and add branch name support

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -2839,6 +2839,7 @@ export class Repository implements Disposable {
 			this._updateResourceGroupsState(resourceGroups);
 
 			this._onDidChangeStatus.fire();
+			this._updateBranchName();
 		}
 		catch (err) {
 			if (err instanceof CancellationError) {
@@ -2863,6 +2864,13 @@ export class Repository implements Disposable {
 
 		// set count badge
 		this.setCountBadge();
+	}
+
+	private _updateBranchName(): void {
+		// Update the branch name in the source control provider
+		// This allows the terminal and other components to access the current branch
+		// via repository.provider.branchName without needing the Git extension API
+		this._sourceControl.branchName = this.HEAD?.name;
 	}
 
 	private async getStatus(cancellationToken?: CancellationToken): Promise<GitResourceGroups> {

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -337,6 +337,9 @@ class MainThreadSCMProvider implements ISCMProvider {
 	private readonly _actionButton = observableValue<ISCMActionButtonDescriptor | undefined>(this, undefined);
 	get actionButton(): IObservable<ISCMActionButtonDescriptor | undefined> { return this._actionButton; }
 
+	private readonly _branchName = observableValue<string | undefined>(this, undefined);
+	get branchName() { return this._branchName; }
+
 	private _quickDiff: IDisposable | undefined;
 	private _stagedQuickDiff: IDisposable | undefined;
 
@@ -391,6 +394,10 @@ class MainThreadSCMProvider implements ISCMProvider {
 
 		if (typeof features.statusBarCommands !== 'undefined') {
 			this._statusBarCommands.set(features.statusBarCommands, undefined);
+		}
+
+		if (typeof features.branchName !== 'undefined') {
+			this._branchName.set(features.branchName, undefined);
 		}
 
 		if (features.hasQuickDiffProvider && !this._quickDiff) {

--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -396,7 +396,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 			this._statusBarCommands.set(features.statusBarCommands, undefined);
 		}
 
-		if (typeof features.branchName !== 'undefined') {
+		if ('branchName' in features) {
 			this._branchName.set(features.branchName, undefined);
 		}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1897,6 +1897,7 @@ export interface SCMProviderFeatures {
 	actionButton?: SCMActionButtonDto | null;
 	statusBarCommands?: ICommandDto[];
 	contextValue?: string;
+	branchName?: string;
 }
 
 export interface SCMActionButtonDto {

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -604,6 +604,21 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		this.#proxy.$updateSourceControl(this.handle, { count });
 	}
 
+	private _branchName: string | undefined = undefined;
+
+	get branchName(): string | undefined {
+		return this._branchName;
+	}
+
+	set branchName(branchName: string | undefined) {
+		if (this._branchName === branchName) {
+			return;
+		}
+
+		this._branchName = branchName;
+		this.#proxy.$updateSourceControl(this.handle, { branchName });
+	}
+
 	private _quickDiffProvider: vscode.QuickDiffProvider | undefined = undefined;
 
 	get quickDiffProvider(): vscode.QuickDiffProvider | undefined {

--- a/src/vs/workbench/contrib/scm/common/scm.ts
+++ b/src/vs/workbench/contrib/scm/common/scm.ts
@@ -81,6 +81,7 @@ export interface ISCMProvider extends IDisposable {
 	readonly onDidChangeResources: Event<void>;
 
 	readonly rootUri?: URI;
+	readonly branchName: IObservable<string | undefined>;
 	readonly iconPath?: URI | { light: URI; dark: URI } | ThemeIcon;
 	readonly isHidden?: boolean;
 	readonly inputBoxTextModel: ITextModel;

--- a/src/vs/workbench/contrib/scm/common/scmService.ts
+++ b/src/vs/workbench/contrib/scm/common/scmService.ts
@@ -451,7 +451,7 @@ export class SCMService implements ISCMService {
 
 			const path = this.uriIdentityService.extUri.relativePath(root, idOrResource);
 
-			if (path && !/^\.\./.test(path) && path.length < bestMatchLength) {
+			if (path !== undefined && !/^\.\./.test(path) && path.length < bestMatchLength) {
 				bestRepository = repository;
 				bestMatchLength = path.length;
 			}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -18,6 +18,7 @@ import { Emitter, Event } from '../../../../base/common/event.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { ISeparator, normalizeDriveLetter, template } from '../../../../base/common/labels.js';
 import { Disposable, DisposableMap, DisposableStore, IDisposable, ImmortalReference, MutableDisposable, dispose, toDisposable, type IReference } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
 import { Schemas } from '../../../../base/common/network.js';
 import * as path from '../../../../base/common/path.js';
 import { OS, OperatingSystem, isMacintosh, isWindows } from '../../../../base/common/platform.js';
@@ -56,6 +57,7 @@ import { IWorkspaceTrustRequestService } from '../../../../platform/workspace/co
 import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND } from '../../../common/theme.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../common/views.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { ISCMService } from '../../scm/common/scm.js';
 import { AccessibilityVerbositySettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
 import { IRequestAddInstanceToGroupEvent, ITerminalConfigurationService, ITerminalContribution, ITerminalInstance, IXtermColorProvider, TerminalDataTransfers } from './terminal.js';
 import { TerminalLaunchHelpAction } from './terminalActions.js';
@@ -183,6 +185,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private readonly _messageTitleDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 	private _widgetManager: TerminalWidgetManager;
 	private readonly _dndObserver: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+	private readonly _scmBranchSubscription: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
 	private _lastLayoutDimensions: dom.Dimension | undefined;
 	private _description?: string;
 	private _processName: string = '';
@@ -394,6 +397,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
+		@ISCMService private readonly _scmService: ISCMService,
 	) {
 		super();
 
@@ -471,6 +475,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					capabilityListeners.set(e.id, e.capability.onDidChangeCwd(e => {
 						this._cwd = e;
 						this._setTitle(this.title, TitleEventSource.Config);
+						// Subscribe to branch name changes for the new cwd
+						this._subscribeToBranchNameChanges(e);
 					}));
 					break;
 				}
@@ -2470,6 +2476,38 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 		}
 	}
+
+	private _subscribeToBranchNameChanges(cwd: string | undefined): void {
+		// Clear any existing subscription
+		this._scmBranchSubscription.clear();
+
+		if (!cwd) {
+			return;
+		}
+
+		try {
+			const cwdUri = URI.file(cwd);
+			const repository = this._scmService.getRepository(cwdUri);
+			if (!repository) {
+				return;
+			}
+
+			const provider = repository.provider;
+			if (!provider || !provider.rootUri) {
+				return;
+			}
+
+			// Subscribe to branch name changes via the observable
+			this._scmBranchSubscription.value = autorun(reader => {
+				provider.branchName.read(reader);
+				// Trigger label refresh when branch name changes
+				this._labelComputer?.refreshLabel(this);
+			});
+		} catch (error) {
+			// Silently fail if we can't subscribe - this is not critical
+			this._logService.debug(`Failed to subscribe to SCM branch name changes for terminal ${this._instanceId}:`, error);
+		}
+	}
 }
 
 class TerminalInstanceDragAndDropController extends Disposable implements dom.IDragAndDropObserverCallbacks {
@@ -2611,6 +2649,7 @@ interface ITerminalLabelTemplateProperties {
 	task?: string | null | undefined;
 	fixedDimensions?: string | null | undefined;
 	separator?: string | ISeparator | null | undefined;
+	branch?: string | null | undefined;
 	shellType?: string | undefined;
 	shellCommand?: string | undefined;
 	shellPromptInput?: string | undefined;
@@ -2633,7 +2672,8 @@ export class TerminalLabelComputer extends Disposable {
 	constructor(
 		@IFileService private readonly _fileService: IFileService,
 		@ITerminalConfigurationService private readonly _terminalConfigurationService: ITerminalConfigurationService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ISCMService private readonly _scmService: ISCMService
 	) {
 		super();
 	}
@@ -2670,6 +2710,7 @@ export class TerminalLabelComputer extends Disposable {
 				? (instance.fixedRows ? `\u2194${instance.fixedCols} \u2195${instance.fixedRows}` : `\u2194${instance.fixedCols}`)
 				: (instance.fixedRows ? `\u2195${instance.fixedRows}` : ''),
 			separator: { label: this._terminalConfigurationService.config.tabs.separator },
+			branch: this._getBranchName(instance.cwd || instance.initialCwd),
 			shellType: instance.shellType,
 			// Shell command requires high confidence
 			shellCommand: commandDetection?.executingCommand && commandDetection.executingCommandConfidence === 'high' && promptInputModel
@@ -2716,6 +2757,38 @@ export class TerminalLabelComputer extends Disposable {
 		// Remove special characters that could mess with rendering
 		const label = template(labelTemplate, (templateProperties as unknown) as { [key: string]: string | ISeparator | undefined | null }).replace(/[\n\r\t]/g, '').trim();
 		return label === '' && labelType === TerminalLabelType.Title ? (instance.processName || '') : label;
+	}
+
+	private _getBranchName(cwd: string | undefined): string | undefined {
+		if (!cwd) {
+			return undefined;
+		}
+
+		try {
+			const cwdUri = URI.file(cwd);
+			const repository = this._scmService.getRepository(cwdUri);
+			if (!repository) {
+				return undefined;
+			}
+
+			// Get the branch name from the repository provider
+			const provider = repository.provider;
+			if (!provider || !provider.rootUri) {
+				return undefined;
+			}
+
+			// Access the git branch name exposed through the provider
+			// The git extension updates this whenever the git status changes
+			const branchName = provider.branchName.get();
+			if (branchName) {
+				return branchName;
+			}
+
+			return undefined;
+		} catch (error) {
+			// Silently fail if we can't get branch info - this is not critical
+			return undefined;
+		}
 	}
 
 	private _getProgressStateString(progressState?: IProgressState): string {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -475,8 +475,13 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 					capabilityListeners.set(e.id, e.capability.onDidChangeCwd(e => {
 						this._cwd = e;
 						this._setTitle(this.title, TitleEventSource.Config);
-						// Subscribe to branch name changes for the new cwd
-						this._subscribeToBranchNameChanges(e);
+						// If the cwd was already known before the CwdDetection capability started
+						// emitting events (for example, via initialCwd or process properties),
+						// ensure we still subscribe to branch name changes for that cwd so that
+						// ${branch} in the tab label will update correctly.
+						if (this._cwd) {
+							this._subscribeToBranchNameChanges(this._cwd);
+						}
 					}));
 					break;
 				}
@@ -2486,7 +2491,21 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		try {
-			const cwdUri = URI.file(cwd);
+			let cwdUri: URI | undefined;
+			// Prefer a URI that matches the workspace folder's scheme/authority (for remote workspaces)
+			const workspace = this._workspaceContextService.getWorkspace();
+			for (const folder of workspace.folders) {
+				if (folder.uri.scheme !== Schemas.file && cwd.startsWith(folder.uri.path)) {
+					const relativePath = cwd.substring(folder.uri.path.length);
+					cwdUri = folder.uri.with({ path: folder.uri.path + relativePath });
+					break;
+				}
+			}
+			if (!cwdUri) {
+				// Fallback for local workspaces or when no matching remote folder is found
+				cwdUri = URI.file(cwd);
+			}
+
 			const repository = this._scmService.getRepository(cwdUri);
 			if (!repository) {
 				return;
@@ -2765,7 +2784,22 @@ export class TerminalLabelComputer extends Disposable {
 		}
 
 		try {
-			const cwdUri = URI.file(cwd);
+			let cwdUri: URI | undefined;
+			// Try to build a URI for cwd that matches the workspace folder's scheme/authority
+			// so that SCM repositories can be resolved correctly in remote workspaces.
+			const workspace = this._workspaceContextService.getWorkspace();
+			for (const folder of workspace.folders) {
+				const folderPath = folder.uri.path;
+				if (cwd.startsWith(folderPath)) {
+					cwdUri = folder.uri.with({ path: cwd });
+					break;
+				}
+			}
+			// Fallback to a local file URI if no matching workspace folder was found
+			if (!cwdUri) {
+				cwdUri = URI.file(cwd);
+			}
+
 			const repository = this._scmService.getRepository(cwdUri);
 			if (!repository) {
 				return undefined;

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -29,6 +29,7 @@ const terminalDescriptors = '\n- ' + [
 	'`\${separator}`: ' + localize('separator', "a conditional separator {0} that only shows when it's surrounded by variables with values or static text.", '(` - `)'),
 	'`\${sequence}`: ' + localize('sequence', "the name provided to the terminal by the process."),
 	'`\${task}`: ' + localize('task', "indicates this terminal is associated with a task."),
+	'`\${branch}`: ' + localize('branch', "the git branch name for the terminal's current working directory."),
 	'`\${shellType}`: ' + localize('shellType', "the detected shell type."),
 	'`\${shellCommand}`: ' + localize('shellCommand', "the command being executed according to shell integration. This also requires high confidence in the detected command line, which may not work in some prompt frameworks."),
 	'`\${shellPromptInput}`: ' + localize('shellPromptInput', "the shell's full prompt input according to shell integration."),

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -18,6 +18,7 @@ import { TerminalCapabilityStore } from '../../../../../platform/terminal/common
 import { GeneralShellType, ITerminalChildProcess, ITerminalProfile, TitleEventSource, type IShellLaunchConfig, type ITerminalBackend, type ITerminalProcessOptions } from '../../../../../platform/terminal/common/terminal.js';
 import { IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
+import { ISCMService } from '../../../scm/common/scm.js';
 import { ITerminalConfigurationService, ITerminalInstance, ITerminalInstanceService, ITerminalService } from '../../browser/terminal.js';
 import { TerminalConfigurationService } from '../../browser/terminalConfigurationService.js';
 import { parseExitResult, TerminalInstance, TerminalLabelComputer } from '../../browser/terminalInstance.js';
@@ -397,6 +398,20 @@ suite('Workbench - TerminalInstance', () => {
 			terminalLabelComputer.refreshLabel(createInstance({ capabilities, processName: 'zsh', shellLaunchConfig: { type: 'Task' } }));
 			strictEqual(terminalLabelComputer.title, 'zsh');
 			strictEqual(terminalLabelComputer.description, '');
+		});
+		test('should resolve branch', () => {
+			instantiationService.stub(ISCMService, {
+				getRepository: (_uri: URI) => ({
+					provider: {
+						rootUri: URI.file(ROOT_1),
+						branchName: { get: () => 'my-branch' }
+					}
+				})
+			} as unknown as ISCMService);
+			const terminalLabelComputer = createLabelComputer({ terminal: { integrated: { tabs: { separator: ' - ', title: '${branch}', description: '${branch}' } } } });
+			terminalLabelComputer.refreshLabel(createInstance({ capabilities, cwd: ROOT_1 }));
+			strictEqual(terminalLabelComputer.title, 'my-branch');
+			strictEqual(terminalLabelComputer.description, 'my-branch');
 		});
 		test('should always return static title when specified', () => {
 			const terminalLabelComputer = createLabelComputer({ terminal: { integrated: { tabs: { separator: ' ~ ', title: '${process}', description: '${workspaceFolder}' } } } });

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -16598,6 +16598,11 @@ declare module 'vscode' {
 		readonly inputBox: SourceControlInputBox;
 
 		/**
+		 * The name of the current branch.
+		 */
+		branchName?: string;
+
+		/**
 		 * The UI-visible count of {@link SourceControlResourceState resource states} of
 		 * this source control.
 		 *


### PR DESCRIPTION
This pull request adds support for displaying the current Git branch name in the integrated terminal's tab labels and descriptions. It achieves this by exposing the branch name from the Git extension through the SCM provider, making it observable, and wiring it into the terminal label computation and updates. The changes also include tests and documentation for the new `${branch}` variable.

These changes allow the terminal UI to dynamically display the current Git branch, improving user awareness and workflow integration.

Fixes https://github.com/microsoft/vscode/issues/237004