### PR TITLE
Hide Pin/Unpin actions on archived sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -589,7 +589,8 @@ export class UnpinAgentSessionAction extends BaseAgentSessionAction {
 				order: 0,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
-					ChatContextKeys.isPinnedAgentSession
+					ChatContextKeys.isPinnedAgentSession,
+					ChatContextKeys.isArchivedAgentSession.negate()
 				),
 			}, {
 				id: MenuId.AgentSessionsContext,
@@ -597,7 +598,8 @@ export class UnpinAgentSessionAction extends BaseAgentSessionAction {
 				order: 1,
 				when: ContextKeyExpr.and(
 					IsSessionsWindowContext,
-					ChatContextKeys.isPinnedAgentSession
+					ChatContextKeys.isPinnedAgentSession,
+					ChatContextKeys.isArchivedAgentSession.negate()
 				),
 			}]
 		});


### PR DESCRIPTION
Adds `ChatContextKeys.isArchivedAgentSession.negate()` to the `when` clauses of `UnpinAgentSessionAction`, hiding the Unpin button on archived sessions in both the item toolbar and context menu.

The Pin action already had this guard; this makes Unpin consistent.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>