### PR TITLE
Disable task.notifyWindowOnTaskCompletion in sessions window

### DIFF
--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -56,7 +56,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'search.quickOpen.includeHistory': false,
 
-		'task.notifyWindowOnTaskCompletion': false,
+		'task.notifyWindowOnTaskCompletion': -1,
 
 		'terminal.integrated.initialHint': false,
 

--- a/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
+++ b/src/vs/sessions/contrib/configuration/browser/configuration.contribution.ts
@@ -56,6 +56,8 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerDefaultCon
 
 		'search.quickOpen.includeHistory': false,
 
+		'task.notifyWindowOnTaskCompletion': false,
+
 		'terminal.integrated.initialHint': false,
 
 		'workbench.editor.doubleClickTabToToggleEditorGroupSizes': 'maximize',


### PR DESCRIPTION
Disables `task.notifyWindowOnTaskCompletion` by setting it to `-1` in the Agent Sessions window configuration overrides.