### PR TITLE
Allow multiple code reviews per session version

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/test/browser/sessionEditorComments.test.ts
+++ b/src/vs/sessions/contrib/agentFeedback/test/browser/sessionEditorComments.test.ts
@@ -7,8 +7,8 @@ import assert from 'assert';
 import { URI } from '../../../../../base/common/uri.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CodeReviewStateKind, ICodeReviewState, IPRReviewState, PRReviewStateKind } from '../../../codeReview/browser/codeReviewService.js';
 import { getResourceEditorComments, getSessionEditorComments, groupNearbySessionEditorComments, hasAgentFeedbackComments, SessionEditorCommentSource } from '../../browser/sessionEditorComments.js';
+import { ICodeReviewState, CodeReviewStateKind, IPRReviewState, PRReviewStateKind } from '../../../codeReview/browser/codeReviewService.js';
 
 type ICodeReviewResultState = Extract<ICodeReviewState, { kind: CodeReviewStateKind.Result }>;
 
@@ -23,7 +23,9 @@ suite('SessionEditorComments', () => {
 		return {
 			kind: CodeReviewStateKind.Result,
 			version: 'v1',
+			reviewCount: 1,
 			comments,
+			didProduceComments: comments.length > 0,
 		};
 	}
 

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -166,16 +166,16 @@ class CodeReviewToolbarContribution extends Disposable implements IWorkbenchCont
 				canRunCodeReview = false;
 				tooltip = localize('sessions.runCodeReview.tooltip.loading', "Creating code review...");
 				icon = Codicon.commentDraft;
-			} else if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
-				canRunCodeReview = false;
-				tooltip = localize('sessions.runCodeReview.tooltip.limitReached', "Maximum of {0} code reviews reached for this session version.", MAX_CODE_REVIEWS_PER_SESSION_VERSION);
-				icon = Codicon.codeReview;
 			} else if (totalCommentCount > 0) {
 				canRunCodeReview = true;
 				icon = Codicon.commentUnresolved;
 				tooltip = totalCommentCount === 1
 					? localize('sessions.runCodeReview.tooltip.oneUnresolved', "1 review comment unresolved.")
 					: localize('sessions.runCodeReview.tooltip.manyUnresolved', "{0} review comments unresolved.", totalCommentCount);
+			} else if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
+				canRunCodeReview = false;
+				tooltip = localize('sessions.runCodeReview.tooltip.limitReached', "Maximum of {0} code reviews reached for this session version.", MAX_CODE_REVIEWS_PER_SESSION_VERSION);
+				icon = Codicon.codeReview;
 			} else if (reviewState.kind === CodeReviewStateKind.Result && reviewState.version === version) {
 				canRunCodeReview = true;
 				tooltip = reviewState.didProduceComments

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -86,10 +86,6 @@ function registerSessionCodeReviewAction(tooltip: string, icon: ThemeIcon): Disp
 			const codeReviewCount = reviewState.kind === CodeReviewStateKind.Result && reviewState.version === version ? reviewState.comments.length : 0;
 			const prReviewCount = prReviewState.kind === PRReviewStateKind.Loaded ? prReviewState.comments.length : 0;
 
-			if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
-				return;
-			}
-
 			if (codeReviewCount > 0 || prReviewCount > 0) {
 				const comments = getSessionEditorComments(
 					resource,
@@ -101,6 +97,10 @@ function registerSessionCodeReviewAction(tooltip: string, icon: ThemeIcon): Disp
 				if (first) {
 					await agentFeedbackService.revealSessionComment(resource, first.id, first.resourceUri, first.range);
 				}
+				return;
+			}
+
+			if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
 				return;
 			}
 

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -19,10 +19,10 @@ import { AgentSessionProviders } from '../../../../workbench/contrib/chat/browse
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { CHAT_CATEGORY } from '../../../../workbench/contrib/chat/browser/actions/chatActions.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
-import { CodeReviewService, CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion, ICodeReviewService, PRReviewStateKind } from './codeReviewService.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IAgentFeedbackService } from '../../agentFeedback/browser/agentFeedbackService.js';
 import { getSessionEditorComments } from '../../agentFeedback/browser/sessionEditorComments.js';
+import { CodeReviewService, CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion, ICodeReviewService, MAX_CODE_REVIEWS_PER_SESSION_VERSION, PRReviewStateKind } from './codeReviewService.js';
 
 registerSingleton(ICodeReviewService, CodeReviewService, InstantiationType.Delayed);
 
@@ -82,8 +82,13 @@ function registerSessionCodeReviewAction(tooltip: string, icon: ThemeIcon): Disp
 			// If there are existing comments (code review or PR review), navigate to the first one
 			const reviewState = codeReviewService.getReviewState(resource).get();
 			const prReviewState = codeReviewService.getPRReviewState(resource).get();
+			const reviewCount = reviewState.kind !== CodeReviewStateKind.Idle && reviewState.version === version ? reviewState.reviewCount : 0;
 			const codeReviewCount = reviewState.kind === CodeReviewStateKind.Result && reviewState.version === version ? reviewState.comments.length : 0;
 			const prReviewCount = prReviewState.kind === PRReviewStateKind.Loaded ? prReviewState.comments.length : 0;
+
+			if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
+				return;
+			}
 
 			if (codeReviewCount > 0 || prReviewCount > 0) {
 				const comments = getSessionEditorComments(
@@ -147,6 +152,7 @@ class CodeReviewToolbarContribution extends Disposable implements IWorkbenchCont
 			const version = getCodeReviewVersion(files);
 			const reviewState = this._codeReviewService.getReviewState(sessionResource).read(reader);
 			const prReviewState = this._codeReviewService.getPRReviewState(sessionResource).read(reader);
+			const reviewCount = reviewState.kind !== CodeReviewStateKind.Idle && reviewState.version === version ? reviewState.reviewCount : 0;
 
 			const codeReviewCount = reviewState.kind === CodeReviewStateKind.Result && reviewState.version === version ? reviewState.comments.length : 0;
 			const prReviewCount = prReviewState.kind === PRReviewStateKind.Loaded ? prReviewState.comments.length : 0;
@@ -160,6 +166,10 @@ class CodeReviewToolbarContribution extends Disposable implements IWorkbenchCont
 				canRunCodeReview = false;
 				tooltip = localize('sessions.runCodeReview.tooltip.loading', "Creating code review...");
 				icon = Codicon.commentDraft;
+			} else if (reviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
+				canRunCodeReview = false;
+				tooltip = localize('sessions.runCodeReview.tooltip.limitReached', "Maximum of {0} code reviews reached for this session version.", MAX_CODE_REVIEWS_PER_SESSION_VERSION);
+				icon = Codicon.codeReview;
 			} else if (totalCommentCount > 0) {
 				canRunCodeReview = true;
 				icon = Codicon.commentUnresolved;
@@ -167,9 +177,11 @@ class CodeReviewToolbarContribution extends Disposable implements IWorkbenchCont
 					? localize('sessions.runCodeReview.tooltip.oneUnresolved', "1 review comment unresolved.")
 					: localize('sessions.runCodeReview.tooltip.manyUnresolved', "{0} review comments unresolved.", totalCommentCount);
 			} else if (reviewState.kind === CodeReviewStateKind.Result && reviewState.version === version) {
-				canRunCodeReview = false;
-				tooltip = localize('sessions.runCodeReview.tooltip.allResolved', "All review comments have been addressed.");
-				icon = Codicon.comment;
+				canRunCodeReview = true;
+				tooltip = reviewState.didProduceComments
+					? localize('sessions.runCodeReview.tooltip.runAgain', "Run another code review.")
+					: localize('sessions.runCodeReview.tooltip.noCommentsRunAgain', "Previous code review did not produce any comments, run code review again.");
+				icon = reviewState.didProduceComments ? Codicon.comment : Codicon.codeReview;
 			}
 
 			canRunCodeReviewContext.set(canRunCodeReview);

--- a/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReview.contributions.ts
@@ -180,7 +180,7 @@ class CodeReviewToolbarContribution extends Disposable implements IWorkbenchCont
 				canRunCodeReview = true;
 				tooltip = reviewState.didProduceComments
 					? localize('sessions.runCodeReview.tooltip.runAgain', "Run another code review.")
-					: localize('sessions.runCodeReview.tooltip.noCommentsRunAgain', "Previous code review did not produce any comments, run code review again.");
+					: localize('sessions.runCodeReview.tooltip.noCommentsRunAgain', "Previous code review produced no comments. Run code review again.");
 				icon = reviewState.didProduceComments ? Codicon.comment : Codicon.codeReview;
 			}
 

--- a/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
@@ -70,6 +70,8 @@ export function getCodeReviewVersion(files: readonly ICodeReviewFile[]): string 
 	return `v1:${stableFileList.length}:${hash(stableFileList)}`;
 }
 
+export const MAX_CODE_REVIEWS_PER_SESSION_VERSION = 5;
+
 export const enum CodeReviewStateKind {
 	Idle = 'idle',
 	Loading = 'loading',
@@ -79,9 +81,9 @@ export const enum CodeReviewStateKind {
 
 export type ICodeReviewState =
 	| { readonly kind: CodeReviewStateKind.Idle }
-	| { readonly kind: CodeReviewStateKind.Loading; readonly version: string }
-	| { readonly kind: CodeReviewStateKind.Result; readonly version: string; readonly comments: readonly ICodeReviewComment[] }
-	| { readonly kind: CodeReviewStateKind.Error; readonly version: string; readonly reason: string };
+	| { readonly kind: CodeReviewStateKind.Loading; readonly version: string; readonly reviewCount: number }
+	| { readonly kind: CodeReviewStateKind.Result; readonly version: string; readonly reviewCount: number; readonly comments: readonly ICodeReviewComment[]; readonly didProduceComments: boolean }
+	| { readonly kind: CodeReviewStateKind.Error; readonly version: string; readonly reviewCount: number; readonly reason: string };
 
 // --- PR Review Types ---------------------------------------------------------
 
@@ -169,7 +171,8 @@ export interface ICodeReviewService {
 	/**
 	 * Request a code review for the given session. The review is associated with
 	 * a version string (fingerprint of changed files). If a review is already in
-	 * progress or completed for this version, this is a no-op.
+	 * progress or there are still unresolved review comments for this version,
+	 * this is a no-op.
 	 */
 	requestReview(sessionResource: URI, version: string, files: readonly { readonly currentUri: URI; readonly baseUri?: URI }[]): void;
 
@@ -204,6 +207,8 @@ export interface ICodeReviewService {
 
 interface IStoredCodeReview {
 	readonly version: string;
+	readonly reviewCount?: number;
+	readonly didProduceComments?: boolean;
 	readonly comments: readonly IStoredCodeReviewComment[];
 }
 
@@ -347,16 +352,20 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 	requestReview(sessionResource: URI, version: string, files: readonly { readonly currentUri: URI; readonly baseUri?: URI }[]): void {
 		const data = this._getOrCreateData(sessionResource);
 		const currentState = data.state.get();
+		const currentReviewCount = currentState.kind !== CodeReviewStateKind.Idle && currentState.version === version ? currentState.reviewCount : 0;
 
-		// Don't re-request if already loading or completed for this version
+		// Don't re-request if already loading or unresolved comments remain for this version.
 		if (currentState.kind === CodeReviewStateKind.Loading && currentState.version === version) {
 			return;
 		}
-		if (currentState.kind === CodeReviewStateKind.Result && currentState.version === version) {
+		if (currentReviewCount >= MAX_CODE_REVIEWS_PER_SESSION_VERSION) {
+			return;
+		}
+		if (currentState.kind === CodeReviewStateKind.Result && currentState.version === version && currentState.comments.length > 0) {
 			return;
 		}
 
-		data.state.set({ kind: CodeReviewStateKind.Loading, version }, undefined);
+		data.state.set({ kind: CodeReviewStateKind.Loading, version, reviewCount: currentReviewCount + 1 }, undefined);
 
 		this._executeReview(sessionResource, version, files, data);
 	}
@@ -373,7 +382,7 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 		}
 
 		const filtered = state.comments.filter(c => c.id !== commentId);
-		data.state.set({ kind: CodeReviewStateKind.Result, version: state.version, comments: filtered }, undefined);
+		data.state.set({ kind: CodeReviewStateKind.Result, version: state.version, reviewCount: state.reviewCount, comments: filtered, didProduceComments: state.didProduceComments }, undefined);
 		this._saveToStorage();
 	}
 
@@ -389,7 +398,7 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 		}
 
 		const updated = state.comments.map(c => c.id === commentId ? { ...c, body: newBody } : c);
-		data.state.set({ kind: CodeReviewStateKind.Result, version: state.version, comments: updated }, undefined);
+		data.state.set({ kind: CodeReviewStateKind.Result, version: state.version, reviewCount: state.reviewCount, comments: updated, didProduceComments: state.didProduceComments }, undefined);
 		this._saveToStorage();
 	}
 
@@ -440,7 +449,7 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 			}
 
 			if (result.type === 'error') {
-				data.state.set({ kind: CodeReviewStateKind.Error, version, reason: result.reason ?? 'Unknown error' }, undefined);
+				data.state.set({ kind: CodeReviewStateKind.Error, version, reviewCount: currentState.reviewCount, reason: result.reason ?? 'Unknown error' }, undefined);
 				return;
 			}
 
@@ -456,14 +465,14 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 				}));
 
 				transaction(tx => {
-					data.state.set({ kind: CodeReviewStateKind.Result, version, comments }, tx);
+					data.state.set({ kind: CodeReviewStateKind.Result, version, reviewCount: currentState.reviewCount, comments, didProduceComments: comments.length > 0 }, tx);
 				});
 				this._saveToStorage();
 			}
 		} catch (err) {
 			const currentState = data.state.get();
 			if (currentState.kind === CodeReviewStateKind.Loading && currentState.version === version) {
-				data.state.set({ kind: CodeReviewStateKind.Error, version, reason: String(err) }, undefined);
+				data.state.set({ kind: CodeReviewStateKind.Error, version, reviewCount: currentState.reviewCount, reason: String(err) }, undefined);
 			}
 		}
 	}
@@ -487,10 +496,10 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 					suggestion: c.suggestion,
 				}));
 				const data = this._getOrCreateData(URI.parse(key));
-				data.state.set({ kind: CodeReviewStateKind.Result, version: review.version, comments }, undefined);
+				data.state.set({ kind: CodeReviewStateKind.Result, version: review.version, reviewCount: review.reviewCount ?? 1, comments, didProduceComments: review.didProduceComments ?? comments.length > 0 }, undefined);
 			}
 		} catch {
-			// Corrupted storage data — ignore
+			// Corrupted storage data - ignore
 		}
 	}
 
@@ -501,6 +510,8 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 			if (state.kind === CodeReviewStateKind.Result) {
 				stored[key] = {
 					version: state.version,
+					reviewCount: state.reviewCount,
+					didProduceComments: state.didProduceComments,
 					comments: state.comments.map(c => ({
 						id: c.id,
 						uri: c.uri.toJSON(),
@@ -545,14 +556,14 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 
 				const session = this._agentSessionsService.getSession(URI.parse(key));
 				if (!session) {
-					// Session no longer exists — clean up
+					// Session no longer exists - clean up
 					data.state.set({ kind: CodeReviewStateKind.Idle }, undefined);
 					changed = true;
 					continue;
 				}
 
 				if (!(session.changes instanceof Array) || session.changes.length === 0) {
-					// Session has no file-level changes — clean up
+					// Session has no file-level changes - clean up
 					data.state.set({ kind: CodeReviewStateKind.Idle }, undefined);
 					changed = true;
 					continue;
@@ -561,7 +572,7 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 				const files = getCodeReviewFilesFromSessionChanges(session.changes);
 				const currentVersion = getCodeReviewVersion(files);
 				if (state.version !== currentVersion) {
-					// Version mismatch — review is stale
+					// Version mismatch - review is stale
 					data.state.set({ kind: CodeReviewStateKind.Idle }, undefined);
 					changed = true;
 				}

--- a/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
+++ b/src/vs/sessions/contrib/codeReview/test/browser/codeReviewService.test.ts
@@ -18,9 +18,9 @@ import { InMemoryStorageService, IStorageService, StorageScope, StorageTarget } 
 import { IAgentSession, IAgentSessionsModel } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { IChatSessionFileChange2 } from '../../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { IAgentSessionsService } from '../../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
-import { CodeReviewService, CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion, ICodeReviewService } from '../../browser/codeReviewService.js';
 import { IGitHubService } from '../../../github/browser/githubService.js';
 import { IActiveSessionItem, ISessionsManagementService } from '../../../sessions/browser/sessionsManagementService.js';
+import { ICodeReviewService, CodeReviewService, CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion } from '../../browser/codeReviewService.js';
 
 suite('CodeReviewService', () => {
 
@@ -249,6 +249,7 @@ suite('CodeReviewService', () => {
 		assert.strictEqual(state.kind, CodeReviewStateKind.Loading);
 		if (state.kind === CodeReviewStateKind.Loading) {
 			assert.strictEqual(state.version, 'v1');
+			assert.strictEqual(state.reviewCount, 1);
 		}
 
 		// Resolve to avoid leaking
@@ -301,6 +302,7 @@ suite('CodeReviewService', () => {
 		assert.strictEqual(state.kind, CodeReviewStateKind.Result);
 		if (state.kind === CodeReviewStateKind.Result) {
 			assert.strictEqual(state.version, 'v1');
+			assert.strictEqual(state.reviewCount, 1);
 			assert.strictEqual(state.comments.length, 2);
 			assert.strictEqual(state.comments[0].body, 'Bug found');
 			assert.strictEqual(state.comments[0].kind, 'bug');
@@ -320,6 +322,7 @@ suite('CodeReviewService', () => {
 		assert.strictEqual(state.kind, CodeReviewStateKind.Error);
 		if (state.kind === CodeReviewStateKind.Error) {
 			assert.strictEqual(state.version, 'v1');
+			assert.strictEqual(state.reviewCount, 1);
 			assert.strictEqual(state.reason, 'Auth failed');
 		}
 	});
@@ -354,6 +357,7 @@ suite('CodeReviewService', () => {
 		const state = service.getReviewState(session).get();
 		assert.strictEqual(state.kind, CodeReviewStateKind.Error);
 		if (state.kind === CodeReviewStateKind.Error) {
+			assert.strictEqual(state.reviewCount, 1);
 			assert.ok(state.reason.includes('Network error'));
 		}
 	});
@@ -372,8 +376,8 @@ suite('CodeReviewService', () => {
 		commandService.resolveExecution({ type: 'success', comments: [] });
 	});
 
-	test('requestReview is a no-op when result exists for the same version', async () => {
-		commandService.result = { type: 'success', comments: [] };
+	test('requestReview is a no-op when unresolved comments exist for the same version', async () => {
+		commandService.result = { type: 'success', comments: [{ uri: fileA, range: new Range(1, 1, 1, 1), body: 'comment' }] };
 		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
 		await tick();
 
@@ -383,6 +387,71 @@ suite('CodeReviewService', () => {
 		// Should still have the result
 		const state = service.getReviewState(session).get();
 		assert.strictEqual(state.kind, CodeReviewStateKind.Result);
+		if (state.kind === CodeReviewStateKind.Result) {
+			assert.strictEqual(state.comments.length, 1);
+		}
+	});
+
+	test('requestReview reruns when previous result for the same version had no comments', async () => {
+		commandService.result = { type: 'success', comments: [] };
+		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+		await tick();
+
+		commandService.deferNextExecution();
+		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+
+		const state = service.getReviewState(session).get();
+		assert.strictEqual(state.kind, CodeReviewStateKind.Loading);
+
+		commandService.resolveExecution({ type: 'success', comments: [] });
+		await tick();
+	});
+
+	test('requestReview reruns when all comments for the same version were removed', async () => {
+		commandService.result = { type: 'success', comments: [{ uri: fileA, range: new Range(1, 1, 1, 1), body: 'comment' }] };
+		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+		await tick();
+
+		const initialState = service.getReviewState(session).get();
+		assert.strictEqual(initialState.kind, CodeReviewStateKind.Result);
+		if (initialState.kind !== CodeReviewStateKind.Result) {
+			return;
+		}
+
+		service.removeComment(session, initialState.comments[0].id);
+
+		commandService.deferNextExecution();
+		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+
+		const state = service.getReviewState(session).get();
+		assert.strictEqual(state.kind, CodeReviewStateKind.Loading);
+
+		commandService.resolveExecution({ type: 'success', comments: [] });
+		await tick();
+	});
+
+	test('requestReview is a no-op after five reviews for the same version', async () => {
+		commandService.result = { type: 'success', comments: [] };
+
+		for (let i = 0; i < 5; i++) {
+			service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+			await tick();
+		}
+
+		const stateBefore = service.getReviewState(session).get();
+		assert.strictEqual(stateBefore.kind, CodeReviewStateKind.Result);
+		if (stateBefore.kind === CodeReviewStateKind.Result) {
+			assert.strictEqual(stateBefore.reviewCount, 5);
+		}
+
+		commandService.deferNextExecution();
+		service.requestReview(session, 'v1', [{ currentUri: fileA }]);
+
+		const stateAfter = service.getReviewState(session).get();
+		assert.strictEqual(stateAfter.kind, CodeReviewStateKind.Result);
+		if (stateAfter.kind === CodeReviewStateKind.Result) {
+			assert.strictEqual(stateAfter.reviewCount, 5);
+		}
 	});
 
 	test('requestReview for a new version replaces loading state', async () => {
@@ -759,6 +828,7 @@ suite('CodeReviewService', () => {
 		const reviewData = stored[session.toString()];
 		assert.ok(reviewData);
 		assert.strictEqual(reviewData.version, 'v1');
+		assert.strictEqual(reviewData.reviewCount, 1);
 		assert.strictEqual(reviewData.comments.length, 1);
 		assert.strictEqual(reviewData.comments[0].body, 'Persisted comment');
 	});
@@ -777,6 +847,7 @@ suite('CodeReviewService', () => {
 		assert.strictEqual(state.kind, CodeReviewStateKind.Result);
 		if (state.kind === CodeReviewStateKind.Result) {
 			assert.strictEqual(state.version, 'v1');
+			assert.strictEqual(state.reviewCount, 1);
 			assert.strictEqual(state.comments.length, 1);
 			assert.strictEqual(state.comments[0].body, 'Restored comment');
 			assert.strictEqual(state.comments[0].uri.toString(), fileA.toString());


### PR DESCRIPTION
```Copilot Generated Description:``` Enable requesting up to five code reviews for the same session version. Update tooltips and disable actions accordingly based on the review count.

closes https://github.com/microsoft/vscode/issues/302669
