### PR TITLE
Remove the use of `/d` in Windows task command

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -409,7 +409,7 @@
 			"type": "shell",
 			"command": "npm ci && npm run watch",
 			"windows": {
-				"command": "cmd /d /c \"npm ci && npm run watch\""
+				"command": "cmd /c \"npm ci && npm run watch\""
 			},
 			"inSessions": true,
 			"runOptions": {


### PR DESCRIPTION
```Copilot Generated Description:``` Update the Windows task command to eliminate the use of `/d`, simplifying the command execution.

