### PR TITLE
chat: add marketplace validation with busy state for plugin installation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -14,6 +14,7 @@ import { IPluginInstallService } from '../../common/plugins/pluginInstallService
 import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { InstalledAgentPluginsViewId } from '../agentPluginsView.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
 export class ManagePluginsAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.managePlugins';
@@ -64,12 +65,21 @@ class InstallFromSourceAction extends Action2 {
 		const quickInputService = accessor.get(IQuickInputService);
 		const pluginInstallService = accessor.get(IPluginInstallService);
 
-		const inputBox = quickInputService.createInputBox();
+		const store = new DisposableStore();
+		const inputBox = store.add(quickInputService.createInputBox());
 		inputBox.placeholder = localize('pluginSourcePlaceholder', "owner/repo or git clone URL");
 		inputBox.prompt = localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from");
 		inputBox.show();
 
-		inputBox.onDidAccept(async () => {
+		store.add(inputBox.onDidChangeValue(() => {
+			inputBox.validationMessage = undefined;
+		}));
+
+		store.add(inputBox.onDidHide(() => {
+			store.dispose();
+		}));
+
+		store.add(inputBox.onDidAccept(async () => {
 			const source = inputBox.value.trim();
 			if (!source) {
 				return;
@@ -82,16 +92,26 @@ class InstallFromSourceAction extends Action2 {
 				return;
 			}
 
-			// Hide the input box so it doesn't conflict with trust/progress dialogs.
-			inputBox.hide();
+			// Show busy state and prevent concurrent installs.
+			inputBox.busy = true;
+			inputBox.enabled = false;
+			try {
+				// Hide the input box so it doesn't conflict with trust/progress dialogs.
+				inputBox.hide();
 
-			const result = await pluginInstallService.installPluginFromValidatedSource(source);
-			if (result.message) {
-				// Re-open with the error so the user can correct their input.
-				inputBox.validationMessage = result.message;
-				inputBox.show();
+				const result = await pluginInstallService.installPluginFromValidatedSource(source);
+				if (!result.success) {
+					if (result.message) {
+						// Re-open with the error so the user can correct their input.
+						inputBox.validationMessage = result.message;
+					}
+					inputBox.show();
+				}
+			} finally {
+				inputBox.busy = false;
+				inputBox.enabled = true;
 			}
-		});
+		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -64,16 +64,34 @@ class InstallFromSourceAction extends Action2 {
 		const quickInputService = accessor.get(IQuickInputService);
 		const pluginInstallService = accessor.get(IPluginInstallService);
 
-		const source = await quickInputService.input({
-			placeHolder: localize('pluginSourcePlaceholder', "owner/repo or git clone URL"),
-			prompt: localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from"),
+		const inputBox = quickInputService.createInputBox();
+		inputBox.placeholder = localize('pluginSourcePlaceholder', "owner/repo or git clone URL");
+		inputBox.prompt = localize('pluginSourcePrompt', "Enter a GitHub repository or git URL to install a plugin from");
+		inputBox.show();
+
+		inputBox.onDidAccept(async () => {
+			const source = inputBox.value.trim();
+			if (!source) {
+				return;
+			}
+
+			// Quick format validation keeps the input box open for correction.
+			const validationError = pluginInstallService.validatePluginSource(source);
+			if (validationError) {
+				inputBox.validationMessage = validationError;
+				return;
+			}
+
+			// Hide the input box so it doesn't conflict with trust/progress dialogs.
+			inputBox.hide();
+
+			const result = await pluginInstallService.installPluginFromValidatedSource(source);
+			if (result.message) {
+				// Re-open with the error so the user can correct their input.
+				inputBox.validationMessage = result.message;
+				inputBox.show();
+			}
 		});
-
-		if (!source) {
-			return;
-		}
-
-		await pluginInstallService.installPluginFromSource(source.trim());
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -119,19 +119,11 @@ export class PluginInstallService implements IPluginInstallService {
 		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
 
 		if (discoveredPlugins.length === 0) {
-			// No marketplace.json — treat the repo root as a single plugin.
-			const repoName = basename(URI.parse(reference.cloneUrl));
-			const plugin: IMarketplacePlugin = {
-				name: repoName.replace(/\.git$/i, ''),
-				description: '',
-				version: '',
-				source: '',
-				sourceDescriptor,
-				marketplace: reference.displayLabel,
-				marketplaceReference: reference,
-				marketplaceType: MarketplaceType.OpenPlugin,
-			};
-			this._pluginMarketplaceService.addInstalledPlugin(repoDir, plugin);
+			this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
+			this._notificationService.notify({
+				severity: Severity.Error,
+				message: localize('noPluginsFound', "No plugins found in '{0}'. This does not appear to be a valid plugin marketplace.", reference.displayLabel),
+			});
 			return;
 		}
 
@@ -161,6 +153,104 @@ export class PluginInstallService implements IPluginInstallService {
 		const plugin = selected.plugin;
 		const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
 		this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+	}
+
+	validatePluginSource(source: string): string | undefined {
+		const reference = parseMarketplaceReference(source);
+		if (!reference) {
+			return localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source);
+		}
+		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
+			return localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL.");
+		}
+		return undefined;
+	}
+
+	async installPluginFromValidatedSource(source: string): Promise<{ success: boolean; message?: string }> {
+		const reference = parseMarketplaceReference(source)!;
+
+		// Build a source descriptor for the git clone.
+		const sourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
+			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo! }
+			: { kind: PluginSourceKind.GitUrl as const, url: reference.cloneUrl };
+
+		// Build a temporary plugin object for the trust gate and clone step.
+		const tempPlugin: IMarketplacePlugin = {
+			name: reference.displayLabel,
+			description: '',
+			version: '',
+			source: '',
+			sourceDescriptor,
+			marketplace: reference.displayLabel,
+			marketplaceReference: reference,
+			marketplaceType: MarketplaceType.OpenPlugin,
+		};
+
+		if (!await this._ensureMarketplaceTrusted(tempPlugin)) {
+			return { success: false };
+		}
+
+		// Clone the repository.
+		let repoDir: URI;
+		try {
+			repoDir = await this._pluginRepositoryService.ensurePluginSource(tempPlugin, {
+				progressTitle: localize('cloningSource', "Cloning plugin source '{0}'...", reference.displayLabel),
+				failureLabel: reference.displayLabel,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+		} catch {
+			return {
+				success: false,
+				message: localize('cloneFailed', "Failed to clone plugin source '{0}'.", reference.displayLabel),
+			};
+		}
+
+		const repoExists = await this._fileService.exists(repoDir);
+		if (!repoExists) {
+			return {
+				success: false,
+				message: localize('cloneFailed', "Failed to clone plugin source '{0}'.", reference.displayLabel),
+			};
+		}
+
+		// Scan for marketplace.json to discover plugins.
+		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
+
+		if (discoveredPlugins.length === 0) {
+			this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
+			return {
+				success: false,
+				message: localize('noPluginsFound', "No plugins found in '{0}'. This does not appear to be a valid plugin marketplace.", reference.displayLabel),
+			};
+		}
+
+		if (discoveredPlugins.length === 1) {
+			const plugin = discoveredPlugins[0];
+			const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
+			this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+			return { success: true };
+		}
+
+		// Multiple plugins — let the user choose.
+		const picks: (IQuickPickItem & { plugin: IMarketplacePlugin })[] = discoveredPlugins.map(p => ({
+			label: p.name,
+			description: p.description,
+			plugin: p,
+		}));
+
+		const selected = await this._quickInputService.pick(picks, {
+			placeHolder: localize('selectPlugin', "Select a plugin to install from '{0}'", reference.displayLabel),
+			canPickMany: false,
+		});
+
+		if (!selected) {
+			return { success: false };
+		}
+
+		const plugin = selected.plugin;
+		const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
+		this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+		return { success: true };
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -6,7 +6,6 @@
 import { Action } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -18,7 +17,7 @@ import { IProgressService, ProgressLocation } from '../../../../platform/progres
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../common/plugins/pluginInstallService.js';
-import { IMarketplacePlugin, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
 
 export class PluginInstallService implements IPluginInstallService {
 	declare readonly _serviceBrand: undefined;
@@ -73,86 +72,13 @@ export class PluginInstallService implements IPluginInstallService {
 			return;
 		}
 
-		// Build a source descriptor for the git clone.
-		const sourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
-			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo! }
-			: { kind: PluginSourceKind.GitUrl as const, url: reference.cloneUrl };
-
-		// Build a temporary plugin object for the trust gate and clone step.
-		const tempPlugin: IMarketplacePlugin = {
-			name: reference.displayLabel,
-			description: '',
-			version: '',
-			source: '',
-			sourceDescriptor,
-			marketplace: reference.displayLabel,
-			marketplaceReference: reference,
-			marketplaceType: MarketplaceType.OpenPlugin,
-		};
-
-		if (!await this._ensureMarketplaceTrusted(tempPlugin)) {
-			return;
-		}
-
-		// Clone the repository.
-		let repoDir: URI;
-		try {
-			repoDir = await this._pluginRepositoryService.ensurePluginSource(tempPlugin, {
-				progressTitle: localize('cloningSource', "Cloning plugin source '{0}'...", reference.displayLabel),
-				failureLabel: reference.displayLabel,
-				marketplaceType: MarketplaceType.OpenPlugin,
-			});
-		} catch {
-			return;
-		}
-
-		const repoExists = await this._fileService.exists(repoDir);
-		if (!repoExists) {
+		const result = await this._doInstallFromSource(reference);
+		if (!result.success && result.message) {
 			this._notificationService.notify({
 				severity: Severity.Error,
-				message: localize('cloneFailed', "Failed to clone plugin source '{0}'.", reference.displayLabel),
+				message: result.message,
 			});
-			return;
 		}
-
-		// Scan for marketplace.json to discover plugins.
-		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
-
-		if (discoveredPlugins.length === 0) {
-			this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
-			this._notificationService.notify({
-				severity: Severity.Error,
-				message: localize('noPluginsFound', "No plugins found in '{0}'. This does not appear to be a valid plugin marketplace.", reference.displayLabel),
-			});
-			return;
-		}
-
-		if (discoveredPlugins.length === 1) {
-			const plugin = discoveredPlugins[0];
-			const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
-			this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
-			return;
-		}
-
-		// Multiple plugins — let the user choose.
-		const picks: (IQuickPickItem & { plugin: IMarketplacePlugin })[] = discoveredPlugins.map(p => ({
-			label: p.name,
-			description: p.description,
-			plugin: p,
-		}));
-
-		const selected = await this._quickInputService.pick(picks, {
-			placeHolder: localize('selectPlugin', "Select a plugin to install from '{0}'", reference.displayLabel),
-			canPickMany: false,
-		});
-
-		if (!selected) {
-			return;
-		}
-
-		const plugin = selected.plugin;
-		const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
-		this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
 	}
 
 	validatePluginSource(source: string): string | undefined {
@@ -167,8 +93,24 @@ export class PluginInstallService implements IPluginInstallService {
 	}
 
 	async installPluginFromValidatedSource(source: string): Promise<{ success: boolean; message?: string }> {
-		const reference = parseMarketplaceReference(source)!;
+		const reference = parseMarketplaceReference(source);
+		if (!reference) {
+			return {
+				success: false,
+				message: localize('invalidSource', "'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.", source),
+			};
+		}
+		if (reference.kind === MarketplaceReferenceKind.LocalFileUri) {
+			return {
+				success: false,
+				message: localize('localSourceNotSupported', "Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL."),
+			};
+		}
 
+		return this._doInstallFromSource(reference);
+	}
+
+	private async _doInstallFromSource(reference: IMarketplaceReference): Promise<{ success: boolean; message?: string }> {
 		// Build a source descriptor for the git clone.
 		const sourceDescriptor = reference.kind === MarketplaceReferenceKind.GitHubShorthand
 			? { kind: PluginSourceKind.GitHub as const, repo: reference.githubRepo! }
@@ -198,10 +140,11 @@ export class PluginInstallService implements IPluginInstallService {
 				failureLabel: reference.displayLabel,
 				marketplaceType: MarketplaceType.OpenPlugin,
 			});
-		} catch {
+		} catch (e) {
+			const detail = e instanceof Error ? e.message : String(e);
 			return {
 				success: false,
-				message: localize('cloneFailed', "Failed to clone plugin source '{0}'.", reference.displayLabel),
+				message: localize('cloneFailedDetail', "Failed to clone plugin source '{0}': {1}", reference.displayLabel, detail),
 			};
 		}
 
@@ -217,7 +160,7 @@ export class PluginInstallService implements IPluginInstallService {
 		const discoveredPlugins = await this._pluginMarketplaceService.readPluginsFromDirectory(repoDir, reference);
 
 		if (discoveredPlugins.length === 0) {
-			this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
+			void this._pluginRepositoryService.cleanupPluginSource(tempPlugin);
 			return {
 				success: false,
 				message: localize('noPluginsFound', "No plugins found in '{0}'. This does not appear to be a valid plugin marketplace.", reference.displayLabel),

--- a/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/pluginInstallService.ts
@@ -51,6 +51,19 @@ export interface IPluginInstallService {
 	installPluginFromSource(source: string): Promise<void>;
 
 	/**
+	 * Synchronously validates the format of a plugin source string.
+	 * Returns an error message if the format is invalid, or undefined if valid.
+	 */
+	validatePluginSource(source: string): string | undefined;
+
+	/**
+	 * Installs a plugin from an already-validated source string.
+	 * Handles trust, cloning, scanning, and registration. Returns a result
+	 * with an optional error message (e.g. no plugins found).
+	 */
+	installPluginFromValidatedSource(source: string): Promise<{ success: boolean; message?: string }>;
+
+	/**
 	 * Pulls the latest changes for an already-cloned marketplace repository.
 	 */
 	updatePlugin(plugin: IMarketplacePlugin): Promise<boolean>;

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -845,7 +845,7 @@ suite('PluginInstallService', () => {
 			assert.strictEqual(state.addedPlugins[0].plugin.name, 'my-discovered-plugin');
 		});
 
-		test('installs repo-root plugin when no marketplace.json found', async () => {
+		test('shows error when no marketplace.json found', async () => {
 			const { service, state } = createService({
 				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/cool-tool'),
 				readPluginsResult: [],
@@ -853,9 +853,9 @@ suite('PluginInstallService', () => {
 
 			await service.installPluginFromSource('owner/cool-tool');
 
-			assert.strictEqual(state.addedPlugins.length, 1);
-			assert.strictEqual(state.addedPlugins[0].plugin.name, 'cool-tool');
-			assert.strictEqual(state.addedPlugins[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitHub);
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
+			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 
 		test('shows quick pick for multi-plugin repos', async () => {
@@ -924,7 +924,7 @@ suite('PluginInstallService', () => {
 			assert.strictEqual(state.addedPlugins.length, 0);
 		});
 
-		test('installs from full git URL', async () => {
+		test('shows error when no plugins found in git URL', async () => {
 			const { service, state } = createService({
 				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/my-tool'),
 				readPluginsResult: [],
@@ -932,9 +932,9 @@ suite('PluginInstallService', () => {
 
 			await service.installPluginFromSource('https://github.com/owner/my-tool.git');
 
-			assert.strictEqual(state.addedPlugins.length, 1);
-			assert.strictEqual(state.addedPlugins[0].plugin.name, 'my-tool');
-			assert.strictEqual(state.addedPlugins[0].plugin.sourceDescriptor.kind, PluginSourceKind.GitUrl);
+			assert.strictEqual(state.addedPlugins.length, 0);
+			assert.strictEqual(state.notifications.length, 1);
+			assert.ok(state.notifications[0].message.includes('No plugins found'));
 		});
 
 		test('shows error when clone directory does not exist', async () => {


### PR DESCRIPTION
Adds validation when installing plugins from source to ensure repositories are valid plugin marketplaces. Previously, repos with no plugins would be silently treated as single plugins. Now the system:

- Validates plugin source format before cloning (inline error in quickinput)
- Shows busy state while metadata is retrieved
- Displays validation error if 0 plugins found in marketplace.json
- Allows users to correct input and retry on validation errors
- Cleans up cloned repositories when validation fails
- Separates synchronous format validation from async install operations

Changes:
- Add validatePluginSource() synchronous format check method
- Add installPluginFromValidatedSource() async install method  
- Update InstallFromSourceAction to use createInputBox for validation flow
- Hide quickinput during trust dialog to prevent overlap
- Call cleanupPluginSource() when no plugins found to avoid disk clutter
- Update tests to expect error on empty marketplace.json

Fixes https://github.com/microsoft/vscode/issues/302511

(Commit message generated by Copilot)