### PR TITLE
fix: submenu item loses focus unexpectedly

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -208,7 +208,7 @@ export class Menu extends ActionBar {
 					this.updateFocus();
 				}
 			}
-		}));
+		}, true));
 
 		// Support touch on actions list to focus items (needed for submenus)
 		this._register(Gesture.addTarget(this.actionsList));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #302387

## Overview

Below are two videos with logs: one showing the bug reproduction and the other showing the expected behavior.


https://github.com/user-attachments/assets/c9521765-0fb8-4a92-b531-9e2163e8f6e9


https://github.com/user-attachments/assets/9f1d6710-bff9-4d43-8426-74a74b64f613



The difference between them is that, in the bug reproduction case, the mouse moves too quickly and a `mouseover` event on the **container of a menu item inside the submenu** is skipped compared to the normal case.

The following diagram illustrates the general flow of how this issue occurs.  
The core problem is caused by `mouseover` event bubbling, which leads to a focus conflict.

<img width="1251" height="1587" alt="bug-reproduce" src="https://github.com/user-attachments/assets/f3c3005d-5c2a-4279-8328-77319b52cfaa" />

When the event bubbles from child to parent, both elements may attempt to update the focus state, resulting in the submenu item briefly gaining focus and then immediately losing it.



## Solution

To resolve this issue, the event listener is changed to use **capture phase** (`useCapture`).

By handling the event during the capture phase, the focus transition occurs **from parent to child**.