### PR TITLE
Add config for linkActivationModifier and prevent link following when any other modifiers are down

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -106,6 +106,7 @@ export const enum TerminalSettingId {
 	PersistentSessionScrollback = 'terminal.integrated.persistentSessionScrollback',
 	InheritEnv = 'terminal.integrated.inheritEnv',
 	ShowLinkHover = 'terminal.integrated.showLinkHover',
+	LinkActivationModifier = 'terminal.integrated.linkActivationModifier',
 	IgnoreProcessNames = 'terminal.integrated.ignoreProcessNames',
 	ShellIntegrationEnabled = 'terminal.integrated.shellIntegration.enabled',
 	ShellIntegrationShowWelcome = 'terminal.integrated.shellIntegration.showWelcome',

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -183,7 +183,7 @@ export interface ITerminalConfiguration {
 	wordSeparators: string;
 	enableFileLinks: 'off' | 'on' | 'notRemote';
 	allowedLinkSchemes: string[];
-	linkActivationModifier: 'ctrlCmd' | 'alt';
+	linkActivationModifier: 'ctrlCmd' | 'alt' | 'disabled';
 	unicodeVersion: '6' | '11';
 	enablePersistentSessions: boolean;
 	tabs: {

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -183,6 +183,7 @@ export interface ITerminalConfiguration {
 	wordSeparators: string;
 	enableFileLinks: 'off' | 'on' | 'notRemote';
 	allowedLinkSchemes: string[];
+	linkActivationModifier: 'ctrlCmd' | 'alt';
 	unicodeVersion: '6' | '11';
 	enablePersistentSessions: boolean;
 	tabs: {

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -527,6 +527,16 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 			'vscode-insiders',
 		]
 	},
+	[TerminalSettingId.LinkActivationModifier]: {
+		description: localize('terminal.integrated.linkActivationModifier', "The modifier key required to follow links in the terminal. The exact modifier must be the only one held; combinations with additional modifiers (such as Shift) will not trigger link following."),
+		type: 'string',
+		enum: ['ctrlCmd', 'alt'],
+		enumDescriptions: [
+			localize('terminal.integrated.linkActivationModifier.ctrlCmd', "Ctrl (or Cmd on macOS) only."),
+			localize('terminal.integrated.linkActivationModifier.alt', "Alt (or Option on macOS) only.")
+		],
+		default: 'ctrlCmd'
+	},
 	[TerminalSettingId.UnicodeVersion]: {
 		type: 'string',
 		enum: ['6', '11'],

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -530,10 +530,11 @@ const terminalConfiguration: IStringDictionary<IConfigurationPropertySchema> = {
 	[TerminalSettingId.LinkActivationModifier]: {
 		description: localize('terminal.integrated.linkActivationModifier', "The modifier key required to follow links in the terminal. The exact modifier must be the only one held; combinations with additional modifiers (such as Shift) will not trigger link following."),
 		type: 'string',
-		enum: ['ctrlCmd', 'alt'],
+		enum: ['ctrlCmd', 'alt', 'disabled'],
 		enumDescriptions: [
 			localize('terminal.integrated.linkActivationModifier.ctrlCmd', "Ctrl (or Cmd on macOS) only."),
-			localize('terminal.integrated.linkActivationModifier.alt', "Alt (or Option on macOS) only.")
+			localize('terminal.integrated.linkActivationModifier.alt', "Alt (or Option on macOS) only."),
+			localize('terminal.integrated.linkActivationModifier.disabled', "Disable link following by click.")
 		],
 		default: 'ctrlCmd'
 	},

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLink.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLink.ts
@@ -7,10 +7,10 @@ import type { IViewportRange, IBufferRange, ILink, ILinkDecorations, Terminal } 
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import * as dom from '../../../../../base/browser/dom.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
-import { convertBufferRangeToViewport } from './terminalLinkHelpers.js';
-import { isMacintosh } from '../../../../../base/common/platform.js';
+import { convertBufferRangeToViewport, isLinkModifierDown } from './terminalLinkHelpers.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ITerminalConfiguration, TERMINAL_CONFIG_SECTION } from '../../../terminal/common/terminal.js';
 import { TerminalLinkType } from './links.js';
 import type { URI } from '../../../../../base/common/uri.js';
 import type { IParsedLink } from './terminalLinkParsing.js';
@@ -135,10 +135,7 @@ export class TerminalLink extends Disposable implements ILink {
 	}
 
 	private _isModifierDown(event: MouseEvent | KeyboardEvent): boolean {
-		const multiCursorModifier = this._configurationService.getValue<'ctrlCmd' | 'alt'>('editor.multiCursorModifier');
-		if (multiCursorModifier === 'ctrlCmd') {
-			return !!event.altKey;
-		}
-		return isMacintosh ? event.metaKey : event.ctrlKey;
+		const modifier = this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).linkActivationModifier;
+		return isLinkModifierDown(event, modifier);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkHelpers.ts
@@ -258,7 +258,10 @@ export function osPathModule(os: OperatingSystem): IPath {
  * Returns whether the link activation modifier is the only modifier key currently held for the given event.
  * All other modifiers are required to be up to prevent conflicts, e.g., ctrl+shift+c copy.
  */
-export function isLinkModifierDown(event: MouseEvent | KeyboardEvent, modifier: 'ctrlCmd' | 'alt'): boolean {
+export function isLinkModifierDown(event: MouseEvent | KeyboardEvent, modifier: 'ctrlCmd' | 'alt' | 'disabled'): boolean {
+	if (modifier === 'disabled') {
+		return false;
+	}
 	if (modifier === 'alt') {
 		return event.altKey && !event.ctrlKey && !event.shiftKey && !event.metaKey;
 	}

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkHelpers.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkHelpers.ts
@@ -5,7 +5,7 @@
 
 import type { IViewportRange, IBufferRange, IBufferLine, IBuffer, IBufferCellPosition } from '@xterm/xterm';
 import { IRange } from '../../../../../editor/common/core/range.js';
-import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { isMacintosh, OperatingSystem } from '../../../../../base/common/platform.js';
 import { IPath, posix, win32 } from '../../../../../base/common/path.js';
 import { ITerminalCapabilityStore, TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalLogService } from '../../../../../platform/terminal/common/terminal.js';
@@ -252,4 +252,17 @@ export function updateLinkWithRelativeCwd(capabilities: ITerminalCapabilityStore
 
 export function osPathModule(os: OperatingSystem): IPath {
 	return os === OperatingSystem.Windows ? win32 : posix;
+}
+
+/**
+ * Returns whether the link activation modifier is the only modifier key currently held for the given event.
+ * All other modifiers are required to be up to prevent conflicts, e.g., ctrl+shift+c copy.
+ */
+export function isLinkModifierDown(event: MouseEvent | KeyboardEvent, modifier: 'ctrlCmd' | 'alt'): boolean {
+	if (modifier === 'alt') {
+		return event.altKey && !event.ctrlKey && !event.shiftKey && !event.metaKey;
+	}
+	const primaryKey = isMacintosh ? event.metaKey : event.ctrlKey;
+	const otherKey = isMacintosh ? event.ctrlKey : event.metaKey;
+	return primaryKey && !event.shiftKey && !event.altKey && !otherKey;
 }

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -441,7 +441,7 @@ export class TerminalLinkManager extends DisposableStore {
 			} else {
 				clickLabel = nls.localize('terminalLinkHandler.followLinkAlt', "alt + click");
 			}
-		} else {
+		} else if (modifier === 'ctrlCmd') {
 			if (isMacintosh) {
 				clickLabel = nls.localize('terminalLinkHandler.followLinkCmd', "cmd + click");
 			} else {

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -149,6 +149,9 @@ export class TerminalLinkManager extends DisposableStore {
 				activeHoverDisposable?.dispose();
 				activeHoverDisposable = undefined;
 				activeTooltipScheduler?.dispose();
+				if (this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).linkActivationModifier === 'disabled') {
+					return;
+				}
 				activeTooltipScheduler = new RunOnceScheduler(() => {
 					interface XtermWithCore extends Terminal {
 						_core: IXtermCore;
@@ -348,6 +351,9 @@ export class TerminalLinkManager extends DisposableStore {
 
 	private _tooltipCallback(link: TerminalLink, viewportRange: IViewportRange, modifierDownCallback?: () => void, modifierUpCallback?: () => void) {
 		if (!this._widgetManager) {
+			return;
+		}
+		if (this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).linkActivationModifier === 'disabled') {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -27,7 +27,7 @@ import { IXtermCore } from '../../../terminal/browser/xterm-private.js';
 import { ITerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalConfiguration, ITerminalProcessInfo, TERMINAL_CONFIG_SECTION } from '../../../terminal/common/terminal.js';
 import type { ILink, ILinkProvider, IViewportRange, Terminal } from '@xterm/xterm';
-import { convertBufferRangeToViewport } from './terminalLinkHelpers.js';
+import { convertBufferRangeToViewport, isLinkModifierDown } from './terminalLinkHelpers.js';
 import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { ITerminalLogService } from '../../../../../platform/terminal/common/terminal.js';
 import { TerminalMultiLineLinkDetector } from './terminalMultiLineLinkDetector.js';
@@ -427,18 +427,15 @@ export class TerminalLinkManager extends DisposableStore {
 	}
 
 	protected _isLinkActivationModifierDown(event: MouseEvent): boolean {
-		const editorConf = this._configurationService.getValue<{ multiCursorModifier: 'ctrlCmd' | 'alt' }>('editor');
-		if (editorConf.multiCursorModifier === 'ctrlCmd') {
-			return !!event.altKey;
-		}
-		return isMacintosh ? event.metaKey : event.ctrlKey;
+		const modifier = this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).linkActivationModifier;
+		return isLinkModifierDown(event, modifier);
 	}
 
 	private _getLinkHoverString(uri: string, label: string | undefined): IMarkdownString {
-		const editorConf = this._configurationService.getValue<{ multiCursorModifier: 'ctrlCmd' | 'alt' }>('editor');
+		const modifier = this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).linkActivationModifier;
 
 		let clickLabel = '';
-		if (editorConf.multiCursorModifier === 'ctrlCmd') {
+		if (modifier === 'alt') {
 			if (isMacintosh) {
 				clickLabel = nls.localize('terminalLinkHandler.followLinkAlt.mac', "option + click");
 			} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR implements what is requested in #302645, mainly to prevent unwanted link following when extra modifiers are down, and isolates link following modifier in terminal from `multiCursorModifier`. The new config key is `terminal.integrated.linkActivationModifier`.