### PR TITLE
Sessions: use live ChatModel title for dynamic LLM-generated session names

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -264,16 +264,20 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 	 */
 	private _getActiveSessionLabel(): string {
 		const activeSession = this.activeSessionService.getActiveSession();
-		const label = activeSession?.label;
-		if (label) {
-			return label; // prefer session label to support renamed sessions
-		}
 
+		// Prefer the live chat model title — it reflects LLM-generated
+		// titles immediately (via provideChatTitle / setCustomTitle),
+		// including user renames.
 		if (activeSession) {
 			const activeModel = this.chatService.getSession(activeSession.resource);
 			if (activeModel?.title) {
-				return activeModel.title; // fall back to chat model title if available
+				return activeModel.title;
 			}
+		}
+
+		// Fall back to session label for historical sessions without a live model
+		if (activeSession?.label) {
+			return activeSession.label;
 		}
 
 		return localize('agentSessions.newSession', "New Session");


### PR DESCRIPTION
## Problem

Chat titles in the Agent Sessions window just showed the first few words of the prompt. The existing `provideChatTitle` API already supports LLM-generated titles — `generateInitialChatTitleIfNeeded()` calls the default agent's title provider on the first request and sets the result via `model.setCustomTitle()`. However, the sessions titlebar widget wasn't surfacing these titles.

## Root Cause

`_getActiveSessionLabel()` in `sessionsTitleBarWidget.ts` checked `activeSession.label` first (a snapshot from the sessions model), and only fell back to `activeModel.title` if the label was undefined. Since the label is always set (default title = first line of prompt), the live ChatModel title (which includes LLM-generated titles via `setCustomTitle`) was never consulted.

The widget already listened for `setCustomTitle` events and re-rendered, but re-rendering just read the stale snapshot again.

## Fix

Reverse the preference in `_getActiveSessionLabel()`: check the live `ChatModel.title` first (which reflects LLM-generated titles immediately via `setCustomTitle`), and fall back to the session label for historical sessions without a loaded model.

This is safe because:
- `ChatModel.title` returns `_customTitle || getDefaultTitle()` — same value as the session snapshot initially, but updates immediately when an LLM title arrives
- User renames also go through `setCustomTitle`, so renamed sessions still work
- Historical sessions without a loaded ChatModel fall back to the persisted label