### PR TITLE
Agent Debug Panel: Copilot CLI changes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -60,7 +60,7 @@ export function registerChatOpenAgentDebugPanelAction() {
 				title: localize2('chat.openAgentDebugPanelForSession.label', "Show Agent Debug Logs"),
 				f1: false,
 				category: CHAT_CATEGORY,
-				precondition: ContextKeyExpr.and(ChatContextKeys.enabled, ChatContextKeys.chatSessionHasDebugData),
+				precondition: ChatContextKeys.enabled,
 				menu: [{
 					id: CHAT_CONFIG_MENU_ID,
 					when: ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.equals('view', ChatViewId)),

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -119,17 +119,13 @@ export class ChatDebugHomeView extends Disposable {
 					sessionTitle = rawTitle;
 				} else if (LocalChatSessionUri.isLocalSession(sessionResource)) {
 					sessionTitle = localize('chatDebug.newSession', "New Chat");
+				} else if (this.chatDebugService.getImportedSessionTitle(sessionResource)) {
+					sessionTitle = localize('chatDebug.importedSession', "Imported: {0}", this.chatDebugService.getImportedSessionTitle(sessionResource)!);
+				} else if (sessionResource.scheme === 'copilotcli') {
+					const shortId = sessionResource.path.replace(/^\//, '').split('-')[0] || '';
+					sessionTitle = localize('chatDebug.copilotCliSessionWithId', "Copilot CLI: {0}", shortId);
 				} else {
-					// For imported/external sessions, use the stored title if available
-					const importedTitle = this.chatDebugService.getImportedSessionTitle(sessionResource);
-					if (importedTitle) {
-						sessionTitle = localize('chatDebug.importedSession', "Imported: {0}", importedTitle);
-					} else {
-						// Fall back to URI segment
-						const uriLabel = sessionResource.path || sessionResource.fragment || sessionResource.toString();
-						const segment = uriLabel.replace(/^\/+/, '').split('/').pop() || uriLabel;
-						sessionTitle = localize('chatDebug.importedSession', "Imported: {0}", segment);
-					}
+					sessionTitle = localize('chatDebug.newSession', "New Chat");
 				}
 				const isActive = activeSessionResource !== undefined && sessionResource.toString() === activeSessionResource.toString();
 

--- a/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView.ts
@@ -114,15 +114,17 @@ export class ChatDebugHomeView extends Disposable {
 
 			for (const sessionResource of sessionResources) {
 				const rawTitle = this.chatService.getSessionTitle(sessionResource);
+				const importedTitle = this.chatDebugService.getImportedSessionTitle(sessionResource);
 				let sessionTitle: string;
 				if (rawTitle && !isUUID(rawTitle)) {
 					sessionTitle = rawTitle;
 				} else if (LocalChatSessionUri.isLocalSession(sessionResource)) {
 					sessionTitle = localize('chatDebug.newSession', "New Chat");
-				} else if (this.chatDebugService.getImportedSessionTitle(sessionResource)) {
-					sessionTitle = localize('chatDebug.importedSession', "Imported: {0}", this.chatDebugService.getImportedSessionTitle(sessionResource)!);
+				} else if (importedTitle) {
+					sessionTitle = localize('chatDebug.importedSession', "Imported: {0}", importedTitle);
 				} else if (sessionResource.scheme === 'copilotcli') {
-					const shortId = sessionResource.path.replace(/^\//, '').split('-')[0] || '';
+					const pathId = sessionResource.path.replace(/^\//, '').split('-')[0];
+					const shortId = pathId || sessionResource.authority || sessionResource.toString();
 					sessionTitle = localize('chatDebug.copilotCliSessionWithId', "Copilot CLI: {0}", shortId);
 				} else {
 					sessionTitle = localize('chatDebug.newSession', "New Chat");

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -12,6 +12,7 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { extUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugLogProvider, IChatDebugResolvedEventContent, IChatDebugService } from './chatDebugService.js';
+import { LocalChatSessionUri } from './model/chatUri.js';
 
 /**
  * Per-session circular buffer for debug events.
@@ -108,7 +109,7 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	/** Events that were returned by providers (not internally logged). */
 	private readonly _providerEvents = new WeakSet<IChatDebugEvent>();
 
-	/** Session URIs created via import, allowed through the invokeProviders guard. */
+	/** Session URIs created via import. */
 	private readonly _importedSessions = new ResourceMap<boolean>();
 
 	/** Human-readable titles for imported sessions. */
@@ -116,7 +117,21 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 
 	activeSessionResource: URI | undefined;
 
+	/** Schemes eligible for debug logging and provider invocation. */
+	private static readonly _debugEligibleSchemes = new Set([
+		LocalChatSessionUri.scheme,	// vscode-chat-session (local sessions)
+		'copilotcli',				// Copilot CLI background sessions
+	]);
+
+	private _isDebugEligibleSession(sessionResource: URI): boolean {
+		return ChatDebugServiceImpl._debugEligibleSchemes.has(sessionResource.scheme)
+			|| this._importedSessions.has(sessionResource);
+	}
+
 	log(sessionResource: URI, name: string, details?: string, level: ChatDebugLogLevel = ChatDebugLogLevel.Info, options?: { id?: string; category?: string; parentEventId?: string }): void {
+		if (!this._isDebugEligibleSession(sessionResource)) {
+			return;
+		}
 		this.addEvent({
 			kind: 'generic',
 			id: options?.id,
@@ -222,6 +237,9 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 
 	async invokeProviders(sessionResource: URI): Promise<void> {
 
+		if (!this._isDebugEligibleSession(sessionResource)) {
+			return;
+		}
 		// Cancel only the previous invocation for THIS session, not others.
 		// Each session has its own pipeline so events from multiple sessions
 		// can be streamed concurrently.

--- a/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatDebugServiceImpl.ts
@@ -12,7 +12,6 @@ import { ResourceMap } from '../../../../base/common/map.js';
 import { extUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ChatDebugLogLevel, IChatDebugEvent, IChatDebugLogProvider, IChatDebugResolvedEventContent, IChatDebugService } from './chatDebugService.js';
-import { LocalChatSessionUri } from './model/chatUri.js';
 
 /**
  * Per-session circular buffer for debug events.
@@ -118,9 +117,6 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 	activeSessionResource: URI | undefined;
 
 	log(sessionResource: URI, name: string, details?: string, level: ChatDebugLogLevel = ChatDebugLogLevel.Info, options?: { id?: string; category?: string; parentEventId?: string }): void {
-		if (!LocalChatSessionUri.isLocalSession(sessionResource)) {
-			return;
-		}
 		this.addEvent({
 			kind: 'generic',
 			id: options?.id,
@@ -226,9 +222,6 @@ export class ChatDebugServiceImpl extends Disposable implements IChatDebugServic
 
 	async invokeProviders(sessionResource: URI): Promise<void> {
 
-		if (!LocalChatSessionUri.isLocalSession(sessionResource) && !this._importedSessions.has(sessionResource)) {
-			return;
-		}
 		// Cancel only the previous invocation for THIS session, not others.
 		// Each session has its own pipeline so events from multiple sessions
 		// can be streamed concurrently.

--- a/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
@@ -22,6 +22,7 @@ suite('ChatDebugServiceImpl', () => {
 	const sessionB = LocalChatSessionUri.forSession('b');
 	const sessionGeneric = URI.parse('vscode-chat-session://local/session');
 	const nonLocalSession = URI.parse('some-other-scheme://authority/session-1');
+	const copilotCliSession = URI.parse('copilotcli:/test-session-id');
 
 	setup(() => {
 		service = disposables.add(new ChatDebugServiceImpl());
@@ -148,14 +149,24 @@ suite('ChatDebugServiceImpl', () => {
 			assert.strictEqual(event.parentEventId, 'parent-1');
 		});
 
-		test('should log events for any session URI scheme', () => {
+		test('should not log events for ineligible session schemes', () => {
 			const firedEvents: IChatDebugEvent[] = [];
 			disposables.add(service.onDidAddEvent(e => firedEvents.push(e)));
 
-			service.log(nonLocalSession, 'should-be-logged', 'details');
+			service.log(nonLocalSession, 'should-be-skipped', 'details');
+
+			assert.strictEqual(firedEvents.length, 0);
+			assert.strictEqual(service.getEvents(nonLocalSession).length, 0);
+		});
+
+		test('should log events for copilotcli sessions', () => {
+			const firedEvents: IChatDebugEvent[] = [];
+			disposables.add(service.onDidAddEvent(e => firedEvents.push(e)));
+
+			service.log(copilotCliSession, 'cli-event', 'details');
 
 			assert.strictEqual(firedEvents.length, 1);
-			assert.strictEqual(service.getEvents(nonLocalSession).length, 1);
+			assert.strictEqual(service.getEvents(copilotCliSession).length, 1);
 		});
 	});
 
@@ -435,7 +446,7 @@ suite('ChatDebugServiceImpl', () => {
 			assert.strictEqual(tokenA.isCancellationRequested, false, 'session-a token should not be cancelled');
 		});
 
-		test('should invoke providers for any session URI scheme', async () => {
+		test('should not invoke providers for ineligible session schemes', async () => {
 			let providerCalled = false;
 
 			const provider: IChatDebugLogProvider = {
@@ -445,7 +456,7 @@ suite('ChatDebugServiceImpl', () => {
 						kind: 'generic',
 						sessionResource: nonLocalSession,
 						created: new Date(),
-						name: 'from-non-local',
+						name: 'should-not-appear',
 						level: ChatDebugLogLevel.Info,
 					}];
 				},
@@ -454,8 +465,31 @@ suite('ChatDebugServiceImpl', () => {
 			disposables.add(service.registerProvider(provider));
 			await service.invokeProviders(nonLocalSession);
 
+			assert.strictEqual(providerCalled, false);
+			assert.strictEqual(service.getEvents(nonLocalSession).length, 0);
+		});
+
+		test('should invoke providers for copilotcli sessions', async () => {
+			let providerCalled = false;
+
+			const provider: IChatDebugLogProvider = {
+				provideChatDebugLog: async () => {
+					providerCalled = true;
+					return [{
+						kind: 'generic',
+						sessionResource: copilotCliSession,
+						created: new Date(),
+						name: 'cli-provider-event',
+						level: ChatDebugLogLevel.Info,
+					}];
+				},
+			};
+
+			disposables.add(service.registerProvider(provider));
+			await service.invokeProviders(copilotCliSession);
+
 			assert.strictEqual(providerCalled, true);
-			assert.ok(service.getEvents(nonLocalSession).length > 0);
+			assert.ok(service.getEvents(copilotCliSession).length > 0);
 		});
 
 		test('newly registered provider should be invoked for active sessions', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatDebugServiceImpl.test.ts
@@ -21,7 +21,7 @@ suite('ChatDebugServiceImpl', () => {
 	const sessionA = LocalChatSessionUri.forSession('a');
 	const sessionB = LocalChatSessionUri.forSession('b');
 	const sessionGeneric = URI.parse('vscode-chat-session://local/session');
-	const nonLocalSession = URI.parse('vscode-chat-session://remote-provider/session-1');
+	const nonLocalSession = URI.parse('some-other-scheme://authority/session-1');
 
 	setup(() => {
 		service = disposables.add(new ChatDebugServiceImpl());
@@ -148,14 +148,14 @@ suite('ChatDebugServiceImpl', () => {
 			assert.strictEqual(event.parentEventId, 'parent-1');
 		});
 
-		test('should not log events for non-local sessions', () => {
+		test('should log events for any session URI scheme', () => {
 			const firedEvents: IChatDebugEvent[] = [];
 			disposables.add(service.onDidAddEvent(e => firedEvents.push(e)));
 
-			service.log(nonLocalSession, 'should-be-skipped', 'details');
+			service.log(nonLocalSession, 'should-be-logged', 'details');
 
-			assert.strictEqual(firedEvents.length, 0);
-			assert.strictEqual(service.getEvents(nonLocalSession).length, 0);
+			assert.strictEqual(firedEvents.length, 1);
+			assert.strictEqual(service.getEvents(nonLocalSession).length, 1);
 		});
 	});
 
@@ -435,7 +435,7 @@ suite('ChatDebugServiceImpl', () => {
 			assert.strictEqual(tokenA.isCancellationRequested, false, 'session-a token should not be cancelled');
 		});
 
-		test('should not invoke providers for non-local sessions', async () => {
+		test('should invoke providers for any session URI scheme', async () => {
 			let providerCalled = false;
 
 			const provider: IChatDebugLogProvider = {
@@ -445,7 +445,7 @@ suite('ChatDebugServiceImpl', () => {
 						kind: 'generic',
 						sessionResource: nonLocalSession,
 						created: new Date(),
-						name: 'should-not-appear',
+						name: 'from-non-local',
 						level: ChatDebugLogLevel.Info,
 					}];
 				},
@@ -454,8 +454,8 @@ suite('ChatDebugServiceImpl', () => {
 			disposables.add(service.registerProvider(provider));
 			await service.invokeProviders(nonLocalSession);
 
-			assert.strictEqual(providerCalled, false);
-			assert.strictEqual(service.getEvents(nonLocalSession).length, 0);
+			assert.strictEqual(providerCalled, true);
+			assert.ok(service.getEvents(nonLocalSession).length > 0);
 		});
 
 		test('newly registered provider should be invoked for active sessions', async () => {


### PR DESCRIPTION
The Agent Debug Logs panel previously only supported local chat sessions (vscode-chat-session://local/...). Copilot CLI sessions use a different URI scheme (copilotcli:/...) and were silently filtered out at multiple levels.