### PR TITLE
Fix terminal tool output truncation 

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -61,6 +61,12 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			const idlePromptPromise = trackIdleOnPrompt(this._instance, 1000, store);
 			const onDone = Promise.race([
 				Event.toPromise(Event.filter(this._commandDetection.onCommandFinished, e => {
+					// When no commandId is provided, this basic strategy cannot reliably attach
+					// an id to the command (sendText path), so avoid id-based filtering and
+					// accept the first finished command event.
+					if (!commandId) {
+						return true;
+					}
 					const isMatch = commandMatchesRequestedId(e, commandId);
 					if (!isMatch) {
 						this._log(`Ignoring command-finished event for id=${e.id ?? 'none'}, waiting for requested=${commandId}`);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/basicExecuteStrategy.ts
@@ -10,7 +10,7 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../../.
 import { isNumber } from '../../../../../../base/common/types.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
-import { trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { commandMatchesRequestedId, trackIdleOnPrompt, waitForIdle, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult, waitForOutputFlush } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
@@ -60,7 +60,13 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 		try {
 			const idlePromptPromise = trackIdleOnPrompt(this._instance, 1000, store);
 			const onDone = Promise.race([
-				Event.toPromise(this._commandDetection.onCommandFinished, store).then(e => {
+				Event.toPromise(Event.filter(this._commandDetection.onCommandFinished, e => {
+					const isMatch = commandMatchesRequestedId(e, commandId);
+					if (!isMatch) {
+						this._log(`Ignoring command-finished event for id=${e.id ?? 'none'}, waiting for requested=${commandId}`);
+					}
+					return isMatch;
+				}), store).then(e => {
 					// When shell integration is basic, it means that the end execution event is
 					// often misfired since we don't have command line verification. Because of this
 					// we make sure the prompt is idle after the end execution event happens.
@@ -154,6 +160,7 @@ export class BasicExecuteStrategy extends Disposable implements ITerminalExecute
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
 			}
+			await waitForOutputFlush(this._instance.onData);
 			const endMarker = store.add(xterm.raw.registerMarker());
 
 			// Assemble final result

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -57,9 +57,31 @@ export function commandMatchesRequestedId(command: ICommandLike, commandId?: str
 
 /**
  * Waits briefly for terminal output to settle before reading output from xterm markers.
+ *
+ * The wait is bounded by {@link maxWaitMs} and can be cancelled via {@link token}.
  */
-export async function waitForOutputFlush(onData: Event<unknown>): Promise<void> {
-	await waitForIdle(onData, 50);
+export async function waitForOutputFlush(onData: Event<unknown>, token?: CancellationToken, maxWaitMs: number = 2000): Promise<void> {
+	if (token?.isCancellationRequested) {
+		return;
+	}
+
+	const waitForIdlePromise = waitForIdle(onData, 50);
+	const maxWaitPromise = timeout(maxWaitMs);
+
+	if (!token) {
+		await Promise.race([waitForIdlePromise, maxWaitPromise]);
+	} else {
+		const store = new DisposableStore();
+		try {
+			const cancellationPromise = new Promise<void>(resolve => {
+				store.add(token.onCancellationRequested(() => resolve()));
+			});
+			await Promise.race([waitForIdlePromise, maxWaitPromise, cancellationPromise]);
+		} finally {
+			store.dispose();
+		}
+	}
+
 	await timeout(0);
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/executeStrategy.ts
@@ -3,12 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DeferredPromise, RunOnceScheduler } from '../../../../../../base/common/async.js';
+import { DeferredPromise, RunOnceScheduler, timeout } from '../../../../../../base/common/async.js';
 import type { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import type { Event } from '../../../../../../base/common/event.js';
 import { DisposableStore, type IDisposable } from '../../../../../../base/common/lifecycle.js';
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
+
+interface ICommandLike {
+	id: string | undefined;
+}
 
 export interface ITerminalExecuteStrategy extends IDisposable {
 	readonly type: 'rich' | 'basic' | 'none';
@@ -41,6 +45,22 @@ export async function waitForIdle(onData: Event<unknown>, idleDurationMs: number
 	store.add(onData(() => scheduler.schedule()));
 	scheduler.schedule();
 	return deferred.p.finally(() => store.dispose());
+}
+
+/**
+ * Returns whether the finished command matches the requested command id. When no command id is
+ * provided, any command is considered a match.
+ */
+export function commandMatchesRequestedId(command: ICommandLike, commandId?: string): boolean {
+	return !commandId || command.id === commandId;
+}
+
+/**
+ * Waits briefly for terminal output to settle before reading output from xterm markers.
+ */
+export async function waitForOutputFlush(onData: Event<unknown>): Promise<void> {
+	await waitForIdle(onData, 50);
+	await timeout(0);
 }
 
 export interface IPromptDetectionResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/noneExecuteStrategy.ts
@@ -8,7 +8,7 @@ import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
-import { waitForIdle, waitForIdleWithPromptHeuristics, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { waitForIdle, waitForIdleWithPromptHeuristics, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult, waitForOutputFlush } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
@@ -101,6 +101,7 @@ export class NoneExecuteStrategy extends Disposable implements ITerminalExecuteS
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
 			}
+			await waitForOutputFlush(this._instance.onData);
 			const endMarker = store.add(xterm.raw.registerMarker());
 
 			// Assemble final result - exit code is not available without shell integration

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/executeStrategy/richExecuteStrategy.ts
@@ -11,7 +11,7 @@ import { isNumber } from '../../../../../../base/common/types.js';
 import type { ICommandDetectionCapability } from '../../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { ITerminalLogService } from '../../../../../../platform/terminal/common/terminal.js';
 import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
-import { trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult } from './executeStrategy.js';
+import { commandMatchesRequestedId, trackIdleOnPrompt, type ITerminalExecuteStrategy, type ITerminalExecuteStrategyResult, waitForOutputFlush } from './executeStrategy.js';
 import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import { createAltBufferPromise, setupRecreatingStartMarker } from './strategyHelpers.js';
 
@@ -49,7 +49,13 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			const alternateBufferPromise = createAltBufferPromise(xterm, store, this._log.bind(this));
 
 			const onDone = Promise.race([
-				Event.toPromise(this._commandDetection.onCommandFinished, store).then(e => {
+				Event.toPromise(Event.filter(this._commandDetection.onCommandFinished, e => {
+					const isMatch = commandMatchesRequestedId(e, commandId);
+					if (!isMatch) {
+						this._log(`Ignoring command-finished event for id=${e.id ?? 'none'}, waiting for requested=${commandId}`);
+					}
+					return isMatch;
+				}), store).then(e => {
 					this._log('onDone via end event');
 					return {
 						'type': 'success',
@@ -100,6 +106,7 @@ export class RichExecuteStrategy extends Disposable implements ITerminalExecuteS
 			if (token.isCancellationRequested) {
 				throw new CancellationError();
 			}
+			await waitForOutputFlush(this._instance.onData);
 			const endMarker = store.add(xterm.raw.registerMarker());
 
 			// Assemble final result

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/executeStrategy.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/executeStrategy.test.ts
@@ -5,7 +5,7 @@
 
 import { strictEqual } from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { detectsCommonPromptPattern } from '../../browser/executeStrategy/executeStrategy.js';
+import { commandMatchesRequestedId, detectsCommonPromptPattern } from '../../browser/executeStrategy/executeStrategy.js';
 
 suite('Execute Strategy - Prompt Detection', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -67,5 +67,16 @@ user@host:~$ `;
 		strictEqual(detectsCommonPromptPattern('output\n\n\n').detected, false);
 		strictEqual(detectsCommonPromptPattern('\n\n$ \n\n').detected, true); // prompt with surrounding whitespace
 		strictEqual(detectsCommonPromptPattern('output\nPS C:\\> ').detected, true); // prompt at end after output
+	});
+
+	test('commandMatchesRequestedId accepts any command when no id is requested', () => {
+		strictEqual(commandMatchesRequestedId({ id: 'abc' }, undefined), true);
+		strictEqual(commandMatchesRequestedId({ id: undefined }, undefined), true);
+	});
+
+	test('commandMatchesRequestedId only accepts matching requested id', () => {
+		strictEqual(commandMatchesRequestedId({ id: 'cmd-1' }, 'cmd-1'), true);
+		strictEqual(commandMatchesRequestedId({ id: 'cmd-2' }, 'cmd-1'), false);
+		strictEqual(commandMatchesRequestedId({ id: undefined }, 'cmd-1'), false);
 	});
 });


### PR DESCRIPTION
fix #297109

NOTE I COULD NOT REPRO THIS ON MAC, need to test on Windows

This fixes non-deterministic output truncation in terminal chat tool execution.
1. Added command-id matching for command-finished events in rich/basic execute strategies so unrelated finish events are ignored.
2. Added a short output-flush wait before creating the end marker to reduce race conditions where final lines were not yet captured.
3. Reused shared helpers for both behaviors to keep strategy logic consistent.
4. Added targeted unit tests for command-id matching behavior.

Terminal command output capture is more reliable, especially for the final lines of command output, and less susceptible to event timing races.