### PR TITLE
Fix spinning icon for in-progress CI status checks in sessions window

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/ciStatusWidget.ts
@@ -499,7 +499,7 @@ function buildFixChecksPrompt(failedChecks: ReadonlyArray<{ check: IGitHubCIChec
 function getHeaderIconAndClass(checks: readonly IGitHubCICheck[], overallStatus: GitHubCIOverallStatus): { icon: ThemeIcon; className: string } {
 	const counts = getCheckCounts(checks);
 	if (counts.running > 0) {
-		return { icon: Codicon.loading, className: 'ci-status-running' };
+		return { icon: Codicon.clock, className: 'ci-status-running' };
 	}
 
 	switch (overallStatus) {
@@ -517,7 +517,7 @@ function getHeaderIconAndClass(checks: readonly IGitHubCICheck[], overallStatus:
 function getCheckIcon(check: IGitHubCICheck): ThemeIcon {
 	switch (check.status) {
 		case GitHubCheckStatus.InProgress:
-			return Codicon.loading;
+			return Codicon.clock;
 		case GitHubCheckStatus.Queued:
 			return Codicon.circleFilled;
 		case GitHubCheckStatus.Completed:


### PR DESCRIPTION
The CI status widget in the sessions window was using \Codicon.loading\ for in-progress checks, which triggers a CSS spin animation on the entire label — making it look buggy.

Replaced with \Codicon.clock\, a static icon that cleanly represents the in-progress state without any animation.

**Changes:**
- Header icon (\getHeaderIconAndClass\): running checks now show a clock icon
- Individual check icon (\getCheckIcon\): in-progress checks now show a clock icon