### PR TITLE
Limit task tool output to the current task run in reused terminals

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -216,7 +216,9 @@ export async function collectTerminalResults(
 	progress.report({ message: new MarkdownString(`Checking output for ${terminalNames.map(n => `\`${n}\``).join(', ')}`) });
 
 	const terminalPromises = terminals.map(async (instance) => {
-		const startMarker = startMarkersByTerminalInstanceId?.get(instance.instanceId) ?? instance.registerMarker();
+		const startMarker = startMarkersByTerminalInstanceId
+			? startMarkersByTerminalInstanceId.get(instance.instanceId)
+			: instance.registerMarker();
 		let terminalTask = task;
 
 		// For composite tasks, find the actual dependency task running in this terminal

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -296,7 +296,7 @@ export async function collectTerminalResults(
 		const activeInstanceIds = new Set(terminals.map(instance => instance.instanceId));
 		for (const [instanceId, marker] of startMarkersByTerminalInstanceId) {
 			if (!activeInstanceIds.has(instanceId)) {
-				marker.dispose();
+				marker?.dispose();
 				startMarkersByTerminalInstanceId.delete(instanceId);
 			}
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -291,6 +291,17 @@ export async function collectTerminalResults(
 
 	const parallelResults = await Promise.all(terminalPromises);
 	results.push(...parallelResults);
+
+	if (startMarkersByTerminalInstanceId) {
+		const activeInstanceIds = new Set(terminals.map(instance => instance.instanceId));
+		for (const [instanceId, marker] of startMarkersByTerminalInstanceId) {
+			if (!activeInstanceIds.has(instanceId)) {
+				marker.dispose();
+				startMarkersByTerminalInstanceId.delete(instanceId);
+			}
+		}
+	}
+
 	return results;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/taskHelpers.ts
@@ -23,6 +23,7 @@ import { IExecution, IPollingResult, OutputMonitorState } from './tools/monitori
 import { Event } from '../../../../../base/common/event.js';
 import { IReconnectionTaskData } from '../../../tasks/browser/terminalTaskSystem.js';
 import { isString } from '../../../../../base/common/types.js';
+import type { IMarker as IXtermMarker } from '@xterm/xterm';
 
 
 export function getTaskDefinition(id: string) {
@@ -180,7 +181,8 @@ export async function collectTerminalResults(
 	disposableStore: DisposableStore,
 	isActive?: (task: Task) => Promise<boolean>,
 	dependencyTasks?: Task[],
-	taskService?: ITaskService
+	taskService?: ITaskService,
+	startMarkersByTerminalInstanceId?: Map<number, IXtermMarker | undefined>
 ): Promise<Array<{
 	name: string;
 	output: string;
@@ -214,6 +216,7 @@ export async function collectTerminalResults(
 	progress.report({ message: new MarkdownString(`Checking output for ${terminalNames.map(n => `\`${n}\``).join(', ')}`) });
 
 	const terminalPromises = terminals.map(async (instance) => {
+		const startMarker = startMarkersByTerminalInstanceId?.get(instance.instanceId) ?? instance.registerMarker();
 		let terminalTask = task;
 
 		// For composite tasks, find the actual dependency task running in this terminal
@@ -237,7 +240,7 @@ export async function collectTerminalResults(
 		}
 
 		const execution: IExecution = {
-			getOutput: () => getOutput(instance) ?? '',
+			getOutput: (marker) => getOutput(instance, marker ?? startMarker) ?? '',
 			task: terminalTask,
 			isActive: isActive ? () => isActive(terminalTask) : undefined,
 			instance,
@@ -258,28 +261,32 @@ export async function collectTerminalResults(
 			}
 		}
 
-		const hasProblemMatchers = terminalTask.configurationProperties.problemMatchers && terminalTask.configurationProperties.problemMatchers.length > 0;
-		const outputMonitor = disposableStore.add(instantiationService.createInstance(OutputMonitor, execution, hasProblemMatchers ? taskProblemPollFn : undefined, invocationContext, token, task._label));
-		await Promise.race([
-			Event.toPromise(outputMonitor.onDidFinishCommand),
-			Event.toPromise(token.onCancellationRequested as Event<unknown>)
-		]);
-		const pollingResult = outputMonitor.pollingResult;
-		return {
-			name: instance.shellLaunchConfig.name ?? instance.title ?? 'unknown',
-			output: pollingResult?.output ?? '',
-			pollDurationMs: pollingResult?.pollDurationMs ?? 0,
-			resources: pollingResult?.resources,
-			state: pollingResult?.state || OutputMonitorState.Idle,
-			inputToolManualAcceptCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualAcceptCount ?? 0,
-			inputToolManualRejectCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualRejectCount ?? 0,
-			inputToolManualChars: outputMonitor.outputMonitorTelemetryCounters.inputToolManualChars ?? 0,
-			inputToolAutoAcceptCount: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoAcceptCount ?? 0,
-			inputToolAutoChars: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoChars ?? 0,
-			inputToolManualShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualShownCount ?? 0,
-			inputToolFreeFormInputShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount ?? 0,
-			inputToolFreeFormInputCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputCount ?? 0,
-		};
+		try {
+			const hasProblemMatchers = terminalTask.configurationProperties.problemMatchers && terminalTask.configurationProperties.problemMatchers.length > 0;
+			const outputMonitor = disposableStore.add(instantiationService.createInstance(OutputMonitor, execution, hasProblemMatchers ? taskProblemPollFn : undefined, invocationContext, token, task._label));
+			await Promise.race([
+				Event.toPromise(outputMonitor.onDidFinishCommand),
+				Event.toPromise(token.onCancellationRequested as Event<unknown>)
+			]);
+			const pollingResult = outputMonitor.pollingResult;
+			return {
+				name: instance.shellLaunchConfig.name ?? instance.title ?? 'unknown',
+				output: pollingResult?.output ?? '',
+				pollDurationMs: pollingResult?.pollDurationMs ?? 0,
+				resources: pollingResult?.resources,
+				state: pollingResult?.state || OutputMonitorState.Idle,
+				inputToolManualAcceptCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualAcceptCount ?? 0,
+				inputToolManualRejectCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualRejectCount ?? 0,
+				inputToolManualChars: outputMonitor.outputMonitorTelemetryCounters.inputToolManualChars ?? 0,
+				inputToolAutoAcceptCount: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoAcceptCount ?? 0,
+				inputToolAutoChars: outputMonitor.outputMonitorTelemetryCounters.inputToolAutoChars ?? 0,
+				inputToolManualShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolManualShownCount ?? 0,
+				inputToolFreeFormInputShownCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputShownCount ?? 0,
+				inputToolFreeFormInputCount: outputMonitor.outputMonitorTelemetryCounters.inputToolFreeFormInputCount ?? 0,
+			};
+		} finally {
+			startMarker?.dispose();
+		}
 	});
 
 	const parallelResults = await Promise.all(terminalPromises);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -102,10 +102,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		let terminalResults: Awaited<ReturnType<typeof collectTerminalResults>> = [];
 		try {
 			const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
-			const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
-			const preRunTerminals = preRunResources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[] | undefined;
 			const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
-			for (const terminal of preRunTerminals ?? []) {
+			for (const terminal of this._terminalService.instances) {
 				const marker = terminal.registerMarker();
 				startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
 				if (marker) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -98,6 +98,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 		}
 
 		const preRunMarkersStore = new DisposableStore();
+		let result: ITaskSummary | undefined;
+		let terminalResults: Awaited<ReturnType<typeof collectTerminalResults>> = [];
 		try {
 			const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
 			const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
@@ -106,12 +108,14 @@ export class CreateAndRunTaskTool implements IToolImpl {
 			for (const terminal of preRunTerminals ?? []) {
 				const marker = terminal.registerMarker();
 				startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
-				preRunMarkersStore.add(marker);
+				if (marker) {
+					preRunMarkersStore.add(marker);
+				}
 			}
 
 			_progress.report({ message: new MarkdownString(localize('copilotChat.runningTask', 'Running task `{0}`', args.task.label)) });
 			const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
-			const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
+			result = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
 			const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 			const terminals = resources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[];
@@ -119,23 +123,26 @@ export class CreateAndRunTaskTool implements IToolImpl {
 				return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', args.task.label)) };
 			}
 			const store = new DisposableStore();
-			const terminalResults = await collectTerminalResults(
-				terminals,
-				task,
-				this._instantiationService,
-				invocation.context!,
-				_progress,
-				token,
-				store,
-				(terminalTask) => this._isTaskActive(terminalTask),
-				dependencyTasks,
-				this._tasksService,
-				startMarkersByTerminalInstanceId
-			);
+			try {
+				terminalResults = await collectTerminalResults(
+					terminals,
+					task,
+					this._instantiationService,
+					invocation.context!,
+					_progress,
+					token,
+					store,
+					(terminalTask) => this._isTaskActive(terminalTask),
+					dependencyTasks,
+					this._tasksService,
+					startMarkersByTerminalInstanceId
+				);
+			} finally {
+				store.dispose();
+			}
 		} finally {
 			preRunMarkersStore.dispose();
 		}
-		store.dispose();
 		for (const r of terminalResults) {
 			this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.runTaskTool.createAndRunTask', {
 				taskId: args.task.label,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -97,37 +97,44 @@ export class CreateAndRunTaskTool implements IToolImpl {
 			return { content: [{ kind: 'text', value: `Task not found: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.task.label)) };
 		}
 
-		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
-		const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
-		const preRunTerminals = preRunResources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[] | undefined;
-		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
-		for (const terminal of preRunTerminals ?? []) {
-			startMarkersByTerminalInstanceId.set(terminal.instanceId, terminal.registerMarker());
-		}
+		const preRunMarkersStore = new DisposableStore();
+		try {
+			const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
+			const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
+			const preRunTerminals = preRunResources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[] | undefined;
+			const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
+			for (const terminal of preRunTerminals ?? []) {
+				const marker = terminal.registerMarker();
+				startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
+				preRunMarkersStore.add(marker);
+			}
 
-		_progress.report({ message: new MarkdownString(localize('copilotChat.runningTask', 'Running task `{0}`', args.task.label)) });
-		const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
-		const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
+			_progress.report({ message: new MarkdownString(localize('copilotChat.runningTask', 'Running task `{0}`', args.task.label)) });
+			const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
+			const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
-		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
-		const terminals = resources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[];
-		if (!terminals || terminals.length === 0) {
-			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', args.task.label)) };
+			const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
+			const terminals = resources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[];
+			if (!terminals || terminals.length === 0) {
+				return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.noTerminal', 'Task started but no terminal was found for: `{0}`', args.task.label)) };
+			}
+			const store = new DisposableStore();
+			const terminalResults = await collectTerminalResults(
+				terminals,
+				task,
+				this._instantiationService,
+				invocation.context!,
+				_progress,
+				token,
+				store,
+				(terminalTask) => this._isTaskActive(terminalTask),
+				dependencyTasks,
+				this._tasksService,
+				startMarkersByTerminalInstanceId
+			);
+		} finally {
+			preRunMarkersStore.dispose();
 		}
-		const store = new DisposableStore();
-		const terminalResults = await collectTerminalResults(
-			terminals,
-			task,
-			this._instantiationService,
-			invocation.context!,
-			_progress,
-			token,
-			store,
-			(terminalTask) => this._isTaskActive(terminalTask),
-			dependencyTasks,
-			this._tasksService,
-			startMarkersByTerminalInstanceId
-		);
 		store.dispose();
 		for (const r of terminalResults) {
 			this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.runTaskTool.createAndRunTask', {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/createAndRunTaskTool.ts
@@ -97,11 +97,18 @@ export class CreateAndRunTaskTool implements IToolImpl {
 			return { content: [{ kind: 'text', value: `Task not found: ${args.task.label}` }], toolResultMessage: new MarkdownString(localize('copilotChat.taskNotFound', 'Task not found: `{0}`', args.task.label)) };
 		}
 
+		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
+		const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
+		const preRunTerminals = preRunResources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[] | undefined;
+		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
+		for (const terminal of preRunTerminals ?? []) {
+			startMarkersByTerminalInstanceId.set(terminal.instanceId, terminal.registerMarker());
+		}
+
 		_progress.report({ message: new MarkdownString(localize('copilotChat.runningTask', 'Running task `{0}`', args.task.label)) });
 		const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
 		const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
-		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
 		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 		const terminals = resources?.map(resource => this._terminalService.instances.find(t => t.resource.path === resource?.path && t.resource.scheme === resource.scheme)).filter(Boolean) as ITerminalInstance[];
 		if (!terminals || terminals.length === 0) {
@@ -118,7 +125,8 @@ export class CreateAndRunTaskTool implements IToolImpl {
 			store,
 			(terminalTask) => this._isTaskActive(terminalTask),
 			dependencyTasks,
-			this._tasksService
+			this._tasksService,
+			startMarkersByTerminalInstanceId
 		);
 		store.dispose();
 		for (const r of terminalResults) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -62,62 +62,69 @@ export class RunTaskTool implements IToolImpl {
 		for (const terminal of preRunTerminals) {
 			const marker = terminal.registerMarker();
 			startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
-			startMarkersDisposableStore.add(marker);
+			if (marker) {
+				startMarkersDisposableStore.add(marker);
+			}
 		}
+		try {
+			const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
+			const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
-		const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
-		const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
+			const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
+			if (!resources || resources.length === 0) {
+				return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
+			}
+			const terminals = this._terminalService.instances.filter(t => resources.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
+			if (terminals.length === 0) {
+				return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
+			}
 
-		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
-		if (!resources || resources.length === 0) {
+			const store = new DisposableStore();
+			let terminalResults: Awaited<ReturnType<typeof collectTerminalResults>> = [];
+			try {
+				terminalResults = await collectTerminalResults(
+					terminals,
+					task,
+					this._instantiationService,
+					invocation.context!,
+					_progress,
+					token,
+					store,
+					(terminalTask) => this._isTaskActive(terminalTask),
+					dependencyTasks,
+					this._tasksService,
+					startMarkersByTerminalInstanceId
+				);
+			} finally {
+				store.dispose();
+			}
+			for (const r of terminalResults) {
+				this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.runTaskTool.run', {
+					taskId: args.id,
+					bufferLength: r.output.length ?? 0,
+					pollDurationMs: r.pollDurationMs ?? 0,
+					inputToolManualAcceptCount: r.inputToolManualAcceptCount ?? 0,
+					inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
+					inputToolManualChars: r.inputToolManualChars ?? 0,
+					inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
+					inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0,
+					inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0
+				});
+			}
+
+			const details = terminalResults.map(r => `Terminal: ${r.name}\nOutput:\n${r.output}`);
+			const uniqueDetails = Array.from(new Set(details)).join('\n\n');
+			const toolResultDetails = toolResultDetailsFromResponse(terminalResults);
+			const toolResultMessage = toolResultMessageFromResponse(result, taskLabel, toolResultDetails, terminalResults, undefined, task.configurationProperties.isBackground);
+
+			return {
+				content: [{ kind: 'text', value: uniqueDetails }],
+				toolResultMessage,
+				toolResultDetails
+			};
+		} finally {
 			startMarkersDisposableStore.dispose();
-			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
 		}
-		const terminals = this._terminalService.instances.filter(t => resources.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
-		if (terminals.length === 0) {
-			startMarkersDisposableStore.dispose();
-			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
-		}
-
-		const store = new DisposableStore();
-		const terminalResults = await collectTerminalResults(
-			terminals,
-			task,
-			this._instantiationService,
-			invocation.context!,
-			_progress,
-			token,
-			store,
-			(terminalTask) => this._isTaskActive(terminalTask),
-			dependencyTasks,
-			this._tasksService,
-			startMarkersByTerminalInstanceId
-		);
-		store.dispose();
-		for (const r of terminalResults) {
-			this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.runTaskTool.run', {
-				taskId: args.id,
-				bufferLength: r.output.length ?? 0,
-				pollDurationMs: r.pollDurationMs ?? 0,
-				inputToolManualAcceptCount: r.inputToolManualAcceptCount ?? 0,
-				inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
-				inputToolManualChars: r.inputToolManualChars ?? 0,
-				inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
-				inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0,
-				inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0
-			});
-		}
-
-		const details = terminalResults.map(r => `Terminal: ${r.name}\nOutput:\n${r.output}`);
-		const uniqueDetails = Array.from(new Set(details)).join('\n\n');
-		const toolResultDetails = toolResultDetailsFromResponse(terminalResults);
-		const toolResultMessage = toolResultMessageFromResponse(result, taskLabel, toolResultDetails, terminalResults, undefined, task.configurationProperties.isBackground);
-
-		return {
-			content: [{ kind: 'text', value: uniqueDetails }],
-			toolResultMessage,
-			toolResultDetails
-		};
 	}
 
 	private async _isTaskActive(task: Task): Promise<boolean> {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -54,10 +54,17 @@ export class RunTaskTool implements IToolImpl {
 			return { content: [{ kind: 'text', value: `The task ${taskLabel} is already running.` }], toolResultMessage: new MarkdownString(localize('chat.taskAlreadyRunning', 'The task \`{0}\` is already running.', taskLabel)) };
 		}
 
+		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
+		const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
+		const preRunTerminals = this._terminalService.instances.filter(t => preRunResources?.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
+		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<(typeof preRunTerminals)[number]['registerMarker']>>();
+		for (const terminal of preRunTerminals) {
+			startMarkersByTerminalInstanceId.set(terminal.instanceId, terminal.registerMarker());
+		}
+
 		const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
 		const result: ITaskSummary | undefined = raceResult && typeof raceResult === 'object' ? raceResult as ITaskSummary : undefined;
 
-		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
 		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 		if (!resources || resources.length === 0) {
 			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
@@ -78,7 +85,8 @@ export class RunTaskTool implements IToolImpl {
 			store,
 			(terminalTask) => this._isTaskActive(terminalTask),
 			dependencyTasks,
-			this._tasksService
+			this._tasksService,
+			startMarkersByTerminalInstanceId
 		);
 		store.dispose();
 		for (const r of terminalResults) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -10,7 +10,7 @@ import { ITelemetryService } from '../../../../../../../platform/telemetry/commo
 import { CountTokensCallback, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocation, IToolInvocationPreparationContext, IToolResult, ToolDataSource, ToolProgress } from '../../../../../chat/common/tools/languageModelToolsService.js';
 import { ITaskService, ITaskSummary, Task, TasksAvailableContext } from '../../../../../tasks/common/taskService.js';
 import { TaskRunSource } from '../../../../../tasks/common/tasks.js';
-import { ITerminalService } from '../../../../../terminal/browser/terminal.js';
+import { ITerminalInstance, ITerminalService } from '../../../../../terminal/browser/terminal.js';
 import { collectTerminalResults, getTaskDefinition, getTaskForTool, resolveDependencyTasks, tasksMatch } from '../../taskHelpers.js';
 import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
@@ -55,11 +55,9 @@ export class RunTaskTool implements IToolImpl {
 		}
 
 		const dependencyTasks = await resolveDependencyTasks(task, args.workspaceFolder, this._configurationService, this._tasksService);
-		const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
-		const preRunTerminals = this._terminalService.instances.filter(t => preRunResources?.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
-		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<(typeof preRunTerminals)[number]['registerMarker']>>();
+		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
 		const startMarkersDisposableStore = new DisposableStore();
-		for (const terminal of preRunTerminals) {
+		for (const terminal of this._terminalService.instances) {
 			const marker = terminal.registerMarker();
 			startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
 			if (marker) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/runTaskTool.ts
@@ -58,8 +58,11 @@ export class RunTaskTool implements IToolImpl {
 		const preRunResources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 		const preRunTerminals = this._terminalService.instances.filter(t => preRunResources?.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
 		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<(typeof preRunTerminals)[number]['registerMarker']>>();
+		const startMarkersDisposableStore = new DisposableStore();
 		for (const terminal of preRunTerminals) {
-			startMarkersByTerminalInstanceId.set(terminal.instanceId, terminal.registerMarker());
+			const marker = terminal.registerMarker();
+			startMarkersByTerminalInstanceId.set(terminal.instanceId, marker);
+			startMarkersDisposableStore.add(marker);
 		}
 
 		const raceResult = await Promise.race([this._tasksService.run(task, undefined, TaskRunSource.ChatAgent), timeout(3000)]);
@@ -67,10 +70,12 @@ export class RunTaskTool implements IToolImpl {
 
 		const resources = this._tasksService.getTerminalsForTasks(dependencyTasks ?? task);
 		if (!resources || resources.length === 0) {
+			startMarkersDisposableStore.dispose();
 			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
 		}
 		const terminals = this._terminalService.instances.filter(t => resources.some(r => r.path === t.resource.path && r.scheme === t.resource.scheme));
 		if (terminals.length === 0) {
+			startMarkersDisposableStore.dispose();
 			return { content: [{ kind: 'text', value: `Task started but no terminal was found for: ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('chat.noTerminal', 'Task started but no terminal was found for: \`{0}\`', taskLabel)) };
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
@@ -1,0 +1,182 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../../base/common/event.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IToolInvocationContext } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { Task } from '../../../../tasks/common/taskService.js';
+import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+import { collectTerminalResults } from '../../browser/taskHelpers.js';
+import { IExecution, OutputMonitorState } from '../../browser/tools/monitoring/types.js';
+
+suite('Task Helpers', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('collectTerminalResults reads output from invocation start marker', async () => {
+		const lines = ['old output', 'more old output', 'new output line 1', 'new output line 2'];
+		let markerDisposed = false;
+		const marker = {
+			line: 2,
+			dispose: () => { markerDisposed = true; }
+		};
+		const terminal = {
+			instanceId: 1,
+			title: 'task-terminal',
+			shellLaunchConfig: { name: 'task-terminal' },
+			registerMarker: () => marker,
+			xterm: {
+				raw: {
+					buffer: {
+						active: {
+							length: lines.length,
+							getLine: (y: number) => ({ translateToString: () => lines[y] })
+						}
+					}
+				}
+			}
+		} as unknown as ITerminalInstance;
+		const task = {
+			_label: 'my-task',
+			configurationProperties: {}
+		} as Task;
+		const invocationContext: IToolInvocationContext = {
+			sessionResource: URI.parse('vscode-chat-session://test')
+		};
+		const instantiationService = {
+			createInstance: (_ctor: unknown, execution: IExecution) => {
+				const didFinishEmitter = new Emitter<void>();
+				const monitor = {
+					onDidFinishCommand: didFinishEmitter.event,
+					pollingResult: {
+						output: execution.getOutput(),
+						pollDurationMs: 1,
+						state: OutputMonitorState.Idle
+					},
+					outputMonitorTelemetryCounters: {
+						inputToolManualAcceptCount: 0,
+						inputToolManualRejectCount: 0,
+						inputToolManualChars: 0,
+						inputToolAutoAcceptCount: 0,
+						inputToolAutoChars: 0,
+						inputToolManualShownCount: 0,
+						inputToolFreeFormInputShownCount: 0,
+						inputToolFreeFormInputCount: 0,
+					},
+					dispose: () => didFinishEmitter.dispose()
+				};
+				setTimeout(() => didFinishEmitter.fire(), 0);
+				return monitor;
+			}
+		} as unknown as IInstantiationService;
+
+		const disposableStore = new DisposableStore();
+		const results = await collectTerminalResults(
+			[terminal],
+			task,
+			instantiationService,
+			invocationContext,
+			{ report: () => { } },
+			CancellationToken.None,
+			disposableStore
+		);
+		disposableStore.dispose();
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].output, 'new output line 1\nnew output line 2');
+		assert.strictEqual(markerDisposed, true);
+	});
+
+	test('collectTerminalResults uses provided pre-run marker when present', async () => {
+		const lines = ['old output', 'new output line 1', 'new output line 2', '* Terminal will be reused by tasks, press any key to close it.'];
+		let defaultMarkerDisposed = false;
+		let preRunMarkerDisposed = false;
+		const defaultMarker = {
+			line: 3,
+			dispose: () => { defaultMarkerDisposed = true; }
+		};
+		const preRunMarker = {
+			line: 1,
+			dispose: () => { preRunMarkerDisposed = true; }
+		};
+		const terminal = {
+			instanceId: 1,
+			title: 'task-terminal',
+			shellLaunchConfig: { name: 'task-terminal' },
+			registerMarker: () => defaultMarker,
+			xterm: {
+				raw: {
+					buffer: {
+						active: {
+							length: lines.length,
+							getLine: (y: number) => ({ translateToString: () => lines[y] })
+						}
+					}
+				}
+			}
+		} as unknown as ITerminalInstance;
+		const task = {
+			_label: 'my-task',
+			configurationProperties: {}
+		} as Task;
+		const invocationContext: IToolInvocationContext = {
+			sessionResource: URI.parse('vscode-chat-session://test')
+		};
+		const instantiationService = {
+			createInstance: (_ctor: unknown, execution: IExecution) => {
+				const didFinishEmitter = new Emitter<void>();
+				const monitor = {
+					onDidFinishCommand: didFinishEmitter.event,
+					pollingResult: {
+						output: execution.getOutput(),
+						pollDurationMs: 1,
+						state: OutputMonitorState.Idle
+					},
+					outputMonitorTelemetryCounters: {
+						inputToolManualAcceptCount: 0,
+						inputToolManualRejectCount: 0,
+						inputToolManualChars: 0,
+						inputToolAutoAcceptCount: 0,
+						inputToolAutoChars: 0,
+						inputToolManualShownCount: 0,
+						inputToolFreeFormInputShownCount: 0,
+						inputToolFreeFormInputCount: 0,
+					},
+					dispose: () => didFinishEmitter.dispose()
+				};
+				setTimeout(() => didFinishEmitter.fire(), 0);
+				return monitor;
+			}
+		} as unknown as IInstantiationService;
+
+		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
+		startMarkersByTerminalInstanceId.set(terminal.instanceId, preRunMarker);
+
+		const disposableStore = new DisposableStore();
+		const results = await collectTerminalResults(
+			[terminal],
+			task,
+			instantiationService,
+			invocationContext,
+			{ report: () => { } },
+			CancellationToken.None,
+			disposableStore,
+			undefined,
+			undefined,
+			undefined,
+			startMarkersByTerminalInstanceId
+		);
+		disposableStore.dispose();
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].output, 'new output line 1\nnew output line 2\n* Terminal will be reused by tasks, press any key to close it.');
+		assert.strictEqual(preRunMarkerDisposed, true);
+		assert.strictEqual(defaultMarkerDisposed, false);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
@@ -182,4 +182,84 @@ suite('Task Helpers', () => {
 		assert.strictEqual(preRunMarkerDisposed, true);
 		assert.strictEqual(defaultMarkerDisposed, false);
 	});
+
+	test('collectTerminalResults reads full output when pre-run marker map has no marker for terminal', async () => {
+		const lines = ['new output line 1', 'new output line 2', '* Terminal will be reused by tasks, press any key to close it.'];
+		let defaultMarkerDisposed = false;
+		const defaultMarker = {
+			line: 1,
+			dispose: () => { defaultMarkerDisposed = true; }
+		};
+		const terminal = {
+			instanceId: 1,
+			title: 'task-terminal',
+			shellLaunchConfig: { name: 'task-terminal' },
+			registerMarker: () => defaultMarker,
+			xterm: {
+				raw: {
+					buffer: {
+						active: {
+							length: lines.length,
+							getLine: (y: number) => ({ translateToString: () => lines[y] })
+						}
+					}
+				}
+			}
+		} as unknown as ITerminalInstance;
+		const task = {
+			_label: 'my-task',
+			configurationProperties: {}
+		} as Task;
+		const invocationContext: IToolInvocationContext = {
+			sessionResource: URI.parse('vscode-chat-session://test')
+		};
+		const instantiationService = {
+			createInstance: (_ctor: unknown, execution: IExecution) => {
+				const didFinishEmitter = new Emitter<void>();
+				const monitor = {
+					onDidFinishCommand: didFinishEmitter.event,
+					pollingResult: {
+						output: execution.getOutput(),
+						pollDurationMs: 1,
+						state: OutputMonitorState.Idle
+					},
+					outputMonitorTelemetryCounters: {
+						inputToolManualAcceptCount: 0,
+						inputToolManualRejectCount: 0,
+						inputToolManualChars: 0,
+						inputToolAutoAcceptCount: 0,
+						inputToolAutoChars: 0,
+						inputToolManualShownCount: 0,
+						inputToolFreeFormInputShownCount: 0,
+						inputToolFreeFormInputCount: 0,
+					},
+					dispose: () => didFinishEmitter.dispose()
+				};
+				setTimeout(() => didFinishEmitter.fire(), 0);
+				return monitor;
+			}
+		} as unknown as IInstantiationService;
+
+		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
+
+		const disposableStore = new DisposableStore();
+		const results = await collectTerminalResults(
+			[terminal],
+			task,
+			instantiationService,
+			invocationContext,
+			{ report: () => { } },
+			CancellationToken.None,
+			disposableStore,
+			undefined,
+			undefined,
+			undefined,
+			startMarkersByTerminalInstanceId
+		);
+		disposableStore.dispose();
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].output, 'new output line 1\nnew output line 2\n* Terminal will be reused by tasks, press any key to close it.');
+		assert.strictEqual(defaultMarkerDisposed, false);
+	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/taskHelpers.test.ts
@@ -102,7 +102,10 @@ suite('Task Helpers', () => {
 			dispose: () => { defaultMarkerDisposed = true; }
 		};
 		const preRunMarker = {
+			id: 1,
 			line: 1,
+			isDisposed: false,
+			onDispose: new Emitter<void>().event,
 			dispose: () => { preRunMarkerDisposed = true; }
 		};
 		const terminal = {
@@ -156,7 +159,7 @@ suite('Task Helpers', () => {
 		} as unknown as IInstantiationService;
 
 		const startMarkersByTerminalInstanceId = new Map<number, ReturnType<ITerminalInstance['registerMarker']>>();
-		startMarkersByTerminalInstanceId.set(terminal.instanceId, preRunMarker);
+		startMarkersByTerminalInstanceId.set(terminal.instanceId, preRunMarker as ReturnType<ITerminalInstance['registerMarker']>);
 
 		const disposableStore = new DisposableStore();
 		const results = await collectTerminalResults(


### PR DESCRIPTION
fix #301608

Before this change, task output collection could include the entire terminal buffer (including previous runs). With this update, a marker is set for the current task invocation so only output from that run is returned.

Before:

<img width="765" height="796" alt="Screenshot 2026-03-17 at 4 49 56 PM" src="https://github.com/user-attachments/assets/11d0d140-97e9-4372-9841-8549144c8c37" />

After:

<img width="860" height="671" alt="Screenshot 2026-03-17 at 4 49 27 PM" src="https://github.com/user-attachments/assets/e2df406d-cc15-4092-b339-5fc08827603d" />

cc @tyriar
