### PR TITLE
feat: allow LLM to request unsandboxed terminal execution with user confirmation

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -524,9 +524,9 @@ export interface IChatTerminalToolInvocationData {
 	/** Whether the terminal command was started as a background execution */
 	isBackground?: boolean;
 	/** Whether the command was explicitly approved to run outside the sandbox */
-	dangerouslyDisableSandbox?: boolean;
+	requestUnsandboxedExecution?: boolean;
 	/** The model-provided reason for requesting sandbox bypass */
-	dangerouslyDisableSandboxReason?: string;
+	requestUnsandboxedExecutionReason?: string;
 	/** Serialized URI for the command that was executed in the terminal */
 	terminalCommandUri?: UriComponents;
 	/** Serialized output of the executed command */

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -523,6 +523,10 @@ export interface IChatTerminalToolInvocationData {
 	terminalCommandId?: string;
 	/** Whether the terminal command was started as a background execution */
 	isBackground?: boolean;
+	/** Whether the command was explicitly approved to run outside the sandbox */
+	dangerouslyDisableSandbox?: boolean;
+	/** The model-provided reason for requesting sandbox bypass */
+	dangerouslyDisableSandboxReason?: string;
 	/** Serialized URI for the command that was executed in the terminal */
 	terminalCommandUri?: UriComponents;
 	/** Serialized output of the executed command */

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
@@ -17,7 +17,7 @@ export interface ICommandLineRewriterOptions {
 	cwd: URI | undefined;
 	shell: string;
 	os: OperatingSystem;
-	dangerouslyDisableSandbox?: boolean;
+	requestUnsandboxedExecution?: boolean;
 }
 
 export interface ICommandLineRewriterResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineRewriter.ts
@@ -17,6 +17,7 @@ export interface ICommandLineRewriterOptions {
 	cwd: URI | undefined;
 	shell: string;
 	os: OperatingSystem;
+	dangerouslyDisableSandbox?: boolean;
 }
 
 export interface ICommandLineRewriterResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
@@ -15,6 +15,10 @@ export class CommandLineSandboxRewriter extends Disposable implements ICommandLi
 	}
 
 	async rewrite(options: ICommandLineRewriterOptions): Promise<ICommandLineRewriterResult | undefined> {
+		if (options.dangerouslyDisableSandbox) {
+			return undefined;
+		}
+
 		if (!(await this._sandboxService.isEnabled())) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineRewriter/commandLineSandboxRewriter.ts
@@ -15,7 +15,7 @@ export class CommandLineSandboxRewriter extends Disposable implements ICommandLi
 	}
 
 	async rewrite(options: ICommandLineRewriterOptions): Promise<ICommandLineRewriterResult | undefined> {
-		if (options.dangerouslyDisableSandbox) {
+		if (options.requestUnsandboxedExecution) {
 			return undefined;
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -124,7 +124,8 @@ function createPowerShellModelDescription(shell: string): string {
 	].join('\n');
 }
 
-const genericDescription = `
+function createGenericDescription(isSandboxEnabled: boolean): string {
+	const parts = [`
 Command Execution:
 - Use && to chain simple commands on one line
 - Prefer pipelines | over temporary files for data flow
@@ -144,12 +145,18 @@ Program Execution:
 
 Background Processes:
 - For long-running tasks (e.g., servers), set isBackground=true
-- Returns a terminal ID for checking status and runtime later
+- Returns a terminal ID for checking status and runtime later`];
 
+	if (isSandboxEnabled) {
+		parts.push(`
 Sandboxing:
-- When terminal sandboxing is enabled, commands run in the sandbox by default
-- Only set requestUnsandboxedExecution=true when this specific command must run outside the sandbox
-- When setting requestUnsandboxedExecution=true, also provide requestUnsandboxedExecutionReason; the user will be prompted before it runs unsandboxed
+- ATTENTION: Terminal sandboxing is enabled, commands run in a sandbox by default
+- When a command fails due to sandbox restrictions, immediately re-run it with requestUnsandboxedExecution=true and prompt the user to bypass the sandbox
+- Only set requestUnsandboxedExecution=true when there is evidence of failures caused by the sandbox, e.g. 'Operation not permitted' errors, network failures, or file access errors, etc
+- When setting requestUnsandboxedExecution=true, also provide requestUnsandboxedExecutionReason; the user will be prompted before it runs unsandboxed`);
+	}
+
+	parts.push(`
 
 Output Management:
 - Output is automatically truncated if longer than 60KB to prevent context overflow
@@ -161,22 +168,25 @@ Best Practices:
 - Quote variables: "$var" instead of $var to handle spaces
 - Use find with -exec or xargs for file operations
 - Be specific with commands to avoid excessive output
-- Avoid printing credentials unless absolutely required`;
+- Avoid printing credentials unless absolutely required`);
 
-function createBashModelDescription(): string {
+	return parts.join('');
+}
+
+function createBashModelDescription(isSandboxEnabled: boolean): string {
 	return [
 		'This tool allows you to execute shell commands in a persistent bash terminal session, preserving environment variables, working directory, and other context across multiple commands.',
-		genericDescription,
+		createGenericDescription(isSandboxEnabled),
 		'- Use [[ ]] for conditional tests instead of [ ]',
 		'- Prefer $() over backticks for command substitution',
 		'- Use set -e at start of complex commands to exit on errors'
 	].join('\n');
 }
 
-function createZshModelDescription(): string {
+function createZshModelDescription(isSandboxEnabled: boolean): string {
 	return [
 		'This tool allows you to execute shell commands in a persistent zsh terminal session, preserving environment variables, working directory, and other context across multiple commands.',
-		genericDescription,
+		createGenericDescription(isSandboxEnabled),
 		'- Use type to check command type (builtin, function, alias)',
 		'- Use jobs, fg, bg for job control',
 		'- Use [[ ]] for conditional tests instead of [ ]',
@@ -186,10 +196,10 @@ function createZshModelDescription(): string {
 	].join('\n');
 }
 
-function createFishModelDescription(): string {
+function createFishModelDescription(isSandboxEnabled: boolean): string {
 	return [
 		'This tool allows you to execute shell commands in a persistent fish terminal session, preserving environment variables, working directory, and other context across multiple commands.',
-		genericDescription,
+		createGenericDescription(isSandboxEnabled),
 		'- Use type to check command type (builtin, function, alias)',
 		'- Use jobs, fg, bg for job control',
 		'- Use test expressions for conditionals (no [[ ]] syntax)',
@@ -204,20 +214,24 @@ export async function createRunInTerminalToolData(
 	accessor: ServicesAccessor
 ): Promise<IToolData> {
 	const instantiationService = accessor.get(IInstantiationService);
+	const terminalSandboxService = accessor.get(ITerminalSandboxService);
 
 	const profileFetcher = instantiationService.createInstance(TerminalProfileFetcher);
-	const shell = await profileFetcher.getCopilotShell();
-	const os = await profileFetcher.osBackend;
+	const [shell, os, isSandboxEnabled] = await Promise.all([
+		profileFetcher.getCopilotShell(),
+		profileFetcher.osBackend,
+		terminalSandboxService.isEnabled(),
+	]);
 
 	let modelDescription: string;
 	if (shell && os && isPowerShell(shell, os)) {
 		modelDescription = createPowerShellModelDescription(shell);
 	} else if (shell && os && isZsh(shell, os)) {
-		modelDescription = createZshModelDescription();
+		modelDescription = createZshModelDescription(isSandboxEnabled);
 	} else if (shell && os && isFish(shell, os)) {
-		modelDescription = createFishModelDescription();
+		modelDescription = createFishModelDescription(isSandboxEnabled);
 	} else {
-		modelDescription = createBashModelDescription();
+		modelDescription = createBashModelDescription(isSandboxEnabled);
 	}
 
 	return {
@@ -252,14 +266,16 @@ export async function createRunInTerminalToolData(
 					type: 'number',
 					description: 'An optional timeout in milliseconds. When provided, the tool will stop tracking the command after this duration and return the output collected so far. Be conservative with the timeout duration, give enough time that the command would complete on a low-end machine. Use 0 for no timeout. If it\'s not clear how long the command will take then use 0 to avoid prematurely terminating it, never guess too low.',
 				},
-				requestUnsandboxedExecution: {
-					type: 'boolean',
-					description: 'Request that this command run outside the terminal sandbox. Only set this when the command clearly needs unsandboxed access. The user will be prompted before the command runs unsandboxed.'
-				},
-				requestUnsandboxedExecutionReason: {
-					type: 'string',
-					description: 'A short explanation of why this command must run outside the terminal sandbox. Only provide this when requestUnsandboxedExecution is true.'
-				},
+				...isSandboxEnabled ? {
+					requestUnsandboxedExecution: {
+						type: 'boolean',
+						description: 'Request that this command run outside the terminal sandbox. Only set this when the command clearly needs unsandboxed access. The user will be prompted before the command runs unsandboxed.'
+					},
+					requestUnsandboxedExecutionReason: {
+						type: 'string',
+						description: 'A short explanation of why this command must run outside the terminal sandbox. Only provide this when requestUnsandboxedExecution is true.'
+					},
+				} : {},
 			},
 			required: [
 				'command',

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -72,6 +72,7 @@ import { clamp } from '../../../../../../base/common/numbers.js';
 import { IOutputAnalyzer } from './outputAnalyzer.js';
 import { SandboxOutputAnalyzer } from './sandboxOutputAnalyzer.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
+import { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
 
 // #region Tool data
 
@@ -144,6 +145,11 @@ Program Execution:
 Background Processes:
 - For long-running tasks (e.g., servers), set isBackground=true
 - Returns a terminal ID for checking status and runtime later
+
+Sandboxing:
+- When terminal sandboxing is enabled, commands run in the sandbox by default
+- Only set dangerouslyDisableSandbox=true when this specific command must run outside the sandbox
+- When setting dangerouslyDisableSandbox=true, also provide dangerouslyDisableSandboxReason; the user will be prompted before it runs unsandboxed
 
 Output Management:
 - Output is automatically truncated if longer than 60KB to prevent context overflow
@@ -246,6 +252,14 @@ export async function createRunInTerminalToolData(
 					type: 'number',
 					description: 'An optional timeout in milliseconds. When provided, the tool will stop tracking the command after this duration and return the output collected so far. Be conservative with the timeout duration, give enough time that the command would complete on a low-end machine. Use 0 for no timeout. If it\'s not clear how long the command will take then use 0 to avoid prematurely terminating it, never guess too low.',
 				},
+				dangerouslyDisableSandbox: {
+					type: 'boolean',
+					description: 'Request that this command run outside the terminal sandbox. Only set this when the command clearly needs unsandboxed access. The user will be prompted before the command runs unsandboxed.'
+				},
+				dangerouslyDisableSandboxReason: {
+					type: 'string',
+					description: 'A short explanation of why this command must run outside the terminal sandbox. Only provide this when dangerouslyDisableSandbox is true.'
+				},
 			},
 			required: [
 				'command',
@@ -279,6 +293,8 @@ export interface IRunInTerminalInputParams {
 	goal: string;
 	isBackground: boolean;
 	timeout?: number;
+	dangerouslyDisableSandbox?: boolean;
+	dangerouslyDisableSandboxReason?: string;
 }
 
 /**
@@ -381,6 +397,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		@ITerminalChatService private readonly _terminalChatService: ITerminalChatService,
 		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ITerminalSandboxService private readonly _terminalSandboxService: ITerminalSandboxService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IAgentSessionsService private readonly _agentSessionsService: IAgentSessionsService,
@@ -466,7 +483,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				instance = toolTerminal.instance;
 			}
 		}
-		const [os, shell, cwd] = await Promise.all([
+		const [os, shell, cwd, isTerminalSandboxEnabled] = await Promise.all([
 			this._osBackend,
 			this._profileFetcher.getCopilotShell(),
 			(async () => {
@@ -477,9 +494,11 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 					cwd = workspaceFolder?.uri;
 				}
 				return cwd;
-			})()
+			})(),
+			this._terminalSandboxService.isEnabled()
 		]);
 		const language = os === OperatingSystem.Windows ? 'pwsh' : 'sh';
+		const requiresUnsandboxConfirmation = isTerminalSandboxEnabled && args.dangerouslyDisableSandbox === true;
 
 		const terminalToolSessionId = generateUuid();
 		// Generate a custom command ID to link the command between renderer and pty host
@@ -492,7 +511,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				commandLine: rewrittenCommand,
 				cwd,
 				shell,
-				os
+				os,
+				dangerouslyDisableSandbox: requiresUnsandboxConfirmation,
 			});
 			if (rewriteResult) {
 				rewrittenCommand = rewriteResult.rewritten;
@@ -513,6 +533,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			cwd,
 			language,
 			isBackground: args.isBackground,
+			dangerouslyDisableSandbox: requiresUnsandboxConfirmation,
+			dangerouslyDisableSandboxReason: args.dangerouslyDisableSandboxReason,
 		};
 
 		// HACK: Exit early if there's an alternative recommendation, this is a little hacky but
@@ -573,7 +595,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		const analyzersIsAutoApproveAllowed = commandLineAnalyzerResults.every(e => e.isAutoApproveAllowed);
-		const customActions = isEligibleForAutoApproval() && analyzersIsAutoApproveAllowed ? commandLineAnalyzerResults.map(e => e.customActions ?? []).flat() : undefined;
+		const customActions = !requiresUnsandboxConfirmation && isEligibleForAutoApproval() && analyzersIsAutoApproveAllowed ? commandLineAnalyzerResults.map(e => e.customActions ?? []).flat() : undefined;
 
 		let shellType = basename(shell, '.exe');
 		if (shellType === 'powershell') {
@@ -667,6 +689,16 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			}
 		}
 
+		if (requiresUnsandboxConfirmation) {
+			disclaimer = new MarkdownString([
+				disclaimer?.value,
+				localize('runInTerminal.unsandboxed.disclaimer', "$(warning) This command will run outside the terminal sandbox and may access files, network resources, or system state that sandboxed commands cannot reach.")
+			].filter(Boolean).join(' '), { supportThemeIcons: true, isTrusted: disclaimer?.isTrusted });
+			confirmationTitle = args.isBackground
+				? localize('runInTerminal.unsandboxed.background', "Run `{0}` command outside the sandbox in background?", shellType)
+				: localize('runInTerminal.unsandboxed', "Run `{0}` command outside the sandbox?", shellType);
+		}
+
 		// Check if the session's permission level (Autopilot/Bypass Approvals) auto-approves all tools.
 		// When active, skip terminal confirmation entirely since the user has opted into full auto-approval.
 		const isSessionAutoApproved = chatSessionResource && this._isSessionAutoApproveLevel(chatSessionResource);
@@ -694,11 +726,21 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
-		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
+		const shouldShowConfirmation = requiresUnsandboxConfirmation || (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
+		const confirmationMessage = requiresUnsandboxConfirmation
+			? new MarkdownString(localize(
+				'runInTerminal.unsandboxed.confirmationMessage',
+				"Explanation: {0}\n\nGoal: {1}\n\nReason for leaving the sandbox: {2}",
+				args.explanation,
+				args.goal,
+				args.dangerouslyDisableSandboxReason || localize('runInTerminal.unsandboxed.confirmationMessage.defaultReason', "The model indicated that this command needs unsandboxed access.")
+			))
+			: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal));
 		const confirmationMessages = shouldShowConfirmation ? {
 			title: confirmationTitle,
-			message: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal)),
+			message: confirmationMessage,
 			disclaimer,
+			allowAutoConfirm: requiresUnsandboxConfirmation ? false : undefined,
 			terminalCustomActions: customActions,
 		} : undefined;
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -148,8 +148,8 @@ Background Processes:
 
 Sandboxing:
 - When terminal sandboxing is enabled, commands run in the sandbox by default
-- Only set dangerouslyDisableSandbox=true when this specific command must run outside the sandbox
-- When setting dangerouslyDisableSandbox=true, also provide dangerouslyDisableSandboxReason; the user will be prompted before it runs unsandboxed
+- Only set requestUnsandboxedExecution=true when this specific command must run outside the sandbox
+- When setting requestUnsandboxedExecution=true, also provide requestUnsandboxedExecutionReason; the user will be prompted before it runs unsandboxed
 
 Output Management:
 - Output is automatically truncated if longer than 60KB to prevent context overflow
@@ -252,13 +252,13 @@ export async function createRunInTerminalToolData(
 					type: 'number',
 					description: 'An optional timeout in milliseconds. When provided, the tool will stop tracking the command after this duration and return the output collected so far. Be conservative with the timeout duration, give enough time that the command would complete on a low-end machine. Use 0 for no timeout. If it\'s not clear how long the command will take then use 0 to avoid prematurely terminating it, never guess too low.',
 				},
-				dangerouslyDisableSandbox: {
+				requestUnsandboxedExecution: {
 					type: 'boolean',
 					description: 'Request that this command run outside the terminal sandbox. Only set this when the command clearly needs unsandboxed access. The user will be prompted before the command runs unsandboxed.'
 				},
-				dangerouslyDisableSandboxReason: {
+				requestUnsandboxedExecutionReason: {
 					type: 'string',
-					description: 'A short explanation of why this command must run outside the terminal sandbox. Only provide this when dangerouslyDisableSandbox is true.'
+					description: 'A short explanation of why this command must run outside the terminal sandbox. Only provide this when requestUnsandboxedExecution is true.'
 				},
 			},
 			required: [
@@ -293,8 +293,8 @@ export interface IRunInTerminalInputParams {
 	goal: string;
 	isBackground: boolean;
 	timeout?: number;
-	dangerouslyDisableSandbox?: boolean;
-	dangerouslyDisableSandboxReason?: string;
+	requestUnsandboxedExecution?: boolean;
+	requestUnsandboxedExecutionReason?: string;
 }
 
 /**
@@ -498,7 +498,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			this._terminalSandboxService.isEnabled()
 		]);
 		const language = os === OperatingSystem.Windows ? 'pwsh' : 'sh';
-		const requiresUnsandboxConfirmation = isTerminalSandboxEnabled && args.dangerouslyDisableSandbox === true;
+		const requiresUnsandboxConfirmation = isTerminalSandboxEnabled && args.requestUnsandboxedExecution === true;
 
 		const terminalToolSessionId = generateUuid();
 		// Generate a custom command ID to link the command between renderer and pty host
@@ -512,7 +512,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				cwd,
 				shell,
 				os,
-				dangerouslyDisableSandbox: requiresUnsandboxConfirmation,
+				requestUnsandboxedExecution: requiresUnsandboxConfirmation,
 			});
 			if (rewriteResult) {
 				rewrittenCommand = rewriteResult.rewritten;
@@ -533,8 +533,8 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			cwd,
 			language,
 			isBackground: args.isBackground,
-			dangerouslyDisableSandbox: requiresUnsandboxConfirmation,
-			dangerouslyDisableSandboxReason: args.dangerouslyDisableSandboxReason,
+			requestUnsandboxedExecution: requiresUnsandboxConfirmation,
+			requestUnsandboxedExecutionReason: args.requestUnsandboxedExecutionReason,
 		};
 
 		// HACK: Exit early if there's an alternative recommendation, this is a little hacky but
@@ -733,7 +733,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				"Explanation: {0}\n\nGoal: {1}\n\nReason for leaving the sandbox: {2}",
 				args.explanation,
 				args.goal,
-				args.dangerouslyDisableSandboxReason || localize('runInTerminal.unsandboxed.confirmationMessage.defaultReason', "The model indicated that this command needs unsandboxed access.")
+				args.requestUnsandboxedExecutionReason || localize('runInTerminal.unsandboxed.confirmationMessage.defaultReason', "The model indicated that this command needs unsandboxed access.")
 			))
 			: new MarkdownString(localize('runInTerminal.confirmationMessage', "Explanation: {0}\n\nGoal: {1}", args.explanation, args.goal));
 		const confirmationMessages = shouldShowConfirmation ? {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
@@ -78,4 +78,28 @@ suite('CommandLineSandboxRewriter', () => {
 		strictEqual(result?.reasoning, 'Wrapped command for sandbox execution');
 		deepStrictEqual(calls, ['getSandboxConfigPath', 'wrapCommand']);
 	});
+
+	test('does not wrap command when sandbox bypass was explicitly requested', async () => {
+		const calls: string[] = [];
+		stubSandboxService({
+			isEnabled: async () => true,
+			wrapCommand: command => {
+				calls.push(`wrap:${command}`);
+				return `wrapped:${command}`;
+			},
+			getSandboxConfigPath: async () => {
+				calls.push('config');
+				return '/tmp/sandbox.json';
+			},
+		});
+
+		const rewriter = store.add(instantiationService.createInstance(CommandLineSandboxRewriter));
+		const result = await rewriter.rewrite({
+			...createRewriteOptions('echo hello'),
+			dangerouslyDisableSandbox: true,
+		});
+
+		strictEqual(result, undefined);
+		deepStrictEqual(calls, []);
+	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/commandLineSandboxRewriter.test.ts
@@ -96,7 +96,7 @@ suite('CommandLineSandboxRewriter', () => {
 		const rewriter = store.add(instantiationService.createInstance(CommandLineSandboxRewriter));
 		const result = await rewriter.rewrite({
 			...createRewriteOptions('echo hello'),
-			dangerouslyDisableSandbox: true,
+			requestUnsandboxedExecution: true,
 		});
 
 		strictEqual(result, undefined);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -67,6 +67,7 @@ suite('RunInTerminalTool', () => {
 	let terminalServiceDisposeEmitter: Emitter<ITerminalInstance>;
 	let chatServiceDisposeEmitter: Emitter<{ sessionResource: URI[]; reason: 'cleared' }>;
 	let chatSessionArchivedEmitter: Emitter<IAgentSession>;
+	let sandboxEnabled: boolean;
 
 	let runInTerminalTool: TestRunInTerminalTool;
 
@@ -81,6 +82,7 @@ suite('RunInTerminalTool', () => {
 
 		setConfig(TerminalChatAgentToolsSettingId.EnableAutoApprove, true);
 		setConfig(TerminalChatAgentToolsSettingId.BlockDetectedFileWrites, 'outsideWorkspace');
+		sandboxEnabled = false;
 		terminalServiceDisposeEmitter = new Emitter<ITerminalInstance>();
 		chatServiceDisposeEmitter = new Emitter<{ sessionResource: URI[]; reason: 'cleared' }>();
 		chatSessionArchivedEmitter = new Emitter<IAgentSession>();
@@ -107,9 +109,9 @@ suite('RunInTerminalTool', () => {
 		});
 		instantiationService.stub(ITerminalSandboxService, {
 			_serviceBrand: undefined,
-			isEnabled: async () => false,
-			wrapCommand: command => command,
-			getSandboxConfigPath: async () => undefined,
+			isEnabled: async () => sandboxEnabled,
+			wrapCommand: command => `sandbox:${command}`,
+			getSandboxConfigPath: async () => sandboxEnabled ? '/tmp/sandbox.json' : undefined,
 			getTempDir: () => undefined,
 			setNeedsForceUpdateConfigFile: () => { }
 		});
@@ -432,6 +434,40 @@ suite('RunInTerminalTool', () => {
 					assertConfirmationRequired(await executeToolTest({ command }));
 				});
 			}
+		});
+	});
+
+	suite('sandbox bypass requests', () => {
+		test('should force confirmation for explicit unsandboxed execution requests', async () => {
+			sandboxEnabled = true;
+			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
+
+			const result = await executeToolTest({
+				dangerouslyDisableSandbox: true,
+				dangerouslyDisableSandboxReason: 'Needs network access outside the sandbox',
+			});
+
+			assertConfirmationRequired(result, 'Run `bash` command outside the sandbox?');
+			strictEqual(result?.confirmationMessages?.allowAutoConfirm, false);
+			const terminalData = result?.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.dangerouslyDisableSandbox, true);
+			strictEqual(terminalData.dangerouslyDisableSandboxReason, 'Needs network access outside the sandbox');
+			strictEqual(terminalData.commandLine.toolEdited, undefined);
+
+			const confirmationMessage = result?.confirmationMessages?.message;
+			ok(confirmationMessage && typeof confirmationMessage !== 'string');
+			if (!confirmationMessage || typeof confirmationMessage === 'string') {
+				throw new Error('Expected markdown confirmation message');
+			}
+			ok(confirmationMessage.value.includes('Reason for leaving the sandbox: Needs network access outside the sandbox'));
+
+			const disclaimer = result?.confirmationMessages?.disclaimer;
+			ok(disclaimer && typeof disclaimer !== 'string');
+			if (!disclaimer || typeof disclaimer === 'string') {
+				throw new Error('Expected markdown disclaimer');
+			}
+			ok(disclaimer.value.includes('outside the terminal sandbox'));
+			strictEqual(result?.confirmationMessages?.terminalCustomActions, undefined);
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -443,15 +443,15 @@ suite('RunInTerminalTool', () => {
 			runInTerminalTool.setBackendOs(OperatingSystem.Linux);
 
 			const result = await executeToolTest({
-				dangerouslyDisableSandbox: true,
-				dangerouslyDisableSandboxReason: 'Needs network access outside the sandbox',
+				requestUnsandboxedExecution: true,
+				requestUnsandboxedExecutionReason: 'Needs network access outside the sandbox',
 			});
 
 			assertConfirmationRequired(result, 'Run `bash` command outside the sandbox?');
 			strictEqual(result?.confirmationMessages?.allowAutoConfirm, false);
 			const terminalData = result?.toolSpecificData as IChatTerminalToolInvocationData;
-			strictEqual(terminalData.dangerouslyDisableSandbox, true);
-			strictEqual(terminalData.dangerouslyDisableSandboxReason, 'Needs network access outside the sandbox');
+			strictEqual(terminalData.requestUnsandboxedExecution, true);
+			strictEqual(terminalData.requestUnsandboxedExecutionReason, 'Needs network access outside the sandbox');
 			strictEqual(terminalData.commandLine.toolEdited, undefined);
 
 			const confirmationMessage = result?.confirmationMessages?.message;


### PR DESCRIPTION
## Summary

When terminal sandboxing is enabled (`chat.tools.terminal.sandbox.enabled: true`), the LLM can now explicitly request that a command runs outside the sandbox by setting `requestUnsandboxedExecution: true` on the `run_in_terminal` tool call. The user is always prompted with a clear confirmation before the command executes unsandboxed.

## Changes

### Tool schema & model description
- Added `requestUnsandboxedExecution` (boolean) and `requestUnsandboxedExecutionReason` (string) to the `run_in_terminal` input schema
- Added a "Sandboxing" section to the generic model description so the LLM knows about the capability

### Confirmation UX
- When the flag is set and sandboxing is enabled, a special confirmation is forced (even if auto-approve rules would normally skip it)
- Title changes to "Run `<shell>` command outside the sandbox?"
- A warning disclaimer is appended explaining the command will have full system access
- The model-provided reason is surfaced in the confirmation message
- `allowAutoConfirm` is set to `false` so this can never be silently approved
- Custom auto-approve actions are suppressed for unsandboxed requests

### Sandbox bypass plumbing
- `ICommandLineRewriterOptions` gains `requestUnsandboxedExecution?` flag
- `CommandLineSandboxRewriter` short-circuits when the flag is set, skipping sandbox wrapping for that invocation only
- `IChatTerminalToolInvocationData` carries the flag and reason for downstream consumers

### Tests
- New `CommandLineSandboxRewriter` test: bypass skips wrapping
- New `RunInTerminalTool` suite: verifies forced confirmation, title, disclaimer, reason text, `allowAutoConfirm: false`, and no custom actions

## Design decisions
- **Explicit-only**: no automatic retry-on-failure flow; future work can add evidence-based retry suggestions
- **Per-invocation**: the bypass applies only to the specific approved invocation, not the session
- **Always prompts**: even in auto-approve / autopilot sessions, this forces user confirmation