### PR TITLE
feat: add harness filtering layer to Chat Customizations

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -14,9 +14,10 @@ src/vs/workbench/contrib/chat/browser/aiCustomization/
 ├── aiCustomizationManagement.ts                # IDs + context keys
 ├── aiCustomizationManagementEditor.ts          # SplitView list/editor
 ├── aiCustomizationManagementEditorInput.ts     # Singleton input
-├── aiCustomizationListWidget.ts                # Search + grouped list
+├── aiCustomizationListWidget.ts                # Search + grouped list + harness toggle
 ├── aiCustomizationDebugPanel.ts                # Debug diagnostics panel
 ├── aiCustomizationWorkspaceService.ts          # Core VS Code workspace service impl
+├── customizationHarnessService.ts              # Core harness service impl (VS Code harness)
 ├── customizationCreatorService.ts              # AI-guided creation flow
 ├── mcpListWidget.ts                            # MCP servers section
 ├── aiCustomizationIcons.ts                     # Icons
@@ -24,7 +25,8 @@ src/vs/workbench/contrib/chat/browser/aiCustomization/
     └── aiCustomizationManagement.css
 
 src/vs/workbench/contrib/chat/common/
-└── aiCustomizationWorkspaceService.ts          # IAICustomizationWorkspaceService + IStorageSourceFilter
+├── aiCustomizationWorkspaceService.ts          # IAICustomizationWorkspaceService + IStorageSourceFilter
+└── customizationHarnessService.ts              # ICustomizationHarnessService + CustomizationHarness enum
 ```
 
 The tree view and overview live in `vs/sessions` (sessions window only):
@@ -44,6 +46,7 @@ Sessions-specific overrides:
 ```
 src/vs/sessions/contrib/chat/browser/
 ├── aiCustomizationWorkspaceService.ts          # Sessions workspace service override
+├── customizationHarnessService.ts              # Sessions harness service (CLI + Claude harnesses)
 └── promptsService.ts                           # AgenticPromptsService (CLI user roots)
 src/vs/sessions/contrib/sessions/browser/
 ├── customizationCounts.ts                      # Source count utilities (type-aware)
@@ -57,9 +60,25 @@ The `IAICustomizationWorkspaceService` interface controls per-window behavior:
 | Property / Method | Core VS Code | Sessions Window |
 |----------|-------------|----------|
 | `managementSections` | All sections except Models | Same minus MCP |
-| `getStorageSourceFilter(type)` | All sources, no user root filter | Per-type (see below) |
+| `getStorageSourceFilter(type)` | Delegates to `ICustomizationHarnessService` | Delegates to `ICustomizationHarnessService` |
 | `isSessionsWindow` | `false` | `true` |
 | `activeProjectRoot` | First workspace folder | Active session worktree |
+
+### ICustomizationHarnessService
+
+A harness represents the AI execution environment that consumes customizations.
+Storage answers "where did this come from?"; harness answers "who consumes it?".
+
+Available harnesses:
+
+| Harness | Label | Description |
+|---------|-------|-------------|
+| `vscode` | VS Code | Shows all storage sources (default in core) |
+| `cli` | Copilot CLI | Restricts user roots to `~/.copilot`, `~/.claude`, `~/.agents` |
+| `claude` | Claude | Restricts user roots to `~/.claude` |
+
+In core VS Code, only the `vscode` harness is registered (toggle hidden).
+In sessions, `cli` and `claude` harnesses are registered with a toggle bar above the list.
 
 ### IStorageSourceFilter
 
@@ -75,13 +94,23 @@ interface IStorageSourceFilter {
 
 The shared `applyStorageSourceFilter()` helper applies this filter to any `{uri, storage}` array.
 
-**Sessions filter behavior by type:**
+**Sessions filter behavior by harness and type:**
+
+CLI harness:
 
 | Type | sources | includedUserFileRoots |
 |------|---------|----------------------|
-| Hooks | `[local]` | N/A |
-| Prompts | `[local, user]` | `undefined` (all roots) |
-| Agents, Skills, Instructions | `[local, user]` | `[~/.copilot, ~/.claude, ~/.agents]` |
+| Hooks | `[local, plugin]` | N/A |
+| Prompts | `[local, user, plugin, builtin]` | `undefined` (all roots) |
+| Agents, Skills, Instructions | `[local, user, plugin, builtin]` | `[~/.copilot, ~/.claude, ~/.agents]` |
+
+Claude harness:
+
+| Type | sources | includedUserFileRoots |
+|------|---------|----------------------|
+| Hooks | `[local, plugin]` | N/A |
+| Prompts | `[local, user, plugin, builtin]` | `undefined` (all roots) |
+| Agents, Skills, Instructions | `[local, user, plugin, builtin]` | `[~/.claude]` |
 
 **Core VS Code:** All types use `[local, user, extension, plugin]` with no user root filter.
 

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -69,6 +69,11 @@ The `IAICustomizationWorkspaceService` interface controls per-window behavior:
 A harness represents the AI execution environment that consumes customizations.
 Storage answers "where did this come from?"; harness answers "who consumes it?".
 
+The service is defined in `common/customizationHarnessService.ts` which also provides:
+- **`CustomizationHarnessServiceBase`** — reusable base class handling active-harness state, the observable list, and `getStorageSourceFilter` dispatch.
+- **Factory functions** — `createVSCodeHarnessDescriptor`, `createCliHarnessDescriptor`, `createClaudeHarnessDescriptor` — parameterized by an `extras` array (the additional storage sources beyond `local`, `user`, `plugin`). Core passes `[PromptsStorage.extension]`; sessions passes `[BUILTIN_STORAGE]`.
+- **Well-known root helpers** — `getCliUserRoots(userHome)` and `getClaudeUserRoots(userHome)` centralize the `~/.copilot`, `~/.claude`, `~/.agents` path knowledge so it isn't duplicated.
+
 Available harnesses:
 
 | Harness | Label | Description |
@@ -77,7 +82,7 @@ Available harnesses:
 | `cli` | Copilot CLI | Restricts user roots to `~/.copilot`, `~/.claude`, `~/.agents` |
 | `claude` | Claude | Restricts user roots to `~/.claude` |
 
-In core VS Code, only the `vscode` harness is registered (toggle hidden).
+In core VS Code, all three harnesses are registered; VS Code is the default.
 In sessions, `cli` and `claude` harnesses are registered with a toggle bar above the list.
 
 ### IStorageSourceFilter

--- a/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
+++ b/src/vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService.ts
@@ -4,17 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { derived, IObservable, observableValue, ISettableObservable } from '../../../../base/common/observable.js';
-import { joinPath, relativePath } from '../../../../base/common/resources.js';
+import { relativePath } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection, IStorageSourceFilter, applyStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { IChatPromptSlashCommand, IPromptsService, PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
-import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
+import { IChatPromptSlashCommand, IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { CustomizationCreatorService } from '../../../../workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -43,37 +42,16 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 	 */
 	private readonly _overrideRoot: ISettableObservable<URI | undefined>;
 
-	/**
-	 * CLI-accessible user directories for customization file filtering and creation.
-	 */
-	private readonly _cliUserRoots: readonly URI[];
-
-	/**
-	 * Pre-built filter for types that should only show CLI-accessible user roots.
-	 */
-	private readonly _cliUserFilter: IStorageSourceFilter;
-
 	constructor(
 		@ISessionsManagementService private readonly sessionsService: ISessionsManagementService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IPromptsService private readonly promptsService: IPromptsService,
-		@IPathService pathService: IPathService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 		@ICommandService private readonly commandService: ICommandService,
 		@ILogService private readonly logService: ILogService,
 		@IFileService private readonly fileService: IFileService,
 		@INotificationService private readonly notificationService: INotificationService,
 	) {
-		const userHome = pathService.userHome({ preferLocal: true });
-		this._cliUserRoots = [
-			joinPath(userHome, '.copilot'),
-			joinPath(userHome, '.claude'),
-			joinPath(userHome, '.agents'),
-		];
-		this._cliUserFilter = {
-			sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
-			includedUserFileRoots: this._cliUserRoots,
-		};
-
 		this._overrideRoot = observableValue(this, undefined);
 
 		this.activeProjectRoot = derived(reader => {
@@ -117,24 +95,8 @@ export class SessionsAICustomizationWorkspaceService implements IAICustomization
 		AICustomizationManagementSection.Plugins,
 	];
 
-	private static readonly _hooksFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.plugin],
-	};
-
-	private static readonly _allUserRootsFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
-	};
-
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-		if (type === PromptsType.hook) {
-			return SessionsAICustomizationWorkspaceService._hooksFilter;
-		}
-		if (type === PromptsType.prompt) {
-			// Prompts are shown from all user roots (including VS Code profile)
-			return SessionsAICustomizationWorkspaceService._allUserRootsFilter;
-		}
-		// Other types only show user files from CLI-accessible roots (~/.copilot, ~/.claude, ~/.agents)
-		return this._cliUserFilter;
+		return this.harnessService.getStorageSourceFilter(type);
 	}
 
 	readonly isSessionsWindow = true;

--- a/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/sessions/contrib/chat/browser/chat.contribution.ts
@@ -28,7 +28,9 @@ import { AgenticPromptsService } from './promptsService.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { ISessionsConfigurationService, SessionsConfigurationService } from './sessionsConfigurationService.js';
 import { IAICustomizationWorkspaceService } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { ICustomizationHarnessService } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { SessionsAICustomizationWorkspaceService } from './aiCustomizationWorkspaceService.js';
+import { SessionsCustomizationHarnessService } from './customizationHarnessService.js';
 import { ChatViewContainerId, ChatViewId } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { NewChatViewPane, SessionsViewId } from './newChatViewPane.js';
@@ -195,3 +197,4 @@ registerWorkbenchContribution2(RunScriptContribution.ID, RunScriptContribution, 
 registerSingleton(IPromptsService, AgenticPromptsService, InstantiationType.Delayed);
 registerSingleton(ISessionsConfigurationService, SessionsConfigurationService, InstantiationType.Delayed);
 registerSingleton(IAICustomizationWorkspaceService, SessionsAICustomizationWorkspaceService, InstantiationType.Delayed);
+registerSingleton(ICustomizationHarnessService, SessionsCustomizationHarnessService, InstantiationType.Delayed);

--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../base/common/codicons.js';
+import { constObservable, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { localize } from '../../../../nls.js';
+import { IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
+import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
+import { PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
+import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
+
+/**
+ * Filter: hooks are always local + plugin only.
+ */
+const HOOKS_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.plugin],
+};
+
+/**
+ * Filter: prompts are shown from all user roots.
+ */
+const ALL_USER_ROOTS_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
+};
+
+function createCliHarness(cliUserRoots: readonly URI[]): IHarnessDescriptor {
+	const cliUserFilter: IStorageSourceFilter = {
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
+		includedUserFileRoots: cliUserRoots,
+	};
+
+	return {
+		id: CustomizationHarness.CLI,
+		label: localize('harness.cli', "Copilot CLI"),
+		icon: ThemeIcon.fromId(Codicon.terminal.id),
+		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+			if (type === PromptsType.hook) {
+				return HOOKS_FILTER;
+			}
+			if (type === PromptsType.prompt) {
+				return ALL_USER_ROOTS_FILTER;
+			}
+			// Agents, skills, instructions — only CLI-accessible user roots
+			return cliUserFilter;
+		},
+	};
+}
+
+function createClaudeHarness(claudeRoots: readonly URI[]): IHarnessDescriptor {
+	const claudeFilter: IStorageSourceFilter = {
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
+		includedUserFileRoots: claudeRoots,
+	};
+
+	return {
+		id: CustomizationHarness.Claude,
+		label: localize('harness.claude', "Claude"),
+		icon: ThemeIcon.fromId(Codicon.sparkle.id),
+		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+			if (type === PromptsType.hook) {
+				return HOOKS_FILTER;
+			}
+			if (type === PromptsType.prompt) {
+				return ALL_USER_ROOTS_FILTER;
+			}
+			return claudeFilter;
+		},
+	};
+}
+
+/**
+ * Sessions-window override of the customization harness service.
+ *
+ * Exposes CLI and Claude harnesses with restricted user-root filters
+ * so the customizations UI only shows items accessible to each harness.
+ */
+export class SessionsCustomizationHarnessService implements ICustomizationHarnessService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _activeHarness = observableValue<CustomizationHarness>(this, CustomizationHarness.CLI);
+	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
+
+	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
+
+	private readonly _harnesses: readonly IHarnessDescriptor[];
+
+	constructor(
+		@IPathService pathService: IPathService,
+	) {
+		const userHome = pathService.userHome({ preferLocal: true });
+
+		const cliUserRoots = [
+			joinPath(userHome, '.copilot'),
+			joinPath(userHome, '.claude'),
+			joinPath(userHome, '.agents'),
+		];
+
+		const claudeRoots = [
+			joinPath(userHome, '.claude'),
+		];
+
+		this._harnesses = [
+			createCliHarness(cliUserRoots),
+			createClaudeHarness(claudeRoots),
+		];
+		this.availableHarnesses = constObservable(this._harnesses);
+	}
+
+	setActiveHarness(id: CustomizationHarness): void {
+		if (this._harnesses.some(h => h.id === id)) {
+			this._activeHarness.set(id, undefined);
+		}
+	}
+
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+		const activeId = this._activeHarness.get();
+		const descriptor = this._harnesses.find(h => h.id === activeId);
+		return descriptor?.getStorageSourceFilter(type) ?? this._harnesses[0].getStorageSourceFilter(type);
+	}
+}

--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -7,9 +7,7 @@ import {
 	CustomizationHarness,
 	CustomizationHarnessServiceBase,
 	createCliHarnessDescriptor,
-	createClaudeHarnessDescriptor,
 	getCliUserRoots,
-	getClaudeUserRoots,
 } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
@@ -17,8 +15,8 @@ import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
 /**
  * Sessions-window override of the customization harness service.
  *
- * Exposes CLI and Claude harnesses with restricted user-root filters
- * so the customizations UI only shows items accessible to each harness.
+ * Only the CLI harness is registered because sessions always run via
+ * the Copilot CLI. With a single harness the toggle bar is hidden.
  */
 export class SessionsCustomizationHarnessService extends CustomizationHarnessServiceBase {
 	constructor(
@@ -27,10 +25,7 @@ export class SessionsCustomizationHarnessService extends CustomizationHarnessSer
 		const userHome = pathService.userHome({ preferLocal: true });
 		const extras = [BUILTIN_STORAGE];
 		super(
-			[
-				createCliHarnessDescriptor(getCliUserRoots(userHome), extras),
-				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), extras),
-			],
+			[createCliHarnessDescriptor(getCliUserRoots(userHome), extras)],
 			CustomizationHarness.CLI,
 		);
 	}

--- a/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
+++ b/src/vs/sessions/contrib/chat/browser/customizationHarnessService.ts
@@ -3,77 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Codicon } from '../../../../base/common/codicons.js';
-import { constObservable, IObservable, observableValue } from '../../../../base/common/observable.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
-import { URI } from '../../../../base/common/uri.js';
-import { joinPath } from '../../../../base/common/resources.js';
-import { localize } from '../../../../nls.js';
-import { IStorageSourceFilter } from '../../../../workbench/contrib/chat/common/aiCustomizationWorkspaceService.js';
-import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor } from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
-import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
-import { PromptsStorage } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import {
+	CustomizationHarness,
+	CustomizationHarnessServiceBase,
+	createCliHarnessDescriptor,
+	createClaudeHarnessDescriptor,
+	getCliUserRoots,
+	getClaudeUserRoots,
+} from '../../../../workbench/contrib/chat/common/customizationHarnessService.js';
 import { IPathService } from '../../../../workbench/services/path/common/pathService.js';
 import { BUILTIN_STORAGE } from '../common/builtinPromptsStorage.js';
-
-/**
- * Filter: hooks are always local + plugin only.
- */
-const HOOKS_FILTER: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.plugin],
-};
-
-/**
- * Filter: prompts are shown from all user roots.
- */
-const ALL_USER_ROOTS_FILTER: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
-};
-
-function createCliHarness(cliUserRoots: readonly URI[]): IHarnessDescriptor {
-	const cliUserFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
-		includedUserFileRoots: cliUserRoots,
-	};
-
-	return {
-		id: CustomizationHarness.CLI,
-		label: localize('harness.cli', "Copilot CLI"),
-		icon: ThemeIcon.fromId(Codicon.terminal.id),
-		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-			if (type === PromptsType.hook) {
-				return HOOKS_FILTER;
-			}
-			if (type === PromptsType.prompt) {
-				return ALL_USER_ROOTS_FILTER;
-			}
-			// Agents, skills, instructions — only CLI-accessible user roots
-			return cliUserFilter;
-		},
-	};
-}
-
-function createClaudeHarness(claudeRoots: readonly URI[]): IHarnessDescriptor {
-	const claudeFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, BUILTIN_STORAGE],
-		includedUserFileRoots: claudeRoots,
-	};
-
-	return {
-		id: CustomizationHarness.Claude,
-		label: localize('harness.claude', "Claude"),
-		icon: ThemeIcon.fromId(Codicon.sparkle.id),
-		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-			if (type === PromptsType.hook) {
-				return HOOKS_FILTER;
-			}
-			if (type === PromptsType.prompt) {
-				return ALL_USER_ROOTS_FILTER;
-			}
-			return claudeFilter;
-		},
-	};
-}
 
 /**
  * Sessions-window override of the customization harness service.
@@ -81,47 +20,18 @@ function createClaudeHarness(claudeRoots: readonly URI[]): IHarnessDescriptor {
  * Exposes CLI and Claude harnesses with restricted user-root filters
  * so the customizations UI only shows items accessible to each harness.
  */
-export class SessionsCustomizationHarnessService implements ICustomizationHarnessService {
-	declare readonly _serviceBrand: undefined;
-
-	private readonly _activeHarness = observableValue<CustomizationHarness>(this, CustomizationHarness.CLI);
-	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
-
-	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
-
-	private readonly _harnesses: readonly IHarnessDescriptor[];
-
+export class SessionsCustomizationHarnessService extends CustomizationHarnessServiceBase {
 	constructor(
 		@IPathService pathService: IPathService,
 	) {
 		const userHome = pathService.userHome({ preferLocal: true });
-
-		const cliUserRoots = [
-			joinPath(userHome, '.copilot'),
-			joinPath(userHome, '.claude'),
-			joinPath(userHome, '.agents'),
-		];
-
-		const claudeRoots = [
-			joinPath(userHome, '.claude'),
-		];
-
-		this._harnesses = [
-			createCliHarness(cliUserRoots),
-			createClaudeHarness(claudeRoots),
-		];
-		this.availableHarnesses = constObservable(this._harnesses);
-	}
-
-	setActiveHarness(id: CustomizationHarness): void {
-		if (this._harnesses.some(h => h.id === id)) {
-			this._activeHarness.set(id, undefined);
-		}
-	}
-
-	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-		const activeId = this._activeHarness.get();
-		const descriptor = this._harnesses.find(h => h.id === activeId);
-		return descriptor?.getStorageSourceFilter(type) ?? this._harnesses[0].getStorageSourceFilter(type);
+		const extras = [BUILTIN_STORAGE];
+		super(
+			[
+				createCliHarnessDescriptor(getCliUserRoots(userHome), extras),
+				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), extras),
+			],
+			CustomizationHarness.CLI,
+		);
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -478,6 +478,7 @@ export class AICustomizationListWidget extends Disposable {
 		// Re-filter when the active harness changes
 		this._register(autorun(reader => {
 			this.harnessService.activeHarness.read(reader);
+			this.updateAddButton();
 			this.refresh();
 		}));
 
@@ -774,6 +775,8 @@ export class AICustomizationListWidget extends Disposable {
 
 	/**
 	 * Gets the dropdown actions for the add button.
+	 * Respects the active harness filter — user-scoped creation is only
+	 * offered when the harness shows all user roots (i.e. "Local").
 	 */
 	private getDropdownActions(): Action[] {
 		this.dropdownActionDisposables.clear();
@@ -796,11 +799,22 @@ export class AICustomizationListWidget extends Disposable {
 			return actions;
 		}
 
+		// User-scoped creation: in core VS Code, only when the harness shows
+		// all user roots (no includedUserFileRoots restriction). Restricted
+		// harnesses like CLI/Claude filter user roots, so creating in the
+		// VS Code profile directory wouldn't be visible in the current view.
+		// In sessions, user creation always targets CLI-accessible paths
+		// (AgenticPromptsService routes to ~/.copilot/...) so it's always valid.
+		const filter = this.harnessService.getStorageSourceFilter(promptType);
+		const showUserCreate = this.workspaceService.isSessionsWindow || !filter.includedUserFileRoots;
+
 		if (this.workspaceService.isSessionsWindow) {
 			// Sessions: primary is workspace, dropdown has user
-			actions.push(this.dropdownActionDisposables.add(new Action('createUser', `$(${Codicon.account.id}) New ${typeLabel} (User)`, undefined, true, () => {
-				this._onDidRequestCreateManual.fire({ type: promptType, target: 'user' });
-			})));
+			if (showUserCreate) {
+				actions.push(this.dropdownActionDisposables.add(new Action('createUser', `$(${Codicon.account.id}) New ${typeLabel} (User)`, undefined, true, () => {
+					this._onDidRequestCreateManual.fire({ type: promptType, target: 'user' });
+				})));
+			}
 			// For instructions: offer AGENTS.md at workspace root
 			if (promptType === PromptsType.instructions && this.hasActiveWorkspace()) {
 				actions.push(this.dropdownActionDisposables.add(new Action('createAgentsMd', `$(${Codicon.file.id}) New ${AGENT_MD_FILENAME}`, undefined, true, () => {
@@ -814,9 +828,11 @@ export class AICustomizationListWidget extends Disposable {
 					this._onDidRequestCreateManual.fire({ type: promptType, target: 'workspace' });
 				})));
 			}
-			actions.push(this.dropdownActionDisposables.add(new Action('createUser', `$(${Codicon.account.id}) New ${typeLabel} (User)`, undefined, true, () => {
-				this._onDidRequestCreateManual.fire({ type: promptType, target: 'user' });
-			})));
+			if (showUserCreate) {
+				actions.push(this.dropdownActionDisposables.add(new Action('createUser', `$(${Codicon.account.id}) New ${typeLabel} (User)`, undefined, true, () => {
+					this._onDidRequestCreateManual.fire({ type: promptType, target: 'user' });
+				})));
+			}
 		}
 
 		return actions;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -51,7 +51,7 @@ import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { CustomizationHarness, ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 
 export { truncateToFirstSentence } from './aiCustomizationListWidgetUtils.js';
 
@@ -425,10 +425,6 @@ export class AICustomizationListWidget extends Disposable {
 	private emptyStateText!: HTMLElement;
 	private emptyStateSubtext!: HTMLElement;
 
-	private harnessToggleContainer!: HTMLElement;
-	private harnessToggleButtons: Map<CustomizationHarness, HTMLElement> = new Map();
-	private readonly harnessToggleDisposables = this._register(new DisposableStore());
-
 	private currentSection: AICustomizationManagementSection = AICustomizationManagementSection.Agents;
 	private allItems: IAICustomizationListItem[] = [];
 	private displayEntries: IListEntry[] = [];
@@ -482,17 +478,12 @@ export class AICustomizationListWidget extends Disposable {
 		// Re-filter when the active harness changes
 		this._register(autorun(reader => {
 			this.harnessService.activeHarness.read(reader);
-			this.updateHarnessToggle();
 			this.refresh();
 		}));
 
 	}
 
 	private create(): void {
-		// Harness toggle bar (shown when multiple harnesses available)
-		this.harnessToggleContainer = DOM.append(this.element, $('.harness-toggle-container'));
-		this.createHarnessToggle();
-
 		// Search and button container
 		this.searchAndButtonContainer = DOM.append(this.element, $('.list-search-and-button-container'));
 
@@ -619,80 +610,6 @@ export class AICustomizationListWidget extends Disposable {
 			}
 		}));
 		this.updateSectionHeader();
-	}
-
-	/**
-	 * Creates the harness toggle pill buttons with proper tablist semantics.
-	 */
-	private createHarnessToggle(): void {
-		this.harnessToggleDisposables.clear();
-		this.harnessToggleButtons.clear();
-		DOM.clearNode(this.harnessToggleContainer);
-
-		const harnesses = this.harnessService.availableHarnesses.get();
-		if (harnesses.length <= 1) {
-			this.harnessToggleContainer.style.display = 'none';
-			return;
-		}
-
-		this.harnessToggleContainer.style.display = '';
-		this.harnessToggleContainer.setAttribute('role', 'tablist');
-		this.harnessToggleContainer.setAttribute('aria-label', localize('harnessToggleLabel', "Customization filter"));
-
-		const activeId = this.harnessService.activeHarness.get();
-
-		for (const harness of harnesses) {
-			const pill = DOM.append(this.harnessToggleContainer, $('button.harness-toggle-pill'));
-			pill.setAttribute('role', 'tab');
-			pill.setAttribute('aria-selected', harness.id === activeId ? 'true' : 'false');
-			pill.tabIndex = harness.id === activeId ? 0 : -1;
-
-			const iconEl = DOM.append(pill, $('span.harness-toggle-icon'));
-			iconEl.classList.add(...ThemeIcon.asClassNameArray(harness.icon));
-
-			const labelEl = DOM.append(pill, $('span.harness-toggle-label'));
-			labelEl.textContent = harness.label;
-
-			if (harness.id === activeId) {
-				pill.classList.add('active');
-			}
-
-			this.harnessToggleDisposables.add(DOM.addDisposableListener(pill, 'click', () => {
-				this.harnessService.setActiveHarness(harness.id);
-			}));
-
-			this.harnessToggleDisposables.add(DOM.addDisposableListener(pill, 'keydown', (e: KeyboardEvent) => {
-				const pills = Array.from(this.harnessToggleButtons.values());
-				const index = pills.indexOf(pill);
-				let next: number | undefined;
-				if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-					next = (index + 1) % pills.length;
-				} else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-					next = (index - 1 + pills.length) % pills.length;
-				}
-				if (next !== undefined) {
-					e.preventDefault();
-					pills[next].focus();
-					const ids = Array.from(this.harnessToggleButtons.keys());
-					this.harnessService.setActiveHarness(ids[next]);
-				}
-			}));
-
-			this.harnessToggleButtons.set(harness.id, pill);
-		}
-	}
-
-	/**
-	 * Updates the visual state of the harness toggle pills.
-	 */
-	private updateHarnessToggle(): void {
-		const activeId = this.harnessService.activeHarness.get();
-		for (const [id, pill] of this.harnessToggleButtons) {
-			const isActive = id === activeId;
-			pill.classList.toggle('active', isActive);
-			pill.setAttribute('aria-selected', isActive ? 'true' : 'false');
-			pill.tabIndex = isActive ? 0 : -1;
-		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -51,6 +51,7 @@ import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { CustomizationHarness, ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 
 export { truncateToFirstSentence } from './aiCustomizationListWidgetUtils.js';
 
@@ -424,6 +425,9 @@ export class AICustomizationListWidget extends Disposable {
 	private emptyStateText!: HTMLElement;
 	private emptyStateSubtext!: HTMLElement;
 
+	private harnessToggleContainer!: HTMLElement;
+	private harnessToggleButtons: Map<CustomizationHarness, HTMLElement> = new Map();
+
 	private currentSection: AICustomizationManagementSection = AICustomizationManagementSection.Agents;
 	private allItems: IAICustomizationListItem[] = [];
 	private displayEntries: IListEntry[] = [];
@@ -461,6 +465,7 @@ export class AICustomizationListWidget extends Disposable {
 		@IFileService private readonly fileService: IFileService,
 		@IPathService private readonly pathService: IPathService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 	) {
 		super();
 		this.element = $('.ai-customization-list-widget');
@@ -473,9 +478,20 @@ export class AICustomizationListWidget extends Disposable {
 			this.refresh();
 		}));
 
+		// Re-filter when the active harness changes
+		this._register(autorun(reader => {
+			this.harnessService.activeHarness.read(reader);
+			this.updateHarnessToggle();
+			this.refresh();
+		}));
+
 	}
 
 	private create(): void {
+		// Harness toggle bar (shown when multiple harnesses available)
+		this.harnessToggleContainer = DOM.append(this.element, $('.harness-toggle-container'));
+		this.createHarnessToggle();
+
 		// Search and button container
 		this.searchAndButtonContainer = DOM.append(this.element, $('.list-search-and-button-container'));
 
@@ -602,6 +618,52 @@ export class AICustomizationListWidget extends Disposable {
 			}
 		}));
 		this.updateSectionHeader();
+	}
+
+	/**
+	 * Creates the harness toggle pill buttons.
+	 */
+	private createHarnessToggle(): void {
+		const harnesses = this.harnessService.availableHarnesses.get();
+		if (harnesses.length <= 1) {
+			this.harnessToggleContainer.style.display = 'none';
+			return;
+		}
+
+		const activeId = this.harnessService.activeHarness.get();
+
+		for (const harness of harnesses) {
+			const pill = DOM.append(this.harnessToggleContainer, $('button.harness-toggle-pill'));
+			pill.setAttribute('role', 'tab');
+			pill.setAttribute('aria-selected', harness.id === activeId ? 'true' : 'false');
+
+			const iconEl = DOM.append(pill, $('span.harness-toggle-icon'));
+			iconEl.classList.add(...ThemeIcon.asClassNameArray(harness.icon));
+
+			const labelEl = DOM.append(pill, $('span.harness-toggle-label'));
+			labelEl.textContent = harness.label;
+
+			if (harness.id === activeId) {
+				pill.classList.add('active');
+			}
+
+			this._register(DOM.addDisposableListener(pill, 'click', () => {
+				this.harnessService.setActiveHarness(harness.id);
+			}));
+
+			this.harnessToggleButtons.set(harness.id, pill);
+		}
+	}
+
+	/**
+	 * Updates the visual state of the harness toggle pills.
+	 */
+	private updateHarnessToggle(): void {
+		const activeId = this.harnessService.activeHarness.get();
+		for (const [id, pill] of this.harnessToggleButtons) {
+			pill.classList.toggle('active', id === activeId);
+			pill.setAttribute('aria-selected', id === activeId ? 'true' : 'false');
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -427,6 +427,7 @@ export class AICustomizationListWidget extends Disposable {
 
 	private harnessToggleContainer!: HTMLElement;
 	private harnessToggleButtons: Map<CustomizationHarness, HTMLElement> = new Map();
+	private readonly harnessToggleDisposables = this._register(new DisposableStore());
 
 	private currentSection: AICustomizationManagementSection = AICustomizationManagementSection.Agents;
 	private allItems: IAICustomizationListItem[] = [];
@@ -621,14 +622,22 @@ export class AICustomizationListWidget extends Disposable {
 	}
 
 	/**
-	 * Creates the harness toggle pill buttons.
+	 * Creates the harness toggle pill buttons with proper tablist semantics.
 	 */
 	private createHarnessToggle(): void {
+		this.harnessToggleDisposables.clear();
+		this.harnessToggleButtons.clear();
+		DOM.clearNode(this.harnessToggleContainer);
+
 		const harnesses = this.harnessService.availableHarnesses.get();
 		if (harnesses.length <= 1) {
 			this.harnessToggleContainer.style.display = 'none';
 			return;
 		}
+
+		this.harnessToggleContainer.style.display = '';
+		this.harnessToggleContainer.setAttribute('role', 'tablist');
+		this.harnessToggleContainer.setAttribute('aria-label', localize('harnessToggleLabel', "Customization filter"));
 
 		const activeId = this.harnessService.activeHarness.get();
 
@@ -636,6 +645,7 @@ export class AICustomizationListWidget extends Disposable {
 			const pill = DOM.append(this.harnessToggleContainer, $('button.harness-toggle-pill'));
 			pill.setAttribute('role', 'tab');
 			pill.setAttribute('aria-selected', harness.id === activeId ? 'true' : 'false');
+			pill.tabIndex = harness.id === activeId ? 0 : -1;
 
 			const iconEl = DOM.append(pill, $('span.harness-toggle-icon'));
 			iconEl.classList.add(...ThemeIcon.asClassNameArray(harness.icon));
@@ -647,8 +657,25 @@ export class AICustomizationListWidget extends Disposable {
 				pill.classList.add('active');
 			}
 
-			this._register(DOM.addDisposableListener(pill, 'click', () => {
+			this.harnessToggleDisposables.add(DOM.addDisposableListener(pill, 'click', () => {
 				this.harnessService.setActiveHarness(harness.id);
+			}));
+
+			this.harnessToggleDisposables.add(DOM.addDisposableListener(pill, 'keydown', (e: KeyboardEvent) => {
+				const pills = Array.from(this.harnessToggleButtons.values());
+				const index = pills.indexOf(pill);
+				let next: number | undefined;
+				if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+					next = (index + 1) % pills.length;
+				} else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+					next = (index - 1 + pills.length) % pills.length;
+				}
+				if (next !== undefined) {
+					e.preventDefault();
+					pills[next].focus();
+					const ids = Array.from(this.harnessToggleButtons.keys());
+					this.harnessService.setActiveHarness(ids[next]);
+				}
 			}));
 
 			this.harnessToggleButtons.set(harness.id, pill);
@@ -661,8 +688,10 @@ export class AICustomizationListWidget extends Disposable {
 	private updateHarnessToggle(): void {
 		const activeId = this.harnessService.activeHarness.get();
 		for (const [id, pill] of this.harnessToggleButtons) {
-			pill.classList.toggle('active', id === activeId);
-			pill.setAttribute('aria-selected', id === activeId ? 'true' : 'false');
+			const isActive = id === activeId;
+			pill.classList.toggle('active', isActive);
+			pill.setAttribute('aria-selected', isActive ? 'true' : 'false');
+			pill.tabIndex = isActive ? 0 : -1;
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -81,6 +81,7 @@ import { IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
 import { AgentPluginEditor } from '../agentPluginEditor/agentPluginEditor.js';
 import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
 import { IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 
 const $ = DOM.$;
 
@@ -288,6 +289,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 
 	private dimension: DOM.Dimension | undefined;
 	private readonly sections: ISectionItem[] = [];
+	private readonly allSections: ISectionItem[] = [];
 	private selectedSection: AICustomizationManagementSection = AICustomizationManagementSection.Agents;
 
 	private readonly editorDisposables = this._register(new DisposableStore());
@@ -298,6 +300,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private folderPickerContainer: HTMLElement | undefined;
 	private folderPickerLabel: HTMLElement | undefined;
 	private folderPickerClearButton: HTMLElement | undefined;
+
+	// Harness dropdown
+	private harnessDropdownButton: HTMLElement | undefined;
+	private harnessDropdownIcon: HTMLElement | undefined;
+	private harnessDropdownLabel: HTMLElement | undefined;
 
 	private readonly inEditorContextKey: IContextKey<boolean>;
 	private readonly sectionContextKey: IContextKey<string>;
@@ -322,6 +329,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@IFileService private readonly fileService: IFileService,
 		@INotificationService private readonly notificationService: INotificationService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 	) {
 		super(AICustomizationManagementEditor.ID, group, telemetryService, themeService, storageService);
 
@@ -355,9 +363,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 		for (const id of this.workspaceService.managementSections) {
 			const info = sectionInfo[id];
 			if (info) {
-				this.sections.push({ id, ...info, count: 0 });
+				this.allSections.push({ id, ...info, count: 0 });
 			}
 		}
+		this.rebuildVisibleSections();
 
 		// Restore selected section from storage, falling back to first available
 		const savedSection = this.storageService.get(AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY, StorageScope.PROFILE);
@@ -453,8 +462,41 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}));
 	}
 
+	/**
+	 * Rebuilds the visible sections list based on the active harness's
+	 * `hiddenSections`. If the current selection falls into a hidden
+	 * section, the first visible section is selected instead.
+	 */
+	private rebuildVisibleSections(): void {
+		const activeId = this.harnessService.activeHarness.get();
+		const descriptor = this.harnessService.availableHarnesses.get().find(h => h.id === activeId);
+		const hidden = new Set(descriptor?.hiddenSections ?? []);
+
+		this.sections.length = 0;
+		for (const s of this.allSections) {
+			if (!hidden.has(s.id)) {
+				this.sections.push(s);
+			}
+		}
+
+		// Update the list widget if it exists
+		if (this.sectionsList) {
+			this.sectionsList.splice(0, this.sectionsList.length, this.sections);
+		}
+
+		// If the current selection is hidden, fall back to first visible
+		if (!this.sections.some(s => s.id === this.selectedSection) && this.sections.length > 0) {
+			this.selectSection(this.sections[0].id);
+		} else {
+			this.ensureSectionsListReflectsActiveSection();
+		}
+	}
+
 	private createSidebar(): void {
 		const sidebarContent = DOM.append(this.sidebarContainer, $('.sidebar-content'));
+
+		// Harness dropdown (shown when multiple harnesses available)
+		this.createHarnessDropdown(sidebarContent);
 
 		// Main sections list container (takes remaining space)
 		const sectionsListContainer = DOM.append(sidebarContent, $('.sidebar-sections-list'));
@@ -491,10 +533,80 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.selectSection(e.elements[0].id);
 		}));
 
+		// React to harness changes — rebuild visible sections
+		this.editorDisposables.add(autorun(reader => {
+			this.harnessService.activeHarness.read(reader);
+			this.rebuildVisibleSections();
+			this.updateHarnessDropdown();
+		}));
+
 		// Folder picker (sessions window only)
 		if (this.workspaceService.isSessionsWindow) {
 			this.createFolderPicker(sidebarContent);
 		}
+	}
+
+	private createHarnessDropdown(sidebarContent: HTMLElement): void {
+		const harnesses = this.harnessService.availableHarnesses.get();
+		if (harnesses.length <= 1) {
+			return;
+		}
+
+		const container = DOM.append(sidebarContent, $('.sidebar-harness-dropdown'));
+
+		this.harnessDropdownButton = DOM.append(container, $('button.harness-dropdown-button'));
+		this.harnessDropdownButton.setAttribute('aria-label', localize('selectHarness', "Select customization target"));
+		this.harnessDropdownButton.setAttribute('aria-haspopup', 'listbox');
+
+		this.harnessDropdownIcon = DOM.append(this.harnessDropdownButton, $('span.harness-dropdown-icon'));
+		this.harnessDropdownLabel = DOM.append(this.harnessDropdownButton, $('span.harness-dropdown-label'));
+		DOM.append(this.harnessDropdownButton, $('span.harness-dropdown-chevron.codicon.codicon-chevron-down'));
+
+		this.updateHarnessDropdown();
+
+		this.editorDisposables.add(DOM.addDisposableListener(this.harnessDropdownButton, 'click', () => {
+			this.showHarnessPicker();
+		}));
+	}
+
+	private updateHarnessDropdown(): void {
+		if (!this.harnessDropdownIcon || !this.harnessDropdownLabel) {
+			return;
+		}
+		const activeId = this.harnessService.activeHarness.get();
+		const descriptor = this.harnessService.availableHarnesses.get().find(h => h.id === activeId);
+		if (descriptor) {
+			this.harnessDropdownIcon.className = 'harness-dropdown-icon';
+			this.harnessDropdownIcon.classList.add(...ThemeIcon.asClassNameArray(descriptor.icon));
+			this.harnessDropdownLabel.textContent = descriptor.label;
+		}
+	}
+
+	private showHarnessPicker(): void {
+		const harnesses = this.harnessService.availableHarnesses.get();
+		const activeId = this.harnessService.activeHarness.get();
+
+		const items = harnesses.map(h => ({
+			label: h.label,
+			iconClass: ThemeIcon.asClassName(h.icon),
+			id: h.id,
+			picked: h.id === activeId,
+		}));
+
+		const picker = this.quickInputService.createQuickPick();
+		picker.items = items;
+		picker.placeholder = localize('selectTarget', "Select customization target");
+		picker.canSelectMany = false;
+		picker.activeItems = items.filter(i => i.picked);
+		picker.onDidAccept(() => {
+			const selected = picker.activeItems[0] as typeof items[0] | undefined;
+			if (selected) {
+				this.harnessService.setActiveHarness(selected.id);
+			}
+			picker.dispose();
+		});
+		picker.onDidHide(() => picker.dispose());
+		picker.show();
 	}
 
 	private createFolderPicker(sidebarContent: HTMLElement): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWorkspaceService.ts
@@ -9,9 +9,10 @@ import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { IAICustomizationWorkspaceService, AICustomizationManagementSection, IStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { IChatPromptSlashCommand, IPromptsService, PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { IChatPromptSlashCommand, IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 import {
 	GENERATE_AGENT_COMMAND_ID,
 	GENERATE_HOOK_COMMAND_ID,
@@ -29,6 +30,7 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IPromptsService private readonly promptsService: IPromptsService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 	) {
 		const workspaceFolders = observableFromEventOpts(
 			{ owner: this },
@@ -56,12 +58,8 @@ class AICustomizationWorkspaceService implements IAICustomizationWorkspaceServic
 		AICustomizationManagementSection.Plugins,
 	];
 
-	private static readonly _defaultFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
-	};
-
-	getStorageSourceFilter(_type: PromptsType): IStorageSourceFilter {
-		return AICustomizationWorkspaceService._defaultFilter;
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+		return this.harnessService.getStorageSourceFilter(type);
 	}
 
 	readonly isSessionsWindow = false;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
@@ -15,6 +15,7 @@ import { isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { localize } from '../../../../../nls.js';
+import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
 
 /**
  * Service that opens an AI-guided chat session to help the user create
@@ -33,6 +34,7 @@ export class CustomizationCreatorService {
 		@IAICustomizationWorkspaceService private readonly workspaceService: IAICustomizationWorkspaceService,
 		@IPromptsService private readonly promptsService: IPromptsService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@ICustomizationHarnessService private readonly harnessService: ICustomizationHarnessService,
 	) { }
 
 	async createWithAI(type: PromptsType): Promise<void> {
@@ -109,10 +111,14 @@ export class CustomizationCreatorService {
 	private async resolveTargetDirectoryWithPicker(type: PromptsType): Promise<URI | undefined | null> {
 		const allFolders = await this.promptsService.getSourceFolders(type);
 		const projectRoot = this.workspaceService.getActiveProjectRoot();
+		const descriptor = this.harnessService.getActiveDescriptor();
+		const subpaths = descriptor.workspaceSubpaths;
 
 		// Filter to only workspace-scoped folders (under the active project root).
 		// Don't rely on storage tags — tilde-expanded user paths can be tagged local.
 		// Deduplicate by URI to avoid inflated counts and duplicate picker entries.
+		// When the active harness specifies workspaceSubpaths, further restrict to
+		// directories whose path includes one of those sub-paths (e.g. `.claude`).
 		const seen = new Set<string>();
 		const workspaceFolders = projectRoot
 			? allFolders.filter(f => {
@@ -124,6 +130,10 @@ export class CustomizationCreatorService {
 					return false;
 				}
 				seen.add(key);
+				if (subpaths) {
+					const path = f.uri.path;
+					return subpaths.some(sp => path.includes(sp));
+				}
 				return true;
 			})
 			: [];

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -3,126 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Codicon } from '../../../../../base/common/codicons.js';
-import { joinPath } from '../../../../../base/common/resources.js';
-import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
-import { ThemeIcon } from '../../../../../base/common/themables.js';
-import { URI } from '../../../../../base/common/uri.js';
-import { localize } from '../../../../../nls.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
-import { IStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
-import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
-import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import {
+	CustomizationHarness,
+	CustomizationHarnessServiceBase,
+	ICustomizationHarnessService,
+	createCliHarnessDescriptor,
+	createClaudeHarnessDescriptor,
+	createVSCodeHarnessDescriptor,
+	getCliUserRoots,
+	getClaudeUserRoots,
+} from '../../common/customizationHarnessService.js';
 import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
-
-const DEFAULT_FILTER: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
-};
-
-const HOOKS_FILTER: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.plugin],
-};
-
-const ALL_USER_ROOTS_FILTER: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
-};
-
-function createVSCodeHarness(): IHarnessDescriptor {
-	return {
-		id: CustomizationHarness.VSCode,
-		label: localize('harness.vscode', "VS Code"),
-		icon: ThemeIcon.fromId(Codicon.copilot.id),
-		getStorageSourceFilter(_type: PromptsType): IStorageSourceFilter {
-			return DEFAULT_FILTER;
-		},
-	};
-}
-
-function createCliHarness(cliUserRoots: readonly URI[]): IHarnessDescriptor {
-	const cliUserFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
-		includedUserFileRoots: cliUserRoots,
-	};
-	return {
-		id: CustomizationHarness.CLI,
-		label: localize('harness.cli', "Copilot CLI"),
-		icon: ThemeIcon.fromId(Codicon.terminal.id),
-		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-			if (type === PromptsType.hook) {
-				return HOOKS_FILTER;
-			}
-			if (type === PromptsType.prompt) {
-				return ALL_USER_ROOTS_FILTER;
-			}
-			return cliUserFilter;
-		},
-	};
-}
-
-function createClaudeHarness(claudeRoots: readonly URI[]): IHarnessDescriptor {
-	const claudeFilter: IStorageSourceFilter = {
-		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
-		includedUserFileRoots: claudeRoots,
-	};
-	return {
-		id: CustomizationHarness.Claude,
-		label: localize('harness.claude', "Claude"),
-		icon: ThemeIcon.fromId(Codicon.sparkle.id),
-		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-			if (type === PromptsType.hook) {
-				return HOOKS_FILTER;
-			}
-			if (type === PromptsType.prompt) {
-				return ALL_USER_ROOTS_FILTER;
-			}
-			return claudeFilter;
-		},
-	};
-}
 
 /**
  * Core implementation of the customization harness service.
  * Exposes VS Code, CLI, and Claude harnesses for filtering customizations.
- * Sessions overrides this to further restrict user file roots to CLI-only paths.
  */
-class CustomizationHarnessService implements ICustomizationHarnessService {
-	declare readonly _serviceBrand: undefined;
-
-	private readonly _activeHarness = observableValue<CustomizationHarness>(this, CustomizationHarness.VSCode);
-	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
-
-	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
-	private readonly _harnesses: readonly IHarnessDescriptor[];
-
+class CustomizationHarnessService extends CustomizationHarnessServiceBase {
 	constructor(
 		@IPathService pathService: IPathService,
 	) {
 		const userHome = pathService.userHome({ preferLocal: true });
-		this._harnesses = [
-			createVSCodeHarness(),
-			createCliHarness([
-				joinPath(userHome, '.copilot'),
-				joinPath(userHome, '.claude'),
-				joinPath(userHome, '.agents'),
-			]),
-			createClaudeHarness([
-				joinPath(userHome, '.claude'),
-			]),
-		];
-		this.availableHarnesses = constObservable(this._harnesses);
-	}
-
-	setActiveHarness(id: CustomizationHarness): void {
-		if (this._harnesses.some(h => h.id === id)) {
-			this._activeHarness.set(id, undefined);
-		}
-	}
-
-	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
-		const activeId = this._activeHarness.get();
-		const descriptor = this._harnesses.find(h => h.id === activeId);
-		return descriptor?.getStorageSourceFilter(type) ?? DEFAULT_FILTER;
+		const extras = [PromptsStorage.extension];
+		super(
+			[
+				createVSCodeHarnessDescriptor(extras),
+				createCliHarnessDescriptor(getCliUserRoots(userHome), extras),
+				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), extras),
+			],
+			CustomizationHarness.VSCode,
+		);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { joinPath } from '../../../../../base/common/resources.js';
+import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { localize } from '../../../../../nls.js';
+import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { IStorageSourceFilter } from '../../common/aiCustomizationWorkspaceService.js';
+import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor } from '../../common/customizationHarnessService.js';
+import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
+import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+
+const DEFAULT_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
+};
+
+const HOOKS_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.plugin],
+};
+
+const ALL_USER_ROOTS_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
+};
+
+function createVSCodeHarness(): IHarnessDescriptor {
+	return {
+		id: CustomizationHarness.VSCode,
+		label: localize('harness.vscode', "VS Code"),
+		icon: ThemeIcon.fromId(Codicon.copilot.id),
+		getStorageSourceFilter(_type: PromptsType): IStorageSourceFilter {
+			return DEFAULT_FILTER;
+		},
+	};
+}
+
+function createCliHarness(cliUserRoots: readonly URI[]): IHarnessDescriptor {
+	const cliUserFilter: IStorageSourceFilter = {
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
+		includedUserFileRoots: cliUserRoots,
+	};
+	return {
+		id: CustomizationHarness.CLI,
+		label: localize('harness.cli', "Copilot CLI"),
+		icon: ThemeIcon.fromId(Codicon.terminal.id),
+		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+			if (type === PromptsType.hook) {
+				return HOOKS_FILTER;
+			}
+			if (type === PromptsType.prompt) {
+				return ALL_USER_ROOTS_FILTER;
+			}
+			return cliUserFilter;
+		},
+	};
+}
+
+function createClaudeHarness(claudeRoots: readonly URI[]): IHarnessDescriptor {
+	const claudeFilter: IStorageSourceFilter = {
+		sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension, PromptsStorage.plugin],
+		includedUserFileRoots: claudeRoots,
+	};
+	return {
+		id: CustomizationHarness.Claude,
+		label: localize('harness.claude', "Claude"),
+		icon: ThemeIcon.fromId(Codicon.sparkle.id),
+		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+			if (type === PromptsType.hook) {
+				return HOOKS_FILTER;
+			}
+			if (type === PromptsType.prompt) {
+				return ALL_USER_ROOTS_FILTER;
+			}
+			return claudeFilter;
+		},
+	};
+}
+
+/**
+ * Core implementation of the customization harness service.
+ * Exposes VS Code, CLI, and Claude harnesses for filtering customizations.
+ * Sessions overrides this to further restrict user file roots to CLI-only paths.
+ */
+class CustomizationHarnessService implements ICustomizationHarnessService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _activeHarness = observableValue<CustomizationHarness>(this, CustomizationHarness.VSCode);
+	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
+
+	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
+	private readonly _harnesses: readonly IHarnessDescriptor[];
+
+	constructor(
+		@IPathService pathService: IPathService,
+	) {
+		const userHome = pathService.userHome({ preferLocal: true });
+		this._harnesses = [
+			createVSCodeHarness(),
+			createCliHarness([
+				joinPath(userHome, '.copilot'),
+				joinPath(userHome, '.claude'),
+				joinPath(userHome, '.agents'),
+			]),
+			createClaudeHarness([
+				joinPath(userHome, '.claude'),
+			]),
+		];
+		this.availableHarnesses = constObservable(this._harnesses);
+	}
+
+	setActiveHarness(id: CustomizationHarness): void {
+		if (this._harnesses.some(h => h.id === id)) {
+			this._activeHarness.set(id, undefined);
+		}
+	}
+
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+		const activeId = this._activeHarness.get();
+		const descriptor = this._harnesses.find(h => h.id === activeId);
+		return descriptor?.getStorageSourceFilter(type) ?? DEFAULT_FILTER;
+	}
+}
+
+registerSingleton(ICustomizationHarnessService, CustomizationHarnessService, InstantiationType.Delayed);
+

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -172,6 +172,49 @@
 	height: 100%;
 }
 
+/* Harness toggle bar */
+.ai-customization-list-widget .harness-toggle-container {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	padding: 6px 0 2px;
+}
+
+.ai-customization-list-widget .harness-toggle-pill {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 10px;
+	border: 1px solid var(--vscode-widget-border, transparent);
+	border-radius: 16px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	font-size: 12px;
+	transition: background-color 0.1s ease, color 0.1s ease, border-color 0.1s ease;
+}
+
+.ai-customization-list-widget .harness-toggle-pill:hover {
+	background-color: var(--vscode-list-hoverBackground);
+	color: var(--vscode-foreground);
+}
+
+.ai-customization-list-widget .harness-toggle-pill.active {
+	background-color: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	border-color: var(--vscode-badge-background);
+}
+
+.ai-customization-list-widget .harness-toggle-pill .harness-toggle-icon {
+	font-size: 14px;
+	flex-shrink: 0;
+}
+
+.ai-customization-list-widget .harness-toggle-pill .harness-toggle-label {
+	white-space: nowrap;
+}
+
 /* Search and button container - consistent with Models view */
 .ai-customization-list-widget .list-search-and-button-container,
 .mcp-list-widget .list-search-and-button-container {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -172,52 +172,54 @@
 	height: 100%;
 }
 
-/* Harness toggle bar */
-.ai-customization-list-widget .harness-toggle-container {
-	display: flex;
-	align-items: center;
-	gap: 4px;
+/* Harness dropdown in sidebar */
+.ai-customization-management-editor .sidebar-harness-dropdown {
 	flex-shrink: 0;
-	padding: 6px 0 2px;
+	padding: 6px 4px 4px;
 }
 
-.ai-customization-list-widget .harness-toggle-pill {
+.ai-customization-management-editor .harness-dropdown-button {
 	display: flex;
 	align-items: center;
-	gap: 4px;
-	padding: 4px 10px;
-	border: 1px solid var(--vscode-widget-border, transparent);
-	border-radius: 16px;
-	background: transparent;
-	color: var(--vscode-descriptionForeground);
+	gap: 6px;
+	width: 100%;
+	padding: 5px 8px;
+	border: 1px solid var(--vscode-dropdown-border, transparent);
+	border-radius: 4px;
+	background: var(--vscode-dropdown-background);
+	color: var(--vscode-dropdown-foreground);
 	cursor: pointer;
 	font-size: 12px;
-	transition: background-color 0.1s ease, color 0.1s ease, border-color 0.1s ease;
+	text-align: left;
 }
 
-.ai-customization-list-widget .harness-toggle-pill:hover {
-	background-color: var(--vscode-list-hoverBackground);
-	color: var(--vscode-foreground);
+.ai-customization-management-editor .harness-dropdown-button:hover {
+	background: var(--vscode-dropdown-background);
+	border-color: var(--vscode-focusBorder);
 }
 
-.ai-customization-list-widget .harness-toggle-pill:focus-visible {
+.ai-customization-management-editor .harness-dropdown-button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.ai-customization-list-widget .harness-toggle-pill.active {
-	background-color: var(--vscode-badge-background);
-	color: var(--vscode-badge-foreground);
-	border-color: var(--vscode-badge-background);
-}
-
-.ai-customization-list-widget .harness-toggle-pill .harness-toggle-icon {
+.ai-customization-management-editor .harness-dropdown-icon {
 	font-size: 14px;
 	flex-shrink: 0;
+	color: inherit;
 }
 
-.ai-customization-list-widget .harness-toggle-pill .harness-toggle-label {
+.ai-customization-management-editor .harness-dropdown-label {
+	flex: 1;
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.ai-customization-management-editor .harness-dropdown-chevron {
+	font-size: 12px;
+	flex-shrink: 0;
+	opacity: 0.7;
 }
 
 /* Search and button container - consistent with Models view */

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -200,6 +200,11 @@
 	color: var(--vscode-foreground);
 }
 
+.ai-customization-list-widget .harness-toggle-pill:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
 .ai-customization-list-widget .harness-toggle-pill.active {
 	background-color: var(--vscode-badge-background);
 	color: var(--vscode-badge-foreground);

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -128,6 +128,7 @@ import { ChatLayoutService } from './widget/chatLayoutService.js';
 import { ChatLanguageModelsDataContribution, LanguageModelsConfigurationService } from './languageModelsConfigurationService.js';
 import './chatManagement/chatManagement.contribution.js';
 import './aiCustomization/aiCustomizationWorkspaceService.js';
+import './aiCustomization/customizationHarnessService.js';
 import './aiCustomization/aiCustomizationManagement.contribution.js';
 
 import { ChatOutputRendererService, IChatOutputRendererService } from './chatOutputItemRenderer.js';

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -41,6 +41,13 @@ export interface IHarnessDescriptor {
 	 */
 	readonly hiddenSections?: readonly string[];
 	/**
+	 * Workspace sub-paths that this harness recognizes for file creation.
+	 * When set, the directory picker for new customization files only offers
+	 * workspace directories under these sub-paths (e.g. `.claude` for Claude).
+	 * When `undefined`, all workspace directories are shown (Local harness).
+	 */
+	readonly workspaceSubpaths?: readonly string[];
+	/**
 	 * Returns the storage source filter that should be applied to customization
 	 * items of the given type when this harness is active.
 	 */
@@ -80,6 +87,11 @@ export interface ICustomizationHarnessService {
 	 * and the given customization type.
 	 */
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter;
+
+	/**
+	 * Returns the descriptor of the currently active harness.
+	 */
+	getActiveDescriptor(): IHarnessDescriptor;
 }
 
 // #region Shared filter constants
@@ -154,6 +166,7 @@ function createRestrictedHarnessDescriptor(
 	restrictedUserRoots: readonly URI[],
 	extras: readonly string[],
 	hiddenSections?: readonly string[],
+	workspaceSubpaths?: readonly string[],
 ): IHarnessDescriptor {
 	const allSources = buildAllSources(extras);
 	const allRootsFilter: IStorageSourceFilter = { sources: allSources };
@@ -163,6 +176,7 @@ function createRestrictedHarnessDescriptor(
 		label,
 		icon,
 		hiddenSections,
+		workspaceSubpaths,
 		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
 			if (type === PromptsType.hook) {
 				return HOOKS_FILTER;
@@ -185,6 +199,8 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 		ThemeIcon.fromId(Codicon.worktree.id),
 		cliUserRoots,
 		extras,
+		undefined, // no hidden sections
+		['.github', '.copilot', '.agents', '.claude'],
 	);
 }
 
@@ -200,6 +216,7 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 		claudeRoots,
 		extras,
 		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks],
+		['.claude'],
 	);
 }
 
@@ -238,6 +255,11 @@ export class CustomizationHarnessServiceBase implements ICustomizationHarnessSer
 		const activeId = this._activeHarness.get();
 		const descriptor = this._harnesses.find(h => h.id === activeId);
 		return descriptor?.getStorageSourceFilter(type) ?? this._harnesses[0].getStorageSourceFilter(type);
+	}
+
+	getActiveDescriptor(): IHarnessDescriptor {
+		const activeId = this._activeHarness.get();
+		return this._harnesses.find(h => h.id === activeId) ?? this._harnesses[0];
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -10,7 +10,7 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IStorageSourceFilter } from './aiCustomizationWorkspaceService.js';
+import { AICustomizationManagementSection, IStorageSourceFilter } from './aiCustomizationWorkspaceService.js';
 import { PromptsType } from './promptSyntax/promptTypes.js';
 import { PromptsStorage } from './promptSyntax/service/promptsService.js';
 
@@ -34,6 +34,12 @@ export interface IHarnessDescriptor {
 	readonly id: CustomizationHarness;
 	readonly label: string;
 	readonly icon: ThemeIcon;
+	/**
+	 * Management sections that should be hidden when this harness is active.
+	 * For example, Claude does not support custom agents so the Agents
+	 * section is hidden.
+	 */
+	readonly hiddenSections?: readonly string[];
 	/**
 	 * Returns the storage source filter that should be applied to customization
 	 * items of the given type when this harness is active.
@@ -130,8 +136,8 @@ export function createVSCodeHarnessDescriptor(extras: readonly string[]): IHarne
 	const filter: IStorageSourceFilter = { sources: buildAllSources(extras) };
 	return {
 		id: CustomizationHarness.VSCode,
-		label: localize('harness.vscode', "VS Code"),
-		icon: ThemeIcon.fromId(Codicon.copilot.id),
+		label: localize('harness.local', "Local"),
+		icon: ThemeIcon.fromId(Codicon.vm.id),
 		getStorageSourceFilter: () => filter,
 	};
 }
@@ -147,6 +153,7 @@ function createRestrictedHarnessDescriptor(
 	icon: ThemeIcon,
 	restrictedUserRoots: readonly URI[],
 	extras: readonly string[],
+	hiddenSections?: readonly string[],
 ): IHarnessDescriptor {
 	const allSources = buildAllSources(extras);
 	const allRootsFilter: IStorageSourceFilter = { sources: allSources };
@@ -155,6 +162,7 @@ function createRestrictedHarnessDescriptor(
 		id,
 		label,
 		icon,
+		hiddenSections,
 		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
 			if (type === PromptsType.hook) {
 				return HOOKS_FILTER;
@@ -174,7 +182,7 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 	return createRestrictedHarnessDescriptor(
 		CustomizationHarness.CLI,
 		localize('harness.cli', "Copilot CLI"),
-		ThemeIcon.fromId(Codicon.terminal.id),
+		ThemeIcon.fromId(Codicon.worktree.id),
 		cliUserRoots,
 		extras,
 	);
@@ -182,14 +190,16 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 
 /**
  * Creates a "Claude" harness descriptor.
+ * Claude does not support custom agents or hooks.
  */
 export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
 	return createRestrictedHarnessDescriptor(
 		CustomizationHarness.Claude,
 		localize('harness.claude', "Claude"),
-		ThemeIcon.fromId(Codicon.sparkle.id),
+		ThemeIcon.fromId(Codicon.claude.id),
 		claudeRoots,
 		extras,
+		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks],
 	);
 }
 

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../base/common/codicons.js';
-import { constObservable, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { constObservable, IObservable, ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { joinPath } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -205,14 +205,16 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 export class CustomizationHarnessServiceBase implements ICustomizationHarnessService {
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _activeHarness = observableValue<CustomizationHarness>(this, this._defaultHarness);
-	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
+	private readonly _activeHarness: ISettableObservable<CustomizationHarness>;
+	readonly activeHarness: IObservable<CustomizationHarness>;
 	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
 
 	constructor(
 		private readonly _harnesses: readonly IHarnessDescriptor[],
-		private readonly _defaultHarness: CustomizationHarness,
+		defaultHarness: CustomizationHarness,
 	) {
+		this._activeHarness = observableValue<CustomizationHarness>(this, defaultHarness);
+		this.activeHarness = this._activeHarness;
 		this.availableHarnesses = constObservable(this._harnesses);
 	}
 

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -3,11 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IObservable } from '../../../../base/common/observable.js';
+import { Codicon } from '../../../../base/common/codicons.js';
+import { constObservable, IObservable, observableValue } from '../../../../base/common/observable.js';
+import { joinPath } from '../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { URI } from '../../../../base/common/uri.js';
+import { localize } from '../../../../nls.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IStorageSourceFilter } from './aiCustomizationWorkspaceService.js';
 import { PromptsType } from './promptSyntax/promptTypes.js';
+import { PromptsStorage } from './promptSyntax/service/promptsService.js';
 
 export const ICustomizationHarnessService = createDecorator<ICustomizationHarnessService>('customizationHarnessService');
 
@@ -70,3 +75,158 @@ export interface ICustomizationHarnessService {
 	 */
 	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter;
 }
+
+// #region Shared filter constants
+
+/**
+ * Hooks are always restricted to local + plugin sources regardless of harness.
+ */
+const HOOKS_FILTER: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.plugin],
+};
+
+// #endregion
+
+// #region Well-known user directories
+
+/**
+ * Returns the user-home directories accessible to the Copilot CLI harness.
+ */
+export function getCliUserRoots(userHome: URI): readonly URI[] {
+	return [
+		joinPath(userHome, '.copilot'),
+		joinPath(userHome, '.claude'),
+		joinPath(userHome, '.agents'),
+	];
+}
+
+/**
+ * Returns the user-home directories accessible to the Claude harness.
+ */
+export function getClaudeUserRoots(userHome: URI): readonly URI[] {
+	return [joinPath(userHome, '.claude')];
+}
+
+// #endregion
+
+// #region Harness descriptor factories
+
+/**
+ * Builds the full source list from the base set (local, user, plugin)
+ * plus any additional sources specific to the window type.
+ *
+ * Core passes `[PromptsStorage.extension]`; sessions passes its
+ * BUILTIN_STORAGE constant.
+ */
+function buildAllSources(extras: readonly string[]): readonly string[] {
+	return [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, ...extras];
+}
+
+/**
+ * Creates a "VS Code" harness descriptor that shows all storage sources
+ * with no user-root restrictions.
+ */
+export function createVSCodeHarnessDescriptor(extras: readonly string[]): IHarnessDescriptor {
+	const filter: IStorageSourceFilter = { sources: buildAllSources(extras) };
+	return {
+		id: CustomizationHarness.VSCode,
+		label: localize('harness.vscode', "VS Code"),
+		icon: ThemeIcon.fromId(Codicon.copilot.id),
+		getStorageSourceFilter: () => filter,
+	};
+}
+
+/**
+ * Creates a harness descriptor that restricts user-file roots for most
+ * types (agents, skills, instructions) while leaving hooks and prompts
+ * unrestricted. Used for CLI and Claude harnesses.
+ */
+function createRestrictedHarnessDescriptor(
+	id: CustomizationHarness,
+	label: string,
+	icon: ThemeIcon,
+	restrictedUserRoots: readonly URI[],
+	extras: readonly string[],
+): IHarnessDescriptor {
+	const allSources = buildAllSources(extras);
+	const allRootsFilter: IStorageSourceFilter = { sources: allSources };
+	const restrictedFilter: IStorageSourceFilter = { sources: allSources, includedUserFileRoots: restrictedUserRoots };
+	return {
+		id,
+		label,
+		icon,
+		getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+			if (type === PromptsType.hook) {
+				return HOOKS_FILTER;
+			}
+			if (type === PromptsType.prompt) {
+				return allRootsFilter;
+			}
+			return restrictedFilter;
+		},
+	};
+}
+
+/**
+ * Creates a "Copilot CLI" harness descriptor.
+ */
+export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
+	return createRestrictedHarnessDescriptor(
+		CustomizationHarness.CLI,
+		localize('harness.cli', "Copilot CLI"),
+		ThemeIcon.fromId(Codicon.terminal.id),
+		cliUserRoots,
+		extras,
+	);
+}
+
+/**
+ * Creates a "Claude" harness descriptor.
+ */
+export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
+	return createRestrictedHarnessDescriptor(
+		CustomizationHarness.Claude,
+		localize('harness.claude', "Claude"),
+		ThemeIcon.fromId(Codicon.sparkle.id),
+		claudeRoots,
+		extras,
+	);
+}
+
+// #endregion
+
+// #region Base implementation
+
+/**
+ * Reusable base implementation of {@link ICustomizationHarnessService}.
+ * Concrete registrations only need to supply the list of harness
+ * descriptors and a default harness id.
+ */
+export class CustomizationHarnessServiceBase implements ICustomizationHarnessService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _activeHarness = observableValue<CustomizationHarness>(this, this._defaultHarness);
+	readonly activeHarness: IObservable<CustomizationHarness> = this._activeHarness;
+	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
+
+	constructor(
+		private readonly _harnesses: readonly IHarnessDescriptor[],
+		private readonly _defaultHarness: CustomizationHarness,
+	) {
+		this.availableHarnesses = constObservable(this._harnesses);
+	}
+
+	setActiveHarness(id: CustomizationHarness): void {
+		if (this._harnesses.some(h => h.id === id)) {
+			this._activeHarness.set(id, undefined);
+		}
+	}
+
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter {
+		const activeId = this._activeHarness.get();
+		const descriptor = this._harnesses.find(h => h.id === activeId);
+		return descriptor?.getStorageSourceFilter(type) ?? this._harnesses[0].getStorageSourceFilter(type);
+	}
+}
+
+// #endregion

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IObservable } from '../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IStorageSourceFilter } from './aiCustomizationWorkspaceService.js';
+import { PromptsType } from './promptSyntax/promptTypes.js';
+
+export const ICustomizationHarnessService = createDecorator<ICustomizationHarnessService>('customizationHarnessService');
+
+/**
+ * Identifies the AI harness (execution environment) that customizations
+ * are filtered for. Storage answers "where did this come from?"; harness
+ * answers "who consumes it?".
+ */
+export enum CustomizationHarness {
+	VSCode = 'vscode',
+	CLI = 'cli',
+	Claude = 'claude',
+}
+
+/**
+ * Describes a single harness option for the UI toggle.
+ */
+export interface IHarnessDescriptor {
+	readonly id: CustomizationHarness;
+	readonly label: string;
+	readonly icon: ThemeIcon;
+	/**
+	 * Returns the storage source filter that should be applied to customization
+	 * items of the given type when this harness is active.
+	 */
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter;
+}
+
+/**
+ * Service that manages the active customization harness and provides
+ * per-type storage source filters based on the selected harness.
+ *
+ * The default (core) registration exposes a single "VS Code" harness
+ * that shows all storage sources. The sessions window overrides this
+ * to provide CLI-scoped harnesses.
+ */
+export interface ICustomizationHarnessService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * The currently active harness.
+	 */
+	readonly activeHarness: IObservable<CustomizationHarness>;
+
+	/**
+	 * All harnesses available in this window.
+	 * When only one harness is available the UI should hide the toggle.
+	 */
+	readonly availableHarnesses: IObservable<readonly IHarnessDescriptor[]>;
+
+	/**
+	 * Changes the active harness. The new id must be present in
+	 * `availableHarnesses`.
+	 */
+	setActiveHarness(id: CustomizationHarness): void;
+
+	/**
+	 * Convenience: returns the storage source filter for the active harness
+	 * and the given customization type.
+	 */
+	getStorageSourceFilter(type: PromptsType): IStorageSourceFilter;
+}


### PR DESCRIPTION
## Summary
- introduce a new `ICustomizationHarnessService` to separate harness visibility rules from prompt discovery
- keep prompt discovery unchanged in `IPromptsService`; apply filtering in a dedicated layer used by the customization UI
- delegate `IAICustomizationWorkspaceService.getStorageSourceFilter` to the harness service in both core and sessions
- add a harness toggle bar above customization kinds in the management editor list surface
- add sessions harness implementations for CLI and Claude root filtering

## Validation
- `npm run compile-check-ts-native`
- `npm run valid-layers-check`
- `./scripts/test.sh --grep "applyStorageSourceFilter|customizationCounts"`
