### PR TITLE
Improve CI status widget icons and layout in sessions changes view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -458,6 +458,7 @@ export class ChangesViewPane extends ViewPane {
 
 		// CI Status widget beneath the card
 		this.ciStatusWidget = this._register(this.instantiationService.createInstance(CIStatusWidget, this.bodyContainer));
+		this._register(this.ciStatusWidget.onDidChangeHeight(() => this.layoutTree()));
 
 		this._register(this.onDidChangeBodyVisibility(visible => {
 			if (visible) {
@@ -1053,15 +1054,53 @@ export class ChangesViewPane extends ViewPane {
 		const overviewHeight = this.overviewContainer?.offsetHeight ?? 0;
 		const containerPadding = 8; // 4px top + 4px bottom from .chat-editing-session-container
 		const containerBorder = 2; // 1px top + 1px bottom border
-		const ciWidgetHeight = this.ciStatusWidget?.element.offsetHeight ?? 0;
-		const ciWidgetMargin = ciWidgetHeight > 0 ? 8 : 0; // margin-top on CI widget
 
-		const usedHeight = bodyPadding + actionsHeight + actionsMargin + overviewHeight + containerPadding + containerBorder + ciWidgetHeight + ciWidgetMargin;
-		const availableHeight = Math.max(0, bodyHeight - usedHeight);
+		const fixedUsed = bodyPadding + actionsHeight + actionsMargin + overviewHeight + containerPadding + containerBorder;
 
-		// Limit height to the content so the tree doesn't exceed its items
-		const contentHeight = this.tree.contentHeight;
-		const treeHeight = Math.min(availableHeight, contentHeight);
+		// Determine CI widget space needs
+		const ciWidget = this.ciStatusWidget;
+		const ciVisible = ciWidget?.visible ?? false;
+		const ciHeaderHeight = ciVisible ? CIStatusWidget.HEADER_HEIGHT : 0;
+		const ciMargin = ciVisible ? 8 : 0; // margin-top on CI widget
+		const ciDesiredHeight = ciWidget?.desiredHeight ?? 0;
+
+		const spaceForTreeAndCI = Math.max(0, bodyHeight - fixedUsed - ciMargin);
+
+		// Give the tree priority, then CI gets the rest (with min/max on CI body)
+		const treeContentHeight = this.tree.contentHeight;
+		let treeHeight: number;
+		let ciBodyHeight = 0;
+
+		if (!ciVisible) {
+			treeHeight = Math.min(spaceForTreeAndCI, treeContentHeight);
+		} else {
+			// Reserve space for the CI header
+			const spaceAfterCIHeader = Math.max(0, spaceForTreeAndCI - ciHeaderHeight);
+
+			// Give the tree what it needs first, up to available space
+			treeHeight = Math.min(spaceAfterCIHeader, treeContentHeight);
+
+			// Remaining goes to CI body
+			const remainingForCIBody = Math.max(0, spaceAfterCIHeader - treeHeight);
+			const ciDesiredBodyHeight = Math.max(0, ciDesiredHeight - ciHeaderHeight);
+
+			ciBodyHeight = Math.min(ciDesiredBodyHeight, remainingForCIBody);
+
+			// Ensure CI body gets at least MIN_BODY_HEIGHT if there's content
+			if (ciDesiredBodyHeight > 0 && ciBodyHeight < CIStatusWidget.MIN_BODY_HEIGHT) {
+				const minCIBody = Math.min(CIStatusWidget.MIN_BODY_HEIGHT, ciDesiredBodyHeight);
+				const needed = minCIBody - ciBodyHeight;
+				const canTake = Math.max(0, treeHeight - 0); // tree can shrink to 0
+				const taken = Math.min(needed, canTake);
+				treeHeight -= taken;
+				ciBodyHeight += taken;
+			}
+
+			// Cap CI body at MAX_BODY_HEIGHT
+			ciBodyHeight = Math.min(ciBodyHeight, CIStatusWidget.MAX_BODY_HEIGHT);
+
+			ciWidget!.layout(ciBodyHeight);
+		}
 
 		this.tree.layout(treeHeight, this.currentBodyWidth);
 		this.tree.getHTMLElement().style.height = `${treeHeight}px`;

--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -18,7 +18,6 @@ import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { WorkbenchList } from '../../../../platform/list/browser/listService.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { spinningLoading } from '../../../../platform/theme/common/iconRegistry.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { DEFAULT_LABELS_CONTAINER, IResourceLabel, ResourceLabels } from '../../../../workbench/browser/labels.js';
 import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
@@ -500,7 +499,7 @@ function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHubCIChec
 function getHeaderIconAndClass(checks: readonly IGitHubCICheck[], overallStatus: GitHubCIOverallStatus): { icon: ThemeIcon; className: string } {
 	const counts = getCheckCounts(checks);
 	if (counts.running > 0) {
-		return { icon: spinningLoading, className: 'ci-status-running' };
+		return { icon: Codicon.loading, className: 'ci-status-running' };
 	}
 
 	switch (overallStatus) {
@@ -518,7 +517,7 @@ function getHeaderIconAndClass(checks: readonly IGitHubCICheck[], overallStatus:
 function getCheckIcon(check: IGitHubCICheck): ThemeIcon {
 	switch (check.status) {
 		case GitHubCheckStatus.InProgress:
-			return spinningLoading;
+			return Codicon.loading;
 		case GitHubCheckStatus.Queued:
 			return Codicon.circleFilled;
 		case GitHubCheckStatus.Completed:

--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -286,7 +286,7 @@ export class CIStatusWidget extends Disposable {
 		const fixChecksAction = this._headerActionDisposables.add(new Action(
 			'ci.fixChecks',
 			localize('ci.fixChecks', "Fix Checks"),
-			ThemeIcon.asClassName(Codicon.sparkle),
+			ThemeIcon.asClassName(Codicon.lightbulbAutofix),
 			true,
 			async () => {
 				await this._sendFixChecksPrompt(failedChecks);
@@ -483,6 +483,8 @@ function getCheckIcon(check: IGitHubCICheck): ThemeIcon {
 				default:
 					return Codicon.circleFilled;
 			}
+		default:
+			return Codicon.circleFilled;
 	}
 }
 

--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -456,7 +456,7 @@ function getHeaderIconAndClass(checks: readonly IGitHubCICheck[], overallStatus:
 		case GitHubCIOverallStatus.Failure:
 			return { icon: Codicon.error, className: 'ci-status-failure' };
 		case GitHubCIOverallStatus.Pending:
-			return { icon: Codicon.circle, className: 'ci-status-pending' };
+			return { icon: Codicon.circleFilled, className: 'ci-status-pending' };
 		default:
 			return { icon: Codicon.circleFilled, className: 'ci-status-neutral' };
 	}
@@ -467,7 +467,7 @@ function getCheckIcon(check: IGitHubCICheck): ThemeIcon {
 		case GitHubCheckStatus.InProgress:
 			return spinningLoading;
 		case GitHubCheckStatus.Queued:
-			return Codicon.circle;
+			return Codicon.circleFilled;
 		case GitHubCheckStatus.Completed:
 			switch (check.conclusion) {
 				case GitHubCheckConclusion.Success:

--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -9,6 +9,7 @@ import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js'
 import { IListRenderer, IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { Action } from '../../../../base/common/actions.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
@@ -141,6 +142,10 @@ class CICheckListRenderer implements IListRenderer<ICICheckListItem, ICICheckTem
  */
 export class CIStatusWidget extends Disposable {
 
+	static readonly HEADER_HEIGHT = 30;
+	static readonly MIN_BODY_HEIGHT = 72; // at least 3 checks (3 * 24)
+	static readonly MAX_BODY_HEIGHT = 240; // at most 10 checks (10 * 24)
+
 	private readonly _domNode: HTMLElement;
 	private readonly _headerNode: HTMLElement;
 	private readonly _titleNode: HTMLElement;
@@ -153,12 +158,32 @@ export class CIStatusWidget extends Disposable {
 	private readonly _labels: ResourceLabels;
 	private readonly _headerActionDisposables = this._register(new DisposableStore());
 
+	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
+	readonly onDidChangeHeight = this._onDidChangeHeight.event;
+
 	private _collapsed = true;
+	private _checkCount = 0;
 	private _model: GitHubPullRequestCIModel | undefined;
 	private _sessionResource: URI | undefined;
 
 	get element(): HTMLElement {
 		return this._domNode;
+	}
+
+	/** The full content height the widget would like (header + all checks). */
+	get desiredHeight(): number {
+		if (this._checkCount === 0) {
+			return 0;
+		}
+		if (this._collapsed) {
+			return CIStatusWidget.HEADER_HEIGHT;
+		}
+		return CIStatusWidget.HEADER_HEIGHT + this._checkCount * CICheckListDelegate.ITEM_HEIGHT;
+	}
+
+	/** Whether the widget is currently visible (has checks to show). */
+	get visible(): boolean {
+		return this._checkCount > 0;
 	}
 
 	constructor(
@@ -225,9 +250,11 @@ export class CIStatusWidget extends Disposable {
 			this._sessionResource = sessionResource.read(reader);
 			this._model = model;
 			if (!model) {
+				this._checkCount = 0;
 				this._renderBody([]);
 				this._renderHeaderActions([]);
 				this._domNode.style.display = 'none';
+				this._onDidChangeHeight.fire();
 				return;
 			}
 
@@ -235,16 +262,26 @@ export class CIStatusWidget extends Disposable {
 			const overallStatus = model.overallStatus.read(reader);
 
 			if (checks.length === 0) {
+				this._checkCount = 0;
 				this._renderBody([]);
 				this._renderHeaderActions([]);
 				this._domNode.style.display = 'none';
+				this._onDidChangeHeight.fire();
 				return;
 			}
+
+			const sorted = sortChecks(checks);
+			const oldCount = this._checkCount;
+			this._checkCount = sorted.length;
 
 			this._domNode.style.display = '';
 			this._renderHeader(checks, overallStatus);
 			this._renderHeaderActions(getFailedChecks(checks));
-			this._renderBody(sortChecks(checks));
+			this._renderBody(sorted);
+
+			if (this._checkCount !== oldCount) {
+				this._onDidChangeHeight.fire();
+			}
 		});
 	}
 
@@ -252,6 +289,7 @@ export class CIStatusWidget extends Disposable {
 		this._collapsed = !this._collapsed;
 		this._bodyNode.style.display = this._collapsed ? 'none' : '';
 		this._updateTwistie();
+		this._onDidChangeHeight.fire();
 	}
 
 	private _updateTwistie(): void {
@@ -297,10 +335,25 @@ export class CIStatusWidget extends Disposable {
 		this._headerActionBarContainer.style.display = 'flex';
 	}
 
+	/**
+	 * Layout the widget body list to the given height.
+	 * Called by the parent view after computing available space.
+	 */
+	layout(maxBodyHeight: number): void {
+		if (this._collapsed || this._checkCount === 0) {
+			return;
+		}
+		const contentHeight = this._checkCount * CICheckListDelegate.ITEM_HEIGHT;
+		const bodyHeight = Math.min(contentHeight, maxBodyHeight);
+		this._list.getHTMLElement().style.height = `${bodyHeight}px`;
+		this._list.layout(bodyHeight);
+	}
+
 	private _renderBody(checks: readonly ICICheckListItem[]): void {
-		const height = checks.length * CICheckListDelegate.ITEM_HEIGHT;
-		this._list.getHTMLElement().style.height = `${height}px`;
-		this._list.layout(height);
+		const contentHeight = checks.length * CICheckListDelegate.ITEM_HEIGHT;
+		const bodyHeight = Math.min(contentHeight, CIStatusWidget.MAX_BODY_HEIGHT);
+		this._list.getHTMLElement().style.height = `${bodyHeight}px`;
+		this._list.layout(bodyHeight);
 		this._list.splice(0, this._list.length, checks);
 	}
 

--- a/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
@@ -152,9 +152,12 @@
 
 .ci-status-widget-title.ci-status-running .monaco-icon-label::before,
 .ci-status-widget-check.ci-status-running .monaco-icon-label::before,
-.ci-status-widget-title.ci-status-pending .monaco-icon-label::before,
-.ci-status-widget-check.ci-status-pending .monaco-icon-label::before {
+.ci-status-widget-title.ci-status-pending .monaco-icon-label::before {
 	color: var(--vscode-testing-iconQueued, var(--vscode-editorWarning-foreground));
+}
+
+.ci-status-widget-check.ci-status-pending .monaco-icon-label::before {
+	color: var(--vscode-descriptionForeground);
 }
 
 .ci-status-widget-title.ci-status-neutral .monaco-icon-label::before,


### PR DESCRIPTION
## Summary

Improves the CI checks list in the sessions window changes view with better icons and proper layout/scrolling behavior.

### Icon improvements
- **Header icon**: Shows a pending icon when checks are pending, red error icon on failure, green checkmark on success, and spinning loader when running
- **Queued checks**: Now show a filled circle icon (grey) instead of an empty outline, making them visually distinct
- **Fix Checks button**: Uses `lightbulbAutofix` codicon instead of `sparkle`
- **Default case**: Added fallback for unknown check statuses

### Layout improvements
- CI checks list now has **min height** (72px / 3 items) and **max height** (240px / 10 items)
- The changes tree gets priority for space; CI widget gets remaining space with guaranteed minimum
- CI list is properly scrollable when there are many checks
- Widget fires `onDidChangeHeight` event on expand/collapse and data changes to trigger parent re-layout
- Parent `layoutTree` collaboratively distributes space between the changes tree and CI widget