### PR TITLE
Improve screen reader labels for implicit context attachments

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -218,8 +218,9 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		const fileBasename = basename(file);
 		const fileDirname = dirname(file);
 		const friendlyName = `${fileBasename} ${fileDirname}`;
-		const baseAriaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached {0}, {1}, line {2} to line {3}", attachmentTypeName, friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached {0}, {1}", attachmentTypeName, friendlyName);
-		const ariaLabel = localize('chat.implicitFileContext', "Suggested context, {0}", baseAriaLabel);
+		const ariaLabel = range
+			? localize('chat.implicitFileContextWithRange', "Suggested context, {0}, {1}, line {2} to line {3}", attachmentTypeName, friendlyName, range.startLineNumber, range.endLineNumber)
+			: localize('chat.implicitFileContext', "Suggested context, {0}, {1}", attachmentTypeName, friendlyName);
 
 		const uriLabel = this.labelService.getUriLabel(file, { relative: true });
 		const currentFile = localize('openEditor', "Current {0} context", attachmentTypeName);

--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -99,7 +99,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		// Create toggle button BEFORE the label so it appears on the left
 		if (isSuggestedEnabled) {
 			if (!isSelection) {
-				const buttonMsg = context.enabled ? localize('disable', "Disable current {0} context", attachmentTypeName) : '';
+				const buttonMsg = context.enabled ? localize('removeImplicitContext', "Remove current {0} context", attachmentTypeName) : localize('addToContext', "Add to context");
 				const toggleButton = this.renderDisposables.add(new Button(contextNode, { supportIcons: true, title: buttonMsg }));
 				toggleButton.icon = context.enabled ? Codicon.x : Codicon.plus;
 				this.renderDisposables.add(toggleButton.onDidClick(async (e) => {
@@ -158,6 +158,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		if (isStringImplicitContextValue(context.value)) {
 			markdownTooltip = context.value.tooltip;
 			title = this.renderString(label, context.name, context.icon, context.value.resourceUri, markdownTooltip, localize('openFile', "Current file context"));
+			contextNode.ariaLabel = localize('chat.implicitStringContext', "Suggested context, {0}", context.name);
 		} else {
 			title = this.renderResource(context.value, context.isSelection, context.enabled, label, contextNode);
 		}
@@ -214,7 +215,8 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		const fileBasename = basename(file);
 		const fileDirname = dirname(file);
 		const friendlyName = `${fileBasename} ${fileDirname}`;
-		const ariaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached {0}, {1}, line {2} to line {3}", attachmentTypeName, friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached {0}, {1}", attachmentTypeName, friendlyName);
+		const baseAriaLabel = range ? localize('chat.fileAttachmentWithRange', "Attached {0}, {1}, line {2} to line {3}", attachmentTypeName, friendlyName, range.startLineNumber, range.endLineNumber) : localize('chat.fileAttachment', "Attached {0}, {1}", attachmentTypeName, friendlyName);
+		const ariaLabel = localize('chat.implicitFileContext', "Suggested context, {0}", baseAriaLabel);
 
 		const uriLabel = this.labelService.getUriLabel(file, { relative: true });
 		const currentFile = localize('openEditor', "Current {0} context", attachmentTypeName);

--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -99,7 +99,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		// Create toggle button BEFORE the label so it appears on the left
 		if (isSuggestedEnabled) {
 			if (!isSelection) {
-				const buttonMsg = context.enabled ? localize('removeImplicitContext', "Remove current {0} context", attachmentTypeName) : localize('addToContext', "Add to context");
+				const buttonMsg = context.enabled ? localize('disableImplicitContext', "Disable current {0} context", attachmentTypeName) : localize('addToContext', "Add to context");
 				const toggleButton = this.renderDisposables.add(new Button(contextNode, { supportIcons: true, title: buttonMsg }));
 				toggleButton.icon = context.enabled ? Codicon.x : Codicon.plus;
 				this.renderDisposables.add(toggleButton.onDidClick(async (e) => {

--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -93,13 +93,16 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		contextNode.classList.toggle('disabled', !context.enabled);
 		const file: URI | undefined = context.uri;
 		const attachmentTypeName = file?.scheme === Schemas.vscodeNotebookCell ? localize('cell.lowercase', "cell") : localize('file.lowercase', "file");
+		const contextLabel = context.name ?? (file ? basename(file) : localize('implicitContextFallback', "context"));
 
 		const isSuggestedEnabled = this.configService.getValue('chat.implicitContext.suggestedContext');
 
 		// Create toggle button BEFORE the label so it appears on the left
 		if (isSuggestedEnabled) {
 			if (!isSelection) {
-				const buttonMsg = context.enabled ? localize('disableImplicitContext', "Disable current {0} context", attachmentTypeName) : localize('addToContext', "Add to context");
+				const buttonMsg = context.enabled
+					? localize('disableImplicitContext', "Disable {0} context {1}", attachmentTypeName, contextLabel)
+					: localize('addToContext', "Add {0} to context", contextLabel);
 				const toggleButton = this.renderDisposables.add(new Button(contextNode, { supportIcons: true, title: buttonMsg }));
 				toggleButton.icon = context.enabled ? Codicon.x : Codicon.plus;
 				this.renderDisposables.add(toggleButton.onDidClick(async (e) => {


### PR DESCRIPTION
fixes #301568

Improves accessibility of implicit context attachment widgets in chat input:
- Toggle button labels: The add button (+) now says "Add to context" instead of having an empty string as its accessible name.
- Implicit context aria-labels: Both file-based and string-based implicit context attachments now include "Suggested context" prefix in their aria-label so screen reader users know these are automatically suggested, not manually attached.