### PR TITLE
Add AllowedGitHubOrganizations policy to gate chat features by org membership

### DIFF
--- a/build/lib/policies/policyData.jsonc
+++ b/build/lib/policies/policyData.jsonc
@@ -67,6 +67,20 @@
             "default": ""
         },
         {
+            "key": "chat.allowedGitHubOrganizations",
+            "name": "AllowedGitHubOrganizations",
+            "category": "InteractiveSession",
+            "minimumVersion": "1.113",
+            "localization": {
+                "description": {
+                    "key": "chat.allowedGitHubOrganizations",
+                    "value": "A comma-separated list of GitHub organization login names. When set, policy-gated chat features (such as MCP) are only available if the signed-in GitHub user is a member of one of the listed organizations."
+                }
+            },
+            "type": "string",
+            "default": ""
+        },
+        {
             "key": "extensions.allowed",
             "name": "AllowedExtensions",
             "category": "Extensions",

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -92,6 +92,7 @@ class MockChatEntitlementService implements IChatEntitlementService {
 	readonly isInternal = false;
 	readonly sku = 'free';
 	readonly copilotTrackingId = 'mock-tracking-id';
+	readonly orgPolicySatisfied = true;
 
 	readonly quotas = {};
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -1273,6 +1273,23 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			scope: ConfigurationScope.WINDOW
 		},
+		[ChatConfiguration.AllowedGitHubOrganizations]: {
+			type: 'string',
+			default: '',
+			scope: ConfigurationScope.APPLICATION,
+			included: false,
+			policy: {
+				name: 'AllowedGitHubOrganizations',
+				category: PolicyCategory.InteractiveSession,
+				minimumVersion: '1.113',
+				localization: {
+					description: {
+						key: 'chat.allowedGitHubOrganizations',
+						value: nls.localize('chat.allowedGitHubOrganizations', "A comma-separated list of GitHub organization login names. When set, policy-gated chat features (such as MCP) are only available if the signed-in GitHub user is a member of one of the listed organizations."),
+					}
+				}
+			},
+		},
 		'chat.allowAnonymousAccess': { // TODO@bpasero remove me eventually
 			type: 'boolean',
 			description: nls.localize('chat.allowAnonymousAccess', "Controls whether anonymous access is allowed in chat."),

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -124,6 +124,8 @@ export namespace ChatContextKeys {
 		agentModeDisabledByPolicy: new RawContextKey<boolean>('chatAgentModeDisabledByPolicy', false, { type: 'boolean', description: localize('chatAgentModeDisabledByPolicy', "True when agent mode is disabled by organization policy.") }),
 	};
 
+	export const githubOrgPolicySatisfied = ChatEntitlementContextKeys.githubOrgPolicySatisfied;
+
 	export const panelLocation = new RawContextKey<ViewContainerLocation>('chatPanelLocation', undefined, { type: 'number', description: localize('chatPanelLocation', "The location of the chat panel.") });
 
 	export const agentSessionsViewerFocused = new RawContextKey<boolean>('agentSessionsViewerFocused', true, { type: 'boolean', description: localize('agentSessionsViewerFocused', "If the agent sessions view in the chat view is focused.") });

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -10,6 +10,7 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 
 export enum ChatConfiguration {
 	AIDisabled = 'chat.disableAIFeatures',
+	AllowedGitHubOrganizations = 'chat.allowedGitHubOrganizations',
 	PluginsEnabled = 'chat.plugins.enabled',
 	PluginLocations = 'chat.pluginLocations',
 	PluginMarketplaces = 'chat.plugins.marketplaces',

--- a/src/vs/workbench/contrib/mcp/browser/mcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpDiscovery.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
-import { autorun } from '../../../../base/common/observable.js';
+import { autorun, observableFromEvent } from '../../../../base/common/observable.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { mcpAccessConfig, McpAccessValue } from '../../../../platform/mcp/common/mcpManagement.js';
 import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
+import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 import { mcpDiscoveryRegistry } from '../common/discovery/mcpDiscovery.js';
 
 export class McpDiscovery extends Disposable implements IWorkbenchContribution {
@@ -18,16 +19,21 @@ export class McpDiscovery extends Disposable implements IWorkbenchContribution {
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IConfigurationService configurationService: IConfigurationService,
+		@IChatEntitlementService chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 
 		const mcpAccessValue = observableConfigValue(mcpAccessConfig, McpAccessValue.All, configurationService);
+		const orgPolicySatisfied = observableFromEvent(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.orgPolicySatisfied);
 		const store = this._register(new DisposableStore());
 
 		this._register(autorun(reader => {
 			store.clear();
 			const value = mcpAccessValue.read(reader);
 			if (value === McpAccessValue.None) {
+				return;
+			}
+			if (!orgPolicySatisfied.read(reader)) {
 				return;
 			}
 			for (const descriptor of mcpDiscoveryRegistry.getAll()) {

--- a/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpWorkbenchService.ts
@@ -38,6 +38,7 @@ import { mcpConfigurationSection } from '../common/mcpConfiguration.js';
 import { McpServerInstallData, McpServerInstallClassification } from '../common/mcpServer.js';
 import { HasInstalledMcpServersContext, IMcpConfigPath, IMcpService, IMcpWorkbenchService, IWorkbenchMcpServer, McpCollectionSortOrder, McpServerEnablementState, McpServerInstallState, McpServerEnablementStatus, McpServersGalleryStatusContext } from '../common/mcpTypes.js';
 import { ContributionEnablementState } from '../../chat/common/enablement.js';
+import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 import { McpServerEditorInput } from './mcpServerEditorInput.js';
 import { IMcpGalleryManifestService } from '../../../../platform/mcp/common/mcpGalleryManifest.js';
 import { IIterativePager, IIterativePage } from '../../../../base/common/paging.js';
@@ -194,6 +195,7 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 		@IAllowedMcpServersService private readonly allowedMcpServersService: IAllowedMcpServersService,
 		@IMcpService private readonly mcpService: IMcpService,
 		@IURLService urlService: IURLService,
+		@IChatEntitlementService private readonly chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 		this._register(this.mcpManagementService.onDidInstallMcpServersInCurrentProfile(e => this.onDidInstallMcpServers(e)));
@@ -783,6 +785,16 @@ export class McpWorkbenchService extends Disposable implements IMcpWorkbenchServ
 	private getEnablementStatus(mcpServer: McpWorkbenchServer): McpServerEnablementStatus | undefined {
 		if (!mcpServer.local) {
 			return undefined;
+		}
+
+		if (!this.chatEntitlementService.orgPolicySatisfied) {
+			return {
+				state: McpServerEnablementState.DisabledByAccess,
+				message: {
+					severity: Severity.Warning,
+					text: new MarkdownString(localize('disabled - org policy', "This MCP server is disabled because the signed-in GitHub account is not a member of an allowed organization."))
+				}
+			};
 		}
 
 		const settingsCommandLink = createCommandUri('workbench.action.openSettings', { query: `@id:${mcpAccessConfig}` }).toString();

--- a/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
+++ b/src/vs/workbench/contrib/mcp/common/mcpRegistry.ts
@@ -10,7 +10,7 @@ import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../base/common/iterator.js';
 import { Lazy } from '../../../../base/common/lazy.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
-import { derived, IObservable, observableValue, autorunSelfDisposable } from '../../../../base/common/observable.js';
+import { derived, IObservable, observableValue, autorunSelfDisposable, observableFromEvent } from '../../../../base/common/observable.js';
 import { isDefined } from '../../../../base/common/types.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -27,6 +27,7 @@ import { IQuickInputButton, IQuickInputService, IQuickPickItem } from '../../../
 import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IWorkspaceFolderData } from '../../../../platform/workspace/common/workspace.js';
 import { IWorkspaceTrustManagementService, IWorkspaceTrustRequestService } from '../../../../platform/workspace/common/workspaceTrust.js';
+import { IChatEntitlementService } from '../../../services/chat/common/chatEntitlementService.js';
 import { IConfigurationResolverService } from '../../../services/configurationResolver/common/configurationResolver.js';
 import { ConfigurationResolverExpression, IResolvedValue } from '../../../services/configurationResolver/common/configurationResolverExpression.js';
 import { AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
@@ -45,8 +46,12 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	private readonly _collections = observableValue<readonly McpCollectionDefinition[]>('collections', []);
 	private readonly _delegates = observableValue<readonly IMcpHostDelegate[]>('delegates', []);
 	private readonly _mcpAccessValue: IObservable<string>;
+	private readonly _orgPolicySatisfied: IObservable<boolean>;
 	public readonly collections: IObservable<readonly McpCollectionDefinition[]> = derived(reader => {
 		if (this._mcpAccessValue.read(reader) === McpAccessValue.None) {
+			return [];
+		}
+		if (!this._orgPolicySatisfied.read(reader)) {
 			return [];
 		}
 		return this._collections.read(reader);
@@ -58,7 +63,7 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 	private readonly _ongoingLazyActivations = observableValue(this, 0);
 
 	public readonly lazyCollectionState = derived(reader => {
-		if (this._mcpAccessValue.read(reader) === McpAccessValue.None) {
+		if (this._mcpAccessValue.read(reader) === McpAccessValue.None || !this._orgPolicySatisfied.read(reader)) {
 			return { state: LazyCollectionState.AllKnown, collections: [] };
 		}
 
@@ -90,9 +95,11 @@ export class McpRegistry extends Disposable implements IMcpRegistry {
 		@IMcpSandboxService private readonly _mcpSandboxService: IMcpSandboxService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IWorkspaceTrustRequestService private readonly _workspaceTrustRequestService: IWorkspaceTrustRequestService,
+		@IChatEntitlementService chatEntitlementService: IChatEntitlementService,
 	) {
 		super();
 		this._mcpAccessValue = observableConfigValue(mcpAccessConfig, McpAccessValue.All, configurationService);
+		this._orgPolicySatisfied = observableFromEvent(chatEntitlementService.onDidChangeEntitlement, () => chatEntitlementService.orgPolicySatisfied);
 	}
 
 	public registerDelegate(delegate: IMcpHostDelegate): IDisposable {

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -63,6 +63,8 @@ export namespace ChatEntitlementContextKeys {
 	export const completionsQuotaExceeded = new RawContextKey<boolean>('completionsQuotaExceeded', false, true);
 
 	export const chatAnonymous = new RawContextKey<boolean>('chatAnonymous', false, true);
+
+	export const githubOrgPolicySatisfied = new RawContextKey<boolean>('chatGitHubOrgPolicySatisfied', true, true); // True when GitHub org policy is satisfied (or not configured).
 }
 
 export const IChatEntitlementService = createDecorator<IChatEntitlementService>('chatEntitlementService');
@@ -146,6 +148,18 @@ export interface IChatEntitlementService {
 	readonly isInternal: boolean;
 	readonly sku: string | undefined;
 	readonly copilotTrackingId: string | undefined;
+
+	/**
+	 * Whether the GitHub organization policy gate is satisfied.
+	 *
+	 * When `chat.allowedGitHubOrganizations` is not configured (empty),
+	 * this is always `true`. When configured, this is `true` only if
+	 * the signed-in user belongs to one of the allowed organizations.
+	 *
+	 * Features that should be gated behind this policy can check this
+	 * property or use the `chatGitHubOrgPolicySatisfied` context key.
+	 */
+	readonly orgPolicySatisfied: boolean;
 
 	readonly onDidChangeQuotaExceeded: Event<void>;
 	readonly onDidChangeQuotaRemaining: Event<void>;
@@ -298,7 +312,8 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 					ChatEntitlementContextKeys.Entitlement.signedOut.key,
 					ChatEntitlementContextKeys.Entitlement.organisations.key,
 					ChatEntitlementContextKeys.Entitlement.internal.key,
-					ChatEntitlementContextKeys.Entitlement.sku.key
+					ChatEntitlementContextKeys.Entitlement.sku.key,
+					ChatEntitlementContextKeys.githubOrgPolicySatisfied.key
 				])), this._store
 			), () => { }, this._store
 		);
@@ -379,6 +394,10 @@ export class ChatEntitlementService extends Disposable implements IChatEntitleme
 
 	get previewFeaturesDisabled(): boolean {
 		return this.contextKeyService.getContextKeyValue<boolean>('github.copilot.previewFeaturesDisabled') === true;
+	}
+
+	get orgPolicySatisfied(): boolean {
+		return this.contextKeyService.getContextKeyValue<boolean>(ChatEntitlementContextKeys.githubOrgPolicySatisfied.key) !== false;
 	}
 
 	//#endregion
@@ -1006,6 +1025,7 @@ export class ChatEntitlementContext extends Disposable {
 	private static readonly CHAT_ENTITLEMENT_CONTEXT_STORAGE_KEY = 'chat.setupContext';
 
 	private static readonly CHAT_DISABLED_CONFIGURATION_KEY = 'chat.disableAIFeatures';
+	private static readonly ALLOWED_GITHUB_ORGANIZATIONS_KEY = 'chat.allowedGitHubOrganizations';
 
 	private readonly canSignUpContextKey: IContextKey<boolean>;
 	private readonly signedOutContextKey: IContextKey<boolean>;
@@ -1019,6 +1039,8 @@ export class ChatEntitlementContext extends Disposable {
 	private readonly organisationsContextKey: IContextKey<string[] | undefined>;
 	private readonly isInternalContextKey: IContextKey<boolean>;
 	private readonly skuContextKey: IContextKey<string | undefined>;
+
+	private readonly githubOrgPolicySatisfiedContextKey: IContextKey<boolean>;
 
 	private readonly hiddenContext: IContextKey<boolean>;
 	private readonly laterContext: IContextKey<boolean>;
@@ -1058,6 +1080,8 @@ export class ChatEntitlementContext extends Disposable {
 		this.isInternalContextKey = ChatEntitlementContextKeys.Entitlement.internal.bindTo(contextKeyService);
 		this.skuContextKey = ChatEntitlementContextKeys.Entitlement.sku.bindTo(contextKeyService);
 
+		this.githubOrgPolicySatisfiedContextKey = ChatEntitlementContextKeys.githubOrgPolicySatisfied.bindTo(contextKeyService);
+
 		this.hiddenContext = ChatEntitlementContextKeys.Setup.hidden.bindTo(contextKeyService);
 		this.laterContext = ChatEntitlementContextKeys.Setup.later.bindTo(contextKeyService);
 		this.installedContext = ChatEntitlementContextKeys.Setup.installed.bindTo(contextKeyService);
@@ -1075,6 +1099,9 @@ export class ChatEntitlementContext extends Disposable {
 	private registerListeners(): void {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY)) {
+				this.updateContext();
+			}
+			if (e.affectsConfiguration(ChatEntitlementContext.ALLOWED_GITHUB_ORGANIZATIONS_KEY)) {
 				this.updateContext();
 			}
 		}));
@@ -1169,6 +1196,8 @@ export class ChatEntitlementContext extends Disposable {
 		this.isInternalContextKey.set(Boolean(state.organisations?.some(org => org === 'github' || org === 'microsoft' || org === 'ms-copilot' || org === 'MicrosoftCopilot')));
 		this.skuContextKey.set(state.sku);
 
+		this.githubOrgPolicySatisfiedContextKey.set(this.computeOrgPolicySatisfied(state));
+
 		this.hiddenContext.set(!!state.hidden);
 		this.laterContext.set(!!state.later);
 		this.installedContext.set(!!state.installed);
@@ -1180,6 +1209,33 @@ export class ChatEntitlementContext extends Disposable {
 		logChatEntitlements(state, this.configurationService, this.telemetryService);
 
 		this._onDidChange.fire();
+	}
+
+	/**
+	 * Computes whether the GitHub organization policy gate is satisfied.
+	 *
+	 * - If `chat.allowedGitHubOrganizations` is not configured (empty): always satisfied.
+	 * - If configured: satisfied only when the user's resolved orgs overlap.
+	 * - If configured but orgs are not yet resolved (user not signed in or
+	 *   entitlements pending): not satisfied (block by default).
+	 */
+	private computeOrgPolicySatisfied(state: IChatEntitlementContextState): boolean {
+		const allowedOrgsRaw = this.configurationService.getValue<string>(ChatEntitlementContext.ALLOWED_GITHUB_ORGANIZATIONS_KEY);
+		if (!allowedOrgsRaw) {
+			return true; // no restriction configured
+		}
+
+		const allowedOrgs = allowedOrgsRaw.split(',').map(o => o.trim().toLowerCase()).filter(o => o.length > 0);
+		if (allowedOrgs.length === 0) {
+			return true; // empty after parsing
+		}
+
+		const userOrgs = state.organisations;
+		if (!userOrgs || userOrgs.length === 0) {
+			return false; // policy set but user orgs not resolved or user not signed in
+		}
+
+		return userOrgs.some(org => allowedOrgs.includes(org.toLowerCase()));
 	}
 
 	suspend(): void {

--- a/src/vs/workbench/test/common/workbenchTestServices.ts
+++ b/src/vs/workbench/test/common/workbenchTestServices.ts
@@ -814,6 +814,7 @@ export class TestChatEntitlementService implements IChatEntitlementService {
 	markAnonymousRateLimited(): void { }
 
 	readonly previewFeaturesDisabled = false;
+	readonly orgPolicySatisfied = true;
 }
 
 export class TestLifecycleService extends Disposable implements ILifecycleService {


### PR DESCRIPTION
## Summary

Introduces a hidden, policy-backed setting `chat.allowedGitHubOrganizations` that allows enterprise IT admins to restrict policy-gated chat features (such as MCP) to users who are members of specified GitHub organizations.

Refs: https://github.com/microsoft/vscode-internalbacklog/issues/6435

## Setting

- **Config key**: `chat.allowedGitHubOrganizations`
- **Type**: `string` (comma-separated org login names, e.g. `"microsoft,github"`)
- **Hidden**: `included: false` — not visible in Settings UI, only set via MDM policy
- **Policy**: `AllowedGitHubOrganizations`, category `InteractiveSession`, OS-level MDM delivery

## Gate Logic

When `chat.allowedGitHubOrganizations` is configured (via MDM policy):
- Features are **blocked by default** until the user's org membership is confirmed
- The user's resolved `organization_login_list` from entitlements is compared against the allowed orgs list
- If the user is not a member of any allowed org, features remain blocked
- If the setting is empty/unset, **no restriction applies** (passthrough behavior)

The gate logic lives in `ChatEntitlementContext.computeOrgPolicySatisfied()` and re-evaluates whenever:
- Entitlement data changes (user signs in/out, orgs resolve)
- The `chat.allowedGitHubOrganizations` configuration changes

## How Features Opt In

### Context key (declarative, for UI)
```
when: chatGitHubOrgPolicySatisfied
```

### Service property (programmatic)
```typescript
chatEntitlementService.orgPolicySatisfied // boolean
```

### Observable (reactive)
```typescript
observableFromEvent(
  chatEntitlementService.onDidChangeEntitlement,
  () => chatEntitlementService.orgPolicySatisfied
)
```

## MCP Integration (first consumer)

MCP features check the org gate at three levels:
- **`McpRegistry.collections`** — returns empty when gate not satisfied
- **`McpDiscovery`** — skips server discovery when gate not satisfied
- **`McpWorkbenchService.getEnablementStatus()`** — shows disabled status with org policy message

## Files Changed

| File | Change |
|------|--------|
| `chat/common/constants.ts` | New `AllowedGitHubOrganizations` config key |
| `chat/browser/chat.contribution.ts` | Setting registration with policy |
| `chat/common/chatEntitlementService.ts` | Gate logic, context key, `orgPolicySatisfied` property |
| `chat/common/actions/chatContextKeys.ts` | Re-export context key |
| `mcp/common/mcpRegistry.ts` | Gate MCP collections + lazy state |
| `mcp/browser/mcpDiscovery.ts` | Gate MCP discovery |
| `mcp/browser/mcpWorkbenchService.ts` | Gate MCP enablement status |
| `build/lib/policies/policyData.jsonc` | Exported policy artifact |
| Test mocks | Added `orgPolicySatisfied = true` |