### PR TITLE
fix: redirect focus to list's domNode when removing focused row to prevent focus loss

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1058,6 +1058,15 @@ export class ListView<T> implements IListView<T> {
 		item.checkedDisposable.dispose();
 
 		if (item.row) {
+			// If the row being removed contains the currently focused element,
+			// redirect focus to the list's domNode to prevent focus from escaping
+			// the widget entirely (e.g. when scrolling causes a focused checkbox
+			// to be recycled, which would otherwise blur the whole quick pick).
+			const activeElement = getActiveElement();
+			if (activeElement && isAncestor(activeElement, item.row.domNode)) {
+				this.domNode.focus();
+			}
+
 			const renderer = this.renderers.get(item.templateId);
 
 			if (renderer && renderer.disposeElement) {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -91,6 +91,7 @@ export interface IListViewOptions<T> extends IListViewOptionsUpdate {
 	readonly alwaysConsumeMouseWheel?: boolean;
 	readonly initialSize?: Dimension;
 	readonly scrollToActiveElement?: boolean;
+	readonly redirectFocusOnRemove?: boolean;
 }
 
 const DefaultOptions = {
@@ -378,7 +379,7 @@ export class ListView<T> implements IListView<T> {
 		container: HTMLElement,
 		private virtualDelegate: IListVirtualDelegate<T>,
 		renderers: IListRenderer<any /* TODO@joao */, any>[],
-		options: IListViewOptions<T> = DefaultOptions
+		private options: IListViewOptions<T> = DefaultOptions
 	) {
 		if (options.horizontalScrolling && options.supportDynamicHeights) {
 			throw new Error('Horizontal scrolling and dynamic heights not supported simultaneously');
@@ -1058,13 +1059,16 @@ export class ListView<T> implements IListView<T> {
 		item.checkedDisposable.dispose();
 
 		if (item.row) {
-			// If the row being removed contains the currently focused element,
-			// redirect focus to the list's domNode to prevent focus from escaping
-			// the widget entirely (e.g. when scrolling causes a focused checkbox
-			// to be recycled, which would otherwise blur the whole quick pick).
-			const activeElement = getActiveElement();
-			if (activeElement && isAncestor(activeElement, item.row.domNode)) {
-				this.domNode.focus();
+			// When opted in, if the row being removed contains the currently
+			// focused element, redirect focus to the list's domNode to prevent
+			// focus from escaping the widget entirely (e.g. when scrolling causes
+			// a focused checkbox to be recycled, which would otherwise blur the
+			// whole quick pick).
+			if (this.options.redirectFocusOnRemove) {
+				const activeElement = getActiveElement();
+				if (activeElement && isAncestor(activeElement, item.row.domNode)) {
+					this.domNode.focus();
+				}
 			}
 
 			const renderer = this.renderers.get(item.templateId);

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1098,6 +1098,7 @@ export interface IListOptions<T> extends IListOptionsUpdate {
 	readonly initialSize?: Dimension;
 	readonly paddingTop?: number;
 	readonly paddingBottom?: number;
+	readonly redirectFocusOnRemove?: boolean;
 }
 
 export interface IListStyles {

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -782,7 +782,8 @@ export class QuickInputList extends Disposable {
 				indent: 0,
 				horizontalScrolling: false,
 				allowNonCollapsibleParents: true,
-				alwaysConsumeMouseWheel: true
+				alwaysConsumeMouseWheel: true,
+				redirectFocusOnRemove: true
 			}
 		));
 		this._tree.getHTMLElement().id = id;

--- a/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
+++ b/src/vs/platform/quickinput/browser/tree/quickInputTreeController.ts
@@ -114,7 +114,8 @@ export class QuickInputTreeController extends Disposable {
 				disableExpandOnSpacebar: true,
 				sorter: this._sorter,
 				filter: this._filter,
-				identityProvider: new QuickInputTreeIdentityProvider()
+				identityProvider: new QuickInputTreeIdentityProvider(),
+				redirectFocusOnRemove: true
 			}
 		));
 		this.registerCheckboxStateListeners();


### PR DESCRIPTION
Steps:
1. `workbench.quickOpen.closeOnFocusLost` MUST be true (it's the default)
1. click checkbox in a quick pick or quick tree
1. scroll that checkbox off the screen
1. :bug: quick thing closes

I also repro this when the action bar on the right is focused in a quick pick so it's not specific to checkboxes.

This is because:
1. list widget kills the entry in the list (and the children, checkboxes, action bars, whatever)
2. checkboxes and action bars then `blur()` to the root element of vscode
3. quick pick reacts to being blurred (focused out) and closes itself

This is probably not the right fix, but I want something like this... I'll make a similar fix catered to just the quick pick so that the issue can be resolved but @joaomoreno lmk if you have any ideas.

https://github.com/microsoft/vscode/issues/289980

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
