### PR TITLE
chat: populate githubRepo for GitUri marketplace references

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -157,13 +157,14 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 		return undefined;
 	}
 
+	const gitSuffix = '.git';
 	const authority = match[2];
 	const pathWithGit = match[3].replace(/^\/+/, '');
-	if (!pathWithGit.toLowerCase().endsWith('.git')) {
+	if (!pathWithGit.toLowerCase().endsWith(gitSuffix)) {
 		return undefined;
 	}
 
-	const pathWithoutGit = pathWithGit.slice(0, -4);
+	const pathWithoutGit = pathWithGit.slice(0, -gitSuffix.length);
 	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
 	const githubRepo = extractGitHubRepo(authority, pathWithoutGit);
 

--- a/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/marketplaceReference.ts
@@ -136,6 +136,10 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
 	// Always normalize the canonical path to include .git so that URLs with and without the suffix deduplicate.
 	const canonicalPath = pathHasGitSuffix ? normalizedPath.slice(1).toLowerCase() : `${normalizedPath.slice(1).toLowerCase()}${gitSuffix}`;
+
+	// Extract githubRepo for GitHub URLs so the editor can render a clickable link
+	const githubRepo = extractGitHubRepo(uri.authority, pathWithoutGit);
+
 	return {
 		rawValue,
 		displayLabel: rawValue,
@@ -143,6 +147,7 @@ function parseUriMarketplaceReference(rawValue: string): IMarketplaceReference |
 		canonicalId: `git:${uri.authority.toLowerCase()}/${canonicalPath}`,
 		cacheSegments: [sanitizedAuthority, ...pathSegments],
 		kind: MarketplaceReferenceKind.GitUri,
+		githubRepo,
 	};
 }
 
@@ -158,7 +163,10 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 		return undefined;
 	}
 
-	const pathSegments = pathWithGit.slice(0, -4).split('/').map(sanitizePathSegment);
+	const pathWithoutGit = pathWithGit.slice(0, -4);
+	const pathSegments = pathWithoutGit.split('/').map(sanitizePathSegment);
+	const githubRepo = extractGitHubRepo(authority, pathWithoutGit);
+
 	return {
 		rawValue,
 		displayLabel: rawValue,
@@ -166,6 +174,7 @@ function parseScpMarketplaceReference(rawValue: string): IMarketplaceReference |
 		canonicalId: `git:${authority.toLowerCase()}/${pathWithGit.toLowerCase()}`,
 		cacheSegments: [sanitizePathSegment(authority.toLowerCase()), ...pathSegments],
 		kind: MarketplaceReferenceKind.GitUri,
+		githubRepo,
 	};
 }
 
@@ -189,6 +198,17 @@ function normalizeGitRepoPath(path: string): string | undefined {
 	}
 
 	return withLeadingSlash;
+}
+
+function extractGitHubRepo(authority: string, pathWithoutGit: string): string | undefined {
+	if (authority.toLowerCase() !== 'github.com') {
+		return undefined;
+	}
+	const parts = pathWithoutGit.split('/');
+	if (parts.length >= 2 && parts[0] && parts[1]) {
+		return `${parts[0]}/${parts[1]}`;
+	}
+	return undefined;
 }
 
 function getGitHubCanonicalId(owner: string, repo: string): string {

--- a/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/pluginMarketplaceService.test.ts
@@ -35,6 +35,7 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parsed.canonicalId, 'github:microsoft/vscode');
 		assert.strictEqual(parsed.displayLabel, 'microsoft/vscode');
 		assert.deepStrictEqual(parsed.cacheSegments, ['github.com', 'microsoft', 'vscode']);
+		assert.strictEqual(parsed.githubRepo, 'microsoft/vscode');
 	});
 
 	test('parses direct HTTPS and SSH marketplaces ending in .git', () => {
@@ -66,6 +67,33 @@ suite('PluginMarketplaceService', () => {
 		assert.strictEqual(parsed.cloneUrl, 'git@example.com:org/repo.git');
 		assert.strictEqual(parsed.canonicalId, 'git:example.com/org/repo.git');
 		assert.deepStrictEqual(parsed.cacheSegments, ['example.com', 'org', 'repo']);
+		assert.strictEqual(parsed.githubRepo, undefined);
+	});
+
+	test('populates githubRepo for GitHub HTTPS URLs', () => {
+		const withGit = parseMarketplaceReference('https://github.com/owner/repo.git');
+		assert.ok(withGit);
+		assert.strictEqual(withGit?.githubRepo, 'owner/repo');
+
+		const withoutGit = parseMarketplaceReference('https://github.com/owner/repo');
+		assert.ok(withoutGit);
+		assert.strictEqual(withoutGit?.githubRepo, 'owner/repo');
+	});
+
+	test('populates githubRepo for GitHub SCP-style URLs', () => {
+		const parsed = parseMarketplaceReference('git@github.com:owner/repo.git');
+		assert.ok(parsed);
+		assert.strictEqual(parsed?.githubRepo, 'owner/repo');
+	});
+
+	test('does not populate githubRepo for non-GitHub URLs', () => {
+		const https = parseMarketplaceReference('https://example.com/org/repo.git');
+		assert.ok(https);
+		assert.strictEqual(https?.githubRepo, undefined);
+
+		const scp = parseMarketplaceReference('git@gitlab.com:org/repo.git');
+		assert.ok(scp);
+		assert.strictEqual(scp?.githubRepo, undefined);
 	});
 
 	test('parses local file marketplace references', () => {


### PR DESCRIPTION
chat: populate githubRepo for GitUri marketplace references

When a plugin marketplace reference is a full GitHub URL (e.g.
https://github.com/anthropics/claude-code) parsed as a GitUri, the
githubRepo property was not being set. This caused the AgentPluginEditor
to render the marketplace link as plain text instead of a clickable link.

- Add extractGitHubRepo helper that extracts owner/repo from GitHub URLs
- Set githubRepo on GitUri references when the authority is github.com
- Also handle SCP-style references (git@github.com:org/repo.git)

Fixes https://github.com/microsoft/vscode/issues/301288

(Commit message generated by Copilot)