### PR TITLE
Clear native title attributes from chat inline anchors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatInlineAnchorWidget.ts
@@ -276,6 +276,10 @@ export class InlineAnchorWidget extends Disposable {
 		const fragment = location.range ? `${location.range.startLineNumber},${location.range.startColumn}` : '';
 		element.setAttribute('data-href', (fragment ? location.uri.with({ fragment }) : location.uri).toString());
 
+		// The markdown renderer can leave a native title attribute on the anchor.
+		// Drop it before installing the managed hover to avoid duplicate tooltip paths.
+		element.removeAttribute('title');
+
 		// Hover
 		const relativeLabel = labelService.getUriLabel(location.uri, { relative: true });
 		this._register(hoverService.setupManagedHover(getDefaultHoverDelegate('element'), element, relativeLabel));

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatInlineAnchorWidget.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatInlineAnchorWidget.test.ts
@@ -89,6 +89,18 @@ suite('ChatInlineAnchorWidget Metadata Validation', () => {
 		assert.ok(widget, 'Widget should be rendered for any vscodeLinkType value');
 	});
 
+	test('clears native title attributes before installing managed hover', () => {
+		const element = createTestElement('document.txt', 'file:///path/to/document.txt?vscodeLinkType=file');
+		const anchor = element.querySelector('a');
+		anchor?.setAttribute('title', 'native hover');
+
+		renderFileWidgets(element, instantiationService, mockAnchorService, disposables);
+
+		const widget = element.querySelector<HTMLElement>('.chat-inline-anchor-widget');
+		assert.ok(widget, 'Widget should be rendered');
+		assert.ok(!widget.hasAttribute('title'), 'Widget should remove the native title attribute before installing managed hover');
+	});
+
 	test('handles vscodeLinkType with other query parameters', () => {
 		const element = createTestElement('skillName', 'file:///test.txt?other=value&vscodeLinkType=skill&another=param');
 		renderFileWidgets(element, instantiationService, mockAnchorService, disposables);


### PR DESCRIPTION
Fix the native-title/custom-hover conflict in chat inline anchor widgets.

Repro:

1. Render a chat file pill from a markdown anchor that already has a native `title` attribute.
2. `InlineAnchorWidget` reuses that anchor element and installs a managed hover on it.
3. `hoverService` warns that the element already has a title attribute, and the native tooltip can conflict with the managed hover.

This change removes the stale native `title` attribute before the widget installs its managed hover, and adds a focused browser test covering that path.
