### PR TITLE
Browser: fix URL overflow

### DIFF
--- a/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
+++ b/src/vs/workbench/contrib/browserView/electron-browser/media/browser.css
@@ -58,6 +58,7 @@
 		flex: 1;
 		display: flex;
 		align-items: center;
+		min-width: 0;
 		background-color: var(--vscode-input-background);
 		border: 1px solid var(--vscode-input-border);
 		border-radius: var(--vscode-cornerRadius-small);


### PR DESCRIPTION
Before: 
<img width="585" height="80" alt="image" src="https://github.com/user-attachments/assets/f6644e63-9934-48fc-9531-5aeb7f75adde" />


After: 
<img width="575" height="77" alt="image" src="https://github.com/user-attachments/assets/73a84574-b3c0-419e-b4b2-07969c470959" />
