### PR TITLE
plugins: clear enablement state on marketplace plugin uninstall

### DIFF
--- a/src/vs/workbench/contrib/chat/common/enablement.ts
+++ b/src/vs/workbench/contrib/chat/common/enablement.ts
@@ -26,6 +26,7 @@ export function isContributionDisabled(state: ContributionEnablementState): bool
 export interface IEnablementModel {
 	readEnabled(key: string, reader?: IReader): ContributionEnablementState;
 	setEnabled(key: string, state: ContributionEnablementState): void;
+	remove(key: string): void;
 }
 
 type EnablementMap = ReadonlyMap<string, boolean>;
@@ -118,6 +119,11 @@ export class EnablementModel extends Disposable implements IEnablementModel {
 				break;
 			}
 		}
+	}
+
+	remove(key: string): void {
+		this._deleteFromMap(this._profileState, key);
+		this._deleteFromMap(this._workspaceState, key);
 	}
 
 	private _setInMap(memento: ObservableMemento<EnablementMap>, key: string, value: boolean): void {

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -1101,6 +1101,7 @@ export class MarketplaceAgentPluginDiscovery extends AbstractAgentPluginDiscover
 				uri: stat.resource,
 				fromMarketplace: entry.plugin,
 				remove: () => {
+					this._enablementModel.remove(stat.resource.toString());
 					this._pluginMarketplaceService.removeInstalledPlugin(entry.pluginUri);
 					this._pluginRepositoryService.cleanupPluginSource(entry.plugin).catch(error => {
 						this._logService.error('[MarketplaceAgentPluginDiscovery] Failed to clean up plugin source', error);

--- a/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/agentPluginFormatDetection.test.ts
@@ -85,6 +85,7 @@ suite('AgentPlugin format detection', () => {
 	const mockEnablementModel: IEnablementModel = {
 		readEnabled: () => ContributionEnablementState.EnabledProfile,
 		setEnabled: () => { },
+		remove: () => { },
 	};
 
 	function createDiscovery(): TestPluginDiscovery {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/computeAutomaticInstructions.test.ts
@@ -189,7 +189,7 @@ suite('ComputeAutomaticInstructions', () => {
 
 		instaService.stub(IAgentPluginService, {
 			plugins: observableValue('testPlugins', []),
-			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { } },
+			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
 
 		service = disposables.add(instaService.createInstance(PromptsService));

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -176,7 +176,7 @@ suite('PromptsService', () => {
 
 		instaService.stub(IAgentPluginService, {
 			plugins: testPluginsObservable,
-			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { } },
+			enablementModel: { readEnabled: () => 2 /* EnabledProfile */, setEnabled: () => { }, remove: () => { } },
 		});
 
 		service = disposables.add(instaService.createInstance(PromptsService));

--- a/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
+++ b/src/vs/workbench/contrib/mcp/test/common/testMcpService.ts
@@ -11,6 +11,7 @@ export class TestEnablementModel implements IEnablementModel {
 	readEnabled(_key: string): ContributionEnablementState {
 		return ContributionEnablementState.EnabledProfile;
 	}
+	remove(_key: string): void { }
 	setEnabled(_key: string, _state: ContributionEnablementState): void { }
 }
 


### PR DESCRIPTION
plugins: clear enablement state on marketplace plugin uninstall

- Adds IEnablementModel.remove(key) to delete enablement entries from
  both profile and workspace storage
- Calls remove() when uninstalling a marketplace plugin so that a
  disabled plugin does not retain stale disabled state after uninstall

Fixes https://github.com/microsoft/vscode/issues/301295

(Commit message generated by Copilot)