### PR TITLE
Fix run_in_terminal timeout signaling and avoid foreground reuse after timeout

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -973,6 +973,10 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					didMoveToBackground = true;
 					toolTerminal.isBackground = true;
 					this._sessionTerminalAssociations.delete(chatSessionResource);
+					const processId = toolTerminal.instance.processId;
+					if (isNumber(processId)) {
+						this._associateProcessIdWithSession(chatSessionResource, processId, true);
+					}
 					const timeoutOutput = execution.getOutput();
 					outputLineCount = timeoutOutput ? count(timeoutOutput.trim(), '\n') + 1 : 0;
 					terminalResult = timeoutOutput ?? '';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -973,10 +973,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					didMoveToBackground = true;
 					toolTerminal.isBackground = true;
 					this._sessionTerminalAssociations.delete(chatSessionResource);
-					const processId = toolTerminal.instance.processId;
-					if (isNumber(processId)) {
-						this._associateProcessIdWithSession(chatSessionResource, processId, true);
-					}
+					await this._associateProcessIdWithSession(toolTerminal.instance, chatSessionResource, termId, toolTerminal.shellIntegrationQuality, true);
 					const timeoutOutput = execution.getOutput();
 					outputLineCount = timeoutOutput ? count(timeoutOutput.trim(), '\n') + 1 : 0;
 					terminalResult = timeoutOutput ?? '';

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -837,7 +837,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			const shouldEnforceTimeout = this._configurationService.getValue(TerminalChatAgentToolsSettingId.EnforceTimeoutFromModel) === true;
 			if (shouldEnforceTimeout) {
 				timeoutPromise = timeout(timeoutValue);
-				timeoutRacePromise = timeoutPromise.then(() => ({ type: 'timeout' as const }));
+				timeoutRacePromise = timeoutPromise.then(
+					() => ({ type: 'timeout' as const })
+				).catch(() => ({ type: 'timeout' as const }));
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -244,7 +244,7 @@ export async function createRunInTerminalToolData(
 				},
 				timeout: {
 					type: 'number',
-					description: 'An optional timeout in milliseconds. When provided, the tool will stop tracking the command after this duration and return the output collected so far. Be conservative with the timeout duration, give enough time that the command would complete on a low-end machine. Use 0 for no timeout. If it\'s not clear how long the command will take then use 0 to avoid prematurely terminating it, never guess too low.',
+					description: 'An optional timeout in milliseconds. When provided, the tool will stop tracking the command after this duration and return the output collected so far with a timeout indicator. Be conservative with the timeout duration, give enough time that the command would complete on a low-end machine. Use 0 for no timeout. If it\'s not clear how long the command will take then use 0 to avoid prematurely terminating it, never guess too low.',
 				},
 			},
 			required: [
@@ -826,6 +826,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		let didTimeout = false;
 		let didMoveToBackground = args.isBackground;
 		let timeoutPromise: CancelablePromise<void> | undefined;
+		let timeoutRacePromise: Promise<{ type: 'timeout' }> | undefined;
 		let outputMonitor: OutputMonitor | undefined;
 		let pollingResult: IPollingResult & { pollDurationMs: number } | undefined;
 		const executeCancellation = store.add(new CancellationTokenSource(token));
@@ -836,12 +837,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			const shouldEnforceTimeout = this._configurationService.getValue(TerminalChatAgentToolsSettingId.EnforceTimeoutFromModel) === true;
 			if (shouldEnforceTimeout) {
 				timeoutPromise = timeout(timeoutValue);
-				timeoutPromise.then(() => {
-					if (!executeCancellation.token.isCancellationRequested) {
-						didTimeout = true;
-						executeCancellation.cancel();
-					}
-				});
+				timeoutRacePromise = timeoutPromise.then(() => ({ type: 'timeout' as const }));
 			}
 		}
 
@@ -951,10 +947,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				};
 			} else {
 				// Foreground mode: race execution completion against continue in background
-				const raceResult = await Promise.race([
+				const raceCandidates: Promise<{ type: 'completed'; result: ITerminalExecuteStrategyResult } | { type: 'background' } | { type: 'timeout' }>[] = [
 					executionPromise.then(result => ({ type: 'completed' as const, result })),
 					continueInBackgroundPromise.then(() => ({ type: 'background' as const }))
-				]);
+				];
+				if (timeoutRacePromise) {
+					raceCandidates.push(timeoutRacePromise);
+				}
+				const raceResult = await Promise.race(raceCandidates);
 
 				if (raceResult.type === 'background') {
 					// Moved to background - execution continues running, just return current output
@@ -963,6 +963,17 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					const backgroundOutput = execution.getOutput();
 					outputLineCount = backgroundOutput ? count(backgroundOutput.trim(), '\n') + 1 : 0;
 					terminalResult = backgroundOutput;
+				} else if (raceResult.type === 'timeout') {
+					// Timeout reached - return partial output and keep terminal alive as background.
+					this._logService.debug(`RunInTerminalTool: Timeout reached, returning output collected so far`);
+					error = 'timeout';
+					didTimeout = true;
+					didMoveToBackground = true;
+					toolTerminal.isBackground = true;
+					this._sessionTerminalAssociations.delete(chatSessionResource);
+					const timeoutOutput = execution.getOutput();
+					outputLineCount = timeoutOutput ? count(timeoutOutput.trim(), '\n') + 1 : 0;
+					terminalResult = timeoutOutput ?? '';
 				} else {
 					const executeResult = raceResult.result;
 					// Reset user input state after command execution completes
@@ -1026,6 +1037,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			if (didTimeout && e instanceof CancellationError) {
 				this._logService.debug(`RunInTerminalTool: Timeout reached, returning output collected so far`);
 				error = 'timeout';
+				didMoveToBackground = true;
+				toolTerminal.isBackground = true;
+				this._sessionTerminalAssociations.delete(chatSessionResource);
 				const timeoutOutput = getOutput(toolTerminal.instance, undefined);
 				outputLineCount = timeoutOutput ? count(timeoutOutput.trim(), '\n') + 1 : 0;
 				terminalResult = timeoutOutput ?? '';
@@ -1107,6 +1121,9 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		if (didMoveToBackground && !args.isBackground) {
 			resultText.push(`Note: This terminal execution was moved to the background using the ID ${termId}\n`);
 		}
+		if (didTimeout && timeoutValue !== undefined && timeoutValue > 0) {
+			resultText.push(`Note: Command timed out after ${timeoutValue}ms. Output collected so far is shown below and the command may still be running in terminal ID ${termId}.\n\n`);
+		}
 		let outputAnalyzerMessage: string | undefined;
 		for (const analyzer of this._outputAnalyzers) {
 			const message = await analyzer.analyze({ exitCode, exitResult: terminalResult, commandLine: command });
@@ -1131,6 +1148,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				exitCode: exitCode,
 				id: termId,
 				cwd: endCwd?.toString(),
+				timedOut: didTimeout || undefined,
+				timeoutMs: didTimeout ? timeoutValue : undefined,
 			},
 			toolResultDetails: isError ? {
 				input: command,


### PR DESCRIPTION
fix #299486

When run_in_terminal hit a model-provided timeout, it could return partial output without clearly indicating timeout, which could mislead agents and cause confusing follow-up output behavior.

Now:
1. Treats timeout as an explicit execution outcome in foreground runs.
2. Returns a clear timeout indicator in both result text and metadata.
3. Marks timed-out executions as background and detaches them from foreground session reuse.
4. Updates timeout parameter wording to state that timeout returns output with an indicator.

This allows agents to reliably detect timed-out executions, and subsequent foreground runs are less likely to be polluted by timed-out command output.

cc @tyriar