### PR TITLE
plugins: add manage plugin marketplaces command

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatPluginActions.ts
@@ -4,17 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+import { ChatConfiguration } from '../../common/constants.js';
+import { IAgentPluginRepositoryService } from '../../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../../common/plugins/pluginInstallService.js';
-import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
+import { type IMarketplaceReference, MarketplaceReferenceKind, parseMarketplaceReferences } from '../../common/plugins/pluginMarketplaceService.js';
 import { IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
 import { InstalledAgentPluginsViewId } from '../agentPluginsView.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 
 export class ManagePluginsAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.managePlugins';
@@ -115,7 +121,109 @@ class InstallFromSourceAction extends Action2 {
 	}
 }
 
+interface IMarketplaceQuickPickItem extends IQuickPickItem {
+	readonly reference: IMarketplaceReference;
+}
+
+class ManagePluginMarketplacesAction extends Action2 {
+	static readonly ID = 'workbench.action.chat.managePluginMarketplaces';
+
+	constructor() {
+		super({
+			id: ManagePluginMarketplacesAction.ID,
+			title: localize2('managePluginMarketplaces', 'Manage Plugin Marketplaces'),
+			icon: Codicon.globe,
+			category: CHAT_CATEGORY,
+			precondition: ChatContextKeys.enabled,
+			f1: true,
+			menu: [{
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('view', InstalledAgentPluginsViewId),
+					ChatContextKeys.Setup.hidden.negate(),
+				),
+				group: 'navigation',
+				order: 2,
+			}],
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const configurationService = accessor.get(IConfigurationService);
+		const pluginRepositoryService = accessor.get(IAgentPluginRepositoryService);
+		const extensionsWorkbenchService = accessor.get(IExtensionsWorkbenchService);
+		const commandService = accessor.get(ICommandService);
+		const fileService = accessor.get(IFileService);
+
+		const configuredRefs = configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+		const refs = parseMarketplaceReferences(configuredRefs);
+
+		if (refs.length === 0) {
+			quickInputService.pick([], { placeHolder: localize('noMarketplaces', "No plugin marketplaces configured") });
+			return;
+		}
+
+		// Step 1: pick a marketplace
+		const items: IMarketplaceQuickPickItem[] = refs.map(ref => ({
+			label: ref.displayLabel,
+			description: ref.kind === MarketplaceReferenceKind.LocalFileUri
+				? localize('localMarketplace', "Local")
+				: ref.cloneUrl,
+			reference: ref,
+		}));
+
+		const selected = await quickInputService.pick(items, {
+			placeHolder: localize('selectMarketplace', "Select a plugin marketplace"),
+		});
+
+		if (!selected) {
+			return;
+		}
+
+		const ref = selected.reference;
+
+		// Step 2: pick an action for the selected marketplace
+		const actionItems: IQuickPickItem[] = [
+			{ id: 'showPlugins', label: localize('showPlugins', "Show Plugins") },
+		];
+
+		// "Open Folder" only for cloned/local repos
+		const repoUri = pluginRepositoryService.getRepositoryUri(ref);
+		const repoExists = await fileService.exists(repoUri);
+		if (repoExists) {
+			actionItems.push({ id: 'openDirectory', label: localize('openMarketplaceDirectory', "Open Folder") });
+		}
+
+		actionItems.push({ id: 'removeMarketplace', label: localize('removeMarketplace', "Remove Marketplace") });
+
+		const action = await quickInputService.pick(actionItems, {
+			placeHolder: localize('selectMarketplaceAction', "Select an action for '{0}'", ref.displayLabel),
+		});
+
+		if (!action) {
+			return;
+		}
+
+		switch (action.id) {
+			case 'showPlugins':
+				extensionsWorkbenchService.openSearch(`@agentPlugins ${ref.displayLabel}`);
+				break;
+			case 'openDirectory':
+				await commandService.executeCommand('revealFileInOS', repoUri);
+				break;
+			case 'removeMarketplace': {
+				const currentValues = configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+				const updated = currentValues.filter(v => typeof v === 'string' && v.trim() !== ref.rawValue);
+				await configurationService.updateValue(ChatConfiguration.PluginMarketplaces, updated);
+				break;
+			}
+		}
+	}
+}
+
 export function registerChatPluginActions() {
 	registerAction2(ManagePluginsAction);
 	registerAction2(InstallFromSourceAction);
+	registerAction2(ManagePluginMarketplacesAction);
 }

--- a/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginsView.ts
@@ -421,7 +421,8 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 		if (text) {
 			installed = installed.filter(p =>
 				p.name.toLowerCase().includes(text) ||
-				p.description.toLowerCase().includes(text)
+				p.description.toLowerCase().includes(text) ||
+				(p.marketplace ?? '').toLowerCase().includes(text)
 			);
 		}
 
@@ -453,7 +454,7 @@ export class AgentPluginsListView extends AbstractExtensionsListView<IAgentPlugi
 				});
 			} else {
 				const lowerText = text.toLowerCase();
-				filteredMp = filteredMp.filter(p => p.name.toLowerCase().includes(lowerText) || p.description.toLowerCase().includes(lowerText));
+				filteredMp = filteredMp.filter(p => p.name.toLowerCase().includes(lowerText) || p.description.toLowerCase().includes(lowerText) || p.marketplace.toLowerCase().includes(lowerText));
 			}
 
 			const marketplace = filteredMp.map(marketplacePluginToItem);


### PR DESCRIPTION
- Adds a 'Chat: Manage Plugin Marketplaces' command (f1) that lists
  configured marketplaces and offers actions: show plugins, open the
  cloned directory in the OS file manager, or remove the marketplace.
- Adds a globe icon button in the Agent Plugins - Installed view title
  bar for quick access to the marketplace management flow.
- Extends the @agentPlugins search to also filter by marketplace name,
  so 'Show Plugins' correctly narrows results to that marketplace.

Fixes https://github.com/microsoft/vscode/issues/302513

(Commit message generated by Copilot)