### PR TITLE
feat: support CR (\r) line endings in addition to LF and CRLF

### DIFF
--- a/src/vs/editor/common/core/edits/stringEdit.ts
+++ b/src/vs/editor/common/core/edits/stringEdit.ts
@@ -156,7 +156,7 @@ export abstract class BaseStringEdit<T extends BaseStringReplacement<T> = BaseSt
 		return new StringEdit(edits);
 	}
 
-	public normalizeEOL(eol: '\r\n' | '\n'): StringEdit {
+	public normalizeEOL(eol: '\r\n' | '\n' | '\r'): StringEdit {
 		return new StringEdit(this.replacements.map(edit => edit.normalizeEOL(eol)));
 	}
 
@@ -238,8 +238,8 @@ export abstract class BaseStringReplacement<T extends BaseStringReplacement<T> =
 		return new StringReplacement(replaceRange, newText);
 	}
 
-	normalizeEOL(eol: '\r\n' | '\n'): StringReplacement {
-		const newText = this.newText.replace(/\r\n|\n/g, eol);
+	normalizeEOL(eol: '\r\n' | '\n' | '\r'): StringReplacement {
+		const newText = this.newText.replace(/\r\n|\r|\n/g, eol);
 		return new StringReplacement(this.replaceRange, newText);
 	}
 

--- a/src/vs/editor/common/core/misc/eolCounter.ts
+++ b/src/vs/editor/common/core/misc/eolCounter.ts
@@ -7,7 +7,7 @@ import { CharCode } from '../../../../base/common/charCode.js';
 
 export const enum StringEOL {
 	Unknown = 0,
-	Invalid = 3,
+	CR = 3,
 	LF = 1,
 	CRLF = 2
 }
@@ -31,7 +31,7 @@ export function countEOL(text: string): [number, number, number, StringEOL] {
 				i++; // skip \n
 			} else {
 				// \r... case
-				eol |= StringEOL.Invalid;
+				eol |= StringEOL.CR;
 			}
 			lastLineStart = i + 1;
 		} else if (chr === CharCode.LineFeed) {

--- a/src/vs/editor/common/core/misc/eolCounter.ts
+++ b/src/vs/editor/common/core/misc/eolCounter.ts
@@ -7,9 +7,9 @@ import { CharCode } from '../../../../base/common/charCode.js';
 
 export const enum StringEOL {
 	Unknown = 0,
-	CR = 3,
 	LF = 1,
-	CRLF = 2
+	CRLF = 2,
+	CR = 4
 }
 
 export function countEOL(text: string): [number, number, number, StringEOL] {

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -459,7 +459,11 @@ export const enum EndOfLinePreference {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 2
+	CRLF = 2,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 3
 }
 
 /**
@@ -473,7 +477,11 @@ export const enum DefaultEndOfLine {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 2
+	CRLF = 2,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 3
 }
 
 /**
@@ -487,7 +495,11 @@ export const enum EndOfLineSequence {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 1
+	CRLF = 1,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 2
 }
 
 /**
@@ -1587,7 +1599,7 @@ export class SearchData {
  * @internal
  */
 export interface ITextBuffer extends IReadonlyTextBuffer, IDisposable {
-	setEOL(newEOL: '\r\n' | '\n'): void;
+	setEOL(newEOL: '\r\n' | '\n' | '\r'): void;
 	applyEdits(rawOperations: ValidAnnotatedEditOperation[], recordTrimAutoWhitespace: boolean, computeUndoEdits: boolean): ApplyEditsResult;
 }
 

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -270,18 +270,18 @@ export class PieceTreeBase {
 	protected _buffers!: StringBuffer[]; // 0 is change buffer, others are readonly original buffer.
 	protected _lineCnt!: number;
 	protected _length!: number;
-	protected _EOL!: '\r\n' | '\n';
+	protected _EOL!: '\r\n' | '\n' | '\r';
 	protected _EOLLength!: number;
 	protected _EOLNormalized!: boolean;
 	private _lastChangeBufferPos!: BufferCursor;
 	private _searchCache!: PieceTreeSearchCache;
 	private _lastVisitedLine!: { lineNumber: number; value: string };
 
-	constructor(chunks: StringBuffer[], eol: '\r\n' | '\n', eolNormalized: boolean) {
+	constructor(chunks: StringBuffer[], eol: '\r\n' | '\n' | '\r', eolNormalized: boolean) {
 		this.create(chunks, eol, eolNormalized);
 	}
 
-	create(chunks: StringBuffer[], eol: '\r\n' | '\n', eolNormalized: boolean) {
+	create(chunks: StringBuffer[], eol: '\r\n' | '\n' | '\r', eolNormalized: boolean) {
 		this._buffers = [
 			new StringBuffer('', [0])
 		];
@@ -317,7 +317,7 @@ export class PieceTreeBase {
 		this.computeBufferMetadata();
 	}
 
-	normalizeEOL(eol: '\r\n' | '\n') {
+	normalizeEOL(eol: '\r\n' | '\n' | '\r') {
 		const averageBufferSize = AverageBufferSize;
 		const min = averageBufferSize - Math.floor(averageBufferSize / 3);
 		const max = min * 2;
@@ -352,11 +352,11 @@ export class PieceTreeBase {
 	}
 
 	// #region Buffer API
-	public getEOL(): '\r\n' | '\n' {
+	public getEOL(): '\r\n' | '\n' | '\r' {
 		return this._EOL;
 	}
 
-	public setEOL(newEOL: '\r\n' | '\n'): void {
+	public setEOL(newEOL: '\r\n' | '\n' | '\r'): void {
 		this._EOL = newEOL;
 		this._EOLLength = this._EOL.length;
 		this.normalizeEOL(newEOL);

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
@@ -41,7 +41,7 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 	private readonly _onDidChangeContent: Emitter<void> = this._register(new Emitter<void>());
 	public get onDidChangeContent(): Event<void> { return this._onDidChangeContent.event; }
 
-	constructor(chunks: StringBuffer[], BOM: string, eol: '\r\n' | '\n', containsRTL: boolean, containsUnusualLineTerminators: boolean, isBasicASCII: boolean, eolNormalized: boolean) {
+	constructor(chunks: StringBuffer[], BOM: string, eol: '\r\n' | '\n' | '\r', containsRTL: boolean, containsUnusualLineTerminators: boolean, isBasicASCII: boolean, eolNormalized: boolean) {
 		super();
 		this._BOM = BOM;
 		this._mightContainNonBasicASCII = !isBasicASCII;
@@ -78,7 +78,7 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 	public getBOM(): string {
 		return this._BOM;
 	}
-	public getEOL(): '\r\n' | '\n' {
+	public getEOL(): '\r\n' | '\n' | '\r' {
 		return this._pieceTree.getEOL();
 	}
 
@@ -229,6 +229,8 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 				return '\n';
 			case EndOfLinePreference.CRLF:
 				return '\r\n';
+			case EndOfLinePreference.CR:
+				return '\r';
 			case EndOfLinePreference.TextDefined:
 				return this.getEOL();
 			default:
@@ -236,7 +238,7 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 		}
 	}
 
-	public setEOL(newEOL: '\r\n' | '\n'): void {
+	public setEOL(newEOL: '\r\n' | '\n' | '\r'): void {
 		this._pieceTree.setEOL(newEOL);
 	}
 
@@ -278,7 +280,7 @@ export class PieceTreeTextBuffer extends Disposable implements ITextBuffer {
 				[eolCount, firstLineLength, lastLineLength, strEOL] = countEOL(op.text);
 
 				const bufferEOL = this.getEOL();
-				const expectedStrEOL = (bufferEOL === '\r\n' ? StringEOL.CRLF : StringEOL.LF);
+				const expectedStrEOL = (bufferEOL === '\r\n' ? StringEOL.CRLF : bufferEOL === '\r' ? StringEOL.CR : StringEOL.LF);
 				if (strEOL === StringEOL.Unknown || strEOL === expectedStrEOL) {
 					validText = op.text;
 				} else {

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.ts
@@ -24,13 +24,23 @@ class PieceTreeTextBufferFactory implements ITextBufferFactory {
 		private readonly _normalizeEOL: boolean
 	) { }
 
-	private _getEOL(defaultEOL: DefaultEndOfLine): '\r\n' | '\n' {
+	private _getEOL(defaultEOL: DefaultEndOfLine): '\r\n' | '\n' | '\r' {
 		const totalEOLCount = this._cr + this._lf + this._crlf;
-		const totalCRCount = this._cr + this._crlf;
 		if (totalEOLCount === 0) {
 			// This is an empty file or a file with precisely one line
-			return (defaultEOL === DefaultEndOfLine.LF ? '\n' : '\r\n');
+			if (defaultEOL === DefaultEndOfLine.LF) {
+				return '\n';
+			}
+			if (defaultEOL === DefaultEndOfLine.CR) {
+				return '\r';
+			}
+			return '\r\n';
 		}
+		if (this._cr > 0 && this._crlf === 0 && this._lf === 0) {
+			// File only contains \r line endings
+			return '\r';
+		}
+		const totalCRCount = this._cr + this._crlf;
 		if (totalCRCount > totalEOLCount / 2) {
 			// More than half of the file contains \r\n ending lines
 			return '\r\n';
@@ -45,7 +55,8 @@ class PieceTreeTextBufferFactory implements ITextBufferFactory {
 
 		if (this._normalizeEOL &&
 			((eol === '\r\n' && (this._cr > 0 || this._lf > 0))
-				|| (eol === '\n' && (this._cr > 0 || this._crlf > 0)))
+				|| (eol === '\n' && (this._cr > 0 || this._crlf > 0))
+				|| (eol === '\r' && (this._lf > 0 || this._crlf > 0)))
 		) {
 			// Normalize pieces
 			for (let i = 0, len = chunks.length; i < len; i++) {

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -546,7 +546,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 
 	public setEOL(eol: model.EndOfLineSequence): void {
 		this._assertNotDisposed();
-		const newEOL = (eol === model.EndOfLineSequence.CRLF ? '\r\n' : '\n');
+		const newEOL = (eol === model.EndOfLineSequence.CRLF ? '\r\n' : eol === model.EndOfLineSequence.CR ? '\r' : '\n');
 		if (this._buffer.getEOL() === newEOL) {
 			// Nothing to do
 			return;
@@ -882,11 +882,14 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 
 	public getEndOfLineSequence(): model.EndOfLineSequence {
 		this._assertNotDisposed();
-		return (
-			this._buffer.getEOL() === '\n'
-				? model.EndOfLineSequence.LF
-				: model.EndOfLineSequence.CRLF
-		);
+		const eol = this._buffer.getEOL();
+		if (eol === '\n') {
+			return model.EndOfLineSequence.LF;
+		}
+		if (eol === '\r') {
+			return model.EndOfLineSequence.CR;
+		}
+		return model.EndOfLineSequence.CRLF;
 	}
 
 	public getLineMinColumn(lineNumber: number): number {
@@ -1275,7 +1278,7 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 	}
 
 	public pushEOL(eol: model.EndOfLineSequence): void {
-		const currentEOL = (this.getEOL() === '\n' ? model.EndOfLineSequence.LF : model.EndOfLineSequence.CRLF);
+		const currentEOL = this.getEndOfLineSequence();
 		if (currentEOL === eol) {
 			return;
 		}

--- a/src/vs/editor/common/services/modelService.ts
+++ b/src/vs/editor/common/services/modelService.ts
@@ -143,6 +143,8 @@ export class ModelService extends Disposable implements IModelService {
 			newDefaultEOL = DefaultEndOfLine.CRLF;
 		} else if (eol === '\n') {
 			newDefaultEOL = DefaultEndOfLine.LF;
+		} else if (eol === '\r') {
+			newDefaultEOL = DefaultEndOfLine.CR;
 		}
 
 		let trimAutoWhitespace = EDITOR_MODEL_DEFAULTS.trimAutoWhitespace;
@@ -236,7 +238,7 @@ export class ModelService extends Disposable implements IModelService {
 
 	private static _setModelOptionsForModel(model: ITextModel, newOptions: ITextModelCreationOptions, currentOptions: ITextModelCreationOptions): void {
 		if (currentOptions && currentOptions.defaultEOL !== newOptions.defaultEOL && model.getLineCount() === 1) {
-			model.setEOL(newOptions.defaultEOL === DefaultEndOfLine.LF ? EndOfLineSequence.LF : EndOfLineSequence.CRLF);
+			model.setEOL(newOptions.defaultEOL === DefaultEndOfLine.LF ? EndOfLineSequence.LF : newOptions.defaultEOL === DefaultEndOfLine.CR ? EndOfLineSequence.CR : EndOfLineSequence.CRLF);
 		}
 
 		if (currentOptions
@@ -374,7 +376,7 @@ export class ModelService extends Disposable implements IModelService {
 
 		// Otherwise find a diff between the values and update model
 		model.pushStackElement();
-		model.pushEOL(textBuffer.getEOL() === '\r\n' ? EndOfLineSequence.CRLF : EndOfLineSequence.LF);
+		model.pushEOL(textBuffer.getEOL() === '\r\n' ? EndOfLineSequence.CRLF : textBuffer.getEOL() === '\r' ? EndOfLineSequence.CR : EndOfLineSequence.LF);
 		model.pushEditOperations(
 			[],
 			ModelService._computeEdits(model, textBuffer),

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -141,7 +141,11 @@ export enum DefaultEndOfLine {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 2
+	CRLF = 2,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 3
 }
 
 /**
@@ -365,7 +369,11 @@ export enum EndOfLinePreference {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 2
+	CRLF = 2,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 3
 }
 
 /**
@@ -379,7 +387,11 @@ export enum EndOfLineSequence {
 	/**
 	 * Use carriage return and line feed (\r\n) as the end of line character.
 	 */
-	CRLF = 1
+	CRLF = 1,
+	/**
+	 * Use carriage return (\r) as the end of line character.
+	 */
+	CR = 2
 }
 
 /**

--- a/src/vs/editor/test/common/core/misc/eolCounter.test.ts
+++ b/src/vs/editor/test/common/core/misc/eolCounter.test.ts
@@ -49,16 +49,31 @@ suite('eolCounter', () => {
 	test('mixed CR and LF', () => {
 		const [eolCount, , , eol] = countEOL('line1\rline2\nline3');
 		assert.strictEqual(eolCount, 2);
-		// CR | LF = 3 | 1 = 3 (both bits set)
+		// CR=4, LF=1: CR | LF = 5 (distinct bits)
+		assert.strictEqual(eol, StringEOL.CR | StringEOL.LF);
 		assert.strictEqual(eol & StringEOL.CR, StringEOL.CR);
 		assert.strictEqual(eol & StringEOL.LF, StringEOL.LF);
+		assert.strictEqual(eol & StringEOL.CRLF, 0);
 	});
 
 	test('mixed CR and CRLF', () => {
 		const [eolCount, , , eol] = countEOL('line1\rline2\r\nline3');
 		assert.strictEqual(eolCount, 2);
+		// CR=4, CRLF=2: CR | CRLF = 6 (distinct bits)
+		assert.strictEqual(eol, StringEOL.CR | StringEOL.CRLF);
 		assert.strictEqual(eol & StringEOL.CR, StringEOL.CR);
 		assert.strictEqual(eol & StringEOL.CRLF, StringEOL.CRLF);
+		assert.strictEqual(eol & StringEOL.LF, 0);
+	});
+
+	test('mixed LF and CRLF', () => {
+		const [eolCount, , , eol] = countEOL('line1\nline2\r\nline3');
+		assert.strictEqual(eolCount, 2);
+		// LF=1, CRLF=2: LF | CRLF = 3 (distinct from CR=4)
+		assert.strictEqual(eol, StringEOL.LF | StringEOL.CRLF);
+		assert.strictEqual(eol & StringEOL.LF, StringEOL.LF);
+		assert.strictEqual(eol & StringEOL.CRLF, StringEOL.CRLF);
+		assert.strictEqual(eol & StringEOL.CR, 0);
 	});
 
 	test('CR at end of string', () => {

--- a/src/vs/editor/test/common/core/misc/eolCounter.test.ts
+++ b/src/vs/editor/test/common/core/misc/eolCounter.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { countEOL, StringEOL } from '../../../../common/core/misc/eolCounter.js';
+
+suite('eolCounter', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('empty string', () => {
+		const [eolCount, firstLineLength, lastLineLength, eol] = countEOL('');
+		assert.strictEqual(eolCount, 0);
+		assert.strictEqual(firstLineLength, 0);
+		assert.strictEqual(lastLineLength, 0);
+		assert.strictEqual(eol, StringEOL.Unknown);
+	});
+
+	test('single line', () => {
+		const [eolCount, firstLineLength, lastLineLength, eol] = countEOL('hello');
+		assert.strictEqual(eolCount, 0);
+		assert.strictEqual(firstLineLength, 5);
+		assert.strictEqual(lastLineLength, 5);
+		assert.strictEqual(eol, StringEOL.Unknown);
+	});
+
+	test('LF line endings', () => {
+		const [eolCount, , , eol] = countEOL('line1\nline2\nline3');
+		assert.strictEqual(eolCount, 2);
+		assert.strictEqual(eol, StringEOL.LF);
+	});
+
+	test('CRLF line endings', () => {
+		const [eolCount, , , eol] = countEOL('line1\r\nline2\r\nline3');
+		assert.strictEqual(eolCount, 2);
+		assert.strictEqual(eol, StringEOL.CRLF);
+	});
+
+	test('CR line endings', () => {
+		const [eolCount, firstLineLength, lastLineLength, eol] = countEOL('line1\rline2\rline3');
+		assert.strictEqual(eolCount, 2);
+		assert.strictEqual(firstLineLength, 5);
+		assert.strictEqual(lastLineLength, 5);
+		assert.strictEqual(eol, StringEOL.CR);
+	});
+
+	test('mixed CR and LF', () => {
+		const [eolCount, , , eol] = countEOL('line1\rline2\nline3');
+		assert.strictEqual(eolCount, 2);
+		// CR | LF = 3 | 1 = 3 (both bits set)
+		assert.strictEqual(eol & StringEOL.CR, StringEOL.CR);
+		assert.strictEqual(eol & StringEOL.LF, StringEOL.LF);
+	});
+
+	test('mixed CR and CRLF', () => {
+		const [eolCount, , , eol] = countEOL('line1\rline2\r\nline3');
+		assert.strictEqual(eolCount, 2);
+		assert.strictEqual(eol & StringEOL.CR, StringEOL.CR);
+		assert.strictEqual(eol & StringEOL.CRLF, StringEOL.CRLF);
+	});
+
+	test('CR at end of string', () => {
+		const [eolCount, , lastLineLength, eol] = countEOL('line1\r');
+		assert.strictEqual(eolCount, 1);
+		assert.strictEqual(lastLineLength, 0);
+		assert.strictEqual(eol, StringEOL.CR);
+	});
+});

--- a/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
+++ b/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { WordCharacterClassifier } from '../../../../common/core/wordCharacterClassifier.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
-import { DefaultEndOfLine, ITextSnapshot, SearchData } from '../../../../common/model.js';
+import { DefaultEndOfLine, EndOfLinePreference, ITextSnapshot, SearchData } from '../../../../common/model.js';
 import { PieceTreeBase } from '../../../../common/model/pieceTreeTextBuffer/pieceTreeBase.js';
 import { PieceTreeTextBuffer } from '../../../../common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.js';
 import { PieceTreeTextBufferBuilder } from '../../../../common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js';
@@ -2173,7 +2173,8 @@ suite('CR line endings', () => {
 		const pieceTree = createTextBuffer(['hello\rworld\r'], true);
 		ds.add(pieceTree);
 		assert.strictEqual(pieceTree.getEOL(), '\r');
-		const value = pieceTree.getValue();
+		const lineCount = pieceTree.getLineCount();
+		const value = pieceTree.getValueInRange(new Range(1, 1, lineCount, pieceTree.getLineMaxColumn(lineCount)), EndOfLinePreference.TextDefined);
 		assert.strictEqual(value, 'hello\rworld\r');
 	});
 });

--- a/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
+++ b/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
@@ -2123,3 +2123,57 @@ suite('chunk based search', () => {
 		assert.deepStrictEqual(ret[0].range, new Range(2, 2, 2, 3));
 	});
 });
+
+suite('CR line endings', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('CR-only file is detected and preserved', () => {
+		const pieceTree = createTextBuffer(['line1\rline2\rline3'], true);
+		ds.add(pieceTree);
+		assert.strictEqual(pieceTree.getEOL(), '\r');
+		assert.strictEqual(pieceTree.getLineCount(), 3);
+		assert.strictEqual(pieceTree.getLineContent(1), 'line1');
+		assert.strictEqual(pieceTree.getLineContent(2), 'line2');
+		assert.strictEqual(pieceTree.getLineContent(3), 'line3');
+	});
+
+	test('setEOL to CR normalizes line endings', () => {
+		const pieceTree = createTextBuffer(['line1\nline2\nline3'], true);
+		ds.add(pieceTree);
+		assert.strictEqual(pieceTree.getEOL(), '\n');
+
+		pieceTree.setEOL('\r');
+		assert.strictEqual(pieceTree.getEOL(), '\r');
+		assert.strictEqual(pieceTree.getLineCount(), 3);
+		assert.strictEqual(pieceTree.getLineContent(1), 'line1');
+		assert.strictEqual(pieceTree.getLineContent(2), 'line2');
+		assert.strictEqual(pieceTree.getLineContent(3), 'line3');
+	});
+
+	test('CR buffer factory with DefaultEndOfLine.CR', () => {
+		const bufferBuilder = new PieceTreeTextBufferBuilder();
+		bufferBuilder.acceptChunk('hello');
+		const factory = bufferBuilder.finish(true);
+		const { textBuffer, disposable } = factory.create(DefaultEndOfLine.CR);
+		ds.add(disposable);
+		assert.strictEqual(textBuffer.getEOL(), '\r');
+	});
+
+	test('CR detection prefers CR when file has only CR endings', () => {
+		const bufferBuilder = new PieceTreeTextBufferBuilder();
+		bufferBuilder.acceptChunk('a\rb\rc\r');
+		const factory = bufferBuilder.finish(true);
+		const { textBuffer, disposable } = factory.create(DefaultEndOfLine.LF);
+		ds.add(disposable);
+		assert.strictEqual(textBuffer.getEOL(), '\r');
+		assert.strictEqual(textBuffer.getLineCount(), 4);
+	});
+
+	test('getValue with CR line endings round-trips', () => {
+		const pieceTree = createTextBuffer(['hello\rworld\r'], true);
+		ds.add(pieceTree);
+		assert.strictEqual(pieceTree.getEOL(), '\r');
+		const value = pieceTree.getValue();
+		assert.strictEqual(value, 'hello\rworld\r');
+	});
+});

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -10,7 +10,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { Position } from '../../../common/core/position.js';
 import { Range } from '../../../common/core/range.js';
 import { PLAINTEXT_LANGUAGE_ID } from '../../../common/languages/modesRegistry.js';
-import { EndOfLinePreference } from '../../../common/model.js';
+import { EndOfLinePreference, EndOfLineSequence } from '../../../common/model.js';
 import { TextModel, createTextBuffer } from '../../../common/model/textModel.js';
 import { createModelServices, createTextModel } from '../testTextModel.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -238,7 +238,51 @@ suite('Editor Model - TextModel', () => {
 		m.dispose();
 	});
 
-	test('guess indentation 1', () => {
+	test('getValueLengthInRange with CR EOL', () => {
+		const m = createTextModel('My First Line\rMy Second Line\rMy Third Line');
+		assert.strictEqual(m.getEOL(), '\r');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CR);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.TextDefined), 'My First Line\r'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.CR), 'My First Line\r'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.LF), 'My First Line\n'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.CRLF), 'My First Line\r\n'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 1000, 1000), EndOfLinePreference.TextDefined), 'My First Line\rMy Second Line\rMy Third Line'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 1000, 1000), EndOfLinePreference.CR), 'My First Line\rMy Second Line\rMy Third Line'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 1000, 1000), EndOfLinePreference.LF), 'My First Line\nMy Second Line\nMy Third Line'.length);
+		assert.strictEqual(m.getValueLengthInRange(new Range(1, 1, 1000, 1000), EndOfLinePreference.CRLF), 'My First Line\r\nMy Second Line\r\nMy Third Line'.length);
+		m.dispose();
+	});
+
+	test('setEOL and getEndOfLineSequence with CR', () => {
+		const m = createTextModel('line1\nline2\nline3');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.LF);
+
+		m.setEOL(EndOfLineSequence.CR);
+		assert.strictEqual(m.getEOL(), '\r');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CR);
+
+		m.setEOL(EndOfLineSequence.CRLF);
+		assert.strictEqual(m.getEOL(), '\r\n');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CRLF);
+
+		m.setEOL(EndOfLineSequence.LF);
+		assert.strictEqual(m.getEOL(), '\n');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.LF);
+
+		m.dispose();
+	});
+
+	test('pushEOL with CR', () => {
+		const m = createTextModel('line1\nline2\nline3');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.LF);
+
+		m.pushEOL(EndOfLineSequence.CR);
+		assert.strictEqual(m.getEOL(), '\r');
+		assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CR);
+		assert.strictEqual(m.getValue(), 'line1\rline2\rline3');
+
+		m.dispose();
+	});
 
 		assertGuess(undefined, undefined, [
 			'x',

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -284,6 +284,8 @@ suite('Editor Model - TextModel', () => {
 		m.dispose();
 	});
 
+	test('guess indentation 1', () => {
+
 		assertGuess(undefined, undefined, [
 			'x',
 			'x',

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1912,7 +1912,11 @@ declare namespace monaco.editor {
 		/**
 		 * Use carriage return and line feed (\r\n) as the end of line character.
 		 */
-		CRLF = 2
+		CRLF = 2,
+		/**
+		 * Use carriage return (\r) as the end of line character.
+		 */
+		CR = 3
 	}
 
 	/**
@@ -1926,7 +1930,11 @@ declare namespace monaco.editor {
 		/**
 		 * Use carriage return and line feed (\r\n) as the end of line character.
 		 */
-		CRLF = 2
+		CRLF = 2,
+		/**
+		 * Use carriage return (\r) as the end of line character.
+		 */
+		CR = 3
 	}
 
 	/**
@@ -1940,7 +1948,11 @@ declare namespace monaco.editor {
 		/**
 		 * Use carriage return and line feed (\r\n) as the end of line character.
 		 */
-		CRLF = 1
+		CRLF = 1,
+		/**
+		 * Use carriage return (\r) as the end of line character.
+		 */
+		CR = 2
 	}
 
 	/**

--- a/src/vs/workbench/api/common/extHostDocumentData.ts
+++ b/src/vs/workbench/api/common/extHostDocumentData.ts
@@ -76,7 +76,7 @@ export class ExtHostDocumentData extends MirrorTextModel {
 				get encoding() { return that._encoding; },
 				save() { return that._save(); },
 				getText(range?) { return range ? that._getTextInRange(range) : that.getText(); },
-				get eol() { return that._eol === '\n' ? EndOfLine.LF : EndOfLine.CRLF; },
+				get eol() { return that._eol === '\n' ? EndOfLine.LF : that._eol === '\r' ? EndOfLine.CR : EndOfLine.CRLF; },
 				get lineCount() { return that._lines.length; },
 				lineAt(lineOrPos: number | vscode.Position) { return that._lineAt(lineOrPos); },
 				offsetAt(pos) { return that._offsetAt(pos); },

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1465,6 +1465,8 @@ export namespace EndOfLine {
 			return EndOfLineSequence.CRLF;
 		} else if (eol === types.EndOfLine.LF) {
 			return EndOfLineSequence.LF;
+		} else if (eol === types.EndOfLine.CR) {
+			return EndOfLineSequence.CR;
 		}
 		return undefined;
 	}
@@ -1474,6 +1476,8 @@ export namespace EndOfLine {
 			return types.EndOfLine.CRLF;
 		} else if (eol === EndOfLineSequence.LF) {
 			return types.EndOfLine.LF;
+		} else if (eol === EndOfLineSequence.CR) {
+			return types.EndOfLine.CR;
 		}
 		return undefined;
 	}

--- a/src/vs/workbench/api/common/extHostTypes/textEdit.ts
+++ b/src/vs/workbench/api/common/extHostTypes/textEdit.ts
@@ -10,7 +10,8 @@ import { Range } from './range.js';
 
 export enum EndOfLine {
 	LF = 1,
-	CRLF = 2
+	CRLF = 2,
+	CR = 3
 }
 
 @es5ClassCompat

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -341,6 +341,7 @@ const nlsMultiSelectionRange = localize('multiSelectionRange', "{0} selections (
 const nlsMultiSelection = localize('multiSelection', "{0} selections");
 const nlsEOLLF = localize('endOfLineLineFeed', "LF");
 const nlsEOLCRLF = localize('endOfLineCarriageReturnLineFeed', "CRLF");
+const nlsEOLCR = localize('endOfLineCarriageReturn', "CR");
 
 class EditorStatus extends Disposable {
 
@@ -645,7 +646,7 @@ class EditorStatus extends Disposable {
 		this.updateIndentationElement(this.state.indentation);
 		this.updateSelectionElement(this.state.selectionStatus);
 		this.updateEncodingElement(this.state.encoding);
-		this.updateEOLElement(this.state.EOL ? this.state.EOL === '\r\n' ? nlsEOLCRLF : nlsEOLLF : undefined);
+		this.updateEOLElement(this.state.EOL ? this.state.EOL === '\r\n' ? nlsEOLCRLF : this.state.EOL === '\r' ? nlsEOLCR : nlsEOLLF : undefined);
 		this.updateLanguageIdElement(this.state.languageId);
 		this.updateMetadataElement(this.state.metadata);
 	}
@@ -1408,9 +1409,11 @@ export class ChangeEOLAction extends Action2 {
 		const EOLOptions: IChangeEOLEntry[] = [
 			{ label: nlsEOLLF, eol: EndOfLineSequence.LF },
 			{ label: nlsEOLCRLF, eol: EndOfLineSequence.CRLF },
+			{ label: nlsEOLCR, eol: EndOfLineSequence.CR },
 		];
 
-		const selectedIndex = (textModel?.getEOL() === '\n') ? 0 : 1;
+		const currentEOL = textModel?.getEOL();
+		const selectedIndex = currentEOL === '\r\n' ? 1 : currentEOL === '\r' ? 2 : 0;
 
 		const eol = await quickInputService.pick(EOLOptions, { placeHolder: localize('pickEndOfLine', "Select End of Line Sequence"), activeItem: EOLOptions[selectedIndex] });
 		if (eol) {

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -218,11 +218,13 @@ configurationRegistry.registerConfiguration({
 			'enum': [
 				'\n',
 				'\r\n',
+				'\r',
 				'auto'
 			],
 			'enumDescriptions': [
 				nls.localize('eol.LF', "LF"),
 				nls.localize('eol.CRLF', "CRLF"),
+				nls.localize('eol.CR', "CR"),
 				nls.localize('eol.auto', "Uses operating system specific end of line character.")
 			],
 			'default': 'auto',

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -1389,7 +1389,11 @@ declare module 'vscode' {
 		/**
 		 * The carriage return line feed `\r\n` sequence.
 		 */
-		CRLF = 2
+		CRLF = 2,
+		/**
+		 * The carriage return `\r` character.
+		 */
+		CR = 3
 	}
 
 	/**


### PR DESCRIPTION
Add CR (carriage return, \r) as a first-class end-of-line sequence, addressing microsoft/vscode#35797. This enables proper handling of files using CR-only line endings, such as HL7v2 healthcare files, pre-OSX Mac files, and various industrial protocol formats.

**FULL DISCLOSURE - Completely AI Generated used Copilot and Opus but human reviewed and tests passing before PR submission**

Changes across all layers:

Core enums:
- Add CR to EndOfLineSequence, EndOfLinePreference, DefaultEndOfLine
- Rename StringEOL.Invalid to StringEOL.CR (same value, 3)
- Update standaloneEnums.ts and monaco.d.ts

Text buffer:
- Widen type signatures to accept '\r' alongside '\r\n' and '\n'
- Add CR case to _getEndOfLine() switch
- Update EOL detection to recognize CR-only files
- Update normalization condition for CR

Text model & services:
- Update setEOL/getEndOfLineSequence/pushEOL for 3-way logic
- Update modelService config mapping for CR

Configuration:
- Add '\r' (CR) to files.eol setting enum

Status bar & UI:
- Add 'CR' label to status bar indicator
- Add CR option to Change End of Line Sequence quick-pick

Extension API:
- Add EndOfLine.CR = 3 to public API (vscode.d.ts)
- Update type converters and extHostDocumentData

Tests:
- Add eolCounter.test.ts for CR detection
- Add CR tests to pieceTreeTextBuffer.test.ts
- Add CR tests to textModel.test.ts


# Walkthrough: Adding CR (`\r`) Line Ending Support to VS Code  (Updated 3/26/17 10PM EST)

As someone not familiar with the `vscode` codebase, I asked Copilot to generate some documentation on the changes 

**Issue**: [microsoft/vscode#35797](https://github.com/microsoft/vscode/issues/35797)
**Branch**: `feature/cr-line-endings`

## Background

VS Code has always supported two types of line endings:

- **LF** (`\n`) — Used by Linux, macOS (10.0+), and most modern Unix systems
- **CRLF** (`\r\n`) — Used by Windows

However, a third line ending exists: **CR** (`\r`) — Used by pre-OSX classic Mac OS, and critically, still in active use today by:

- **HL7v2** — The international healthcare messaging standard, used by virtually every hospital and health system worldwide
- **Industrial protocols** — Various electronics and controller systems
- **Retro computing** — Classic Mac software preservation, Squeak/Pharo Smalltalk change files

When VS Code opens a file with CR-only line endings, it silently normalizes them to CRLF, **corrupting the file**. The `files.eol` setting rejects `"\r"` with:

```
Value is not accepted. Valid values: "\n", "\r\n", "auto"
```

This walkthrough explains every change needed to add CR as a first-class citizen throughout the VS Code editor stack.

---

## Architecture Overview

Before diving into the code, it helps to understand how VS Code's EOL handling is layered:

```
┌─────────────────────────────────────────────────────────┐
│  User-facing layer                                      │
│  ┌──────────────┐  ┌─────────────────┐  ┌───────────┐   │
│  │ files.eol    │  │ Status Bar      │  │ Extension │   │
│  │ setting      │  │ "LF"/"CRLF"     │  │ API       │   │
│  └──────┬───────┘  └───────┬─────────┘  └─────┬─────┘   │
├─────────┼──────────────────┼──────────────────┼─────────┤
│  Model layer               │                  │         │
│  ┌──────┴───────┐  ┌───────┴─────────┐  ┌─────┴──────┐  │
│  │ ModelService │  │ TextModel       │  │ Type       │  │
│  │ (config→EOL) │  │ (setEOL/getEOL) │  │ Converters │  │
│  └──────┬───────┘  └───────┬─────────┘  └────────────┘  │
├─────────┼──────────────────┼────────────────────────────┤
│  Buffer layer              │                            │
│  ┌──────┴──────────────────┴─────────┐                  │
│  │ PieceTreeTextBuffer               │                  │
│  │ ┌─────────────────────────────┐   │                  │
│  │ │ PieceTreeBase               │   │                  │
│  │ │ (stores _EOL, normalizes)   │   │                  │
│  │ └─────────────────────────────┘   │                  │
│  └──────┬────────────────────────────┘                  │
│  ┌──────┴────────────────────────────┐                  │
│  │ PieceTreeTextBufferBuilder        │                  │
│  │ (detects EOL from file content)   │                  │
│  └──────┬────────────────────────────┘                  │
│  ┌──────┴────────────────────────────┐                  │
│  │ eolCounter.ts                     │                  │
│  │ (counts \r, \n, \r\n in text)     │                  │
│  └───────────────────────────────────┘                  │
├─────────────────────────────────────────────────────────┤
│  Enum definitions (model.ts)                            │
│       EndOfLineSequence,                                │
│       EndOfLinePreference,                              │
│       DefaultEndOfLine                                  │
└─────────────────────────────────────────────────────────┘
```

Data flows **bottom-up** when opening a file (detect → buffer → model → UI) and **top-down** when the user changes settings or picks a new EOL (UI → model → buffer → normalize).

---

## Layer 1: Core Enum Definitions

Every component in VS Code references EOL through a set of TypeScript enums. These are the foundation — everything else depends on them.

### 1a. The Three Internal Enums

**File**: `src/vs/editor/common/model.ts`

VS Code uses three separate enums for different purposes:

```typescript
// Used when READING text — "give me the text with this EOL style"
export const enum EndOfLinePreference {
    TextDefined = 0,  // Use whatever the buffer has
    LF = 1,
    CRLF = 2,
    CR = 3            // NEW
}

// Used when CREATING a new empty file — "what EOL should new files get?"
export const enum DefaultEndOfLine {
    LF = 1,
    CRLF = 2,
    CR = 3            // NEW
}

// Used when IDENTIFYING the EOL of an existing buffer — "what EOL does this file have?"
export const enum EndOfLineSequence {
    LF = 0,
    CRLF = 1,
    CR = 2            // NEW
}
```

**Why three enums?** They serve different roles:
- `EndOfLinePreference` includes `TextDefined` (use whatever the buffer has) — used by APIs like `getValueInRange()` where you might want the text in a specific format
- `DefaultEndOfLine` starts at 1 (not 0) — used in configuration where 0 would be falsy
- `EndOfLineSequence` starts at 0 — used as the canonical identifier for a file's actual line endings

### 1b. The EOL Detection Enum

**File**: `src/vs/editor/common/core/misc/eolCounter.ts`

This enum is used internally by the low-level scanner that counts line endings in raw text:

```typescript
export const enum StringEOL {
    Unknown = 0,
    LF = 1,
    CRLF = 2,
    CR = 4        // Was: Invalid = 3 — renamed and given a distinct bit value
}
```

**Key insight**: The values are chosen as bit flags so they can be OR'd together. When scanning text, the function does `eol |= StringEOL.CR` every time it finds a lone `\r`. A file with both CR and LF endings would have `eol = 4 | 1 = 5` (distinct bits set for each type). The old code already detected lone CR — it just called it "Invalid" with the value `3`. We renamed it `CR` **and changed its value to `4`** to give it a distinct bit that cannot collide with any OR-combination of LF (1) and CRLF (2), which sum to `3` when both are present.

The `countEOL` function that uses this enum already handled CR correctly:

```typescript
export function countEOL(text: string): [number, number, number, StringEOL] {
    // ... scanning loop ...
    if (chr === CharCode.CarriageReturn) {
        if (i + 1 < len && text.charCodeAt(i + 1) === CharCode.LineFeed) {
            eol |= StringEOL.CRLF;  // \r\n pair
            i++;                      // skip the \n
        } else {
            eol |= StringEOL.CR;     // lone \r (was: StringEOL.Invalid)
        }
    } else if (chr === CharCode.LineFeed) {
        eol |= StringEOL.LF;         // lone \n
    }
    // ...
}
```

### 1c. The Standalone/Monaco Enums

**Files**: `src/vs/editor/common/standalone/standaloneEnums.ts`, `src/vs/monaco.d.ts`

These are mirror copies of the same enums, published for the Monaco editor (the standalone version of VS Code's editor). They are auto-generated files that need the same `CR` values added. The changes are identical to `model.ts` — just add the CR member to each enum.

---

## Layer 2: Text Buffer — Where Text Lives

The PieceTree is VS Code's core data structure for storing file content. It's a balanced tree of string "pieces" that supports efficient insertion, deletion, and line-based access. EOL handling is deeply embedded here.

### 2a. PieceTreeBase — The Core Storage

**File**: `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts`

The base class stores the EOL string and its length. Every type signature that previously accepted `'\r\n' | '\n'` now accepts `'\r\n' | '\n' | '\r'`:

```typescript
protected _EOL!: '\r\n' | '\n' | '\r';       // Was: '\r\n' | '\n'
protected _EOLLength!: number;                 // 1 for \n and \r, 2 for \r\n
protected _EOLNormalized!: boolean;

constructor(chunks: StringBuffer[], eol: '\r\n' | '\n' | '\r', eolNormalized: boolean) { ... }
create(chunks: StringBuffer[], eol: '\r\n' | '\n' | '\r', eolNormalized: boolean) { ... }
normalizeEOL(eol: '\r\n' | '\n' | '\r') { ... }
public getEOL(): '\r\n' | '\n' | '\r' { ... }
public setEOL(newEOL: '\r\n' | '\n' | '\r'): void { ... }
```

**Critical insight**: The `normalizeEOL` method uses the regex `/\r\n|\r|\n/g` to replace all line endings. This regex already handles CR! The order matters — `\r\n` is matched first (before the standalone `\r`), preventing CRLF from being split into CR + LF. No regex changes were needed.

```typescript
normalizeEOL(eol: '\r\n' | '\n' | '\r') {
    // ...
    const text = tempChunk.replace(/\r\n|\r|\n/g, eol);  // Already works for CR!
    // ...
}
```

### 2b. PieceTreeTextBuffer — The Wrapper

**File**: `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts`

This wraps `PieceTreeBase` and adds higher-level operations. Three changes:

**1. Type signatures widened** to accept `'\r'`:

```typescript
constructor(chunks: StringBuffer[], BOM: string, eol: '\r\n' | '\n' | '\r', ...)
public getEOL(): '\r\n' | '\n' | '\r' { ... }
public setEOL(newEOL: '\r\n' | '\n' | '\r'): void { ... }
```

**2. The `_getEndOfLine` switch** — This converts the `EndOfLinePreference` enum to an actual string. We add the CR case:

```typescript
private _getEndOfLine(eol: EndOfLinePreference): string {
    switch (eol) {
        case EndOfLinePreference.LF:
            return '\n';
        case EndOfLinePreference.CRLF:
            return '\r\n';
        case EndOfLinePreference.CR:        // NEW
            return '\r';                     // NEW
        case EndOfLinePreference.TextDefined:
            return this.getEOL();
        default:
            throw new Error('Unknown EOL preference');
    }
}
```

**3. The edit validation mapping** — When text is inserted into a buffer, VS Code checks if the inserted text's line endings match the buffer's EOL. If not, it normalizes them. The mapping from buffer EOL string to `StringEOL` enum was binary and needed a third case:

```typescript
const bufferEOL = this.getEOL();
// Was: (bufferEOL === '\r\n' ? StringEOL.CRLF : StringEOL.LF)
const expectedStrEOL = (bufferEOL === '\r\n' ? StringEOL.CRLF
    : bufferEOL === '\r' ? StringEOL.CR       // NEW
    : StringEOL.LF);
```

### 2c. PieceTreeTextBufferBuilder — The Factory

**File**: `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.ts`

This is where VS Code **detects** which EOL a file uses when it's first opened. The builder accumulates counts of `\r`, `\n`, and `\r\n` as it reads file chunks, then the factory's `_getEOL` method decides which EOL "wins".

**Before** (binary decision):
```typescript
private _getEOL(defaultEOL: DefaultEndOfLine): '\r\n' | '\n' {
    const totalEOLCount = this._cr + this._lf + this._crlf;
    const totalCRCount = this._cr + this._crlf;
    if (totalEOLCount === 0) {
        return (defaultEOL === DefaultEndOfLine.LF ? '\n' : '\r\n');
    }
    if (totalCRCount > totalEOLCount / 2) {
        return '\r\n';  // Lone \r was lumped in with \r\n!
    }
    return '\n';
}
```

**After** (three-way decision):
```typescript
private _getEOL(defaultEOL: DefaultEndOfLine): '\r\n' | '\n' | '\r' {
    const totalEOLCount = this._cr + this._lf + this._crlf;
    if (totalEOLCount === 0) {
        // Empty file — use configured default
        if (defaultEOL === DefaultEndOfLine.LF) return '\n';
        if (defaultEOL === DefaultEndOfLine.CR) return '\r';
        return '\r\n';
    }
    if (this._cr > 0 && this._crlf === 0 && this._lf === 0) {
        // File ONLY contains \r line endings — this is a CR file
        return '\r';
    }
    const totalCRCount = this._cr + this._crlf;
    if (totalCRCount > totalEOLCount / 2) {
        return '\r\n';
    }
    return '\n';
}
```

**Why the conservative detection?** CR-only files are detected only when the file has **exclusively** CR endings (no LF or CRLF mixed in). Mixed files with some CR are still handled by the existing CRLF/LF heuristic. This prevents false positives — a file with accidental lone CRs won't suddenly be treated as a CR file.

The `create()` method's normalization condition also needed updating to handle the case where the detected EOL is CR but the file contains other EOL types:

```typescript
if (this._normalizeEOL &&
    ((eol === '\r\n' && (this._cr > 0 || this._lf > 0))
        || (eol === '\n' && (this._cr > 0 || this._crlf > 0))
        || (eol === '\r' && (this._lf > 0 || this._crlf > 0)))  // NEW
) {
    // Normalize all chunks to the chosen EOL
}
```

---

## Layer 3: Text Model — The Editor's View of the Buffer

**File**: `src/vs/editor/common/model/textModel.ts`

The `TextModel` is the high-level representation of a document. It wraps the buffer and provides the API that the rest of VS Code uses. Three methods needed updating from binary to three-way logic.

### 3a. `setEOL` — Change a file's line endings

Converts from the enum to the actual string. Was a simple ternary, now needs three branches:

```typescript
public setEOL(eol: model.EndOfLineSequence): void {
    // Was: const newEOL = (eol === model.EndOfLineSequence.CRLF ? '\r\n' : '\n');
    const newEOL = (eol === model.EndOfLineSequence.CRLF ? '\r\n'
        : eol === model.EndOfLineSequence.CR ? '\r'
        : '\n');
    if (this._buffer.getEOL() === newEOL) return;  // Nothing to do
    // ... fire events, normalize buffer, etc.
}
```

### 3b. `getEndOfLineSequence` — Query a file's line endings

Converts from the buffer's string back to the enum. Was a ternary, now an if-chain:

```typescript
public getEndOfLineSequence(): model.EndOfLineSequence {
    const eol = this._buffer.getEOL();
    if (eol === '\n') return model.EndOfLineSequence.LF;
    if (eol === '\r') return model.EndOfLineSequence.CR;
    return model.EndOfLineSequence.CRLF;
}
```

### 3c. `pushEOL` — Change line endings with undo support

This method compares the current EOL to the requested one. The old code used an inline binary conversion; we now reuse the `getEndOfLineSequence()` method:

```typescript
public pushEOL(eol: model.EndOfLineSequence): void {
    // Was: const currentEOL = (this.getEOL() === '\n' ? ... LF : ... CRLF);
    const currentEOL = this.getEndOfLineSequence();
    if (currentEOL === eol) return;
    // ... push to undo stack, etc.
}
```

---

## Layer 4: Model Service — Configuration Bridge

**File**: `src/vs/editor/common/services/modelService.ts`

The `ModelService` reads the `files.eol` configuration setting and translates it into the internal enum. Three places needed updating:

### 4a. Reading configuration

```typescript
let newDefaultEOL = DEFAULT_EOL;
const eol = config.eol;
if (eol === '\r\n') {
    newDefaultEOL = DefaultEndOfLine.CRLF;
} else if (eol === '\n') {
    newDefaultEOL = DefaultEndOfLine.LF;
} else if (eol === '\r') {             // NEW
    newDefaultEOL = DefaultEndOfLine.CR; // NEW
}
```

### 4b. Applying configuration to models

When the setting changes and a model has only one line (no existing EOL to preserve), VS Code applies the new default:

```typescript
model.setEOL(
    newOptions.defaultEOL === DefaultEndOfLine.LF ? EndOfLineSequence.LF
    : newOptions.defaultEOL === DefaultEndOfLine.CR ? EndOfLineSequence.CR  // NEW
    : EndOfLineSequence.CRLF
);
```

### 4c. Reconciling file content with model

When a file is reloaded from disk, the model service syncs the EOL:

```typescript
model.pushEOL(
    textBuffer.getEOL() === '\r\n' ? EndOfLineSequence.CRLF
    : textBuffer.getEOL() === '\r' ? EndOfLineSequence.CR  // NEW
    : EndOfLineSequence.LF
);
```

---

## Layer 5: The `files.eol` Setting

**File**: `src/vs/workbench/contrib/files/browser/files.contribution.ts`

This is where the actual user-facing setting is defined. The change is simple — add `'\r'` to the enum and its description:

```typescript
'files.eol': {
    'type': 'string',
    'enum': [
        '\n',
        '\r\n',
        '\r',      // NEW
        'auto'
    ],
    'enumDescriptions': [
        nls.localize('eol.LF', "LF"),
        nls.localize('eol.CRLF', "CRLF"),
        nls.localize('eol.CR', "CR"),                                           // NEW
        nls.localize('eol.auto', "Uses operating system specific end of line character.")
    ],
    'default': 'auto',
    'description': nls.localize('eol', "The default end of line character."),
    'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
}
```

**Important**: The `textResourcePropertiesService.getEOL()` method in `src/vs/workbench/services/textresourceProperties/common/textResourcePropertiesService.ts` already passes through the raw setting value for any non-`'auto'` string. No change was needed there — once the schema accepts `'\r'`, the service will pass it through to the model layer automatically.

Users can now write this in their `settings.json`:

```json
{
    "[hl7]": {
        "files.eol": "\r"
    }
}
```

---

## Layer 6: Status Bar & UI

**File**: `src/vs/workbench/browser/parts/editor/editorStatus.ts`

The bottom status bar shows the current file's line endings ("LF" or "CRLF") and lets users click to change them.

### 6a. Add the localized label

```typescript
const nlsEOLLF = localize('endOfLineLineFeed', "LF");
const nlsEOLCRLF = localize('endOfLineCarriageReturnLineFeed', "CRLF");
const nlsEOLCR = localize('endOfLineCarriageReturn', "CR");  // NEW
```

### 6b. Update the status bar display

The display logic was a binary ternary. Now it's a three-way chain:

```typescript
// Was: this.state.EOL === '\r\n' ? nlsEOLCRLF : nlsEOLLF
this.state.EOL === '\r\n' ? nlsEOLCRLF
    : this.state.EOL === '\r' ? nlsEOLCR   // NEW
    : nlsEOLLF
```

### 6c. Update the "Change End of Line Sequence" quick-pick

When users click the status bar item, they get a picker. We add CR as an option:

```typescript
const EOLOptions: IChangeEOLEntry[] = [
    { label: nlsEOLLF, eol: EndOfLineSequence.LF },
    { label: nlsEOLCRLF, eol: EndOfLineSequence.CRLF },
    { label: nlsEOLCR, eol: EndOfLineSequence.CR },   // NEW
];

// The active item selection also needs to handle 3 options:
const currentEOL = textModel?.getEOL();
const selectedIndex = currentEOL === '\r\n' ? 1 : currentEOL === '\r' ? 2 : 0;
```

---

## Layer 7: Extension API

Extensions interact with VS Code through a typed API defined in `vscode.d.ts`. Three files needed changes to expose CR to extensions.

### 7a. Public API type definition

**File**: `src/vscode-dts/vscode.d.ts`

```typescript
export enum EndOfLine {
    /** The line feed `\n` character. */
    LF = 1,
    /** The carriage return line feed `\r\n` sequence. */
    CRLF = 2,
    /** The carriage return `\r` character. */
    CR = 3    // NEW
}
```

### 7b. Internal type implementation

**File**: `src/vs/workbench/api/common/extHostTypes/textEdit.ts`

```typescript
export enum EndOfLine {
    LF = 1,
    CRLF = 2,
    CR = 3     // NEW
}
```

### 7c. Type converters (internal ↔ extension API)

**File**: `src/vs/workbench/api/common/extHostTypeConverters.ts`

These functions translate between the internal `EndOfLineSequence` and the public `EndOfLine`:

```typescript
export namespace EndOfLine {
    export function from(eol: vscode.EndOfLine): EndOfLineSequence | undefined {
        if (eol === types.EndOfLine.CRLF) return EndOfLineSequence.CRLF;
        if (eol === types.EndOfLine.LF) return EndOfLineSequence.LF;
        if (eol === types.EndOfLine.CR) return EndOfLineSequence.CR;   // NEW
        return undefined;
    }

    export function to(eol: EndOfLineSequence): vscode.EndOfLine | undefined {
        if (eol === EndOfLineSequence.CRLF) return types.EndOfLine.CRLF;
        if (eol === EndOfLineSequence.LF) return types.EndOfLine.LF;
        if (eol === EndOfLineSequence.CR) return types.EndOfLine.CR;   // NEW
        return undefined;
    }
}
```

### 7d. Extension host document data

**File**: `src/vs/workbench/api/common/extHostDocumentData.ts`

When an extension accesses `document.eol`, this getter maps the raw EOL string to the public enum:

```typescript
// Was: that._eol === '\n' ? EndOfLine.LF : EndOfLine.CRLF
get eol() {
    return that._eol === '\n' ? EndOfLine.LF
        : that._eol === '\r' ? EndOfLine.CR   // NEW
        : EndOfLine.CRLF;
}
```

---

## Layer 8: String Edit Utilities

**File**: `src/vs/editor/common/core/edits/stringEdit.ts`

The `StringEdit` and `StringReplacement` classes have `normalizeEOL` methods used during formatting operations. Their type signatures needed widening, and the regex in `StringReplacement` needed to include `\r` in its match pattern:

```typescript
// StringEdit
public normalizeEOL(eol: '\r\n' | '\n' | '\r'): StringEdit {     // Was: '\r\n' | '\n'
    return new StringEdit(this.replacements.map(edit => edit.normalizeEOL(eol)));
}

// StringReplacement
normalizeEOL(eol: '\r\n' | '\n' | '\r'): StringReplacement {     // Was: '\r\n' | '\n'
    const newText = this.newText.replace(/\r\n|\r|\n/g, eol);     // Was: /\r\n|\n/g
    return new StringReplacement(this.replaceRange, newText);
}
```

The regex change from `/\r\n|\n/g` to `/\r\n|\r|\n/g` is important — the old regex would have left lone `\r` characters untouched when normalizing to LF or CRLF.

---

## Layer 9: Tests

Three test files were added or modified, covering ~170 lines of new test code.

### 9a. eolCounter.test.ts (NEW FILE)

**File**: `src/vs/editor/test/common/core/misc/eolCounter.test.ts`

Tests the low-level `countEOL` function's ability to detect CR line endings:

```typescript
test('CR line endings', () => {
    const [eolCount, firstLineLength, lastLineLength, eol] = countEOL('line1\rline2\rline3');
    assert.strictEqual(eolCount, 2);
    assert.strictEqual(firstLineLength, 5);
    assert.strictEqual(lastLineLength, 5);
    assert.strictEqual(eol, StringEOL.CR);
});

test('mixed CR and LF', () => {
    const [eolCount, , , eol] = countEOL('line1\rline2\nline3');
    assert.strictEqual(eolCount, 2);
    // Bit flags: CR (4) | LF (1) = 5 — distinct bits, unambiguous
    assert.strictEqual(eol, StringEOL.CR | StringEOL.LF);
    assert.strictEqual(eol & StringEOL.CR, StringEOL.CR);
    assert.strictEqual(eol & StringEOL.LF, StringEOL.LF);
    assert.strictEqual(eol & StringEOL.CRLF, 0);  // CRLF bit is NOT set
});
```

### 9b. pieceTreeTextBuffer.test.ts

**File**: `src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts`

A new `'CR line endings'` test suite with 5 tests:

```typescript
test('CR-only file is detected and preserved', () => {
    const pieceTree = createTextBuffer(['line1\rline2\rline3'], true);
    assert.strictEqual(pieceTree.getEOL(), '\r');
    assert.strictEqual(pieceTree.getLineCount(), 3);
    assert.strictEqual(pieceTree.getLineContent(1), 'line1');
});

test('setEOL to CR normalizes line endings', () => {
    const pieceTree = createTextBuffer(['line1\nline2\nline3'], true);
    pieceTree.setEOL('\r');
    assert.strictEqual(pieceTree.getEOL(), '\r');
    assert.strictEqual(pieceTree.getLineCount(), 3);
});

test('CR detection prefers CR when file has only CR endings', () => {
    const bufferBuilder = new PieceTreeTextBufferBuilder();
    bufferBuilder.acceptChunk('a\rb\rc\r');
    const factory = bufferBuilder.finish(true);
    const { textBuffer } = factory.create(DefaultEndOfLine.LF);
    assert.strictEqual(textBuffer.getEOL(), '\r');   // CR detected despite LF default
    assert.strictEqual(textBuffer.getLineCount(), 4);
});
```

### 9c. textModel.test.ts

**File**: `src/vs/editor/test/common/model/textModel.test.ts`

Three new tests at the TextModel level:

```typescript
test('getValueLengthInRange with CR EOL', () => {
    const m = createTextModel('My First Line\rMy Second Line\rMy Third Line');
    assert.strictEqual(m.getEOL(), '\r');
    assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CR);
    // Verify CR preference returns correct length (1 char per EOL)
    assert.strictEqual(
        m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.CR),
        'My First Line\r'.length
    );
    // Verify CRLF preference returns correct length (2 chars per EOL)
    assert.strictEqual(
        m.getValueLengthInRange(new Range(1, 1, 2, 1), EndOfLinePreference.CRLF),
        'My First Line\r\n'.length
    );
});

test('setEOL and getEndOfLineSequence with CR', () => {
    const m = createTextModel('line1\nline2\nline3');
    m.setEOL(EndOfLineSequence.CR);
    assert.strictEqual(m.getEOL(), '\r');
    assert.strictEqual(m.getEndOfLineSequence(), EndOfLineSequence.CR);
});

test('pushEOL with CR', () => {
    const m = createTextModel('line1\nline2\nline3');
    m.pushEOL(EndOfLineSequence.CR);
    assert.strictEqual(m.getValue(), 'line1\rline2\rline3');  // Content normalized
});
```

---

## What Didn't Need to Change (and Why)

Several files were reviewed but needed **no modification**:

| File | Reason |
|------|--------|
| `textResourcePropertiesService.ts` | Already passes through raw `files.eol` string for non-`'auto'` values |
| `textModelSearch.ts` | The `lfCounter` is only needed for CRLF→LF offset compensation (CRLF is 2 chars, LF is 1). CR is also 1 char, so no compensation needed |
| `textModel.ts` line 1314 (trailing CR stripping) | Only applies when buffer is CRLF and edit text ends with lone `\r` — CR mode shouldn't strip trailing `\r` since that's the actual line ending |
| `pieceTreeBase.ts` `normalizeEOL` regex | The regex `/\r\n|\r|\n/g` already matches all three EOL types in the correct order |

---

## Summary of All Changed Files

| # | File | Lines Changed | What |
|---|------|:---:|------|
| 1 | `src/vs/editor/common/model.ts` | +12 | Add CR to 3 enums + ITextBuffer interface |
| 2 | `src/vs/editor/common/core/misc/eolCounter.ts` | +2 -2 | Rename `Invalid` → `CR`, change value from `3` to `4` (distinct bit) |
| 3 | `src/vs/editor/common/standalone/standaloneEnums.ts` | +12 | Mirror enum changes |
| 4 | `src/vs/monaco.d.ts` | +12 | Mirror enum changes |
| 5 | `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts` | +6 -6 | Widen type signatures |
| 6 | `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts` | +5 -3 | CR case in switch + type sigs |
| 7 | `src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.ts` | +14 -5 | CR detection logic |
| 8 | `src/vs/editor/common/model/textModel.ts` | +11 -5 | 3-way EOL in setEOL/getEndOfLineSequence/pushEOL |
| 9 | `src/vs/editor/common/services/modelService.ts` | +4 -2 | CR config mapping |
| 10 | `src/vs/editor/common/core/edits/stringEdit.ts` | +3 -3 | Widen types + fix regex |
| 11 | `src/vs/workbench/contrib/files/browser/files.contribution.ts` | +2 | Add `'\r'` to setting |
| 12 | `src/vs/workbench/browser/parts/editor/editorStatus.ts` | +5 -2 | CR label + quick-pick |
| 13 | `src/vs/workbench/api/common/extHostTypes/textEdit.ts` | +1 | `CR = 3` |
| 14 | `src/vs/workbench/api/common/extHostTypeConverters.ts` | +4 | CR conversion |
| 15 | `src/vs/workbench/api/common/extHostDocumentData.ts` | +1 -1 | CR in eol getter |
| 16 | `src/vscode-dts/vscode.d.ts` | +4 | Public API `CR = 3` |
| 17 | `src/vs/editor/test/common/core/misc/eolCounter.test.ts` | +70 | **NEW**: CR detection tests |
| 18 | `src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts` | +54 | CR buffer tests |
| 19 | `src/vs/editor/test/common/model/textModel.test.ts` | +48 | CR model tests |

**Total**: 19 files, +281 insertions, -45 deletions