### PR TITLE
Collapse customizations section by default in sessions sidebar

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -52,7 +52,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
 		// Get initial collapsed state
-		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, false);
+		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
 		if (isCollapsed) {


### PR DESCRIPTION
Changes the default collapsed state of the AI Customizations section in the sessions primary sidebar from expanded to collapsed.

The section persists the user's toggle preference via `agentSessions.customizationsCollapsed` in profile storage, so this only affects the initial state before the user interacts with it.