### PR TITLE
customizations: harness follow up

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -1112,6 +1112,24 @@ export class AICustomizationListWidget extends Disposable {
 		items.length = 0;
 		items.push(...filteredItems);
 
+		// Apply workspace subpath filter — when the active harness specifies
+		// workspaceSubpaths, hide workspace-local items that aren't under one
+		// of the recognized sub-paths (e.g. Claude only shows .claude/ items).
+		const descriptor = this.harnessService.getActiveDescriptor();
+		const subpaths = descriptor.workspaceSubpaths;
+		if (subpaths) {
+			const projectRoot = this.workspaceService.getActiveProjectRoot();
+			for (let i = items.length - 1; i >= 0; i--) {
+				const item = items[i];
+				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
+					const path = item.uri.path;
+					if (!subpaths.some(sp => path.includes(sp))) {
+						items.splice(i, 1);
+					}
+				}
+			}
+		}
+
 		// Sort items by name
 		items.sort((a, b) => a.name.localeCompare(b.name));
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -51,7 +51,7 @@ import { parse as parseJSONC } from '../../../../../base/common/json.js';
 import { Schemas } from '../../../../../base/common/network.js';
 import { OS } from '../../../../../base/common/platform.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
-import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, matchesWorkspaceSubpath } from '../../common/customizationHarnessService.js';
 
 export { truncateToFirstSentence } from './aiCustomizationListWidgetUtils.js';
 
@@ -1122,8 +1122,7 @@ export class AICustomizationListWidget extends Disposable {
 			for (let i = items.length - 1; i >= 0; i--) {
 				const item = items[i];
 				if (item.storage === PromptsStorage.local && projectRoot && isEqualOrParent(item.uri, projectRoot)) {
-					const path = item.uri.path;
-					if (!subpaths.some(sp => path.includes(sp))) {
+					if (!matchesWorkspaceSubpath(item.uri.path, subpaths)) {
 						items.splice(i, 1);
 					}
 				}

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -81,7 +81,7 @@ import { IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
 import { AgentPluginEditor } from '../agentPluginEditor/agentPluginEditor.js';
 import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
 import { IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
-import { ICustomizationHarnessService, CustomizationHarness } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, CustomizationHarness, matchesWorkspaceSubpath } from '../../common/customizationHarnessService.js';
 import { ChatConfiguration } from '../../common/constants.js';
 
 const $ = DOM.$;
@@ -555,7 +555,10 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.refreshAllPromptsSectionCounts();
 		}));
 
-		// When the harness selector setting is off, lock to Local harness
+		// When the harness selector setting is off, lock to Local harness.
+		// In Sessions (single CLI harness) the dropdown is already hidden and
+		// setActiveHarness(VSCode) is a safe no-op since the CLI harness
+		// remains active — filtering stays correct for that window.
 		if (!this.isHarnessSelectorEnabled) {
 			this.harnessService.setActiveHarness(CustomizationHarness.VSCode);
 		}
@@ -1100,8 +1103,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 					// When the active harness specifies workspaceSubpaths, only offer
 					// directories whose path includes one of those sub-paths.
 					if (subpaths) {
-						const path = f.uri.path;
-						return subpaths.some(sp => path.includes(sp));
+						return matchesWorkspaceSubpath(f.uri.path, subpaths);
 					}
 					return true;
 				})

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -533,11 +533,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.selectSection(e.elements[0].id);
 		}));
 
-		// React to harness changes — rebuild visible sections
+		// React to harness changes — rebuild visible sections and refresh counts
 		this.editorDisposables.add(autorun(reader => {
 			this.harnessService.activeHarness.read(reader);
 			this.rebuildVisibleSections();
 			this.updateHarnessDropdown();
+			this.refreshAllPromptsSectionCounts();
 		}));
 
 		// Folder picker (sessions window only)
@@ -1053,6 +1054,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 	private async resolveTargetDirectoryWithPicker(type: PromptsType, target: 'workspace' | 'user'): Promise<URI | undefined | null> {
 		const allFolders = await this.promptsService.getSourceFolders(type);
 		const projectRoot = this.workspaceService.getActiveProjectRoot();
+		const descriptor = this.harnessService.getActiveDescriptor();
+		const subpaths = descriptor.workspaceSubpaths;
 
 		// Partition folders by whether they're under the active project root.
 		// The storage tags from getSourceFolders() are unreliable (tilde-expanded
@@ -1061,7 +1064,18 @@ export class AICustomizationManagementEditor extends EditorPane {
 		let matchingFolders;
 		if (target === 'workspace') {
 			matchingFolders = projectRoot
-				? allFolders.filter(f => isEqualOrParent(f.uri, projectRoot))
+				? allFolders.filter(f => {
+					if (!isEqualOrParent(f.uri, projectRoot)) {
+						return false;
+					}
+					// When the active harness specifies workspaceSubpaths, only offer
+					// directories whose path includes one of those sub-paths.
+					if (subpaths) {
+						const path = f.uri.path;
+						return subpaths.some(sp => path.includes(sp));
+					}
+					return true;
+				})
 				: [];
 		} else {
 			matchingFolders = projectRoot

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -81,7 +81,8 @@ import { IWorkbenchMcpServer } from '../../../mcp/common/mcpTypes.js';
 import { AgentPluginEditor } from '../agentPluginEditor/agentPluginEditor.js';
 import { AgentPluginEditorInput } from '../agentPluginEditor/agentPluginEditorInput.js';
 import { IAgentPluginItem } from '../agentPluginEditor/agentPluginItems.js';
-import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, CustomizationHarness } from '../../common/customizationHarnessService.js';
+import { ChatConfiguration } from '../../common/constants.js';
 
 const $ = DOM.$;
 
@@ -463,14 +464,27 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	/**
+	 * Whether the harness selector UI is enabled.
+	 * When disabled, the editor behaves as if "Local" is always selected.
+	 */
+	private get isHarnessSelectorEnabled(): boolean {
+		return this.configurationService.getValue<boolean>(ChatConfiguration.ChatCustomizationHarnessSelectorEnabled) !== false;
+	}
+
+	/**
 	 * Rebuilds the visible sections list based on the active harness's
 	 * `hiddenSections`. If the current selection falls into a hidden
 	 * section, the first visible section is selected instead.
 	 */
 	private rebuildVisibleSections(): void {
-		const activeId = this.harnessService.activeHarness.get();
-		const descriptor = this.harnessService.availableHarnesses.get().find(h => h.id === activeId);
-		const hidden = new Set(descriptor?.hiddenSections ?? []);
+		let hidden: Set<string>;
+		if (this.isHarnessSelectorEnabled) {
+			const activeId = this.harnessService.activeHarness.get();
+			const descriptor = this.harnessService.availableHarnesses.get().find(h => h.id === activeId);
+			hidden = new Set(descriptor?.hiddenSections ?? []);
+		} else {
+			hidden = new Set(); // Local harness has no hidden sections
+		}
 
 		this.sections.length = 0;
 		for (const s of this.allSections) {
@@ -541,6 +555,18 @@ export class AICustomizationManagementEditor extends EditorPane {
 			this.refreshAllPromptsSectionCounts();
 		}));
 
+		// When the harness selector setting is off, lock to Local harness
+		if (!this.isHarnessSelectorEnabled) {
+			this.harnessService.setActiveHarness(CustomizationHarness.VSCode);
+		}
+		this.editorDisposables.add(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(ChatConfiguration.ChatCustomizationHarnessSelectorEnabled)) {
+				if (!this.isHarnessSelectorEnabled) {
+					this.harnessService.setActiveHarness(CustomizationHarness.VSCode);
+				}
+			}
+		}));
+
 		// Folder picker (sessions window only)
 		if (this.workspaceService.isSessionsWindow) {
 			this.createFolderPicker(sidebarContent);
@@ -548,6 +574,9 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private createHarnessDropdown(sidebarContent: HTMLElement): void {
+		if (!this.isHarnessSelectorEnabled) {
+			return;
+		}
 		const harnesses = this.harnessService.availableHarnesses.get();
 		if (harnesses.length <= 1) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService.ts
@@ -15,7 +15,7 @@ import { isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { localize } from '../../../../../nls.js';
-import { ICustomizationHarnessService } from '../../common/customizationHarnessService.js';
+import { ICustomizationHarnessService, matchesWorkspaceSubpath } from '../../common/customizationHarnessService.js';
 
 /**
  * Service that opens an AI-guided chat session to help the user create
@@ -131,8 +131,7 @@ export class CustomizationCreatorService {
 				}
 				seen.add(key);
 				if (subpaths) {
-					const path = f.uri.path;
-					return subpaths.some(sp => path.includes(sp));
+					return matchesWorkspaceSubpath(f.uri.path, subpaths);
 				}
 				return true;
 			})

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/customizationHarnessService.ts
@@ -26,12 +26,15 @@ class CustomizationHarnessService extends CustomizationHarnessServiceBase {
 		@IPathService pathService: IPathService,
 	) {
 		const userHome = pathService.userHome({ preferLocal: true });
-		const extras = [PromptsStorage.extension];
+		// Only the Local harness includes extension-contributed customizations.
+		// CLI and Claude harnesses don't consume extension contributions.
+		const localExtras = [PromptsStorage.extension];
+		const restrictedExtras: readonly string[] = [];
 		super(
 			[
-				createVSCodeHarnessDescriptor(extras),
-				createCliHarnessDescriptor(getCliUserRoots(userHome), extras),
-				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), extras),
+				createVSCodeHarnessDescriptor(localExtras),
+				createCliHarnessDescriptor(getCliUserRoots(userHome), restrictedExtras),
+				createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), restrictedExtras),
 			],
 			CustomizationHarness.VSCode,
 		);

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1318,6 +1318,12 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('chat.aiCustomizationMenu.enabled', "Controls whether the Chat Customizations editor is available in the Command Palette. When disabled, the Chat Customizations editor and related commands are hidden."),
 			default: true,
 		},
+		[ChatConfiguration.ChatCustomizationHarnessSelectorEnabled]: {
+			type: 'boolean',
+			tags: ['preview'],
+			description: nls.localize('chat.customizations.harnessSelector.enabled', "Controls whether the harness selector (Local, Copilot CLI, Claude) is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering."),
+			default: true,
+		},
 	}
 });
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -54,6 +54,7 @@ export enum ChatConfiguration {
 	ExplainChangesEnabled = 'chat.editing.explainChanges.enabled',
 	GrowthNotificationEnabled = 'chat.growthNotification.enabled',
 	ChatCustomizationMenuEnabled = 'chat.customizationsMenu.enabled',
+	ChatCustomizationHarnessSelectorEnabled = 'chat.customizations.harnessSelector.enabled',
 	AutopilotEnabled = 'chat.autopilot.enabled',
 	ImageCarouselEnabled = 'chat.imageCarousel.enabled',
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -206,8 +206,9 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 
 /**
  * Creates a "Claude" harness descriptor.
- * Claude does not support custom agents, hooks, or VS Code-style instructions
- * (it uses CLAUDE.md instead of *.instructions.md).
+ * Claude does not support custom agents, hooks, or prompt files.
+ * It does support instructions via CLAUDE.md and AGENTS.md, and skills
+ * via .claude/skills/.
  */
 export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
 	return createRestrictedHarnessDescriptor(
@@ -216,7 +217,7 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 		ThemeIcon.fromId(Codicon.claude.id),
 		claudeRoots,
 		extras,
-		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks, AICustomizationManagementSection.Instructions],
+		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks, AICustomizationManagementSection.Prompts],
 		['.claude'],
 	);
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -206,7 +206,8 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 
 /**
  * Creates a "Claude" harness descriptor.
- * Claude does not support custom agents or hooks.
+ * Claude does not support custom agents, hooks, or VS Code-style instructions
+ * (it uses CLAUDE.md instead of *.instructions.md).
  */
 export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
 	return createRestrictedHarnessDescriptor(
@@ -215,7 +216,7 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 		ThemeIcon.fromId(Codicon.claude.id),
 		claudeRoots,
 		extras,
-		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks],
+		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks, AICustomizationManagementSection.Instructions],
 		['.claude'],
 	);
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -206,9 +206,9 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
 
 /**
  * Creates a "Claude" harness descriptor.
- * Claude does not support custom agents, hooks, or prompt files.
- * It does support instructions via CLAUDE.md and AGENTS.md, and skills
- * via .claude/skills/.
+ * Claude does not support custom agents or prompt files.
+ * It supports instructions (CLAUDE.md/AGENTS.md), skills (.claude/skills/),
+ * and hooks (.claude/hooks/).
  */
 export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
 	return createRestrictedHarnessDescriptor(
@@ -217,7 +217,7 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 		ThemeIcon.fromId(Codicon.claude.id),
 		claudeRoots,
 		extras,
-		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Hooks, AICustomizationManagementSection.Prompts],
+		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Prompts],
 		['.claude'],
 	);
 }

--- a/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
+++ b/src/vs/workbench/contrib/chat/common/customizationHarnessService.ts
@@ -208,7 +208,7 @@ export function createCliHarnessDescriptor(cliUserRoots: readonly URI[], extras:
  * Creates a "Claude" harness descriptor.
  * Claude does not support custom agents or prompt files.
  * It supports instructions (CLAUDE.md/AGENTS.md), skills (.claude/skills/),
- * and hooks (.claude/hooks/).
+ * and hooks (configured in .claude/settings.json / .claude/settings.local.json).
  */
 export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extras: readonly string[]): IHarnessDescriptor {
 	return createRestrictedHarnessDescriptor(
@@ -220,6 +220,20 @@ export function createClaudeHarnessDescriptor(claudeRoots: readonly URI[], extra
 		[AICustomizationManagementSection.Agents, AICustomizationManagementSection.Prompts],
 		['.claude'],
 	);
+}
+
+// #endregion
+
+// #region Helpers
+
+/**
+ * Tests whether a file path belongs to one of the given workspace sub-paths.
+ * Matches on path segment boundaries to avoid false positives
+ * (e.g. `.claude` must appear as `/.claude/` in the path, not as part of
+ * a longer segment like `not.claude`).
+ */
+export function matchesWorkspaceSubpath(filePath: string, subpaths: readonly string[]): boolean {
+	return subpaths.some(sp => filePath.includes(`/${sp}/`) || filePath.endsWith(`/${sp}`));
 }
 
 // #endregion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Harness filtering followup fixes

Fixes several issues with the harness filtering feature (merged in #302606) for the Chat Customizations editor.

### Changes

1. **Filter workspace directory picker by harness subpaths** — "New X (Workspace)" now only offers directories relevant to the active harness (e.g. Claude → `.claude/` only, not `.github/` or `.agents/`)

2. **Refresh sidebar counts on harness change** — Badge numbers on sidebar sections now update immediately when switching harnesses

3. **Restrict extension sources to Local harness only** — CLI and Claude don't consume extension-contributed customizations, so `PromptsStorage.extension` is excluded from their filters

4. **Correct Claude hidden sections** — `[Agents, Prompts]` (not Hooks or Instructions). Claude supports hooks (`.claude/settings.json`) and instructions (`CLAUDE.md`/`AGENTS.md`), but not agents or `.prompt.md` files

5. **Filter workspace-local items by harness subpaths** — Items like `.github/instructions/*.instructions.md` are now hidden when viewing through the Claude harness

6. **Add `chat.customizations.harnessSelector.enabled` setting** — Default `true`. When `false`, hides the dropdown and locks to "Local" (identical to pre-feature behavior)

7. **Segment-safe subpath matching** — `matchesWorkspaceSubpath()` helper checks `/<sp>/` boundaries to avoid false positives (e.g. `not.claude` won't match `.claude`)

### Files changed (5 files, +79 -12 vs main)

| File | Change |
|------|--------|
| `common/customizationHarnessService.ts` | Claude hiddenSections, `matchesWorkspaceSubpath` helper |
| `browser/aiCustomization/customizationHarnessService.ts` | Separate extras for restricted harnesses |
| `browser/aiCustomization/aiCustomizationListWidget.ts` | Workspace subpath item filtering |
| `browser/aiCustomization/aiCustomizationManagementEditor.ts` | Directory picker fix, count refresh, setting support |
| `common/constants.ts` | New setting key |
