### PR TITLE
Fix Ctrl+D in regex find mode

### DIFF
--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -286,7 +286,7 @@ export class MultiCursorSession {
 		//  - and the search string is non-empty
 		if (!editor.hasTextFocus() && findState.isRevealed && findState.searchString.length > 0) {
 			// Find widget owns what is searched for
-			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, null);
+			return new MultiCursorSession(editor, findController, false, findState.searchString, findState.wholeWord, findState.matchCase, findState.isRegex, null);
 		}
 
 		// Otherwise, the selection gives the search text, and the find widget gives the search settings
@@ -294,14 +294,17 @@ export class MultiCursorSession {
 		let isDisconnectedFromFindController = false;
 		let wholeWord: boolean;
 		let matchCase: boolean;
+		let isRegex: boolean;
 		const selections = editor.getSelections();
 		if (selections.length === 1 && selections[0].isEmpty()) {
 			isDisconnectedFromFindController = true;
 			wholeWord = true;
 			matchCase = true;
+			isRegex = false;
 		} else {
 			wholeWord = findState.wholeWord;
 			matchCase = findState.matchCase;
+			isRegex = findState.isRegex;
 		}
 
 		// Selection owns what is searched for
@@ -322,7 +325,7 @@ export class MultiCursorSession {
 			searchText = editor.getModel().getValueInRange(s).replace(/\r\n/g, '\n');
 		}
 
-		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, currentMatch);
+		return new MultiCursorSession(editor, findController, isDisconnectedFromFindController, searchText, wholeWord, matchCase, isRegex, currentMatch);
 	}
 
 	constructor(
@@ -332,6 +335,7 @@ export class MultiCursorSession {
 		public readonly searchText: string,
 		public readonly wholeWord: boolean,
 		public readonly matchCase: boolean,
+		public readonly isRegex: boolean,
 		public currentMatch: Selection | null
 	) { }
 
@@ -378,7 +382,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const nextMatch = this._editor.getModel().findNextMatch(this.searchText, lastAddedSelection.getEndPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!nextMatch) {
 			return null;
@@ -429,7 +433,7 @@ export class MultiCursorSession {
 
 		const allSelections = this._editor.getSelections();
 		const lastAddedSelection = allSelections[allSelections.length - 1];
-		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
+		const previousMatch = this._editor.getModel().findPreviousMatch(this.searchText, lastAddedSelection.getStartPosition(), this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false);
 
 		if (!previousMatch) {
 			return null;
@@ -446,9 +450,9 @@ export class MultiCursorSession {
 
 		const editorModel = this._editor.getModel();
 		if (searchScope) {
-			return editorModel.findMatches(this.searchText, searchScope, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+			return editorModel.findMatches(this.searchText, searchScope, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 		}
-		return editorModel.findMatches(this.searchText, true, false, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
+		return editorModel.findMatches(this.searchText, true, this.isRegex, this.matchCase, this.wholeWord ? this._editor.getOption(EditorOption.wordSeparators) : null, false, Constants.MAX_SAFE_SMALL_INTEGER);
 	}
 }
 

--- a/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
+++ b/src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts
@@ -502,6 +502,43 @@ suite('Multicursor selection', () => {
 		});
 	});
 
+	test('issue #107090: AddSelectionToNextFindMatchAction respects regex find mode', () => {
+		const text = [
+			'foo1 foo\\d+',
+			'foo2',
+			'foo3',
+			'foo4 foo\\d+',
+		];
+		testAddSelectionToNextFindMatchAction(text, (editor, action, findController) => {
+			editor.setSelections([
+				new Selection(1, 1, 1, 5),
+			]);
+			findController.getState().change({ searchString: 'foo\\d+', isRegex: true, isRevealed: true }, false);
+			editor.setHasTextFocus(false);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 5),
+				new Selection(2, 1, 2, 5),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 5),
+				new Selection(2, 1, 2, 5),
+				new Selection(3, 1, 3, 5),
+			]);
+
+			action.run(null!, editor);
+			assert.deepStrictEqual(editor.getSelections(), [
+				new Selection(1, 1, 1, 5),
+				new Selection(2, 1, 2, 5),
+				new Selection(3, 1, 3, 5),
+				new Selection(4, 1, 4, 5),
+			]);
+		});
+	});
+
 	suite('Find state disassociation', () => {
 
 		const text = [


### PR DESCRIPTION
Fixes #107090.

## Summary
- preserve `isRegex` when the multicursor session is created from the active find state
- use that regex flag for next/previous/select-all lookups in `MultiCursorSession`
- add a regression test covering repeated `AddSelectionToNextFindMatchAction` calls while the find widget owns a regex search

## Validation
- `npm run transpile-client`
- browser multicursor regression slice in Chromium covering `#107090`, `#5400`, `#6661`, and `#20651`