### PR TITLE
Fix terminal chat/tool output line reconstruction at soft-wrap boundaries

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
@@ -141,7 +141,7 @@ export class TerminalCommand implements ITerminalCommand {
 			}
 			// NOTE: xterm stores wrapping state on the *next* line, not the current one.
 			// Use next line's `isWrapped` to determine whether this line should be joined.
-			const isWrapped = !!buffer.getLine(i + 1)?.isWrapped;
+			const isWrapped = i + 1 < endLine ? !!buffer.getLine(i + 1)?.isWrapped : false;
 			currentLine += line.translateToString(!isWrapped);
 			if (!isWrapped) {
 				output += currentLine + '\n';

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
@@ -131,13 +131,25 @@ export class TerminalCommand implements ITerminalCommand {
 			return undefined;
 		}
 		let output = '';
+		let currentLine = '';
 		let line: IBufferLine | undefined;
+		const buffer = this._xterm.buffer.active;
 		for (let i = startLine; i < endLine; i++) {
-			line = this._xterm.buffer.active.getLine(i);
+			line = buffer.getLine(i);
 			if (!line) {
 				continue;
 			}
-			output += line.translateToString(!line.isWrapped) + (line.isWrapped ? '' : '\n');
+			// NOTE: xterm stores wrapping state on the *next* line, not the current one.
+			// Use next line's `isWrapped` to determine whether this line should be joined.
+			const isWrapped = !!buffer.getLine(i + 1)?.isWrapped;
+			currentLine += line.translateToString(!isWrapped);
+			if (!isWrapped) {
+				output += currentLine + '\n';
+				currentLine = '';
+			}
+		}
+		if (currentLine.length > 0) {
+			output += currentLine;
 		}
 		return output === '' ? undefined : output;
 	}

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Terminal } from '@xterm/xterm';
-import { deepStrictEqual, ok } from 'assert';
+import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { ITerminalCommand } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
@@ -132,5 +132,17 @@ suite('CommandDetectionCapability', () => {
 				{ command: 'echo bar', exitCode: 0, cwd: '/home', marker: { line: 2 } }
 			]);
 		});
+	});
+
+	test('should preserve explicit newlines at 80-column wrap boundaries in command output', async () => {
+		const boundaryWidthLine = 'A'.repeat(80);
+		await printStandardCommand('$ ', 'cat content.txt', `${boundaryWidthLine}\r\nafter`, undefined, 0);
+		await printCommandStart('$ ');
+
+		strictEqual(capability.commands.length, 1);
+		const output = capability.commands[0].getOutput();
+		ok(!!output);
+		ok(output.includes(`${boundaryWidthLine}\nafter\n`));
+		ok(!output.includes(`${boundaryWidthLine}after`));
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/outputHelpers.ts
@@ -14,13 +14,29 @@ export function getOutput(instance: ITerminalInstance, startMarker?: IXtermMarke
 		return '';
 	}
 	const buffer = instance.xterm.raw.buffer.active;
-	const startLine = Math.max(startMarker?.line ?? 0, 0);
+	let startLine = Math.max(startMarker?.line ?? 0, 0);
+	while (startLine > 0 && buffer.getLine(startLine)?.isWrapped) {
+		startLine--;
+	}
 	const endLine = buffer.length;
-	const lines: string[] = new Array(endLine - startLine);
+	const lines: string[] = [];
+	let currentLine = '';
 
 	for (let y = startLine; y < endLine; y++) {
 		const line = buffer.getLine(y);
-		lines[y - startLine] = line ? line.translateToString(true) : '';
+		if (!line) {
+			continue;
+		}
+		// NOTE: xterm stores wrapping state on the *next* line, not the current one.
+		const isWrapped = !!buffer.getLine(y + 1)?.isWrapped;
+		currentLine += line.translateToString(!isWrapped);
+		if (!isWrapped) {
+			lines.push(currentLine);
+			currentLine = '';
+		}
+	}
+	if (currentLine) {
+		lines.push(currentLine);
 	}
 
 	let output = lines.join('\n');

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/outputHelpers.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import type { IMarker as IXtermMarker } from '@xterm/xterm';
+import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { getOutput } from '../../browser/outputHelpers.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+
+suite('outputHelpers', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+	function createMockInstance(lines: { text: string; isWrapped?: boolean }[]): ITerminalInstance {
+		const buffer = {
+			length: lines.length,
+			getLine: (index: number) => {
+				const line = lines[index];
+				if (!line) {
+					return undefined;
+				}
+				return {
+					isWrapped: !!line.isWrapped,
+					translateToString: (trimRight?: boolean) => trimRight ? line.text.replace(/\s+$/g, '') : line.text
+				};
+			}
+		};
+		return {
+			xterm: {
+				raw: {
+					buffer: {
+						active: buffer
+					}
+				}
+			}
+		} as unknown as ITerminalInstance;
+	}
+
+	test('preserves explicit newline after an 80-column soft wrap', () => {
+		const line80 = 'A'.repeat(80);
+		const instance = createMockInstance([
+			{ text: line80 },
+			{ text: 'X', isWrapped: true },
+			{ text: 'after' }
+		]);
+
+		const output = getOutput(instance);
+		strictEqual(output, `${line80}X\nafter`);
+	});
+
+	test('rewinds marker when it starts on a wrapped continuation line', () => {
+		const line80 = 'A'.repeat(80);
+		const instance = createMockInstance([
+			{ text: line80 },
+			{ text: 'X', isWrapped: true },
+			{ text: 'after' }
+		]);
+
+		const marker = { line: 1 } as IXtermMarker;
+		const output = getOutput(instance, marker);
+		strictEqual(output, `${line80}X\nafter`);
+	});
+});


### PR DESCRIPTION
fix #300812

This PR fixes newline reconstruction for terminal output captured by chat/tooling paths, especially around terminal-width soft wraps (for example 80-column boundaries).

Captured terminal output could lose or misplace line boundaries near wrap points, which could surface as:
- missing boundary characters
- merged lines 
- incorrect output shape when tools/agents read terminal output (`Reading content.txt`, last-command output, etc).

`ITerminalCommand.getOutput()` was using the current line’s `isWrapped` flag to decide whether to append `\n`.  In xterm, wrap state is represented on the **next** line, so newline decisions were wrong at wrap boundaries.

cc @Tyriar 