### PR TITLE
fix: guard against undefined .value in IMarkdownString badge/description/tooltip

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -311,13 +311,13 @@ class AgentSessionsLogger extends Disposable {
 			lines.push(`  Icon: ${session.icon.id}`);
 
 			if (session.description) {
-				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : session.description.value}`);
+				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : (session.description.value ?? '')}`);
 			}
 			if (session.badge) {
-				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : session.badge.value}`);
+				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : (session.badge.value ?? '')}`);
 			}
 			if (session.tooltip) {
-				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : session.tooltip.value}`);
+				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : (session.tooltip.value ?? '')}`);
 			}
 
 			// Timing info

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -311,13 +311,13 @@ class AgentSessionsLogger extends Disposable {
 			lines.push(`  Icon: ${session.icon.id}`);
 
 			if (session.description) {
-				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : (session.description.value ?? '<undefined>')}`);
+				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : session.description.value}`);
 			}
 			if (session.badge) {
-				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : (session.badge.value ?? '<undefined>')}`);
+				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : session.badge.value}`);
 			}
 			if (session.tooltip) {
-				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : (session.tooltip.value ?? '<undefined>')}`);
+				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : session.tooltip.value}`);
 			}
 
 			// Timing info

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -311,13 +311,13 @@ class AgentSessionsLogger extends Disposable {
 			lines.push(`  Icon: ${session.icon.id}`);
 
 			if (session.description) {
-				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : (session.description.value ?? '')}`);
+				lines.push(`  Description: ${typeof session.description === 'string' ? session.description : (session.description.value ?? '<undefined>')}`);
 			}
 			if (session.badge) {
-				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : (session.badge.value ?? '')}`);
+				lines.push(`  Badge: ${typeof session.badge === 'string' ? session.badge : (session.badge.value ?? '<undefined>')}`);
 			}
 			if (session.tooltip) {
-				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : (session.tooltip.value ?? '')}`);
+				lines.push(`  Tooltip: ${typeof session.tooltip === 'string' ? session.tooltip : (session.tooltip.value ?? '<undefined>')}`);
 			}
 
 			// Timing info

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -282,7 +282,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		// Archived sessions always keep their badge since they are grouped under
 		// the "Archived" section, not a repository section.
 		if (this.options.isGroupedByRepository?.() && !session.element.isArchived()) {
-			const raw = typeof badge === 'string' ? badge : badge.value;
+			const raw = typeof badge === 'string' ? badge : (badge.value ?? '');
 			const match = raw.match(/^\$\((?:repo|folder|worktree)\)\s*(.+)/);
 			if (match) {
 				const badgeName = match[1].trim();
@@ -294,7 +294,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		}
 
 		const normalisedBadge = this.stripCodicons(badge);
-		const badgeValue = typeof normalisedBadge === 'string' ? normalisedBadge : normalisedBadge.value;
+		const badgeValue = typeof normalisedBadge === 'string' ? normalisedBadge : (normalisedBadge.value ?? '');
 		if (!badgeValue) {
 			return false;
 		}
@@ -305,7 +305,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 	}
 
 	private stripCodicons(content: string | IMarkdownString): string | IMarkdownString {
-		const raw = typeof content === 'string' ? content : content.value;
+		const raw = typeof content === 'string' ? content : (content.value ?? '');
 		const stripped = raw.replace(/\$\([a-z0-9\-]+\)\s*/gi, '').trim();
 		if (typeof content === 'string') {
 			return stripped;
@@ -1031,7 +1031,7 @@ export function getRepositoryName(session: IAgentSession): string | undefined {
 	// Fallback: extract repo/folder name from badge
 	const badge = session.badge;
 	if (badge) {
-		const raw = typeof badge === 'string' ? badge : badge.value;
+		const raw = typeof badge === 'string' ? badge : (badge.value ?? '');
 		const badgeMatch = raw.match(/\$\((?:repo|folder|worktree)\)\s*(.+)/);
 		if (badgeMatch) {
 			return badgeMatch[1].trim();

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -13,6 +13,7 @@ import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { AgentSessionsGrouping } from '../../../browser/agentSessions/agentSessionsFilter.js';
+import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 
 suite('sessionDateFromNow', () => {
 
@@ -92,7 +93,7 @@ suite('AgentSessionsDataSource', () => {
 		startTime: number;
 		endTime: number;
 		metadata: { [key: string]: unknown };
-		badge: string;
+		badge: string | IMarkdownString;
 	}> = {}): IAgentSession {
 		const now = Date.now();
 		return {
@@ -1023,6 +1024,16 @@ suite('AgentSessionsDataSource', () => {
 				metadata: { repositoryPath: '/Users/user/Projects/vscode' },
 				badge: '$(repo) vscode',
 			});
+			assert.strictEqual(getRepositoryName(session), 'vscode');
+		});
+
+		test('does not throw when badge is an IMarkdownString with undefined value', () => {
+			const session = createMockSession({ id: '1', badge: { value: undefined! } as IMarkdownString });
+			assert.strictEqual(getRepositoryName(session), undefined);
+		});
+
+		test('extracts repo name from IMarkdownString badge with valid value', () => {
+			const session = createMockSession({ id: '1', badge: { value: '$(repo) vscode' } as IMarkdownString });
 			assert.strictEqual(getRepositoryName(session), 'vscode');
 		});
 	});


### PR DESCRIPTION
## Problem

When restoring a copilotcli session, `IMarkdownString` objects for `badge`, `description`, and `tooltip` can arrive over RPC with `value: undefined`. Code that extracts the value using `typeof x === 'string' ? x : x.value` then calls `.match()` or `.replace()` on `undefined`, crashing with:

```
TypeError: Cannot read properties of undefined (reading 'match')
```

## Fix

Add `?? ''` fallbacks to all 7 instances of the unsafe pattern in:

- **`agentSessionsViewer.ts`** (4 places): `renderBadge`, `stripCodicons`, `getRepositoryName`
- **`agentSessionsModel.ts`** (3 places): debug logging for description, badge, tooltip

## Investigation Notes

The reported error `"Failed to initialize chat session copilotcli:/..."` is logged from `mainThreadChatSessions.ts:262`. Through tracing the full initialization path including the extension host RPC and into the copilot-chat extension's minified code, the primary `.match()` crash originates in the extension's `phn` function (history event conversion in `getChatHistory`). A fix for that needs to happen in the copilot-chat extension.

However, these 7 instances in VS Code core are real latent bugs that would produce the exact same `TypeError` if an `IMarkdownString` with undefined `.value` reaches the viewer — which can happen through RPC serialization.