### PR TITLE
Fix workspace disable action for agent plugins

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentPluginActions.ts
@@ -258,19 +258,23 @@ export function createDisablePluginDropDown(
 	plugin: IAgentPlugin,
 	enablementModel: IEnablementModel,
 	workspaceContextService: IWorkspaceContextService,
-): EnablementDropDownAction {
+): Action {
 	const key = plugin.uri.toString();
 	const hasWorkspace = workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY;
 
 	const disable = new EnablementSubAction('agentPlugin.disable', localize('disable', "Disable"), 'extension-action label disable',
-		isContributionEnabled(plugin.enablement.get()),
+		isContributionEnabled(plugin.enablement.get()) && !hasWorkspace,
 		() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledProfile); return Promise.resolve(); });
 
 	const disableWorkspace = new EnablementSubAction('agentPlugin.disableForWorkspace', localize('disableForWorkspace', "Disable (Workspace)"), 'extension-action label disable',
 		isContributionEnabled(plugin.enablement.get()) && hasWorkspace,
 		() => { enablementModel.setEnabled(key, ContributionEnablementState.DisabledWorkspace); return Promise.resolve(); });
 
-	return new EnablementDropDownAction('agentPlugin.disableDropdown', [disable, disableWorkspace]);
+	if (hasWorkspace) {
+		return disableWorkspace;
+	} else {
+		return disable;
+	}
 }
 
 //#endregion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->## Summary

Fixes the issue where both **"Disable"** and **"Disable (Workspace)"** appeared when a workspace exists.

## Changes

* return only **Disable (Workspace)** when workspace is present
* return only **Disable** when no workspace exists

## Testing

* launched development build
* opened an agent plugin in workspace mode
* verified correct disable action appears without dropdown

