### PR TITLE
chore: disallow node version untested for development

### DIFF
--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -29,10 +29,10 @@ if (!process.env['VSCODE_SKIP_NODE_VERSION_CHECK']) {
 	const requiredMinor = parseInt(requiredVersionMatch[2]);
 	const requiredPatch = parseInt(requiredVersionMatch[3]);
 
-	if (majorNodeVersion < requiredMajor ||
-		(majorNodeVersion === requiredMajor && minorNodeVersion < requiredMinor) ||
-		(majorNodeVersion === requiredMajor && minorNodeVersion === requiredMinor && patchNodeVersion < requiredPatch)) {
-		console.error(`\x1b[1;31m*** Please use Node.js v${requiredVersion} or later for development. Currently using v${process.versions.node}.\x1b[0;0m`);
+	if (majorNodeVersion !== requiredMajor ||
+		minorNodeVersion < requiredMinor ||
+		(minorNodeVersion === requiredMinor && patchNodeVersion < requiredPatch)) {
+		console.error(`\x1b[1;31m*** Please use Node.js v${requiredMajor}.x for development as specified in .nvmrc, Currently using v${process.versions.node}.\x1b[0;0m`);
 		throw new Error();
 	}
 }

--- a/build/npm/preinstall.ts
+++ b/build/npm/preinstall.ts
@@ -32,7 +32,7 @@ if (!process.env['VSCODE_SKIP_NODE_VERSION_CHECK']) {
 	if (majorNodeVersion !== requiredMajor ||
 		minorNodeVersion < requiredMinor ||
 		(minorNodeVersion === requiredMinor && patchNodeVersion < requiredPatch)) {
-		console.error(`\x1b[1;31m*** Please use Node.js v${requiredMajor}.x for development as specified in .nvmrc, Currently using v${process.versions.node}.\x1b[0;0m`);
+		console.error(`\x1b[1;31m*** Please use Node.js v${requiredVersion} or newer with the same major version (${requiredMajor}) as specified in .nvmrc. Currently using v${process.versions.node}.\x1b[0;0m`);
 		throw new Error();
 	}
 }


### PR DESCRIPTION
Certain Node.js versions bring in V8 that bump minimum C++ requirements without bumping `-std` flag which can cause dependencies inside our `build` folder to fail compilation. Restrict version used for development to what is built and tested in CI.