### PR TITLE
fix: track disposables for serialized tool invocations in thinking part

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -1324,14 +1324,19 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 
 			this.toolInvocations.push(toolInvocationOrMarkdown);
 
+			// Ensure a DisposableStore exists for all tool invocation kinds so that
+			// disposables registered via appendItem are tracked and cleaned up.
+			if (!this.toolDisposables.has(toolInvocationOrMarkdown.toolCallId)) {
+				this.toolDisposables.set(toolInvocationOrMarkdown.toolCallId, new DisposableStore());
+			}
+
 			// track state for live/still streaming tools, excluding serialized tools
 			if (toolInvocationOrMarkdown.kind === 'toolInvocation') {
 				let currentToolLabel = toolCallLabel;
 				let isComplete = false;
 				let isStreaming = IChatToolInvocation.isStreaming(toolInvocationOrMarkdown);
 
-				const toolStore = new DisposableStore();
-				this.toolDisposables.set(toolInvocationOrMarkdown.toolCallId, toolStore);
+				const toolStore = this.toolDisposables.get(toolInvocationOrMarkdown.toolCallId)!;
 
 				const updateTitle = (updatedMessage: string) => {
 					if (updatedMessage && updatedMessage !== currentToolLabel) {


### PR DESCRIPTION
## Summary

- Fix disposable leak for serialized tool invocations (`toolInvocationSerialized`) in `ChatThinkingContentPart`
- `trackToolMetadata` only created a `DisposableStore` in `toolDisposables` for live `toolInvocation` kind, causing `appendItem` to silently drop disposables for serialized tools via `toolDisposables.get(id)?.add()`
- This led to leaked `ChatToolInvocationPart` instances (and child `CodeBlockPart` / `MenuWorkbenchToolBar`) when loading session history, accumulating listeners on `ActionViewItemService.onDidChange`

## Details

The recent fix in #302595 correctly added `disposable` to the `createToolPart` return value. However, the disposable is still silently dropped for `toolInvocationSerialized` because `trackToolMetadata` only calls `toolDisposables.set(toolCallId, toolStore)` inside the `kind === 'toolInvocation'` branch.

This fix creates the `DisposableStore` for all tool invocation kinds before the kind-specific state tracking branch, ensuring serialized tools' disposables are properly tracked and cleaned up when the thinking part is disposed.

