### PR TITLE
feat: support opening folders on Mac with vscode

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -224,6 +224,10 @@ export interface ICommonNativeHostService {
 	installShellCommand(): Promise<void>;
 	uninstallShellCommand(): Promise<void>;
 
+	// macOS Finder action
+	installFinderAction(): Promise<void>;
+	uninstallFinderAction(): Promise<void>;
+
 	// Lifecycle
 	notifyReady(): Promise<void>;
 	relaunch(options?: { addArgs?: string[]; removeArgs?: string[] }): Promise<void>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import { exec } from 'child_process';
 import { app, BrowserWindow, clipboard, contentTracing, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, Notification, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, powerSaveBlocker, SaveDialogOptions, SaveDialogReturnValue, screen, shell, webContents } from 'electron';
-import { arch, cpus, freemem, loadavg, platform, release, totalmem, type } from 'os';
+import { arch, cpus, freemem, homedir, loadavg, platform, release, totalmem, type } from 'os';
 import { promisify } from 'util';
 import { memoize } from '../../../base/common/decorators.js';
 import { Emitter, Event } from '../../../base/common/event.js';
@@ -554,6 +554,276 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		}
 
 		return { source, target };
+	}
+
+	//#endregion
+
+	//#region macOS Finder Action
+
+	async installFinderAction(_windowId: number | undefined): Promise<void> {
+		const workflowPath = this.getFinderActionWorkflowPath();
+		const infoPlist = this.getFinderActionInfoPlist();
+		const documentWflow = this.getFinderActionDocumentWflow();
+
+		await fs.promises.mkdir(join(workflowPath, 'Contents'), { recursive: true });
+		await Promise.all([
+			fs.promises.writeFile(join(workflowPath, 'Contents', 'Info.plist'), infoPlist, 'utf-8'),
+			fs.promises.writeFile(join(workflowPath, 'Contents', 'document.wflow'), documentWflow, 'utf-8'),
+		]);
+	}
+
+	async uninstallFinderAction(_windowId: number | undefined): Promise<void> {
+		const workflowPath = this.getFinderActionWorkflowPath();
+
+		try {
+			await fs.promises.rm(workflowPath, { recursive: true });
+		} catch (error) {
+			if (error.code !== 'ENOENT') {
+				throw error;
+			}
+		}
+	}
+
+	private getFinderActionWorkflowPath(): string {
+		const workflowName = `Open with ${this.productService.nameShort}.workflow`;
+		return join(homedir(), 'Library', 'Services', workflowName);
+	}
+
+	private getFinderActionInfoPlist(): string {
+		const nameShort = this.productService.nameShort.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+		return [
+			'<?xml version="1.0" encoding="UTF-8"?>',
+			'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+			'<plist version="1.0">',
+			'<dict>',
+			'\t<key>NSServices</key>',
+			'\t<array>',
+			'\t\t<dict>',
+			'\t\t\t<key>NSMenuItem</key>',
+			'\t\t\t<dict>',
+			`\t\t\t\t<key>default</key>`,
+			`\t\t\t\t<string>Open with ${nameShort}</string>`,
+			'\t\t\t</dict>',
+			'\t\t\t<key>NSMessage</key>',
+			'\t\t\t<string>runWorkflowAsService</string>',
+			'\t\t\t<key>NSSendFileTypes</key>',
+			'\t\t\t<array>',
+			'\t\t\t\t<string>public.item</string>',
+			'\t\t\t\t<string>public.folder</string>',
+			'\t\t\t</array>',
+			'\t\t</dict>',
+			'\t</array>',
+			'</dict>',
+			'</plist>',
+			'',
+		].join('\n');
+	}
+
+	/**
+	 * Generates an Automator "Run Shell Script" workflow plist.
+	 * The static metadata values (AMApplicationBuild, AMApplicationVersion, etc.)
+	 * match what Automator.app produces when creating a new Quick Action workflow
+	 * with a single "Run Shell Script" action configured to pass input as arguments.
+	 */
+	private getFinderActionDocumentWflow(): string {
+		const appName = this.productService.nameLong.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+		return [
+			'<?xml version="1.0" encoding="UTF-8"?>',
+			'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+			'<plist version="1.0">',
+			'<dict>',
+			'\t<key>AMApplicationBuild</key>',
+			'\t<string>523</string>',
+			'\t<key>AMApplicationVersion</key>',
+			'\t<string>2.10</string>',
+			'\t<key>AMDocumentVersion</key>',
+			'\t<string>2</string>',
+			'\t<key>actions</key>',
+			'\t<array>',
+			'\t\t<dict>',
+			'\t\t\t<key>action</key>',
+			'\t\t\t<dict>',
+			'\t\t\t\t<key>AMAccepts</key>',
+			'\t\t\t\t<dict>',
+			'\t\t\t\t\t<key>Container</key>',
+			'\t\t\t\t\t<string>List</string>',
+			'\t\t\t\t\t<key>Optional</key>',
+			'\t\t\t\t\t<false/>',
+			'\t\t\t\t\t<key>Types</key>',
+			'\t\t\t\t\t<array>',
+			'\t\t\t\t\t\t<string>com.apple.cocoa.path</string>',
+			'\t\t\t\t\t</array>',
+			'\t\t\t\t</dict>',
+			'\t\t\t\t<key>AMActionVersion</key>',
+			'\t\t\t\t<string>1.0.2</string>',
+			'\t\t\t\t<key>AMApplication</key>',
+			'\t\t\t\t<array>',
+			'\t\t\t\t\t<string>Automator</string>',
+			'\t\t\t\t</array>',
+			'\t\t\t\t<key>AMLargeIcon</key>',
+			'\t\t\t\t<false/>',
+			'\t\t\t\t<key>AMParameterProperties</key>',
+			'\t\t\t\t<dict>',
+			'\t\t\t\t\t<key>COMMAND_STRING</key>',
+			'\t\t\t\t\t<dict/>',
+			'\t\t\t\t\t<key>CheckedForUserDefaultShell</key>',
+			'\t\t\t\t\t<dict/>',
+			'\t\t\t\t\t<key>inputMethod</key>',
+			'\t\t\t\t\t<dict/>',
+			'\t\t\t\t\t<key>shell</key>',
+			'\t\t\t\t\t<dict/>',
+			'\t\t\t\t\t<key>source</key>',
+			'\t\t\t\t\t<dict/>',
+			'\t\t\t\t</dict>',
+			'\t\t\t\t<key>AMProvides</key>',
+			'\t\t\t\t<dict>',
+			'\t\t\t\t\t<key>Container</key>',
+			'\t\t\t\t\t<string>List</string>',
+			'\t\t\t\t\t<key>Types</key>',
+			'\t\t\t\t\t<array>',
+			'\t\t\t\t\t\t<string>com.apple.cocoa.path</string>',
+			'\t\t\t\t\t</array>',
+			'\t\t\t\t</dict>',
+			'\t\t\t\t<key>ActionBundlePath</key>',
+			'\t\t\t\t<string>/System/Library/Automator/Run Shell Script.action</string>',
+			'\t\t\t\t<key>ActionName</key>',
+			'\t\t\t\t<string>Run Shell Script</string>',
+			'\t\t\t\t<key>ActionParameters</key>',
+			'\t\t\t\t<dict>',
+			'\t\t\t\t\t<key>COMMAND_STRING</key>',
+			`\t\t\t\t\t<string>open -a "${appName}" "$@"</string>`,
+			'\t\t\t\t\t<key>CheckedForUserDefaultShell</key>',
+			'\t\t\t\t\t<true/>',
+			'\t\t\t\t\t<key>inputMethod</key>',
+			'\t\t\t\t\t<integer>1</integer>',
+			'\t\t\t\t\t<key>shell</key>',
+			'\t\t\t\t\t<string>/bin/zsh</string>',
+			'\t\t\t\t\t<key>source</key>',
+			'\t\t\t\t\t<string></string>',
+			'\t\t\t\t</dict>',
+			'\t\t\t\t<key>BundleIdentifier</key>',
+			'\t\t\t\t<string>com.apple.RunShellScript</string>',
+			'\t\t\t\t<key>CFBundleVersion</key>',
+			'\t\t\t\t<string>1.0.2</string>',
+			'\t\t\t\t<key>CanShowSelectedItemsWhenRun</key>',
+			'\t\t\t\t<true/>',
+			'\t\t\t\t<key>CanShowWhenRun</key>',
+			'\t\t\t\t<true/>',
+			'\t\t\t\t<key>Category</key>',
+			'\t\t\t\t<array>',
+			'\t\t\t\t\t<string>AMCategoryUtilities</string>',
+			'\t\t\t\t</array>',
+			'\t\t\t\t<key>Class Name</key>',
+			'\t\t\t\t<string>RunShellScriptAction</string>',
+			'\t\t\t\t<key>InputUUID</key>',
+			'\t\t\t\t<string>A9AAE02E-BF76-4CAB-B87A-3DBE00213F46</string>',
+			'\t\t\t\t<key>Keywords</key>',
+			'\t\t\t\t<array>',
+			'\t\t\t\t\t<string>Shell</string>',
+			'\t\t\t\t\t<string>Script</string>',
+			'\t\t\t\t\t<string>Command</string>',
+			'\t\t\t\t\t<string>Run</string>',
+			'\t\t\t\t</array>',
+			'\t\t\t\t<key>OutputUUID</key>',
+			'\t\t\t\t<string>6B8C4F1E-319A-4055-9F53-4B0104B7E857</string>',
+			'\t\t\t\t<key>UUID</key>',
+			'\t\t\t\t<string>7F2E2D41-A56D-4E4E-A4B0-8C1C4A9D0C3F</string>',
+			'\t\t\t\t<key>UnlocalizedApplications</key>',
+			'\t\t\t\t<array>',
+			'\t\t\t\t\t<string>Automator</string>',
+			'\t\t\t\t</array>',
+			'\t\t\t\t<key>arguments</key>',
+			'\t\t\t\t<dict>',
+			'\t\t\t\t\t<key>0</key>',
+			'\t\t\t\t\t<dict>',
+			'\t\t\t\t\t\t<key>default value</key>',
+			'\t\t\t\t\t\t<integer>0</integer>',
+			'\t\t\t\t\t\t<key>name</key>',
+			'\t\t\t\t\t\t<string>inputMethod</string>',
+			'\t\t\t\t\t\t<key>required</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>type</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>uuid</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t</dict>',
+			'\t\t\t\t\t<key>1</key>',
+			'\t\t\t\t\t<dict>',
+			'\t\t\t\t\t\t<key>default value</key>',
+			`\t\t\t\t\t\t<string>open -a "${appName}" "$@"</string>`,
+			'\t\t\t\t\t\t<key>name</key>',
+			'\t\t\t\t\t\t<string>COMMAND_STRING</string>',
+			'\t\t\t\t\t\t<key>required</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>type</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>uuid</key>',
+			'\t\t\t\t\t\t<string>1</string>',
+			'\t\t\t\t\t</dict>',
+			'\t\t\t\t\t<key>2</key>',
+			'\t\t\t\t\t<dict>',
+			'\t\t\t\t\t\t<key>default value</key>',
+			'\t\t\t\t\t\t<false/>',
+			'\t\t\t\t\t\t<key>name</key>',
+			'\t\t\t\t\t\t<string>CheckedForUserDefaultShell</string>',
+			'\t\t\t\t\t\t<key>required</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>type</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>uuid</key>',
+			'\t\t\t\t\t\t<string>2</string>',
+			'\t\t\t\t\t</dict>',
+			'\t\t\t\t\t<key>3</key>',
+			'\t\t\t\t\t<dict>',
+			'\t\t\t\t\t\t<key>default value</key>',
+			'\t\t\t\t\t\t<string></string>',
+			'\t\t\t\t\t\t<key>name</key>',
+			'\t\t\t\t\t\t<string>source</string>',
+			'\t\t\t\t\t\t<key>required</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>type</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>uuid</key>',
+			'\t\t\t\t\t\t<string>3</string>',
+			'\t\t\t\t\t</dict>',
+			'\t\t\t\t\t<key>4</key>',
+			'\t\t\t\t\t<dict>',
+			'\t\t\t\t\t\t<key>default value</key>',
+			'\t\t\t\t\t\t<string>/bin/zsh</string>',
+			'\t\t\t\t\t\t<key>name</key>',
+			'\t\t\t\t\t\t<string>shell</string>',
+			'\t\t\t\t\t\t<key>required</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>type</key>',
+			'\t\t\t\t\t\t<string>0</string>',
+			'\t\t\t\t\t\t<key>uuid</key>',
+			'\t\t\t\t\t\t<string>4</string>',
+			'\t\t\t\t\t</dict>',
+			'\t\t\t\t</dict>',
+			'\t\t\t\t<key>isViewVisible</key>',
+			'\t\t\t\t<integer>1</integer>',
+			'\t\t\t\t<key>location</key>',
+			'\t\t\t\t<string>309.000000:253.000000</string>',
+			'\t\t\t\t<key>nibPath</key>',
+			'\t\t\t\t<string>/System/Library/Automator/Run Shell Script.action/Contents/Resources/Base.lproj/main.nib</string>',
+			'\t\t\t</dict>',
+			'\t\t\t<key>isViewVisible</key>',
+			'\t\t\t<integer>1</integer>',
+			'\t\t</dict>',
+			'\t</array>',
+			'\t<key>connectors</key>',
+			'\t<dict/>',
+			'\t<key>workflowMetaData</key>',
+			'\t<dict>',
+			'\t\t<key>serviceInputTypeIdentifier</key>',
+			'\t\t<string>com.apple.Automator.fileSystemObject</string>',
+			'\t\t<key>workflowTypeIdentifier</key>',
+			'\t\t<string>com.apple.Automator.servicesMenu</string>',
+			'\t</dict>',
+			'</dict>',
+			'</plist>',
+			'',
+		].join('\n');
 	}
 
 	//#endregion

--- a/src/vs/workbench/electron-browser/actions/installActions.ts
+++ b/src/vs/workbench/electron-browser/actions/installActions.ts
@@ -75,3 +75,63 @@ export class UninstallShellScriptAction extends Action2 {
 		}
 	}
 }
+
+export class InstallFinderAction extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.installFinderAction',
+			title: localize2('installFinderAction', "Install 'Open with {0}' in Finder", product.nameShort),
+			category: shellCommandCategory,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		const dialogService = accessor.get(IDialogService);
+		const productService = accessor.get(IProductService);
+
+		try {
+			await nativeHostService.installFinderAction();
+
+			dialogService.info(localize('finderActionInstalled', "'Open with {0}' successfully installed in Finder.", productService.nameShort));
+		} catch (error) {
+			if (isCancellationError(error)) {
+				return;
+			}
+
+			dialogService.error(toErrorMessage(error));
+		}
+	}
+}
+
+export class UninstallFinderAction extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.uninstallFinderAction',
+			title: localize2('uninstallFinderAction', "Uninstall 'Open with {0}' from Finder", product.nameShort),
+			category: shellCommandCategory,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const nativeHostService = accessor.get(INativeHostService);
+		const dialogService = accessor.get(IDialogService);
+		const productService = accessor.get(IProductService);
+
+		try {
+			await nativeHostService.uninstallFinderAction();
+
+			dialogService.info(localize('finderActionUninstalled', "'Open with {0}' successfully uninstalled from Finder.", productService.nameShort));
+		} catch (error) {
+			if (isCancellationError(error)) {
+				return;
+			}
+
+			dialogService.error(toErrorMessage(error));
+		}
+	}
+}

--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -19,7 +19,7 @@ import { IsMacContext } from '../../platform/contextkey/common/contextkeys.js';
 import { INativeHostService } from '../../platform/native/common/native.js';
 import { IJSONContributionRegistry, Extensions as JSONExtensions } from '../../platform/jsonschemas/common/jsonContributionRegistry.js';
 import { IJSONSchema } from '../../base/common/jsonSchema.js';
-import { InstallShellScriptAction, UninstallShellScriptAction } from './actions/installActions.js';
+import { InstallShellScriptAction, UninstallShellScriptAction, InstallFinderAction, UninstallFinderAction } from './actions/installActions.js';
 import { EditorsVisibleContext, SingleEditorGroupsContext } from '../common/contextkeys.js';
 import { TELEMETRY_SETTING_ID } from '../../platform/telemetry/common/telemetry.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
@@ -60,10 +60,12 @@ import product from '../../platform/product/common/product.js';
 		});
 	}
 
-	// Actions: Install Shell Script (macOS only)
+	// Actions: Install Shell Script & Finder Action (macOS only)
 	if (isMacintosh) {
 		registerAction2(InstallShellScriptAction);
 		registerAction2(UninstallShellScriptAction);
+		registerAction2(InstallFinderAction);
+		registerAction2(UninstallFinderAction);
 	}
 
 	// Quit

--- a/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-browser/workbenchTestServices.ts
@@ -154,6 +154,8 @@ export class TestNativeHostService implements INativeHostService {
 	async toggleWindowTabsBar(): Promise<void> { }
 	async installShellCommand(): Promise<void> { }
 	async uninstallShellCommand(): Promise<void> { }
+	async installFinderAction(): Promise<void> { }
+	async uninstallFinderAction(): Promise<void> { }
 	async notifyReady(): Promise<void> { }
 	async relaunch(options?: { addArgs?: string[] | undefined; removeArgs?: string[] | undefined } | undefined): Promise<void> { }
 	async reload(): Promise<void> { }


### PR DESCRIPTION
Add **Install 'Open with Code' in Finder** and **Uninstall 'Open with Code' from Finder** commands under the Shell Command category (macOS only).

These commands install/uninstall a macOS Automator Quick Action workflow to \`~/Library/Services/\` that adds an 'Open with {productName}' entry to the Finder right-click context menu (Quick Actions / Services).

The workflow runs \`open -a "{appName}" "$@"\` to open selected files/folders in VS Code.

Each VS Code build (Stable, Insiders, OSS) creates a distinctly-named workflow, so multiple installations coexist without conflict.

### How to use
1. Open VS Code
2. Command Palette → **Shell Command: Install 'Open with Code' in Finder**
3. Right-click a folder in Finder → Quick Actions / Services → **Open with Code**

### Files changed
- \`src/vs/platform/native/common/native.ts\` — added \`installFinderAction\` / \`uninstallFinderAction\` to interface
- \`src/vs/platform/native/electron-main/nativeHostMainService.ts\` — implementation (generates Automator .workflow bundle)
- \`src/vs/workbench/electron-browser/actions/installActions.ts\` — action classes
- \`src/vs/workbench/electron-browser/desktop.contribution.ts\` — registration
- \`src/vs/workbench/test/electron-browser/workbenchTestServices.ts\` — test stubs

### Demo 

https://github.com/user-attachments/assets/48e1ac49-9258-4d48-b4d9-e476a8036918

