### PR TITLE
Substitute `url.parse` with WHATWG `URL` API

### DIFF
--- a/build/lib/builtInExtensionsCG.ts
+++ b/build/lib/builtInExtensionsCG.ts
@@ -5,7 +5,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import url from 'url';
 import ansiColors from 'ansi-colors';
 import type { IExtensionDefinition } from './builtInExtensions.ts';
 
@@ -21,7 +20,8 @@ const contentFileNames = ['package.json', 'package-lock.json'];
 
 async function downloadExtensionDetails(extension: IExtensionDefinition): Promise<void> {
 	const extensionLabel = `${extension.name}@${extension.version}`;
-	const repository = url.parse(extension.repo).path!.substr(1);
+	const repositoryUrl = new URL(extension.repo);
+	const repository = repositoryUrl.pathname.slice(1) + repositoryUrl.search;
 	const repositoryContentBaseUrl = `https://${token ? `${token}@` : ''}${contentBasePath}/${repository}/v${extension.version}`;
 
 

--- a/extensions/theme-seti/build/update-icon-theme.js
+++ b/extensions/theme-seti/build/update-icon-theme.js
@@ -8,7 +8,6 @@
 const path = require('path');
 const fs = require('fs');
 const https = require('https');
-const url = require('url');
 const minimatch = require('minimatch');
 
 // list of languagesId not shipped with VSCode. The information is used to associate an icon with a language association
@@ -97,8 +96,8 @@ function download(source) {
 		return readFile(source);
 	}
 	return new Promise((c, e) => {
-		const _url = url.parse(source);
-		const options = { host: _url.host, port: _url.port, path: _url.path, headers: { 'User-Agent': 'NodeJS' } };
+		const _url = new URL(source);
+		const options = { host: _url.host, port: _url.port, path: _url.pathname + _url.search, headers: { 'User-Agent': 'NodeJS' } };
 		let content = '';
 		https.get(options, function (response) {
 			response.on('data', function (data) {
@@ -472,6 +471,5 @@ exports.update = function () {
 if (path.basename(process.argv[1]) === 'update-icon-theme.js') {
 	exports.copyFont().then(() => exports.update());
 }
-
 
 

--- a/extensions/vscode-test-resolver/src/download.ts
+++ b/extensions/vscode-test-resolver/src/download.ts
@@ -7,7 +7,6 @@ import * as https from 'https';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
-import { parse as parseUrl } from 'url';
 
 function ensureFolderExists(loc: string) {
 	if (!fs.existsSync(loc)) {
@@ -31,9 +30,9 @@ async function downloadVSCodeServerArchive(updateUrl: string, commit: string, qu
 
 	return new Promise((resolve, reject) => {
 		log(`Downloading VS Code Server from: ${downloadUrl}`);
-		const requestOptions: https.RequestOptions = parseUrl(downloadUrl);
+		const requestUrl = new URL(downloadUrl);
 
-		https.get(requestOptions, res => {
+		https.get(requestUrl, res => {
 			if (res.statusCode !== 302) {
 				reject('Failed to get VS Code server archive location');
 				res.resume(); // read the rest of the response data and discard it
@@ -46,7 +45,7 @@ async function downloadVSCodeServerArchive(updateUrl: string, commit: string, qu
 				return;
 			}
 
-			const archiveRequestOptions: https.RequestOptions = parseUrl(archiveUrl);
+			const archiveRequestUrl = new URL(archiveUrl);
 			const archivePath = path.resolve(destDir, `vscode-server-${commit}.${archiveUrl.endsWith('.zip') ? 'zip' : 'tgz'}`);
 			const outStream = fs.createWriteStream(archivePath);
 			outStream.on('finish', () => {
@@ -55,7 +54,7 @@ async function downloadVSCodeServerArchive(updateUrl: string, commit: string, qu
 			outStream.on('error', err => {
 				reject(err);
 			});
-			https.get(archiveRequestOptions, res => {
+			https.get(archiveRequestUrl, res => {
 				res.pipe(outStream);
 				res.on('error', err => {
 					reject(err);

--- a/src/vs/platform/request/node/proxy.ts
+++ b/src/vs/platform/request/node/proxy.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { parse as parseUrl, Url } from 'url';
+import { urlToHttpOptions } from 'url';
 import { isBoolean } from '../../../base/common/types.js';
 
 export type Agent = any;
 
-function getSystemProxyURI(requestURL: Url, env: typeof process.env): string | null {
+function getSystemProxyURI(requestURL: URL, env: typeof process.env): string | null {
 	if (requestURL.protocol === 'http:') {
 		return env.HTTP_PROXY || env.http_proxy || null;
 	} else if (requestURL.protocol === 'https:') {
@@ -24,23 +24,23 @@ export interface IOptions {
 }
 
 export async function getProxyAgent(rawRequestURL: string, env: typeof process.env, options: IOptions = {}): Promise<Agent> {
-	const requestURL = parseUrl(rawRequestURL);
+	const requestURL = new URL(rawRequestURL);
 	const proxyURL = options.proxyUrl || getSystemProxyURI(requestURL, env);
 
 	if (!proxyURL) {
 		return null;
 	}
 
-	const proxyEndpoint = parseUrl(proxyURL);
+	const proxyEndpoint = new URL(proxyURL);
 
-	if (!/^https?:$/.test(proxyEndpoint.protocol || '')) {
+	if (proxyEndpoint.protocol !== "http:" && proxyEndpoint.protocol !== "https:") {
 		return null;
 	}
 
 	const opts = {
-		host: proxyEndpoint.hostname || '',
-		port: (proxyEndpoint.port ? +proxyEndpoint.port : 0) || (proxyEndpoint.protocol === 'https' ? 443 : 80),
-		auth: proxyEndpoint.auth,
+		host: proxyEndpoint.hostname,
+		port: +proxyEndpoint.port || (proxyEndpoint.protocol === 'https:' ? 443 : 80),
+		auth: urlToHttpOptions(proxyEndpoint).auth,
 		rejectUnauthorized: isBoolean(options.strictSSL) ? options.strictSSL : true,
 	};
 

--- a/src/vs/platform/request/node/requestService.ts
+++ b/src/vs/platform/request/node/requestService.ts
@@ -5,7 +5,6 @@
 
 import type * as http from 'http';
 import type * as https from 'https';
-import { parse as parseUrl } from 'url';
 import { Promises, timeout } from '../../../base/common/async.js';
 import { streamToBufferReadableStream } from '../../../base/common/buffer.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
@@ -165,10 +164,8 @@ export async function lookupKerberosAuthorization(urlStr: string, spnConfig: str
 	return client.step('');
 }
 
-async function getNodeRequest(options: IRequestOptions): Promise<IRawRequestFunction> {
-	const endpoint = parseUrl(options.url!);
+async function getNodeRequest(endpoint: URL): Promise<IRawRequestFunction> {
 	const module = endpoint.protocol === 'https:' ? await import('https') : await import('http');
-
 	return module.request;
 }
 
@@ -199,16 +196,16 @@ export async function nodeRequest(options: NodeRequestOptions, token: Cancellati
 
 async function nodeRequestAttempt(options: NodeRequestOptions, token: CancellationToken): Promise<IRequestContext> {
 	return Promises.withAsyncBody<IRequestContext>(async (resolve, reject) => {
-		const endpoint = parseUrl(options.url!);
+		const endpoint = new URL(options.url!);
 		const rawRequest = options.getRawRequest
 			? options.getRawRequest(options)
-			: await getNodeRequest(options);
+			: await getNodeRequest(endpoint);
 
 		const opts: https.RequestOptions & { cache?: 'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache' | 'only-if-cached' } = {
 			hostname: endpoint.hostname,
 			port: endpoint.port ? parseInt(endpoint.port) : (endpoint.protocol === 'https:' ? 443 : 80),
 			protocol: endpoint.protocol,
-			path: endpoint.path,
+			path: endpoint.pathname + endpoint.search,
 			method: options.type || 'GET',
 			headers: options.headers,
 			agent: options.agent,

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -8,7 +8,6 @@ import type * as http from 'http';
 import * as net from 'net';
 import { createRequire } from 'node:module';
 import { performance } from 'perf_hooks';
-import * as url from 'url';
 import { VSBuffer } from '../../base/common/buffer.js';
 import { CharCode } from '../../base/common/charCode.js';
 import { isSigPipeError, onUnexpectedError, setUnexpectedErrorHandler } from '../../base/common/errors.js';
@@ -115,7 +114,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			return serveError(req, res, 400, `Bad request.`);
 		}
 
-		const parsedUrl = url.parse(req.url, true);
+		const parsedUrl = new URL(req.url, 'http://localhost');
 		let pathname = parsedUrl.pathname;
 
 		if (!pathname) {
@@ -152,7 +151,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		if (pathname === '/vscode-remote-resource') {
 			// Handle HTTP requests for resources rendered in the rich client (images, fonts, etc.)
 			// These resources could be files shipped with extensions or even workspace files.
-			const desiredPath = parsedUrl.query['path'];
+			const desiredPath = parsedUrl.searchParams.get('path');
 			if (typeof desiredPath !== 'string') {
 				return serveError(req, res, 400, `Bad request.`);
 			}
@@ -198,14 +197,14 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		let skipWebSocketFrames = false;
 
 		if (req.url) {
-			const query = url.parse(req.url, true).query;
-			if (typeof query.reconnectionToken === 'string') {
-				reconnectionToken = query.reconnectionToken;
+			const query = new URL(req.url, 'http://localhost').searchParams;
+			if (typeof query.get('reconnectionToken') === 'string') {
+				reconnectionToken = query.get('reconnectionToken')!;
 			}
-			if (query.reconnection === 'true') {
+			if (query.get('reconnection') === 'true') {
 				isReconnection = true;
 			}
-			if (query.skipWebSocketFrames === 'true') {
+			if (query.get('skipWebSocketFrames') === 'true') {
 				skipWebSocketFrames = true;
 			}
 		}

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -394,7 +394,7 @@ async function openInBrowser(args: string[], verbose: boolean) {
 	for (const location of args) {
 		try {
 			if (/^[a-z-]+:\/\/.+/.test(location)) {
-				uris.push(url.parse(location).href);
+				uris.push(new URL(location).href);
 			} else {
 				uris.push(pathToURI(location).href);
 			}

--- a/src/vs/server/node/serverConnectionToken.ts
+++ b/src/vs/server/node/serverConnectionToken.ts
@@ -6,7 +6,6 @@
 import * as cookie from 'cookie';
 import * as fs from 'fs';
 import type * as http from 'http';
-import * as url from 'url';
 import * as path from '../../base/common/path.js';
 import { generateUuid } from '../../base/common/uuid.js';
 import { connectionTokenCookieName, connectionTokenQueryName } from '../../base/common/network.js';
@@ -120,9 +119,9 @@ export async function determineServerConnectionToken(args: ServerParsedArgs): Pr
 	return parseServerConnectionToken(args, readOrGenerateConnectionToken);
 }
 
-export function requestHasValidConnectionToken(connectionToken: ServerConnectionToken, req: http.IncomingMessage, parsedUrl: url.UrlWithParsedQuery) {
+export function requestHasValidConnectionToken(connectionToken: ServerConnectionToken, req: http.IncomingMessage, parsedUrl: URL) {
 	// First check if there is a valid query parameter
-	if (connectionToken.validate(parsedUrl.query[connectionTokenQueryName])) {
+	if (connectionToken.validate(parsedUrl.searchParams.get(connectionTokenQueryName))) {
 		return true;
 	}
 

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -5,7 +5,6 @@
 
 import { createReadStream, promises } from 'fs';
 import type * as http from 'http';
-import * as url from 'url';
 import * as cookie from 'cookie';
 import * as crypto from 'crypto';
 import { isEqualOrParent } from '../../base/common/extpath.js';
@@ -120,7 +119,7 @@ export class WebClientServer {
 	 * @param parsedUrl The URL to handle, including base and product path
 	 * @param pathname The pathname of the URL, without base and product path
 	 */
-	async handle(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: url.UrlWithParsedQuery, pathname: string): Promise<void> {
+	async handle(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: URL, pathname: string): Promise<void> {
 		try {
 			if (pathname.startsWith(STATIC_PATH) && pathname.charCodeAt(STATIC_PATH.length) === CharCode.Slash) {
 				return this._handleStatic(req, res, pathname.substring(STATIC_PATH.length));
@@ -238,7 +237,7 @@ export class WebClientServer {
 	/**
 	 * Handle HTTP requests for /
 	 */
-	private async _handleRoot(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: url.UrlWithParsedQuery): Promise<void> {
+	private async _handleRoot(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: URL): Promise<void> {
 
 		const getFirstHeader = (headerName: string) => {
 			const val = req.headers[headerName];
@@ -248,7 +247,7 @@ export class WebClientServer {
 		// Prefix routes with basePath for clients
 		const basePath = getFirstHeader('x-forwarded-prefix') || this._basePath;
 
-		const queryConnectionToken = parsedUrl.query[connectionTokenQueryName];
+		const queryConnectionToken = parsedUrl.searchParams.get(connectionTokenQueryName);
 		if (typeof queryConnectionToken === 'string') {
 			// We got a connection token as a query parameter.
 			// We want to have a clean URL, so we strip it
@@ -262,14 +261,9 @@ export class WebClientServer {
 				}
 			);
 
-			const newQuery = Object.create(null);
-			for (const key in parsedUrl.query) {
-				if (key !== connectionTokenQueryName) {
-					newQuery[key] = parsedUrl.query[key];
-				}
-			}
-			const newLocation = url.format({ pathname: basePath, query: newQuery });
-			responseHeaders['Location'] = newLocation;
+			const newLocation = new URL(parsedUrl);
+			newLocation.searchParams.delete(connectionTokenQueryName);
+			responseHeaders['Location'] = newLocation.href;
 
 			res.writeHead(302, responseHeaders);
 			return void res.end();

--- a/test/integration/browser/src/index.ts
+++ b/test/integration/browser/src/index.ts
@@ -63,7 +63,7 @@ const height = 900;
 type BrowserType = 'chromium' | 'firefox' | 'webkit';
 type BrowserChannel = 'msedge' | 'chrome';
 
-async function runTestsInBrowser(browserType: BrowserType, browserChannel: BrowserChannel, endpoint: url.UrlWithStringQuery, server: cp.ChildProcess): Promise<void> {
+async function runTestsInBrowser(browserType: BrowserType, browserChannel: BrowserChannel, endpoint: URL, server: cp.ChildProcess): Promise<void> {
 	const browser = await playwright[browserType].launch({ headless: !Boolean(args.debug), channel: browserChannel });
 	const context = await browser.newContext();
 
@@ -155,7 +155,7 @@ function consoleLogFn(msg: playwright.ConsoleMessage) {
 	return console.log;
 }
 
-async function launchServer(browserType: BrowserType, browserChannel: BrowserChannel): Promise<{ endpoint: url.UrlWithStringQuery; server: cp.ChildProcess }> {
+async function launchServer(browserType: BrowserType, browserChannel: BrowserChannel): Promise<{ endpoint: URL; server: cp.ChildProcess }> {
 
 	// Ensure a tmp user-data-dir is used for the tests
 	const tmpDir = tmp.dirSync({ prefix: 't' });
@@ -219,7 +219,7 @@ async function launchServer(browserType: BrowserType, browserChannel: BrowserCha
 		serverProcess.stdout!.on('data', data => {
 			const matches = data.toString('ascii').match(/Web UI available at (.+)/);
 			if (matches !== null) {
-				c({ endpoint: url.parse(matches[1]), server: serverProcess });
+				c({ endpoint: new URL(matches[1]), server: serverProcess });
 			}
 		});
 	});


### PR DESCRIPTION
Fix #301941 . The `url.parse` from `node:url` causes deprecated warning

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
