### PR TITLE
fix(telemetry): preserve stack traces in web environments

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -281,6 +281,31 @@ export function getPiiPathsFromEnvironment(paths: IPathEnvironment): string[] {
 	return [paths.appRoot, paths.extensionsPath, paths.userHome.fsPath, paths.tmpDir.fsPath, paths.userDataPath];
 }
 
+/**
+ * Generates PII path patterns for browser/web environments.
+ * In web environments, stack traces contain URLs like https://host/static/build/bundle.js
+ * We need to add these URL patterns to avoid them being fully redacted.
+ * @param webEndpoint The base URL of the web endpoint (e.g., https://vscode.dev or https://codespace.github.dev)
+ * @returns Array of URL patterns that should not be redacted
+ */
+export function getBrowserPiiPaths(webEndpoint: string | undefined): string[] {
+	if (!webEndpoint) {
+		return [];
+	}
+
+	// Normalize endpoint to remove trailing slash
+	const endpoint = webEndpoint.replace(/\/$/, '');
+
+	// Generate patterns for common bundle paths
+	// These patterns will be used to clean stack traces while preserving VS Code's own paths
+	return [
+		endpoint,
+		`${endpoint}/static/`,
+		`${endpoint}/out/`,
+		`${endpoint}/node_modules/`
+	];
+}
+
 //#region Telemetry Cleaning
 
 /**

--- a/src/vs/platform/telemetry/test/common/telemetryUtils.test.ts
+++ b/src/vs/platform/telemetry/test/common/telemetryUtils.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { cleanRemoteAuthority } from '../../common/telemetryUtils.js';
+import { cleanRemoteAuthority, getPiiPathsFromEnvironment, getBrowserPiiPaths } from '../../common/telemetryUtils.js';
 
 suite('TelemetryUtils', () => {
 
@@ -119,6 +119,63 @@ suite('TelemetryUtils', () => {
 
 			assert.strictEqual(cleanRemoteAuthority('ssh-remote', config), 'other');
 			assert.strictEqual(cleanRemoteAuthority(undefined, config), 'none');
+		});
+	});
+
+	suite('getPiiPathsFromEnvironment', () => {
+		test('returns array of paths from IPathEnvironment', () => {
+			const paths = {
+				appRoot: '/Applications/VS Code.app/Contents/Resources/app',
+				extensionsPath: '/Users/test/.vscode/extensions',
+				userDataPath: '/Users/test/Library/Application Support/Code',
+				userHome: { fsPath: '/Users/test' } as any,
+				tmpDir: { fsPath: '/tmp' } as any
+			};
+
+			const result = getPiiPathsFromEnvironment(paths);
+
+			assert.strictEqual(result.length, 5);
+			assert(result.includes('/Applications/VS Code.app/Contents/Resources/app'));
+			assert(result.includes('/Users/test/.vscode/extensions'));
+			assert(result.includes('/Users/test/Library/Application Support/Code'));
+			assert(result.includes('/Users/test'));
+			assert(result.includes('/tmp'));
+		});
+	});
+
+	suite('getBrowserPiiPaths', () => {
+		test('returns empty array when no webEndpoint is provided', () => {
+			const result = getBrowserPiiPaths(undefined);
+			assert.strictEqual(result.length, 0);
+		});
+
+		test('returns path patterns for vscode.dev endpoint', () => {
+			const result = getBrowserPiiPaths('https://vscode.dev');
+
+			assert.strictEqual(result.length, 4);
+			// Should include the origin and common path patterns
+			assert(result.some(p => p.includes('vscode.dev')));
+		});
+
+		test('returns path patterns for codespaces endpoint', () => {
+			const result = getBrowserPiiPaths('https://test-github-1234567.github.dev');
+
+			assert.strictEqual(result.length, 4);
+			assert(result.some(p => p.includes('github.dev')));
+		});
+
+		test('handles endpoint with trailing slash', () => {
+			const result = getBrowserPiiPaths('https://vscode.dev/');
+
+			assert.strictEqual(result.length, 4);
+			assert(result.some(p => p === 'https://vscode.dev'));
+		});
+
+		test('handles endpoint without protocol', () => {
+			const result = getBrowserPiiPaths('vscode.dev');
+
+			// Should still work, though ideally protocol is included
+			assert(result.length > 0);
 		});
 	});
 });

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -14,7 +14,7 @@ import { ClassifiedEvent, IGDPRProperty, OmitMetadata, StrictPropertyCheck } fro
 import { ITelemetryData, ITelemetryService, TelemetryLevel, TELEMETRY_SETTING_ID } from '../../../../platform/telemetry/common/telemetry.js';
 import { TelemetryLogAppender } from '../../../../platform/telemetry/common/telemetryLogAppender.js';
 import { ITelemetryServiceConfig, TelemetryService as BaseTelemetryService } from '../../../../platform/telemetry/common/telemetryService.js';
-import { getTelemetryLevel, isInternalTelemetry, isLoggingOnly, ITelemetryAppender, NullTelemetryService, supportsTelemetry } from '../../../../platform/telemetry/common/telemetryUtils.js';
+import { getBrowserPiiPaths, getTelemetryLevel, isInternalTelemetry, isLoggingOnly, ITelemetryAppender, NullTelemetryService, supportsTelemetry } from '../../../../platform/telemetry/common/telemetryUtils.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IMeteredConnectionService } from '../../../../platform/meteredConnection/common/meteredConnection.js';
@@ -115,6 +115,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 			const config: ITelemetryServiceConfig = {
 				appenders,
 				commonProperties: resolveWorkbenchCommonProperties(storageService, productService, isInternal, environmentService.remoteAuthority, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),
+				piiPaths: getBrowserPiiPaths(typeof window !== 'undefined' ? window.location.origin : undefined),
 				sendErrorTelemetry: this.sendErrorTelemetry,
 				waitForExperimentProperties: experimentsEnabled(configurationService, productService, environmentService),
 				meteredConnectionService,


### PR DESCRIPTION
Fixes #302289

In web environments (vscode.dev, Codespaces), error telemetry stack traces contain HTTPS URLs like `https://host/static/build/bundle.js`. The `anonymizeFilePaths` function was fully redacting these URLs to `<REDACTED: user-file-path>` because no `piiPaths` were configured for browser environments.

**Root Cause:**
The browser telemetry service at `src/vs/workbench/services/telemetry/browser/telemetryService.ts` did not set `piiPaths`, unlike the electron-browser version which uses `getPiiPathsFromEnvironment()`.

**Fix:**
1. Add `getBrowserPiiPaths()` function to generate cleanup patterns for web endpoints based on `window.location.origin`
2. Update browser telemetry service to pass these patterns as `piiPaths` to the base telemetry service
3. This allows VS Code's own bundle URLs to be preserved while still redacting user file paths

**Testing:**
- Added unit tests for `getBrowserPiiPaths()` covering vscode.dev, Codespaces, and edge cases
- Added tests for `getPiiPathsFromEnvironment()` which was previously untested

**Before:**
```
at x3t._delegate (https:/<REDACTED: user-file-path>:1:200953)
```

**After:**
```
at x3t._delegate (https://codespace-host.github.dev/static/build/bundle.js:1:200953)
```