### PR TITLE
fix: preserve error telemetry stack traces in web environments (Codespaces)

### DIFF
--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -1041,5 +1041,44 @@ suite('TelemetryService', () => {
 		sinon.restore();
 	}));
 
+	test('Unexpected Error Telemetry preserves HTTPS URLs in web stack traces when piiPaths includes origin', sinonTestFn(function (this: any) {
+		const origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
+		Errors.setUnexpectedErrorHandler(() => { });
+
+		try {
+			const testAppender = new TestTelemetryAppender();
+			const webOrigin = 'https://codespace-host.github.dev';
+			const service = new TestErrorTelemetryService({ appenders: [testAppender], piiPaths: [webOrigin] });
+			const errorTelemetry = new ErrorTelemetry(service);
+
+			const bundlePath = '/static/build/bundle.js';
+			const stack = [
+				`Error: Something failed`,
+				`    at x3t._delegate (${webOrigin}${bundlePath}:1:200953)`,
+				`    at y4u.run (${webOrigin}${bundlePath}:1:304822)`,
+				`    at DedicatedWorkerGlobalScope.self.onmessage`,
+			];
+
+			const webError: any = new Error('Something failed');
+			webError.stack = stack.join('\n');
+
+			Errors.onUnexpectedError(webError);
+			this.clock.tick(ErrorTelemetry.ERROR_FLUSH_TIMEOUT);
+
+			assert.strictEqual(testAppender.getEventsCount(), 1);
+			const cs = testAppender.events[0].data.callstack;
+			// Verify the web origin is stripped (not leaked as PII)
+			assert.strictEqual(cs.indexOf(webOrigin), -1, 'Web origin should be stripped');
+			assert.strictEqual(cs.indexOf('https://'), -1, 'HTTPS scheme should be stripped');
+			// Verify the bundle path is preserved for debugging
+			assert.notStrictEqual(cs.indexOf(bundlePath), -1, 'Bundle path should be preserved');
+
+			errorTelemetry.dispose();
+			service.dispose();
+		} finally {
+			Errors.setUnexpectedErrorHandler(origErrorHandler);
+		}
+	}));
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -1041,7 +1041,7 @@ suite('TelemetryService', () => {
 		sinon.restore();
 	}));
 
-	test('Unexpected Error Telemetry preserves HTTPS URLs in web stack traces when piiPaths includes origin', sinonTestFn(function (this: any) {
+	test('Unexpected Error Telemetry strips web origin but preserves path in web stack traces when piiPaths includes origin', sinonTestFn(function (this: any) {
 		const origErrorHandler = Errors.errorHandler.getUnexpectedErrorHandler();
 		Errors.setUnexpectedErrorHandler(() => { });
 

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -117,7 +117,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 				appenders,
 				commonProperties: resolveWorkbenchCommonProperties(storageService, productService, isInternal, environmentService.remoteAuthority, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),
 				// Use the web origin as a cleanup pattern (analogous to appRoot on desktop).
-				// This strips the origin from HTTPS URLs in stack traces so the useful
+				// This strips the origin from web URLs in stack traces so the useful
 				// relative path (e.g. /static/build/bundle.js:1:200953) is preserved
 				// for debugging, while the origin itself is removed.
 				piiPaths: [mainWindow.location.origin],

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -18,6 +18,7 @@ import { getTelemetryLevel, isInternalTelemetry, isLoggingOnly, ITelemetryAppend
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IMeteredConnectionService } from '../../../../platform/meteredConnection/common/meteredConnection.js';
+import { mainWindow } from '../../../../base/browser/window.js';
 import { resolveWorkbenchCommonProperties } from './workbenchCommonProperties.js';
 import { experimentsEnabled } from '../common/workbenchTelemetryUtils.js';
 import { IRequestService, NO_FETCH_TELEMETRY } from '../../../../platform/request/common/request.js';
@@ -115,6 +116,11 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 			const config: ITelemetryServiceConfig = {
 				appenders,
 				commonProperties: resolveWorkbenchCommonProperties(storageService, productService, isInternal, environmentService.remoteAuthority, environmentService.options && environmentService.options.resolveCommonTelemetryProperties),
+				// Use the web origin as a cleanup pattern (analogous to appRoot on desktop).
+				// This strips the origin from HTTPS URLs in stack traces so the useful
+				// relative path (e.g. /static/build/bundle.js:1:200953) is preserved
+				// for debugging, while the origin itself is removed.
+				piiPaths: [mainWindow.location.origin],
 				sendErrorTelemetry: this.sendErrorTelemetry,
 				waitForExperimentProperties: experimentsEnabled(configurationService, productService, environmentService),
 				meteredConnectionService,


### PR DESCRIPTION
Fixes #302289

## Problem
In web environments (Codespaces, vscode.dev), error telemetry stack traces contain HTTPS URLs like `https://codespace-host.github.dev/static/build/bundle.js`. The `anonymizeFilePaths` function was fully redacting these URLs to `<REDACTED: user-file-path>` because no `piiPaths` were configured for browser environments — making all web error telemetry useless for debugging.

## Root Cause
The browser telemetry service (`src/vs/workbench/services/telemetry/browser/telemetryService.ts`) did not set `piiPaths`, unlike the electron-browser version which uses `getPiiPathsFromEnvironment(environmentService)`. Without `piiPaths`, the only cleanup pattern is for `vscode-file://` URLs, which doesn't match HTTPS URLs.

## Fix
Add `mainWindow.location.origin` as a `piiPaths` entry in the browser telemetry config. This is analogous to `appRoot` on desktop:
- The origin creates a cleanup pattern that **overlaps** with file regex matches, preventing redaction by `anonymizeFilePaths`
- The origin is **stripped** from the output in the cleanup step, so the useful relative path (e.g. `/static/build/bundle.js:1:200953`) is preserved
- If the origin itself contains PII (e.g. Codespaces hostnames), it gets properly removed

**Before:** `at x3t._delegate (https:/<REDACTED: user-file-path>:1:200953)`
**After:** `at x3t._delegate (/static/build/bundle.js:1:200953)`

## Testing
Added test verifying that HTTPS URLs in web stack traces are correctly handled when `piiPaths` includes the origin (origin stripped, bundle path preserved).