### PR TITLE
plugins: add marketplace to config when installing from source

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
+++ b/src/vs/workbench/contrib/chat/browser/pluginInstallService.ts
@@ -9,6 +9,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -16,8 +17,9 @@ import { INotificationService, Severity } from '../../../../platform/notificatio
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
+import { ChatConfiguration } from '../common/constants.js';
 import { IPluginInstallService, IUpdateAllPluginsOptions, IUpdateAllPluginsResult } from '../common/plugins/pluginInstallService.js';
-import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
+import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, MarketplaceReferenceKind, MarketplaceType, hasSourceChanged, parseMarketplaceReference, parseMarketplaceReferences, PluginSourceKind } from '../common/plugins/pluginMarketplaceService.js';
 
 export class PluginInstallService implements IPluginInstallService {
 	declare readonly _serviceBrand: undefined;
@@ -32,6 +34,7 @@ export class PluginInstallService implements IPluginInstallService {
 		@IProgressService private readonly _progressService: IProgressService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) { }
 
 	async installPlugin(plugin: IMarketplacePlugin): Promise<void> {
@@ -171,6 +174,7 @@ export class PluginInstallService implements IPluginInstallService {
 			const plugin = discoveredPlugins[0];
 			const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
 			this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+			this._addMarketplaceToConfig(reference);
 			return { success: true };
 		}
 
@@ -193,7 +197,17 @@ export class PluginInstallService implements IPluginInstallService {
 		const plugin = selected.plugin;
 		const pluginDir = plugin.source ? URI.joinPath(repoDir, plugin.source) : repoDir;
 		this._pluginMarketplaceService.addInstalledPlugin(pluginDir, plugin);
+		this._addMarketplaceToConfig(reference);
 		return { success: true };
+	}
+
+	private _addMarketplaceToConfig(reference: IMarketplaceReference): void {
+		const currentValues = this._configurationService.getValue<unknown[]>(ChatConfiguration.PluginMarketplaces) ?? [];
+		const existingRefs = parseMarketplaceReferences(currentValues);
+		if (existingRefs.some(r => r.canonicalId === reference.canonicalId)) {
+			return;
+		}
+		this._configurationService.updateValue(ChatConfiguration.PluginMarketplaces, [...currentValues, reference.rawValue]);
 	}
 
 	async updatePlugin(plugin: IMarketplacePlugin, silent?: boolean): Promise<boolean> {

--- a/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/plugins/pluginInstallService.test.ts
@@ -6,6 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
@@ -16,6 +17,7 @@ import { IQuickInputService } from '../../../../../../platform/quickinput/common
 import { ITerminalService } from '../../../../terminal/browser/terminal.js';
 import { PluginInstallService } from '../../../browser/pluginInstallService.js';
 import { IAgentPluginRepositoryService, IEnsureRepositoryOptions, IPullRepositoryOptions } from '../../../common/plugins/agentPluginRepositoryService.js';
+import { ChatConfiguration } from '../../../common/constants.js';
 import { IMarketplacePlugin, IMarketplaceReference, IPluginMarketplaceService, IPluginSourceDescriptor, MarketplaceType, parseMarketplaceReference, PluginSourceKind } from '../../../common/plugins/pluginMarketplaceService.js';
 import { IPluginSource } from '../../../common/plugins/pluginSource.js';
 
@@ -73,6 +75,10 @@ suite('PluginInstallService', () => {
 		quickPickResult: { label: string } | undefined;
 		/** Result of the quick input dialog */
 		quickInputResult: string | undefined;
+		/** Current configured marketplace values */
+		configuredMarketplaces: string[];
+		/** Updated marketplace config values */
+		updatedMarketplaces: string[] | undefined;
 	}
 
 	function createDefaults(): MockState {
@@ -94,6 +100,8 @@ suite('PluginInstallService', () => {
 			readPluginsResult: [],
 			quickPickResult: undefined,
 			quickInputResult: undefined,
+			configuredMarketplaces: [],
+			updatedMarketplaces: undefined,
 		};
 	}
 
@@ -259,6 +267,21 @@ suite('PluginInstallService', () => {
 			},
 			readPluginsFromDirectory: async () => state.readPluginsResult,
 		} as unknown as IPluginMarketplaceService);
+
+		// IConfigurationService
+		instantiationService.stub(IConfigurationService, {
+			getValue: (key: string) => {
+				if (key === ChatConfiguration.PluginMarketplaces) {
+					return state.configuredMarketplaces;
+				}
+				return undefined;
+			},
+			updateValue: async (key: string, value: unknown) => {
+				if (key === ChatConfiguration.PluginMarketplaces) {
+					state.updatedMarketplaces = value as string[];
+				}
+			},
+		} as unknown as IConfigurationService);
 
 		// IQuickInputService
 		instantiationService.stub(IQuickInputService, {
@@ -947,6 +970,72 @@ suite('PluginInstallService', () => {
 
 			assert.strictEqual(state.addedPlugins.length, 0);
 			assert.strictEqual(state.notifications.length, 1);
+		});
+
+		test('adds marketplace to config after installing single plugin', async () => {
+			const ref = makeMarketplaceRef('owner/my-plugin');
+			const discoveredPlugin = createPlugin({
+				name: 'my-discovered-plugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/my-plugin'),
+				readPluginsResult: [discoveredPlugin],
+			});
+
+			await service.installPluginFromSource('owner/my-plugin');
+
+			assert.deepStrictEqual(state.updatedMarketplaces, ['owner/my-plugin']);
+		});
+
+		test('adds marketplace to config after picking from multi-plugin repo', async () => {
+			const ref = makeMarketplaceRef('owner/multi-repo');
+			const pluginA = createPlugin({
+				name: 'plugin-a',
+				source: 'plugins/a',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/a' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const pluginB = createPlugin({
+				name: 'plugin-b',
+				source: 'plugins/b',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: 'plugins/b' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/multi-repo'),
+				readPluginsResult: [pluginA, pluginB],
+				quickPickResult: { label: 'plugin-a' },
+			});
+
+			await service.installPluginFromSource('owner/multi-repo');
+
+			assert.deepStrictEqual(state.updatedMarketplaces, ['owner/multi-repo']);
+		});
+
+		test('does not duplicate marketplace in config', async () => {
+			const ref = makeMarketplaceRef('owner/my-plugin');
+			const discoveredPlugin = createPlugin({
+				name: 'my-discovered-plugin',
+				sourceDescriptor: { kind: PluginSourceKind.RelativePath, path: '' },
+				marketplace: ref.displayLabel,
+				marketplaceReference: ref,
+				marketplaceType: MarketplaceType.OpenPlugin,
+			});
+			const { service, state } = createService({
+				ensurePluginSourceResult: URI.file('/cache/agentPlugins/github.com/owner/my-plugin'),
+				readPluginsResult: [discoveredPlugin],
+				configuredMarketplaces: ['owner/my-plugin'],
+			});
+
+			await service.installPluginFromSource('owner/my-plugin');
+
+			assert.strictEqual(state.updatedMarketplaces, undefined);
 		});
 	});
 });


### PR DESCRIPTION
- When a plugin is installed via "Install Plugin from Source", the source
  repository is now automatically added to the `chat.plugins.marketplaces`
  setting so it appears in the marketplace management UI.
- Deduplicates by canonical ID to avoid adding the same marketplace twice.

Fixes https://github.com/microsoft/vscode/issues/302512

(Commit message generated by Copilot)