### PR TITLE
show generic editing text for complex tool names

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -41,7 +41,7 @@ function extractTextFromPart(content: IChatThinkingPart): string {
 	return raw.trim();
 }
 
-export function isEditToolId(toolId: string): boolean {
+function isEditToolId(toolId: string): boolean {
 	const lowerToolId = toolId.toLowerCase();
 	return lowerToolId.includes('edit') ||
 		lowerToolId.includes('create') ||
@@ -221,6 +221,7 @@ export class ChatThinkingContentPart extends ChatCollapsibleContentPart implemen
 	private workingSpinnerLabel: HTMLElement | undefined;
 	private availableMessagesByCategory = new Map<WorkingMessageCategory, string[]>();
 	private readonly toolWrappersByCallId = new Map<string, HTMLElement>();
+	private readonly toolLabelsByCallId = new Map<string, string>();
 	private readonly toolDisposables = this._register(new DisposableMap<string, DisposableStore>());
 	private pendingRemovals: { toolCallId: string; toolLabel: string }[] = [];
 	private pendingRemovalFlushDisposable: IDisposable | undefined;
@@ -1179,19 +1180,18 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 			(t.kind === 'toolInvocation' || t.kind === 'toolInvocationSerialized') && t.toolCallId === toolCallId
 		);
 		if (toolInvocationsIndex !== -1) {
-			const invocation = this.toolInvocations[toolInvocationsIndex];
-			if (invocation.kind === 'toolInvocation' || invocation.kind === 'toolInvocationSerialized') {
-				const msg = invocation.invocationMessage;
-				const label = msg ? (typeof msg === 'string' ? msg : msg.value) : undefined;
-				if (label) {
-					const titleIndex = this.extractedTitles.indexOf(label);
-					if (titleIndex !== -1) {
-						this.extractedTitles.splice(titleIndex, 1);
-					}
+			// Use the tracked displayed label (which may differ from invocationMessage
+			// for streaming edit tools that show "Editing files")
+			const label = this.toolLabelsByCallId.get(toolCallId);
+			if (label) {
+				const titleIndex = this.extractedTitles.indexOf(label);
+				if (titleIndex !== -1) {
+					this.extractedTitles.splice(titleIndex, 1);
 				}
 			}
 			this.toolInvocations.splice(toolInvocationsIndex, 1);
 		}
+		this.toolLabelsByCallId.delete(toolCallId);
 
 		this.updateDropdownClickability();
 		this._onDidChangeHeight.fire();
@@ -1220,15 +1220,18 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		if (removedItem.kind === 'tool' && removedItem.toolInvocationOrMarkdown && (removedItem.toolInvocationOrMarkdown.kind === 'toolInvocation' || removedItem.toolInvocationOrMarkdown.kind === 'toolInvocationSerialized')) {
 			removedItem.toolInvocationOrMarkdown.isAttachedToThinking = false;
 
-			// Keep extractedTitles in sync when a lazy tool leaves the thinking container
-			const msg = removedItem.toolInvocationOrMarkdown.invocationMessage;
-			const label = msg ? (typeof msg === 'string' ? msg : msg.value) : undefined;
+			// Keep extractedTitles in sync when a lazy tool leaves the thinking container.
+			// Use the tracked displayed label (which may differ from invocationMessage
+			// for streaming edit tools that show "Editing files")
+			const toolCallId = removedItem.toolInvocationOrMarkdown.toolCallId;
+			const label = this.toolLabelsByCallId.get(toolCallId);
 			if (label) {
 				const titleIndex = this.extractedTitles.indexOf(label);
 				if (titleIndex !== -1) {
 					this.extractedTitles.splice(titleIndex, 1);
 				}
 			}
+			this.toolLabelsByCallId.delete(toolCallId);
 		}
 
 		const toolInvocationsIndex = this.toolInvocations.findIndex(t =>
@@ -1311,6 +1314,7 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		if (titleIndex !== -1) {
 			this.extractedTitles.splice(titleIndex, 1);
 		}
+		this.toolLabelsByCallId.delete(toolCallId);
 		this.updateDropdownClickability();
 		this._onDidChangeHeight.fire();
 	}
@@ -1353,6 +1357,10 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 
 			this.toolInvocations.push(toolInvocationOrMarkdown);
 
+			// Track the displayed label for consistent cleanup
+			const toolCallId = toolInvocationOrMarkdown.toolCallId;
+			this.toolLabelsByCallId.set(toolCallId, toolCallLabel);
+
 			// track state for live/still streaming tools, excluding serialized tools
 			if (toolInvocationOrMarkdown.kind === 'toolInvocation') {
 				let currentToolLabel = toolCallLabel;
@@ -1378,6 +1386,7 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 							this.extractedTitles.push(updatedMessage);
 						}
 						currentToolLabel = updatedMessage;
+						this.toolLabelsByCallId.set(toolCallId, updatedMessage);
 						this.lastExtractedTitle = updatedMessage;
 
 						// make sure not to set title if expanded

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -41,6 +41,31 @@ function extractTextFromPart(content: IChatThinkingPart): string {
 	return raw.trim();
 }
 
+export function isEditToolId(toolId: string): boolean {
+	const lowerToolId = toolId.toLowerCase();
+	return lowerToolId.includes('edit') ||
+		lowerToolId.includes('create') ||
+		lowerToolId.includes('replace') ||
+		lowerToolId.includes('patch');
+}
+
+/**
+ * Returns true for edit tools whose generic display name should be replaced
+ * with "Editing files" while streaming (e.g. replace, multi-replace, patch, insertEdit).
+ * Excludes create and notebook tools which already have good labels.
+ */
+function isGenericEditToolId(toolId: string): boolean {
+	const lowerToolId = toolId.toLowerCase();
+	if (lowerToolId.includes('create') || lowerToolId.includes('notebook')) {
+		return false;
+	}
+	return lowerToolId.includes('replace') ||
+		lowerToolId.includes('patch') ||
+		lowerToolId.includes('insertedit') ||
+		lowerToolId.includes('insert_edit') ||
+		lowerToolId.includes('editfile');
+}
+
 export function getToolInvocationIcon(toolId: string): ThemeIcon {
 	const lowerToolId = toolId.toLowerCase();
 
@@ -64,11 +89,7 @@ export function getToolInvocationIcon(toolId: string): ThemeIcon {
 		return Codicon.book;
 	}
 
-	if (
-		lowerToolId.includes('edit') ||
-		lowerToolId.includes('create') ||
-		lowerToolId.includes('replace')
-	) {
+	if (isEditToolId(toolId)) {
 		return Codicon.pencil;
 	}
 
@@ -1320,7 +1341,15 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		const isToolInvocation = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized');
 		if (isToolInvocation && toolInvocationOrMarkdown.invocationMessage) {
 			const message = typeof toolInvocationOrMarkdown.invocationMessage === 'string' ? toolInvocationOrMarkdown.invocationMessage : toolInvocationOrMarkdown.invocationMessage.value;
-			toolCallLabel = message;
+
+			// For edit-type tools that are still streaming, use a friendlier label
+			// instead of the generic tool display name (e.g. "Replace String in File")
+			const isStreamingEditTool = toolInvocationOrMarkdown.kind === 'toolInvocation' && IChatToolInvocation.isStreaming(toolInvocationOrMarkdown) && isGenericEditToolId(toolInvocationOrMarkdown.toolId);
+			if (isStreamingEditTool) {
+				toolCallLabel = localize('chat.thinking.editingFiles', 'Editing files');
+			} else {
+				toolCallLabel = message;
+			}
 
 			this.toolInvocations.push(toolInvocationOrMarkdown);
 

--- a/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatThinkingContentPart.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/chatContentParts/chatThinkingContentPart.test.ts
@@ -14,7 +14,7 @@ import { workbenchInstantiationService } from '../../../../../../test/browser/wo
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ChatThinkingContentPart } from '../../../../browser/widget/chatContentParts/chatThinkingContentPart.js';
-import { IChatMarkdownContent, IChatThinkingPart } from '../../../../common/chatService/chatService.js';
+import { IChatMarkdownContent, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized } from '../../../../common/chatService/chatService.js';
 import { IChatContentPartRenderContext, InlineTextModelCollection } from '../../../../browser/widget/chatContentParts/chatContentParts.js';
 import { IChatRendererContent, IChatResponseViewModel } from '../../../../common/model/chatViewModel.js';
 import { IChatMarkdownAnchorService } from '../../../../browser/widget/chatContentParts/chatMarkdownAnchorService.js';
@@ -26,6 +26,7 @@ import { CodeBlockModelCollection } from '../../../../common/widget/codeBlockMod
 import { EditorPool, DiffEditorPool } from '../../../../browser/widget/chatContentParts/chatContentCodePools.js';
 import { IHoverService } from '../../../../../../../platform/hover/browser/hover.js';
 import { ILanguageModelsService } from '../../../../common/languageModels.js';
+import { ToolDataSource } from '../../../../common/tools/languageModelToolsService.js';
 import { URI } from '../../../../../../../base/common/uri.js';
 
 suite('ChatThinkingContentPart', () => {
@@ -1192,6 +1193,176 @@ suite('ChatThinkingContentPart', () => {
 			// Should have circle-filled icon (not loading spinner) while streaming
 			const circleIcon = part.domNode.querySelector('.codicon-circle-filled');
 			assert.ok(circleIcon, 'Should have circle-filled icon while streaming');
+		});
+
+		function createMockStreamingToolInvocation(toolId: string, invocationMessage: string, toolCallId: string): IChatToolInvocation {
+			return {
+				kind: 'toolInvocation',
+				toolId,
+				toolCallId,
+				invocationMessage,
+				originMessage: undefined,
+				pastTenseMessage: undefined,
+				presentation: undefined,
+				source: ToolDataSource.Internal,
+				isAttachedToThinking: false,
+				generatedTitle: undefined,
+				state: observableValue('state', {
+					type: IChatToolInvocation.StateKind.Streaming,
+					partialInput: observableValue('partialInput', undefined),
+					streamingMessage: observableValue('streamingMessage', undefined),
+				}),
+				toJSON: () => ({} as IChatToolInvocationSerialized),
+			} as IChatToolInvocation;
+		}
+
+		function createMockExecutingToolInvocation(toolId: string, invocationMessage: string, toolCallId: string): IChatToolInvocation {
+			return {
+				kind: 'toolInvocation',
+				toolId,
+				toolCallId,
+				invocationMessage,
+				originMessage: undefined,
+				pastTenseMessage: undefined,
+				presentation: undefined,
+				source: ToolDataSource.Internal,
+				isAttachedToThinking: false,
+				generatedTitle: undefined,
+				state: observableValue('state', {
+					type: IChatToolInvocation.StateKind.Executing,
+					confirmed: { type: 0 },
+					progress: observableValue('progress', { progress: 0 }),
+					parameters: {},
+					confirmationMessages: undefined,
+				}),
+				toJSON: () => ({} as IChatToolInvocationSerialized),
+			} as IChatToolInvocation;
+		}
+
+		test('should show "Editing files" for streaming edit tools instead of generic display name', () => {
+			const content = createThinkingPart('**Working**');
+			const context = createMockRenderContext(false);
+
+			const part = store.add(instantiationService.createInstance(
+				ChatThinkingContentPart,
+				content,
+				context,
+				mockMarkdownRenderer,
+				false
+			));
+
+			mainWindow.document.body.appendChild(part.domNode);
+			disposables.add(toDisposable(() => part.domNode.remove()));
+
+			const streamingReplaceTool = createMockStreamingToolInvocation(
+				'copilot_replaceString', 'Replace String in File', 'call-1'
+			);
+
+			part.appendItem(() => {
+				const div = $('div.test-item');
+				div.textContent = 'Replace tool';
+				return { domNode: div };
+			}, streamingReplaceTool.toolId, streamingReplaceTool);
+
+			// The title should show "Editing files" instead of "Replace String in File"
+			const button = part.domNode.querySelector('.chat-used-context-label .monaco-button');
+			assert.ok(button, 'Should have collapse button');
+			const labelText = button.querySelector('.icon-label')?.textContent ?? button.textContent ?? '';
+			assert.ok(labelText.includes('Editing files'), `Title should contain "Editing files" but got "${labelText}"`);
+		});
+
+		test('should show original message for non-edit streaming tools', () => {
+			const content = createThinkingPart('**Working**');
+			const context = createMockRenderContext(false);
+
+			const part = store.add(instantiationService.createInstance(
+				ChatThinkingContentPart,
+				content,
+				context,
+				mockMarkdownRenderer,
+				false
+			));
+
+			mainWindow.document.body.appendChild(part.domNode);
+			disposables.add(toDisposable(() => part.domNode.remove()));
+
+			const streamingReadTool = createMockStreamingToolInvocation(
+				'copilot_readFile', 'Reading file.ts', 'call-2'
+			);
+
+			part.appendItem(() => {
+				const div = $('div.test-item');
+				div.textContent = 'Read tool';
+				return { domNode: div };
+			}, streamingReadTool.toolId, streamingReadTool);
+
+			const button = part.domNode.querySelector('.chat-used-context-label .monaco-button');
+			assert.ok(button, 'Should have collapse button');
+			const labelText = button.querySelector('.icon-label')?.textContent ?? button.textContent ?? '';
+			assert.ok(labelText.includes('Reading file.ts'), `Title should contain "Reading file.ts" but got "${labelText}"`);
+		});
+
+		test('should show original message for non-streaming edit tools', () => {
+			const content = createThinkingPart('**Working**');
+			const context = createMockRenderContext(false);
+
+			const part = store.add(instantiationService.createInstance(
+				ChatThinkingContentPart,
+				content,
+				context,
+				mockMarkdownRenderer,
+				false
+			));
+
+			mainWindow.document.body.appendChild(part.domNode);
+			disposables.add(toDisposable(() => part.domNode.remove()));
+
+			// Non-streaming (executing) edit tool should show its invocation message
+			const executingReplaceTool = createMockExecutingToolInvocation(
+				'copilot_replaceString', 'Replacing 5 lines in file.ts', 'call-3'
+			);
+
+			part.appendItem(() => {
+				const div = $('div.test-item');
+				div.textContent = 'Replace tool';
+				return { domNode: div };
+			}, executingReplaceTool.toolId, executingReplaceTool);
+
+			const button = part.domNode.querySelector('.chat-used-context-label .monaco-button');
+			assert.ok(button, 'Should have collapse button');
+			const labelText = button.querySelector('.icon-label')?.textContent ?? button.textContent ?? '';
+			assert.ok(labelText.includes('Replacing 5 lines in file.ts'), `Title should contain "Replacing 5 lines in file.ts" but got "${labelText}"`);
+		});
+
+		test('should keep original message for create_file tool even when streaming', () => {
+			const content = createThinkingPart('**Working**');
+			const context = createMockRenderContext(false);
+
+			const part = store.add(instantiationService.createInstance(
+				ChatThinkingContentPart,
+				content,
+				context,
+				mockMarkdownRenderer,
+				false
+			));
+
+			mainWindow.document.body.appendChild(part.domNode);
+			disposables.add(toDisposable(() => part.domNode.remove()));
+
+			const streamingCreateTool = createMockStreamingToolInvocation(
+				'copilot_createFile', 'Creating newFile.ts', 'call-4'
+			);
+
+			part.appendItem(() => {
+				const div = $('div.test-item');
+				div.textContent = 'Create tool';
+				return { domNode: div };
+			}, streamingCreateTool.toolId, streamingCreateTool);
+
+			const button = part.domNode.querySelector('.chat-used-context-label .monaco-button');
+			assert.ok(button, 'Should have collapse button');
+			const labelText = button.querySelector('.icon-label')?.textContent ?? button.textContent ?? '';
+			assert.ok(labelText.includes('Creating newFile.ts'), `Title should contain "Creating newFile.ts" but got "${labelText}"`);
 		});
 	});
 });


### PR DESCRIPTION
don't show the full tool name, instead, show the generic stuff:

<img width="427" height="394" alt="Screenshot 2026-03-18 at 2 23 18 PM" src="https://github.com/user-attachments/assets/cfac0588-70fb-4348-b0e1-5c119208701c" />
