### PR TITLE
chat: add URL handlers for plugin installation and marketplace registration

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -162,6 +162,7 @@ import { PluginInstallService } from './pluginInstallService.js';
 import './promptSyntax/promptCodingAgentActionContribution.js';
 import './promptSyntax/promptToolsCodeLensProvider.js';
 import { ChatSlashCommandsContribution } from './chatSlashCommands.js';
+import { PluginUrlHandler } from './pluginUrlHandler.js';
 import { PromptUrlHandler } from './promptSyntax/promptUrlHandler.js';
 import { ConfigureToolSets, UserToolSetsContributions } from './tools/toolSetsContribution.js';
 import { ChatViewsWelcomeHandler } from './viewsWelcome/chatViewsWelcomeHandler.js';
@@ -1797,6 +1798,7 @@ registerWorkbenchContribution2(ChatEditingEditorContextKeys.ID, ChatEditingEdito
 registerWorkbenchContribution2(ChatTransferContribution.ID, ChatTransferContribution, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatContextContributions.ID, ChatContextContributions, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(PromptUrlHandler.ID, PromptUrlHandler, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(PluginUrlHandler.ID, PluginUrlHandler, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChatEditingNotebookFileSystemProviderContrib.ID, ChatEditingNotebookFileSystemProviderContrib, WorkbenchPhase.BlockStartup);
 registerWorkbenchContribution2(ChatResponseResourceWorkbenchContribution.ID, ChatResponseResourceWorkbenchContribution, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(UserToolSetsContributions.ID, UserToolSetsContributions, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
@@ -15,7 +15,7 @@ import { IURLHandler, IURLService } from '../../../../platform/url/common/url.js
 import { IHostService } from '../../../services/host/browser/host.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { ChatConfiguration } from '../common/constants.js';
-import { parseMarketplaceReference } from '../common/plugins/marketplaceReference.js';
+import { MarketplaceReferenceKind, parseMarketplaceReference, parseMarketplaceReferences } from '../common/plugins/marketplaceReference.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { decodeBase64 } from '../../../../base/common/buffer.js';
 
@@ -72,6 +72,11 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 			return true;
 		}
 
+		if (ref.kind === MarketplaceReferenceKind.LocalFileUri) {
+			this._logService.warn('[PluginUrlHandler] Local file URIs are not supported for install');
+			return true;
+		}
+
 		await this._hostService.focus(mainWindow);
 
 		const { confirmed } = await this._dialogService.confirm({
@@ -120,7 +125,8 @@ export class PluginUrlHandler extends Disposable implements IWorkbenchContributi
 		}
 
 		const existing = this._configurationService.getValue<string[]>(ChatConfiguration.PluginMarketplaces) ?? [];
-		if (!existing.includes(refValue)) {
+		const existingRefs = parseMarketplaceReferences(existing);
+		if (!existingRefs.some(e => e.canonicalId === ref.canonicalId)) {
 			await this._configurationService.updateValue(
 				ChatConfiguration.PluginMarketplaces,
 				[...existing, refValue],

--- a/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginUrlHandler.ts
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mainWindow } from '../../../../base/browser/window.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IURLHandler, IURLService } from '../../../../platform/url/common/url.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { ChatConfiguration } from '../common/constants.js';
+import { parseMarketplaceReference } from '../common/plugins/marketplaceReference.js';
+import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
+import { decodeBase64 } from '../../../../base/common/buffer.js';
+
+/**
+ * Handles `vscode://chat-plugin/install?source=<base64>` and
+ * `vscode://chat-plugin/add-marketplace?ref=<base64>` URLs.
+ *
+ * The `source` / `ref` query parameter is a base64-encoded `owner/repo` or
+ * git clone URL. A confirmation dialog is always shown before any action.
+ */
+export class PluginUrlHandler extends Disposable implements IWorkbenchContribution, IURLHandler {
+
+	static readonly ID = 'workbench.contrib.pluginUrlHandler';
+
+	constructor(
+		@IURLService urlService: IURLService,
+		@IPluginInstallService private readonly _pluginInstallService: IPluginInstallService,
+		@IDialogService private readonly _dialogService: IDialogService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IHostService private readonly _hostService: IHostService,
+		@ILogService private readonly _logService: ILogService,
+	) {
+		super();
+		this._register(urlService.registerHandler(this));
+	}
+
+	async handleURL(uri: URI): Promise<boolean> {
+		if (uri.authority !== 'chat-plugin') {
+			return false;
+		}
+
+		switch (uri.path) {
+			case '/install':
+				return this._handleInstall(uri);
+			case '/add-marketplace':
+				return this._handleAddMarketplace(uri);
+			default:
+				return false;
+		}
+	}
+
+	// --- install a plugin from source ---
+
+	private async _handleInstall(uri: URI): Promise<boolean> {
+		const source = this._decodeQueryParam(uri, 'source');
+		if (!source) {
+			this._logService.warn('[PluginUrlHandler] Missing or invalid "source" query parameter');
+			return true;
+		}
+
+		const ref = parseMarketplaceReference(source);
+		if (!ref) {
+			this._logService.warn(`[PluginUrlHandler] Invalid plugin source: ${source}`);
+			return true;
+		}
+
+		await this._hostService.focus(mainWindow);
+
+		const { confirmed } = await this._dialogService.confirm({
+			type: 'question',
+			message: localize('confirmInstallPlugin', "Install Plugin from '{0}'?", ref.displayLabel),
+			detail: localize('confirmInstallPluginDetail', "An external application wants to install a plugin from this source. Plugins can run code on your machine. Only install plugins from sources you trust.\n\nSource: {0}", ref.rawValue),
+			primaryButton: localize({ key: 'installButton', comment: ['&& denotes a mnemonic'] }, "&&Install"),
+			custom: { icon: Codicon.shield },
+		});
+
+		if (!confirmed) {
+			return true;
+		}
+
+		await this._pluginInstallService.installPluginFromSource(source);
+		return true;
+	}
+
+	// --- add a marketplace ---
+
+	private async _handleAddMarketplace(uri: URI): Promise<boolean> {
+		const refValue = this._decodeQueryParam(uri, 'ref');
+		if (!refValue) {
+			this._logService.warn('[PluginUrlHandler] Missing or invalid "ref" query parameter');
+			return true;
+		}
+
+		const ref = parseMarketplaceReference(refValue);
+		if (!ref) {
+			this._logService.warn(`[PluginUrlHandler] Invalid marketplace reference: ${refValue}`);
+			return true;
+		}
+
+		await this._hostService.focus(mainWindow);
+
+		const { confirmed } = await this._dialogService.confirm({
+			type: 'question',
+			message: localize('confirmAddMarketplace', "Add Plugin Marketplace '{0}'?", ref.displayLabel),
+			detail: localize('confirmAddMarketplaceDetail', "An external application wants to add a plugin marketplace. Plugins from this marketplace will appear in the plugin catalog and can be installed.\n\nSource: {0}", ref.rawValue),
+			primaryButton: localize({ key: 'addMarketplaceButton', comment: ['&& denotes a mnemonic'] }, "&&Add Marketplace"),
+			custom: { icon: Codicon.shield },
+		});
+
+		if (!confirmed) {
+			return true;
+		}
+
+		const existing = this._configurationService.getValue<string[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+		if (!existing.includes(refValue)) {
+			await this._configurationService.updateValue(
+				ChatConfiguration.PluginMarketplaces,
+				[...existing, refValue],
+				ConfigurationTarget.USER,
+			);
+		}
+
+		return true;
+	}
+
+	// --- helpers ---
+
+	/**
+	 * Reads a query parameter and attempts to parse it as a marketplace
+	 * reference. Tries base64-decoding first, then falls back to the raw
+	 * value so that plain-text `owner/repo` values also work in URLs.
+	 */
+	private _decodeQueryParam(uri: URI, key: string): string | undefined {
+		const params = new URLSearchParams(uri.query);
+		const raw = params.get(key);
+		if (!raw) {
+			return undefined;
+		}
+
+		// Try base64 first; if the decoded string is a valid reference, use it.
+		try {
+			const decoded = decodeBase64(raw).toString();
+			if (parseMarketplaceReference(decoded)) {
+				return decoded;
+			}
+		} catch {
+			// not valid base64
+		}
+
+		return raw;
+	}
+}

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
@@ -1,0 +1,191 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { encodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
+import { IURLService } from '../../../../../../platform/url/common/url.js';
+import { IHostService } from '../../../../../services/host/browser/host.js';
+import { PluginUrlHandler } from '../../../browser/pluginUrlHandler.js';
+import { ChatConfiguration } from '../../../common/constants.js';
+import { IPluginInstallService } from '../../../common/plugins/pluginInstallService.js';
+
+function toBase64(value: string): string {
+	return encodeBase64(VSBuffer.fromString(value));
+}
+
+suite('PluginUrlHandler', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	interface MockState {
+		dialogConfirmResult: boolean;
+		installedSources: string[];
+		configUpdates: { key: string; value: unknown; target: ConfigurationTarget }[];
+	}
+
+	function createHandler(stateOverrides?: Partial<MockState>): { handler: PluginUrlHandler; state: MockState } {
+		const state: MockState = {
+			dialogConfirmResult: true,
+			installedSources: [],
+			configUpdates: [],
+			...stateOverrides,
+		};
+
+		const instantiationService = store.add(new TestInstantiationService());
+
+		instantiationService.stub(IURLService, {
+			registerHandler: () => ({ dispose() { } }),
+		} as unknown as IURLService);
+
+		instantiationService.stub(IPluginInstallService, {
+			installPluginFromSource: async (source: string) => { state.installedSources.push(source); },
+		} as unknown as IPluginInstallService);
+
+		instantiationService.stub(IDialogService, {
+			confirm: async () => ({ confirmed: state.dialogConfirmResult }),
+		} as unknown as IDialogService);
+
+		const configService = new TestConfigurationService({
+			[ChatConfiguration.PluginMarketplaces]: ['existing/marketplace'],
+		});
+		// Track updateValue calls
+		const origUpdate = configService.updateValue.bind(configService);
+		configService.updateValue = async (key: string, value: unknown, target?: ConfigurationTarget) => {
+			state.configUpdates.push({ key, value, target: target ?? ConfigurationTarget.USER });
+			return origUpdate(key, value);
+		};
+		instantiationService.stub(IConfigurationService, configService);
+
+		instantiationService.stub(IHostService, {
+			focus: async () => { },
+		} as unknown as IHostService);
+
+		instantiationService.stub(ILogService, new NullLogService());
+
+		const handler = store.add(instantiationService.createInstance(PluginUrlHandler));
+		return { handler, state };
+	}
+
+	function uri(path: string, query: string): URI {
+		return URI.from({ scheme: 'vscode', authority: 'chat-plugin', path, query });
+	}
+
+	// --- routing ---
+
+	test('ignores unrelated authority', async () => {
+		const { handler } = createHandler();
+		assert.strictEqual(await handler.handleURL(URI.parse('vscode://other/install?source=foo/bar')), false);
+	});
+
+	test('ignores unknown path', async () => {
+		const { handler } = createHandler();
+		assert.strictEqual(await handler.handleURL(uri('/unknown', 'source=foo/bar')), false);
+	});
+
+	// --- install: plain text ---
+
+	test('install with plain-text owner/repo source', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/install', 'source=anthropics/claude-code'));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, ['anthropics/claude-code']);
+	});
+
+	// --- install: base64 ---
+
+	test('install with base64-encoded source', async () => {
+		const { handler, state } = createHandler();
+		const encoded = toBase64('anthropics/claude-code');
+		const result = await handler.handleURL(uri('/install', `source=${encoded}`));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, ['anthropics/claude-code']);
+	});
+
+	// --- install: dialog declined ---
+
+	test('install does nothing when dialog is declined', async () => {
+		const { handler, state } = createHandler({ dialogConfirmResult: false });
+		const result = await handler.handleURL(uri('/install', 'source=anthropics/claude-code'));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, []);
+	});
+
+	// --- install: missing/invalid source ---
+
+	test('install handles missing source param', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/install', ''));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, []);
+	});
+
+	test('install handles invalid source', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/install', 'source=not-a-valid-ref'));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, []);
+	});
+
+	// --- add-marketplace: plain text ---
+
+	test('add-marketplace with plain-text ref', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/add-marketplace', 'ref=anthropics/claude-code'));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 1);
+		assert.deepStrictEqual(state.configUpdates[0].value, ['existing/marketplace', 'anthropics/claude-code']);
+	});
+
+	// --- add-marketplace: base64 ---
+
+	test('add-marketplace with base64-encoded ref', async () => {
+		const { handler, state } = createHandler();
+		const encoded = toBase64('anthropics/claude-code');
+		const result = await handler.handleURL(uri('/add-marketplace', `ref=${encoded}`));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 1);
+		assert.deepStrictEqual(state.configUpdates[0].value, ['existing/marketplace', 'anthropics/claude-code']);
+	});
+
+	// --- add-marketplace: dedup ---
+
+	test('add-marketplace does not duplicate existing entry', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/add-marketplace', 'ref=existing/marketplace'));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 0);
+	});
+
+	// --- add-marketplace: dialog declined ---
+
+	test('add-marketplace does nothing when dialog is declined', async () => {
+		const { handler, state } = createHandler({ dialogConfirmResult: false });
+		const result = await handler.handleURL(uri('/add-marketplace', 'ref=anthropics/claude-code'));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 0);
+	});
+
+	// --- add-marketplace: missing/invalid ref ---
+
+	test('add-marketplace handles missing ref param', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/add-marketplace', ''));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 0);
+	});
+
+	test('add-marketplace handles invalid ref', async () => {
+		const { handler, state } = createHandler();
+		const result = await handler.handleURL(uri('/add-marketplace', 'ref=not-valid'));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 0);
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginUrlHandler.test.ts
@@ -134,6 +134,14 @@ suite('PluginUrlHandler', () => {
 		assert.deepStrictEqual(state.installedSources, []);
 	});
 
+	test('install rejects local file URI sources', async () => {
+		const { handler, state } = createHandler();
+		const encoded = toBase64('file:///home/user/my-plugin');
+		const result = await handler.handleURL(uri('/install', `source=${encodeURIComponent(encoded)}`));
+		assert.strictEqual(result, true);
+		assert.deepStrictEqual(state.installedSources, []);
+	});
+
 	// --- add-marketplace: plain text ---
 
 	test('add-marketplace with plain-text ref', async () => {
@@ -160,6 +168,14 @@ suite('PluginUrlHandler', () => {
 	test('add-marketplace does not duplicate existing entry', async () => {
 		const { handler, state } = createHandler();
 		const result = await handler.handleURL(uri('/add-marketplace', 'ref=existing/marketplace'));
+		assert.strictEqual(result, true);
+		assert.strictEqual(state.configUpdates.length, 0);
+	});
+
+	test('add-marketplace deduplicates by canonical ID', async () => {
+		const { handler, state } = createHandler();
+		// The URL form of the same GitHub shorthand should match canonically
+		const result = await handler.handleURL(uri('/add-marketplace', 'ref=existing%2Fmarketplace'));
 		assert.strictEqual(result, true);
 		assert.strictEqual(state.configUpdates.length, 0);
 	});


### PR DESCRIPTION
Adds a PluginUrlHandler workbench contribution that handles vscode:// URIs for
plugin-related actions:

- \scode://chat-plugin/install?source=<owner/repo or base64>\ triggers plugin
  installation from a GitHub repo or git clone URL, with a trust confirmation
  dialog before proceeding.
- \scode://chat-plugin/add-marketplace?ref=<owner/repo or base64>\ adds a
  marketplace reference to the user's \chat.plugins.marketplaces\ setting,
  deduplicating against existing entries.
- Query parameters support both plain-text (\owner/repo\) and base64-encoded
  values, with validation fallback: tries base64 decode first, then raw value.
- Includes unit tests covering routing, base64/plain-text decoding, dialog
  confirmation/rejection, missing/invalid params, and marketplace dedup.

Fixes https://github.com/microsoft/vscode/issues/302316

(Commit message generated by Copilot)