### PR TITLE
aiCustomization: prompt to uninstall plugin when removing plugin-provided components

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -39,7 +39,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { ChatConfiguration } from '../../common/constants.js';
 import { IFileService, FileSystemProviderCapabilities } from '../../../../../platform/files/common/files.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
-import { basename, dirname } from '../../../../../base/common/resources.js';
+import { basename, dirname, isEqualOrParent } from '../../../../../base/common/resources.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, isMacintosh } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
@@ -235,7 +235,7 @@ registerAction2(class extends Action2 {
 		// Plugin-provided files: offer to uninstall the plugin
 		if (storage === PromptsStorage.plugin) {
 			const agentPluginService = accessor.get(IAgentPluginService);
-			const plugin = agentPluginService.plugins.get().find(p => uri.toString().startsWith(p.uri.toString()));
+			const plugin = agentPluginService.plugins.get().find(p => isEqualOrParent(uri, p.uri));
 			if (plugin) {
 				const result = await dialogService.confirm({
 					message: localize('cannotDeletePluginItem', "This item is provided by the plugin '{0}'", plugin.label),
@@ -393,7 +393,7 @@ registerAction2(class extends Action2 {
 		const dialogService = accessor.get(IDialogService);
 
 		const uri = extractURI(context);
-		const plugin = agentPluginService.plugins.get().find(p => uri.toString().startsWith(p.uri.toString()));
+		const plugin = agentPluginService.plugins.get().find(p => isEqualOrParent(uri, p.uri));
 		if (!plugin) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -44,6 +44,7 @@ import { Schemas } from '../../../../../base/common/network.js';
 import { isWindows, isMacintosh } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
 
 //#region Telemetry
 
@@ -231,8 +232,26 @@ registerAction2(class extends Action2 {
 		// For skills, use the parent folder name since skills are structured as <skillname>/SKILL.md.
 		const fileName = isSkill ? basename(dirname(uri)) : basename(uri);
 
-		// Extension, plugin, and built-in files cannot be deleted
-		if (storage === PromptsStorage.extension || storage === PromptsStorage.plugin || storage === BUILTIN_STORAGE) {
+		// Plugin-provided files: offer to uninstall the plugin
+		if (storage === PromptsStorage.plugin) {
+			const agentPluginService = accessor.get(IAgentPluginService);
+			const plugin = agentPluginService.plugins.get().find(p => uri.toString().startsWith(p.uri.toString()));
+			if (plugin) {
+				const result = await dialogService.confirm({
+					message: localize('cannotDeletePluginItem', "This item is provided by the plugin '{0}'", plugin.label),
+					detail: localize('cannotDeletePluginItemDetail', "Individual components from a plugin cannot be removed separately. Would you like to uninstall the entire plugin?"),
+					primaryButton: localize('uninstallPlugin', "Uninstall Plugin"),
+					type: 'question',
+				});
+				if (result.confirmed) {
+					plugin.remove();
+				}
+			}
+			return;
+		}
+
+		// Extension and built-in files cannot be deleted
+		if (storage === PromptsStorage.extension || storage === BUILTIN_STORAGE) {
 			await dialogService.info(
 				localize('cannotDeleteExtension', "Cannot Delete Extension File"),
 				localize('cannotDeleteExtensionDetail', "Files provided by extensions cannot be deleted. You can disable the extension if you no longer want to use this customization.")
@@ -307,6 +326,11 @@ const WHEN_ITEM_IS_DELETABLE = ContextKeyExpr.and(
 	ContextKeyExpr.notEquals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
 );
 
+/**
+ * When clause that shows an action only for plugin items.
+ */
+const WHEN_ITEM_IS_PLUGIN = ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, PromptsStorage.plugin);
+
 // Register context menu items
 
 // Inline hover actions (shown as icon buttons on hover)
@@ -352,6 +376,52 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	group: '4_modify',
 	order: 1,
 	when: WHEN_ITEM_IS_DELETABLE,
+});
+
+// Uninstall Plugin action - shown for plugin-provided items
+const UNINSTALL_PLUGIN_AI_CUSTOMIZATION_ID = 'aiCustomizationManagement.uninstallPlugin';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: UNINSTALL_PLUGIN_AI_CUSTOMIZATION_ID,
+			title: localize2('uninstallPlugin', "Uninstall Plugin"),
+			icon: Codicon.trash,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
+		const agentPluginService = accessor.get(IAgentPluginService);
+		const dialogService = accessor.get(IDialogService);
+
+		const uri = extractURI(context);
+		const plugin = agentPluginService.plugins.get().find(p => uri.toString().startsWith(p.uri.toString()));
+		if (!plugin) {
+			return;
+		}
+
+		const result = await dialogService.confirm({
+			message: localize('confirmUninstallPlugin', "This item is provided by the plugin '{0}'", plugin.label),
+			detail: localize('confirmUninstallPluginDetail', "Individual components from a plugin cannot be removed separately. Would you like to uninstall the entire plugin?"),
+			primaryButton: localize('uninstallPluginBtn', "Uninstall Plugin"),
+			type: 'question',
+		});
+		if (result.confirmed) {
+			plugin.remove();
+		}
+	}
+});
+
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: UNINSTALL_PLUGIN_AI_CUSTOMIZATION_ID, title: localize('uninstallPlugin', "Uninstall Plugin"), icon: Codicon.trash },
+	group: 'inline',
+	order: 10,
+	when: WHEN_ITEM_IS_PLUGIN,
+});
+
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: UNINSTALL_PLUGIN_AI_CUSTOMIZATION_ID, title: localize('uninstallPlugin', "Uninstall Plugin") },
+	group: '4_modify',
+	order: 1,
+	when: WHEN_ITEM_IS_PLUGIN,
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -26,9 +26,11 @@ import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { IContextMenuService, IContextViewService } from '../../../../../platform/contextview/browser/contextView.js';
 import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { Delayer } from '../../../../../base/common/async.js';
-import { IAction, Separator } from '../../../../../base/common/actions.js';
+import { Action, IAction, Separator } from '../../../../../base/common/actions.js';
 import { getContextMenuActions } from '../../../../contrib/mcp/browser/mcpServerActions.js';
 import { LocalMcpServerScope } from '../../../../services/mcp/common/mcpWorkbenchManagementService.js';
+import { IAgentPluginService } from '../../common/plugins/agentPluginService.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { workspaceIcon, userIcon, mcpServerIcon, builtinIcon } from './aiCustomizationIcons.js';
 import { formatDisplayName, truncateToFirstSentence } from './aiCustomizationListWidget.js';
 import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
@@ -56,13 +58,14 @@ interface IMcpServerItemEntry {
 }
 
 /**
- * Represents a built-in MCP server provided by an extension.
+ * Represents a built-in MCP server provided by an extension or plugin.
  */
 interface IMcpBuiltinItemEntry {
 	readonly type: 'builtin-item';
 	readonly id: string;
 	readonly label: string;
 	readonly description: string;
+	readonly collectionId?: string;
 }
 
 type IMcpListEntry = IMcpGroupHeaderEntry | IMcpServerItemEntry | IMcpBuiltinItemEntry;
@@ -335,6 +338,8 @@ export class McpListWidget extends Disposable {
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IAgentPluginService private readonly agentPluginService: IAgentPluginService,
+		@IDialogService private readonly dialogService: IDialogService,
 	) {
 		super();
 		this.element = $('.mcp-list-widget');
@@ -699,6 +704,7 @@ export class McpListWidget extends Disposable {
 						id: `builtin-${server.definition.id}`,
 						label: server.definition.label,
 						description: '',
+						collectionId: server.collection.id,
 					});
 				}
 			}
@@ -770,7 +776,48 @@ export class McpListWidget extends Disposable {
 	 * Handles context menu for MCP server items.
 	 */
 	private onContextMenu(e: IListContextMenuEvent<IMcpListEntry>): void {
-		if (!e.element || e.element.type !== 'server-item') {
+		if (!e.element) {
+			return;
+		}
+
+		// Plugin-provided builtin items get an "Uninstall Plugin" context menu
+		if (e.element.type === 'builtin-item') {
+			const collectionId = e.element.collectionId;
+			if (!collectionId?.startsWith('plugin.')) {
+				return;
+			}
+			const pluginUriStr = collectionId.slice('plugin.'.length);
+			const plugin = this.agentPluginService.plugins.get().find(p => p.uri.toString() === pluginUriStr);
+			if (!plugin) {
+				return;
+			}
+
+			const uninstallAction = new Action(
+				'mcpServer.uninstallPlugin',
+				localize('uninstallPlugin', "Uninstall Plugin"),
+				undefined,
+				true,
+				async () => {
+					const result = await this.dialogService.confirm({
+						message: localize('confirmUninstallPluginMcp', "This MCP server is provided by the plugin '{0}'", plugin.label),
+						detail: localize('confirmUninstallPluginMcpDetail', "Individual MCP servers from a plugin cannot be removed separately. Would you like to uninstall the entire plugin?"),
+						primaryButton: localize('uninstallPluginBtn', "Uninstall Plugin"),
+						type: 'question',
+					});
+					if (result.confirmed) {
+						plugin.remove();
+					}
+				}
+			);
+
+			this.contextMenuService.showContextMenu({
+				getAnchor: () => e.anchor,
+				getActions: () => [uninstallAction],
+			});
+			return;
+		}
+
+		if (e.element.type !== 'server-item') {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -792,7 +792,8 @@ export class McpListWidget extends Disposable {
 				return;
 			}
 
-			const uninstallAction = new Action(
+			const disposables = new DisposableStore();
+			const uninstallAction = disposables.add(new Action(
 				'mcpServer.uninstallPlugin',
 				localize('uninstallPlugin', "Uninstall Plugin"),
 				undefined,
@@ -808,11 +809,12 @@ export class McpListWidget extends Disposable {
 						plugin.remove();
 					}
 				}
-			);
+			));
 
 			this.contextMenuService.showContextMenu({
 				getAnchor: () => e.anchor,
 				getActions: () => [uninstallAction],
+				onHide: () => disposables.dispose(),
 			});
 			return;
 		}


### PR DESCRIPTION
When a user tries to uninstall an individual MCP server or hook that was
installed as part of a plugin, the system now prompts them to uninstall
the entire plugin instead of showing a misleading error or allowing
piecemeal removal.

- Add 'Uninstall Plugin' action to the AI Customization management editor,
  visible as an inline icon and context menu item for plugin-provided items
- Update the delete action to intercept plugin items and offer plugin
  uninstall with a confirmation dialog showing the plugin name
- Separate plugin handling from the extension/built-in guard so the dialog
  text is accurate for each case
- Add plugin-aware context menu to the MCP list widget for builtin servers
  from plugins, with collection ID tracking to identify plugin origin
- Add collectionId to IMcpBuiltinItemEntry to enable plugin detection

Fixes https://github.com/microsoft/vscode/issues/302515

(Commit message generated by Copilot)