### PR TITLE
Add option 'ask' for openFolder

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -191,7 +191,7 @@ export interface IWindowsConfiguration {
 
 export interface IWindowSettings {
 	readonly openFilesInNewWindow: 'on' | 'off' | 'default';
-	readonly openFoldersInNewWindow: 'on' | 'off' | 'default';
+	readonly openFoldersInNewWindow: 'on' | 'off' | 'default' | 'ask';
 	readonly openWithoutArgumentsInNewWindow: 'on' | 'off';
 	readonly restoreWindows: 'preserve' | 'all' | 'folders' | 'one' | 'none';
 	readonly restoreFullscreen: boolean;

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -888,11 +888,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			'window.openFoldersInNewWindow': {
 				'type': 'string',
-				'enum': ['on', 'off', 'default'],
+				'enum': ['on', 'off', 'default', 'ask'],
 				'enumDescriptions': [
 					localize('window.openFoldersInNewWindow.on', "Folders will open in a new window."),
 					localize('window.openFoldersInNewWindow.off', "Folders will replace the last active window."),
-					localize('window.openFoldersInNewWindow.default', "Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu).")
+					localize('window.openFoldersInNewWindow.default', "Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu)."),
+					localize('window.openFoldersInNewWindow.ask', "A prompt will appear asking whether to open the folder in a new window or the current window.")
 				],
 				'default': 'default',
 				'scope': ConfigurationScope.APPLICATION,

--- a/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
@@ -6,6 +6,9 @@
 import { SaveDialogOptions, OpenDialogOptions } from '../../../../base/parts/sandbox/common/electronTypes.js';
 import { IHostService } from '../../host/browser/host.js';
 import { IPickAndOpenOptions, ISaveDialogOptions, IOpenDialogOptions, IFileDialogService, IDialogService, INativeOpenDialogOptions } from '../../../../platform/dialogs/common/dialogs.js';
+import { IWindowSettings } from '../../../../platform/window/common/window.js';
+import Severity from '../../../../base/common/severity.js';
+import * as nls from '../../../../nls.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IHistoryService } from '../../history/common/history.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
@@ -28,6 +31,7 @@ import { IEditorService } from '../../editor/common/editorService.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { getActiveWindow } from '../../../../base/browser/dom.js';
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
+import { isMacintosh } from '../../../../base/common/platform.js';
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
@@ -114,7 +118,60 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		if (this.shouldUseSimplified(schema).useSimplified) {
 			return this.pickFolderAndOpenSimplified(schema, options);
 		}
+
+		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		if (!options.forceNewWindow && windowConfig?.openFoldersInNewWindow === 'ask') {
+			return this.pickFolderAndOpenWithAsk(options);
+		}
+
 		return this.nativeHostService.pickFolderAndOpen(this.toNativeOpenDialogOptions(options));
+	}
+
+	private async pickFolderAndOpenWithAsk(options: IPickAndOpenOptions): Promise<void> {
+		const properties: Array<'openDirectory' | 'createDirectory' | 'multiSelections' | 'treatPackageAsDirectory'> = ['openDirectory', 'createDirectory', 'multiSelections'];
+		if (isMacintosh) {
+			properties.push('treatPackageAsDirectory');
+		}
+
+		const result = await this.nativeHostService.showOpenDialog({
+			title: nls.localize('openFolder.title', 'Open Folder'),
+			defaultPath: options.defaultUri?.fsPath,
+			properties,
+			targetWindowId: getActiveWindow().vscodeWindowId
+		});
+
+		if (!result || result.canceled || result.filePaths.length === 0) {
+			return;
+		}
+
+		type WindowChoice = 'current' | 'new';
+		const { result: windowChoice } = await this.dialogService.prompt<WindowChoice>({
+			type: Severity.Info,
+			message: nls.localize('openFolderInNewWindow', "How would you like to open the folder?"),
+			buttons: [
+				{
+					label: nls.localize({ key: 'openFolderCurrentWindow', comment: ['&& denotes a mnemonic'] }, "&&Current Window"),
+					run: () => 'current' as WindowChoice
+				},
+				{
+					label: nls.localize({ key: 'openFolderNewWindow', comment: ['&& denotes a mnemonic'] }, "&&New Window"),
+					run: () => 'new' as WindowChoice
+				}
+			],
+			cancelButton: true
+		});
+
+		if (!windowChoice) {
+			return; // cancelled
+		}
+
+		await this.hostService.openWindow(
+			result.filePaths.map(path => ({ folderUri: URI.file(path) })),
+			{
+				...(windowChoice === 'current' ? { forceReuseWindow: true } : { forceNewWindow: true }),
+				remoteAuthority: options.remoteAuthority
+			}
+		);
 	}
 
 	async pickWorkspaceAndOpen(options: IPickAndOpenOptions): Promise<void> {

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -248,12 +248,57 @@ export class BrowserHostService extends Disposable implements IHostService {
 		return this.doOpenEmptyWindow(arg1);
 	}
 
+	private async resolveReuseForFolders(options: IOpenWindowOptions): Promise<boolean | undefined> {
+		if (options.waitMarkerFileURI) {
+			return true; // always handle --wait in same window
+		}
+
+		if (options.forceReuseWindow) {
+			return true;
+		}
+
+		if (options.forceNewWindow) {
+			return false;
+		}
+
+		const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+		if (windowConfig?.openFoldersInNewWindow === 'ask') {
+			const { result } = await this.dialogService.prompt<boolean>({
+				type: Severity.Info,
+				message: localize('openFolderInNewWindow', "How would you like to open the folder?"),
+				buttons: [
+					{
+						label: localize({ key: 'openFolderCurrentWindow', comment: ['&& denotes a mnemonic'] }, "&&Current Window"),
+						run: () => true
+					},
+					{
+						label: localize({ key: 'openFolderNewWindow', comment: ['&& denotes a mnemonic'] }, "&&New Window"),
+						run: () => false
+					}
+				],
+				cancelButton: true
+			});
+
+			return result; // undefined when cancelled
+		}
+
+		return this.shouldReuse(options, false /* no file */);
+	}
+
 	private async doOpenWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void> {
 		const payload = this.preservePayload(false /* not an empty window */, options);
 		const fileOpenables: IFileToOpen[] = [];
 
 		const foldersToAdd: IWorkspaceFolderCreationData[] = [];
 		const foldersToRemove: URI[] = [];
+
+		// Pre-resolve the reuse decision for folders/workspaces once for the entire batch
+		// to avoid showing the dialog multiple times when opening multiple folders.
+		const hasFolderOrWorkspace = toOpen.some(o => (isFolderToOpen(o) && !options?.addMode && !options?.removeMode) || isWorkspaceToOpen(o));
+		const reuseForFolders = hasFolderOrWorkspace ? await this.resolveReuseForFolders(options ?? Object.create(null)) : false;
+		if (reuseForFolders === undefined) {
+			return; // cancelled
+		}
 
 		for (const openable of toOpen) {
 			openable.label = openable.label || this.getRecentLabel(openable);
@@ -265,13 +310,13 @@ export class BrowserHostService extends Disposable implements IHostService {
 				} else if (options?.removeMode) {
 					foldersToRemove.push(openable.folderUri);
 				} else {
-					this.doOpen({ folderUri: openable.folderUri }, { reuse: this.shouldReuse(options, false /* no file */), payload });
+					this.doOpen({ folderUri: openable.folderUri }, { reuse: reuseForFolders, payload });
 				}
 			}
 
 			// Workspace
 			else if (isWorkspaceToOpen(openable)) {
-				this.doOpen({ workspaceUri: openable.workspaceUri }, { reuse: this.shouldReuse(options, false /* no file */), payload });
+				this.doOpen({ workspaceUri: openable.workspaceUri }, { reuse: reuseForFolders, payload });
 			}
 
 			// File (handled later in bulk)

--- a/src/vs/workbench/services/host/electron-browser/nativeHostService.ts
+++ b/src/vs/workbench/services/host/electron-browser/nativeHostService.ts
@@ -9,8 +9,12 @@ import { FocusMode, INativeHostService } from '../../../../platform/native/commo
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ILabelService, Verbosity } from '../../../../platform/label/common/label.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
-import { IWindowOpenable, IOpenWindowOptions, isFolderToOpen, isWorkspaceToOpen, IOpenEmptyWindowOptions, IPoint, IRectangle, IOpenedAuxiliaryWindow, IOpenedMainWindow } from '../../../../platform/window/common/window.js';
+import { IWindowOpenable, IOpenWindowOptions, isFolderToOpen, isWorkspaceToOpen, IOpenEmptyWindowOptions, IPoint, IRectangle, IOpenedAuxiliaryWindow, IOpenedMainWindow, IWindowSettings } from '../../../../platform/window/common/window.js';
 import { Disposable, DisposableSet, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import Severity from '../../../../base/common/severity.js';
+import { localize } from '../../../../nls.js';
 import { NativeHostService } from '../../../../platform/native/common/nativeHostService.js';
 import { INativeWorkbenchEnvironmentService } from '../../environment/electron-browser/environmentService.js';
 import { IMainProcessService } from '../../../../platform/ipc/common/mainProcessService.js';
@@ -39,7 +43,9 @@ class WorkbenchHostService extends Disposable implements IHostService {
 	constructor(
 		@INativeHostService private readonly nativeHostService: INativeHostService,
 		@ILabelService private readonly labelService: ILabelService,
-		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService
+		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IDialogService private readonly dialogService: IDialogService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super();
 
@@ -125,7 +131,7 @@ class WorkbenchHostService extends Disposable implements IHostService {
 		return this.doOpenEmptyWindow(arg1);
 	}
 
-	private doOpenWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void> {
+	private async doOpenWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void> {
 		const remoteAuthority = this.environmentService.remoteAuthority;
 		if (remoteAuthority) {
 			toOpen.forEach(openable => openable.label = openable.label || this.getRecentLabel(openable));
@@ -137,7 +143,41 @@ class WorkbenchHostService extends Disposable implements IHostService {
 			}
 		}
 
+		// Resolve 'ask' to a concrete forceNewWindow/forceReuseWindow before IPC
+		// since the main process is synchronous and cannot show UI.
+		const hasFolderOrWorkspace = toOpen.some(o => isFolderToOpen(o) || isWorkspaceToOpen(o));
+		if (hasFolderOrWorkspace && !options?.forceNewWindow && !options?.forceReuseWindow) {
+			const windowConfig = this.configurationService.getValue<IWindowSettings | undefined>('window');
+			if (windowConfig?.openFoldersInNewWindow === 'ask') {
+				const reuseWindow = await this.askUserForWindowBehavior();
+				if (reuseWindow === undefined) {
+					return; // cancelled
+				}
+				options = { ...options, ...(reuseWindow ? { forceReuseWindow: true } : { forceNewWindow: true }) };
+			}
+		}
+
 		return this.nativeHostService.openWindow(toOpen, options);
+	}
+
+	private async askUserForWindowBehavior(): Promise<boolean | undefined> {
+		const { result } = await this.dialogService.prompt<boolean>({
+			type: Severity.Info,
+			message: localize('openFolderInNewWindow', "How would you like to open the folder?"),
+			buttons: [
+				{
+					label: localize({ key: 'openFolderCurrentWindow', comment: ['&& denotes a mnemonic'] }, "&&Current Window"),
+					run: () => true
+				},
+				{
+					label: localize({ key: 'openFolderNewWindow', comment: ['&& denotes a mnemonic'] }, "&&New Window"),
+					run: () => false
+				}
+			],
+			cancelButton: true
+		});
+
+		return result; // undefined when cancelled
 	}
 
 	private getRecentLabel(openable: IWindowOpenable): string {


### PR DESCRIPTION
Add option to make openFolder promt the user whether to open folder in current or new window.

This makes openFolder work like IntelliJ, Android Studio.
When you open folder you prompted where do you want this folder to open, in current window, or new window.
This make life so much better, you should try it before deciding whether to approve it ;)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
