### PR TITLE
fix: create agent feedback editor widgets in reverse order for correct z-ordering

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -586,7 +586,11 @@ class AgentFeedbackEditorWidgetContribution extends Disposable implements IEdito
 
 		const groups = groupNearbySessionEditorComments(fileComments, 5);
 
-		for (const group of groups) {
+		// Create widgets in reverse file order so that widgets further up in the
+		// file are added to the DOM last and therefore render on top of widgets
+		// further down.
+		for (let i = groups.length - 1; i >= 0; i--) {
+			const group = groups[i];
 			const widget = this._instantiationService.createInstance(AgentFeedbackEditorWidget, this._editor, group, this._sessionResource);
 			this._widgets.push(widget);
 


### PR DESCRIPTION
## Summary

Create agent feedback editor widgets in reverse file order so that widgets higher up in the file render above widgets further down.

## Problem

When multiple agent feedback widget groups exist in an editor, overlay widgets added later in the DOM render on top of earlier ones. Since groups were created in top-to-bottom file order, widgets at the bottom of the file would visually overlap widgets at the top — the opposite of what's expected.

## Fix

Reverse the iteration order in `_rebuildWidgets` so that bottom-of-file groups are added to the DOM first and top-of-file groups are added last, ensuring correct z-ordering where higher widgets render above lower ones.

closes https://github.com/microsoft/vscode-internalbacklog/issues/7137