### PR TITLE
extensions: show installed agent plugins when searching @agentPlugins @installed

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -415,7 +415,8 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 		this.currentQuery = query;
 		const stripped = query.replace(/@agentPlugins/i, '').trim();
 		const isRecommended = /^@recommended$/i.test(stripped);
-		const text = isRecommended ? '' : stripped.toLowerCase();
+		const isInstalled = /@installed/i.test(stripped);
+		const text = isRecommended ? '' : stripped.replace(/@installed/gi, '').trim().toLowerCase();
 
 		let installed = this.queryInstalled();
 		if (text) {
@@ -440,7 +441,7 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 
 		let items: IAgentPluginItem[] = installed;
 
-		if (!this.listOptions.installedOnly) {
+		if (!this.listOptions.installedOnly && !isInstalled) {
 			const marketplacePlugins = await this.queryMarketplacePlugins();
 			let filteredMp = marketplacePlugins;
 

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -415,8 +415,8 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 		this.currentQuery = query;
 		const stripped = query.replace(/@agentPlugins/i, '').trim();
 		const isRecommended = /^@recommended$/i.test(stripped);
-		const isInstalled = /@installed/i.test(stripped);
-		const text = isRecommended ? '' : stripped.replace(/@installed/gi, '').trim().toLowerCase();
+		const isInstalled = /(?:^|\s)@installed(?:\s|$)/i.test(stripped);
+		const text = isRecommended ? '' : stripped.replace(/(?:^|\s)@installed(?:\s|$)/gi, ' ').trim().toLowerCase();
 
 		let installed = this.queryInstalled();
 		if (text) {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -1197,11 +1197,11 @@ export class ExtensionsListView extends AbstractExtensionsListView<IExtension> {
 	}
 
 	static isInstalledExtensionsQuery(query: string): boolean {
-		return /@installed$/i.test(query);
+		return /@installed$/i.test(query) && !/@mcp/i.test(query) && !/@agentPlugins/i.test(query);
 	}
 
 	static isSearchInstalledExtensionsQuery(query: string): boolean {
-		return /@installed\s./i.test(query) || this.isFeatureExtensionsQuery(query);
+		return (/@installed\s./i.test(query) && !/@mcp/i.test(query) && !/@agentPlugins/i.test(query)) || this.isFeatureExtensionsQuery(query);
 	}
 
 	static isOutdatedExtensionsQuery(query: string): boolean {

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
@@ -247,6 +247,10 @@ suite('ExtensionsViews Tests', () => {
 		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@disabled searchText'), true);
 		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@outdated searchText'), true);
 		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@updates searchText'), true);
+		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@agentPlugins @installed'), false);
+		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@agentPlugins @installed searchText'), false);
+		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@mcp @installed'), false);
+		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@mcp @installed searchText'), false);
 	});
 
 	test('Test empty query equates to sort by install count', async () => {


### PR DESCRIPTION
Handle @agentPlugins @installed query in the agent plugins view by treating
@installed as a filter modifier rather than search text. Also prevent @installed
modifier from triggering the default installed extensions view when @mcp or
@agentPlugins queries are present.

- Extract @installed from search text in AgentPluginsListView.show() and use
  it as a filter to exclude marketplace plugins from results
- Exclude @mcp and @agentPlugins queries from isInstalledExtensionsQuery and
  isSearchInstalledExtensionsQuery detection methods to prevent incorrect view
  routing
- Add test cases to verify that @mcp and @agentPlugins queries with @installed
  are not treated as installed extension queries

Fixes https://github.com/microsoft/vscode/issues/302509

(Commit message generated by Copilot)