### PR TITLE
Update hover background color in 2026 Dark theme

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -57,7 +57,7 @@
 		"list.activeSelectionForeground": "#ededed",
 		"list.inactiveSelectionBackground": "#2C2D2E",
 		"list.inactiveSelectionForeground": "#ededed",
-		"list.hoverBackground": "#262728",
+		"list.hoverBackground": "#FFFFFF0D",
 		"list.hoverForeground": "#bfbfbf",
 		"list.dropBackground": "#3994BC1A",
 		"toolbar.hoverBackground": "#FFFFFF18",


### PR DESCRIPTION
Change the hover background color for lists in the 2026 Dark theme to improve visibility and aesthetics. Test the changes by switching to the 2026 Dark theme and observing the list hover effect.

