### PR TITLE
Revert "putting line breaks options into computed editor options object" (port to release/1.112)

### DIFF
--- a/src/vs/editor/browser/view/domLineBreaksComputer.ts
+++ b/src/vs/editor/browser/view/domLineBreaksComputer.ts
@@ -8,11 +8,12 @@ import { CharCode } from '../../../base/common/charCode.js';
 import * as strings from '../../../base/common/strings.js';
 import { assertReturnsDefined } from '../../../base/common/types.js';
 import { applyFontInfo } from '../config/domFontInfo.js';
-import { EditorOption, IComputedEditorOptions, WrappingIndent } from '../../common/config/editorOptions.js';
+import { WrappingIndent } from '../../common/config/editorOptions.js';
 import { StringBuilder } from '../../common/core/stringBuilder.js';
 import { InjectedTextOptions } from '../../common/model.js';
 import { ILineBreaksComputer, ILineBreaksComputerContext, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../common/modelLineProjectionData.js';
 import { LineInjectedText } from '../../common/textModelEvents.js';
+import { FontInfo } from '../../common/config/fontInfo.js';
 
 const ttPolicy = createTrustedTypesPolicy('domLineBreaksComputer', { createHTML: value => value });
 
@@ -25,20 +26,20 @@ export class DOMLineBreaksComputerFactory implements ILineBreaksComputerFactory 
 	constructor(private targetWindow: WeakRef<Window>) {
 	}
 
-	public createLineBreaksComputer(context: ILineBreaksComputerContext, options: IComputedEditorOptions, tabSize: number): ILineBreaksComputer {
+	public createLineBreaksComputer(context: ILineBreaksComputerContext, fontInfo: FontInfo, tabSize: number, wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ILineBreaksComputer {
 		const lineNumbers: number[] = [];
 		return {
 			addRequest: (lineNumber: number, previousLineBreakData: ModelLineProjectionData | null) => {
 				lineNumbers.push(lineNumber);
 			},
 			finalize: () => {
-				return createLineBreaks(assertReturnsDefined(this.targetWindow.deref()), context, lineNumbers, options, tabSize);
+				return createLineBreaks(assertReturnsDefined(this.targetWindow.deref()), context, lineNumbers, fontInfo, tabSize, wrappingColumn, wrappingIndent, wordBreak);
 			}
 		};
 	}
 }
 
-function createLineBreaks(targetWindow: Window, context: ILineBreaksComputerContext, lineNumbers: number[], options: IComputedEditorOptions, tabSize: number): (ModelLineProjectionData | null)[] {
+function createLineBreaks(targetWindow: Window, context: ILineBreaksComputerContext, lineNumbers: number[], fontInfo: FontInfo, tabSize: number, firstLineBreakColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll'): (ModelLineProjectionData | null)[] {
 	function createEmptyLineBreakWithPossiblyInjectedText(lineNumber: number): ModelLineProjectionData | null {
 		const injectedTexts = context.getLineInjectedText(lineNumber);
 		if (injectedTexts) {
@@ -55,10 +56,7 @@ function createLineBreaks(targetWindow: Window, context: ILineBreaksComputerCont
 			return null;
 		}
 	}
-	const wrappingIndent = options.get(EditorOption.wrappingIndent);
-	const fontInfo = options.get(EditorOption.fontInfo);
-	const wordBreak = options.get(EditorOption.wordBreak);
-	const firstLineBreakColumn = options.get(EditorOption.wrappingInfo).wrappingColumn;
+
 	if (firstLineBreakColumn === -1) {
 		const result: (ModelLineProjectionData | null)[] = [];
 		for (let i = 0, len = lineNumbers.length; i < len; i++) {

--- a/src/vs/editor/common/modelLineProjectionData.ts
+++ b/src/vs/editor/common/modelLineProjectionData.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { assertNever } from '../../base/common/assert.js';
-import { IComputedEditorOptions } from './config/editorOptions.js';
+import { WrappingIndent } from './config/editorOptions.js';
+import { FontInfo } from './config/fontInfo.js';
 import { Position } from './core/position.js';
 import { InjectedTextCursorStops, InjectedTextOptions, PositionAffinity } from './model.js';
 import { LineInjectedText } from './textModelEvents.js';
@@ -333,7 +334,7 @@ export interface ILineBreaksComputerContext {
 }
 
 export interface ILineBreaksComputerFactory {
-	createLineBreaksComputer(context: ILineBreaksComputerContext, options: IComputedEditorOptions, tabSize: number): ILineBreaksComputer;
+	createLineBreaksComputer(context: ILineBreaksComputerContext, fontInfo: FontInfo, tabSize: number, wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ILineBreaksComputer;
 }
 
 export interface ILineBreaksComputer {

--- a/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
+++ b/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
@@ -7,6 +7,7 @@ import { CharCode } from '../../../base/common/charCode.js';
 import * as strings from '../../../base/common/strings.js';
 import { WrappingIndent, IComputedEditorOptions, EditorOption } from '../config/editorOptions.js';
 import { CharacterClassifier } from '../core/characterClassifier.js';
+import { FontInfo } from '../config/fontInfo.js';
 import { LineInjectedText } from '../textModelEvents.js';
 import { InjectedTextOptions } from '../model.js';
 import { ILineBreaksComputerFactory, ILineBreaksComputer, ModelLineProjectionData, ILineBreaksComputerContext } from '../modelLineProjectionData.js';
@@ -25,7 +26,7 @@ export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFa
 		this.classifier = new WrappingCharacterClassifier(breakBeforeChars, breakAfterChars);
 	}
 
-	public createLineBreaksComputer(context: ILineBreaksComputerContext, options: IComputedEditorOptions, tabSize: number): ILineBreaksComputer {
+	public createLineBreaksComputer(context: ILineBreaksComputerContext, fontInfo: FontInfo, tabSize: number, wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll', wrapOnEscapedLineFeeds: boolean): ILineBreaksComputer {
 		const lineNumbers: number[] = [];
 		const previousBreakingData: (ModelLineProjectionData | null)[] = [];
 		return {
@@ -34,11 +35,6 @@ export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFa
 				previousBreakingData.push(previousLineBreakData);
 			},
 			finalize: () => {
-				const fontInfo = options.get(EditorOption.fontInfo);
-				const wrappingColumn = options.get(EditorOption.wrappingInfo).wrappingColumn;
-				const wrappingIndent = options.get(EditorOption.wrappingIndent);
-				const wordBreak = options.get(EditorOption.wordBreak);
-				const wrapOnEscapedLineFeeds = options.get(EditorOption.wrapOnEscapedLineFeeds);
 				const columnsForFullWidthChar = fontInfo.typicalFullwidthCharacterWidth / fontInfo.typicalHalfwidthCharacterWidth;
 				const result: (ModelLineProjectionData | null)[] = [];
 				for (let i = 0, len = lineNumbers.length; i < len; i++) {

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -97,13 +97,25 @@ export class ViewModel extends Disposable implements IViewModel {
 
 		} else {
 			const options = this._configuration.options;
+			const fontInfo = options.get(EditorOption.fontInfo);
+			const wrappingStrategy = options.get(EditorOption.wrappingStrategy);
+			const wrappingInfo = options.get(EditorOption.wrappingInfo);
+			const wrappingIndent = options.get(EditorOption.wrappingIndent);
+			const wordBreak = options.get(EditorOption.wordBreak);
+			const wrapOnEscapedLineFeeds = options.get(EditorOption.wrapOnEscapedLineFeeds);
+
 			this._lines = new ViewModelLinesFromProjectedModel(
 				this._editorId,
 				this.model,
 				domLineBreaksComputerFactory,
 				monospaceLineBreaksComputerFactory,
-				options,
-				this.model.getOptions().tabSize
+				fontInfo,
+				this.model.getOptions().tabSize,
+				wrappingStrategy,
+				wrappingInfo.wrappingColumn,
+				wrappingIndent,
+				wordBreak,
+				wrapOnEscapedLineFeeds
 			);
 		}
 
@@ -262,8 +274,13 @@ export class ViewModel extends Disposable implements IViewModel {
 	private _onConfigurationChanged(eventsCollector: ViewModelEventsCollector, e: ConfigurationChangedEvent): void {
 		const stableViewport = this._captureStableViewport();
 		const options = this._configuration.options;
+		const fontInfo = options.get(EditorOption.fontInfo);
+		const wrappingStrategy = options.get(EditorOption.wrappingStrategy);
+		const wrappingInfo = options.get(EditorOption.wrappingInfo);
+		const wrappingIndent = options.get(EditorOption.wrappingIndent);
+		const wordBreak = options.get(EditorOption.wordBreak);
 
-		if (this._lines.setWrappingSettings(options)) {
+		if (this._lines.setWrappingSettings(fontInfo, wrappingStrategy, wrappingInfo.wrappingColumn, wrappingIndent, wordBreak)) {
 			eventsCollector.emitViewEvent(new viewEvents.ViewFlushedEvent());
 			eventsCollector.emitViewEvent(new viewEvents.ViewLineMappingChangedEvent());
 			eventsCollector.emitViewEvent(new viewEvents.ViewDecorationsChangedEvent(null));

--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../base/common/lifecycle.js';
-import { EditorOption, IComputedEditorOptions } from '../config/editorOptions.js';
+import { WrappingIndent } from '../config/editorOptions.js';
+import { FontInfo } from '../config/fontInfo.js';
 import { IPosition, Position } from '../core/position.js';
 import { Range } from '../core/range.js';
 import { IModelDecoration, IModelDeltaDecoration, ITextModel, PositionAffinity } from '../model.js';
@@ -21,7 +22,7 @@ import { LineInjectedText } from '../textModelEvents.js';
 export interface IViewModelLines extends IDisposable {
 	createCoordinatesConverter(): ICoordinatesConverter;
 
-	setWrappingSettings(options: IComputedEditorOptions): boolean;
+	setWrappingSettings(fontInfo: FontInfo, wrappingStrategy: 'simple' | 'advanced', wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll'): boolean;
 	setTabSize(newTabSize: number): boolean;
 	getHiddenAreas(): Range[];
 	setHiddenAreas(_ranges: readonly Range[]): boolean;
@@ -64,8 +65,13 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 	private readonly _domLineBreaksComputerFactory: ILineBreaksComputerFactory;
 	private readonly _monospaceLineBreaksComputerFactory: ILineBreaksComputerFactory;
 
-	private options: IComputedEditorOptions;
+	private fontInfo: FontInfo;
 	private tabSize: number;
+	private wrappingColumn: number;
+	private wrappingIndent: WrappingIndent;
+	private wordBreak: 'normal' | 'keepAll';
+	private wrappingStrategy: 'simple' | 'advanced';
+	private wrapOnEscapedLineFeeds: boolean;
 
 	private modelLineProjections!: IModelLineProjection[];
 
@@ -81,16 +87,26 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 		model: ITextModel,
 		domLineBreaksComputerFactory: ILineBreaksComputerFactory,
 		monospaceLineBreaksComputerFactory: ILineBreaksComputerFactory,
-		options: IComputedEditorOptions,
+		fontInfo: FontInfo,
 		tabSize: number,
+		wrappingStrategy: 'simple' | 'advanced',
+		wrappingColumn: number,
+		wrappingIndent: WrappingIndent,
+		wordBreak: 'normal' | 'keepAll',
+		wrapOnEscapedLineFeeds: boolean
 	) {
 		this._editorId = editorId;
 		this.model = model;
 		this._validModelVersionId = -1;
 		this._domLineBreaksComputerFactory = domLineBreaksComputerFactory;
 		this._monospaceLineBreaksComputerFactory = monospaceLineBreaksComputerFactory;
-		this.options = options;
+		this.fontInfo = fontInfo;
 		this.tabSize = tabSize;
+		this.wrappingStrategy = wrappingStrategy;
+		this.wrappingColumn = wrappingColumn;
+		this.wrappingIndent = wrappingIndent;
+		this.wordBreak = wordBreak;
+		this.wrapOnEscapedLineFeeds = wrapOnEscapedLineFeeds;
 
 		this._constructLines(/*resetHiddenAreas*/true, null);
 	}
@@ -258,19 +274,23 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 		return true;
 	}
 
-	public setWrappingSettings(options: IComputedEditorOptions): boolean {
-		const equalFontInfo = this.options.get(EditorOption.fontInfo).equals(options.get(EditorOption.fontInfo));
-		const equalWrappingStrategy = this.options.get(EditorOption.wrappingStrategy) === options.get(EditorOption.wrappingStrategy);
-		const equalWrappingInfo = this.options.get(EditorOption.wrappingInfo) === options.get(EditorOption.wrappingInfo);
-		const equalWrappingIndent = this.options.get(EditorOption.wrappingIndent) === options.get(EditorOption.wrappingIndent);
-		const equalWordBreak = this.options.get(EditorOption.wordBreak) === options.get(EditorOption.wordBreak);
-		if (equalFontInfo && equalWrappingStrategy && equalWrappingInfo && equalWrappingIndent && equalWordBreak) {
+	public setWrappingSettings(fontInfo: FontInfo, wrappingStrategy: 'simple' | 'advanced', wrappingColumn: number, wrappingIndent: WrappingIndent, wordBreak: 'normal' | 'keepAll'): boolean {
+		const equalFontInfo = this.fontInfo.equals(fontInfo);
+		const equalWrappingStrategy = (this.wrappingStrategy === wrappingStrategy);
+		const equalWrappingColumn = (this.wrappingColumn === wrappingColumn);
+		const equalWrappingIndent = (this.wrappingIndent === wrappingIndent);
+		const equalWordBreak = (this.wordBreak === wordBreak);
+		if (equalFontInfo && equalWrappingStrategy && equalWrappingColumn && equalWrappingIndent && equalWordBreak) {
 			return false;
 		}
 
-		const onlyWrappingColumnChanged = (equalFontInfo && equalWrappingStrategy && !equalWrappingInfo && equalWrappingIndent && equalWordBreak);
+		const onlyWrappingColumnChanged = (equalFontInfo && equalWrappingStrategy && !equalWrappingColumn && equalWrappingIndent && equalWordBreak);
 
-		this.options = options;
+		this.fontInfo = fontInfo;
+		this.wrappingStrategy = wrappingStrategy;
+		this.wrappingColumn = wrappingColumn;
+		this.wrappingIndent = wrappingIndent;
+		this.wordBreak = wordBreak;
 
 		let previousLineBreaks: ((ModelLineProjectionData | null)[]) | null = null;
 		if (onlyWrappingColumnChanged) {
@@ -287,7 +307,7 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 
 	public createLineBreaksComputer(_context?: ILineBreaksComputerContext): ILineBreaksComputer {
 		const lineBreaksComputerFactory = (
-			this.options.get(EditorOption.wrappingStrategy) === 'advanced'
+			this.wrappingStrategy === 'advanced'
 				? this._domLineBreaksComputerFactory
 				: this._monospaceLineBreaksComputerFactory
 		);
@@ -299,7 +319,7 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 				return this.model.getLineInjectedText(lineNumber, this._editorId);
 			}
 		};
-		return lineBreaksComputerFactory.createLineBreaksComputer(context, this.options, this.tabSize);
+		return lineBreaksComputerFactory.createLineBreaksComputer(context, this.fontInfo, this.tabSize, this.wrappingColumn, this.wrappingIndent, this.wordBreak, this.wrapOnEscapedLineFeeds);
 	}
 
 	public onModelFlushed(): void {
@@ -1130,7 +1150,7 @@ export class ViewModelLinesFromModelAsIs implements IViewModelLines {
 		return false;
 	}
 
-	public setWrappingSettings(options: IComputedEditorOptions): boolean {
+	public setWrappingSettings(_fontInfo: FontInfo, _wrappingStrategy: 'simple' | 'advanced', _wrappingColumn: number, _wrappingIndent: WrappingIndent): boolean {
 		return false;
 	}
 

--- a/src/vs/editor/test/browser/viewModel/modelLineProjection.test.ts
+++ b/src/vs/editor/test/browser/viewModel/modelLineProjection.test.ts
@@ -94,9 +94,14 @@ suite('Editor ViewModel - SplitLinesCollection', () => {
 	});
 
 	function withSplitLinesCollection(text: string, callback: (model: TextModel, linesCollection: ViewModelLinesFromProjectedModel) => void): void {
-		const config = new TestConfiguration({ wrappingStrategy: 'simple' });
+		const config = new TestConfiguration({});
+		const wrappingInfo = config.options.get(EditorOption.wrappingInfo);
+		const fontInfo = config.options.get(EditorOption.fontInfo);
 		const wordWrapBreakAfterCharacters = config.options.get(EditorOption.wordWrapBreakAfterCharacters);
 		const wordWrapBreakBeforeCharacters = config.options.get(EditorOption.wordWrapBreakBeforeCharacters);
+		const wrappingIndent = config.options.get(EditorOption.wrappingIndent);
+		const wordBreak = config.options.get(EditorOption.wordBreak);
+		const wrapOnEscapedLineFeeds = config.options.get(EditorOption.wrapOnEscapedLineFeeds);
 		const lineBreaksComputerFactory = new MonospaceLineBreaksComputerFactory(wordWrapBreakBeforeCharacters, wordWrapBreakAfterCharacters);
 
 		const model = createTextModel(text);
@@ -106,8 +111,13 @@ suite('Editor ViewModel - SplitLinesCollection', () => {
 			model,
 			lineBreaksComputerFactory,
 			lineBreaksComputerFactory,
-			config.options,
-			model.getOptions().tabSize
+			fontInfo,
+			model.getOptions().tabSize,
+			'simple',
+			wrappingInfo.wrappingColumn,
+			wrappingIndent,
+			wordBreak,
+			wrapOnEscapedLineFeeds
 		);
 
 		callback(model, linesCollection);
@@ -933,11 +943,14 @@ suite('SplitLinesCollection', () => {
 		const configuration = new TestConfiguration({
 			wordWrap: wordWrap,
 			wordWrapColumn: wordWrapColumn,
-			wrappingIndent: 'indent',
-			wrappingStrategy: 'simple'
+			wrappingIndent: 'indent'
 		});
+		const wrappingInfo = configuration.options.get(EditorOption.wrappingInfo);
+		const fontInfo = configuration.options.get(EditorOption.fontInfo);
 		const wordWrapBreakAfterCharacters = configuration.options.get(EditorOption.wordWrapBreakAfterCharacters);
 		const wordWrapBreakBeforeCharacters = configuration.options.get(EditorOption.wordWrapBreakBeforeCharacters);
+		const wrappingIndent = configuration.options.get(EditorOption.wrappingIndent);
+		const wordBreak = configuration.options.get(EditorOption.wordBreak);
 
 		const lineBreaksComputerFactory = new MonospaceLineBreaksComputerFactory(wordWrapBreakBeforeCharacters, wordWrapBreakAfterCharacters);
 
@@ -946,8 +959,13 @@ suite('SplitLinesCollection', () => {
 			model,
 			lineBreaksComputerFactory,
 			lineBreaksComputerFactory,
-			configuration.options,
-			model.getOptions().tabSize
+			fontInfo,
+			model.getOptions().tabSize,
+			'simple',
+			wrappingInfo.wrappingColumn,
+			wrappingIndent,
+			wordBreak,
+			wrapOnEscapedLineFeeds
 		);
 
 		callback(linesCollection);

--- a/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
+++ b/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
-import { EditorOption, EditorOptions, WrappingIndent } from '../../../common/config/editorOptions.js';
+import { EditorOptions, WrappingIndent } from '../../../common/config/editorOptions.js';
 import { FontInfo } from '../../../common/config/fontInfo.js';
 import { ILineBreaksComputerContext, ILineBreaksComputerFactory, ModelLineProjectionData } from '../../../common/modelLineProjectionData.js';
 import { MonospaceLineBreaksComputerFactory } from '../../../common/viewModel/monospaceLineBreaksComputer.js';
-import { ComputedEditorOptions } from '../../../browser/config/editorConfiguration.js';
 
 function parseAnnotatedText(annotatedText: string): { text: string; indices: number[] } {
 	let text = '';
@@ -72,19 +71,7 @@ function getLineBreakData(factory: ILineBreaksComputerFactory, tabSize: number, 
 			return null;
 		}
 	};
-	const options = new ComputedEditorOptions();
-	options._write(EditorOption.fontInfo, fontInfo);
-	options._write(EditorOption.wrappingIndent, wrappingIndent);
-	options._write(EditorOption.wordWrapColumn, breakAfter);
-	options._write(EditorOption.wordBreak, wordBreak);
-	options._write(EditorOption.wrapOnEscapedLineFeeds, wrapOnEscapedLineFeeds);
-	options._write(EditorOption.wrappingInfo, {
-		isDominatedByLongLines: false,
-		isWordWrapMinified: false,
-		isViewportWrapping: false,
-		wrappingColumn: breakAfter,
-	});
-	const lineBreaksComputer = factory.createLineBreaksComputer(context, options, tabSize);
+	const lineBreaksComputer = factory.createLineBreaksComputer(context, fontInfo, tabSize, breakAfter, wrappingIndent, wordBreak, wrapOnEscapedLineFeeds);
 	const previousLineBreakDataClone = previousLineBreakData ? new ModelLineProjectionData(null, null, previousLineBreakData.breakOffsets.slice(0), previousLineBreakData.breakOffsetsVisibleColumn.slice(0), previousLineBreakData.wrappedTextIndentLength) : null;
 	lineBreaksComputer.addRequest(1, previousLineBreakDataClone);
 	return lineBreaksComputer.finalize()[0];


### PR DESCRIPTION
Cherry-pick of 4bd42b07a65b73751134dd48157f3136812185e4 to `release/1.112`.

Original PR: #302386

This reverts commit ccc96be184f11b10279c2c714fdde14ccd06c09a.