### PR TITLE
Fix task reveal logic

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3418,7 +3418,7 @@ function retargetTaskToWorktree(task: Task, worktreePath: string): Task | undefi
 	worktreeTask.detail = task.detail;
 	worktreeTask.group = task.group;
 	worktreeTask.isBackground = task.isBackground;
-	worktreeTask.presentationOptions = { reveal: TaskRevealKind.Never, panel: TaskPanelKind.New, ...task.presentationOptions };
+	worktreeTask.presentationOptions = { ...task.presentationOptions, reveal: TaskRevealKind.Never, panel: TaskPanelKind.New };
 	worktreeTask.runOptions = { ...task.runOptions };
 
 	return worktreeTask;


### PR DESCRIPTION
```Copilot Generated Description:``` Adjust the task presentation options to ensure the reveal behavior is set to never while maintaining other existing options.

