### PR TITLE
Add disable/enable toggle for built-in skills in AI Customization editor

### DIFF
--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -139,20 +139,6 @@ registerAction2(class extends Action2 {
 
 // Inline hover actions (shown as icon buttons on hover)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
-	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
-	group: 'inline',
-	order: 5,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
-});
-
-MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
-	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
-	group: 'inline',
-	order: 5,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
-});
-
-MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_FILE_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
 	group: 'inline',
 	order: 10,
@@ -259,6 +245,22 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable") },
 	group: '4_toggle',
 	order: 1,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+});
+
+// Inline hover: Disable (shown when item is enabled)
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+});
+
+// Inline hover: Enable (shown when item is disabled)
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
+	group: 'inline',
+	order: 5,
 	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
 });
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -7,7 +7,7 @@ import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
+import { AI_CUSTOMIZATION_VIEW_ID, AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
 import { AICustomizationItemDisabledContextKey, AICustomizationItemStorageContextKey, AICustomizationItemTypeContextKey, AICustomizationViewPane } from './aiCustomizationTreeViewViews.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
@@ -19,7 +19,6 @@ import { IClipboardService } from '../../../../platform/clipboard/common/clipboa
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
-import { AI_CUSTOMIZATION_VIEW_ID } from './aiCustomizationTreeView.js';
 import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 
 //#region Utilities

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -139,6 +139,20 @@ registerAction2(class extends Action2 {
 
 // Inline hover actions (shown as icon buttons on hover)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+});
+
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+});
+
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_FILE_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
 	group: 'inline',
 	order: 10,

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -8,7 +8,7 @@ import { Action2, MenuRegistry, registerAction2 } from '../../../../platform/act
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
-import { AICustomizationItemTypeContextKey } from './aiCustomizationTreeViewViews.js';
+import { AICustomizationItemDisabledContextKey, AICustomizationItemTypeContextKey, AICustomizationViewPane } from './aiCustomizationTreeViewViews.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -17,6 +17,9 @@ import { IEditorService } from '../../../../workbench/services/editor/common/edi
 import { IFileService, FileSystemProviderCapabilities } from '../../../../platform/files/common/files.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
+import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
+import { AI_CUSTOMIZATION_VIEW_ID } from './aiCustomizationTreeView.js';
 
 //#region Utilities
 
@@ -24,13 +27,13 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
  * Type for context passed to actions from tree context menus.
  * Handles both direct URI arguments and serialized context objects.
  */
-type URIContext = { uri: URI | string;[key: string]: unknown } | URI | string;
+type ItemContext = { uri: URI | string; promptType?: string; disabled?: boolean;[key: string]: unknown } | URI | string;
 
 /**
  * Extracts a URI from various context formats.
  * Context can be a URI, string, or an object with uri property.
  */
-function extractURI(context: URIContext): URI {
+function extractURI(context: ItemContext): URI {
 	if (URI.isUri(context)) {
 		return context;
 	}
@@ -57,7 +60,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.goToFile,
 		});
 	}
-	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		await editorService.openEditor({
 			resource: extractURI(context)
@@ -76,7 +79,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.play,
 		});
 	}
-	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
 		const commandService = accessor.get(ICommandService);
 		await commandService.executeCommand('workbench.action.chat.run.prompt.current', extractURI(context));
 	}
@@ -92,7 +95,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.trash,
 		});
 	}
-	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
 		const fileService = accessor.get(IFileService);
 		const dialogService = accessor.get(IDialogService);
 		const uri = extractURI(context);
@@ -124,7 +127,7 @@ registerAction2(class extends Action2 {
 			icon: Codicon.clippy,
 		});
 	}
-	async run(accessor: ServicesAccessor, context: URIContext): Promise<void> {
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
 		const clipboardService = accessor.get(IClipboardService);
 		const uri = extractURI(context);
 		const textToCopy = uri.scheme === 'file' ? uri.fsPath : uri.toString(true);
@@ -165,6 +168,84 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_FILE_ID, title: localize('delete', "Delete") },
 	group: '3_modify',
 	order: 10,
+});
+
+// Disable item action
+const DISABLE_AI_CUSTOMIZATION_ITEM_ID = 'aiCustomization.disableItem';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: DISABLE_AI_CUSTOMIZATION_ITEM_ID,
+			title: localize2('disable', "Disable"),
+			icon: Codicon.eyeClosed,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
+		if (typeof context !== 'object' || URI.isUri(context)) {
+			return;
+		}
+		const promptsService = accessor.get(IPromptsService);
+		const viewsService = accessor.get(IViewsService);
+		const uri = extractURI(context);
+		const promptType = context.promptType as PromptsType | undefined;
+		if (!promptType) {
+			return;
+		}
+
+		const disabled = promptsService.getDisabledPromptFiles(promptType);
+		disabled.add(uri);
+		promptsService.setDisabledPromptFiles(promptType, disabled);
+
+		const view = viewsService.getActiveViewWithId<AICustomizationViewPane>(AI_CUSTOMIZATION_VIEW_ID);
+		view?.refresh();
+	}
+});
+
+// Enable item action
+const ENABLE_AI_CUSTOMIZATION_ITEM_ID = 'aiCustomization.enableItem';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: ENABLE_AI_CUSTOMIZATION_ITEM_ID,
+			title: localize2('enable', "Enable"),
+			icon: Codicon.eye,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: ItemContext): Promise<void> {
+		if (typeof context !== 'object' || URI.isUri(context)) {
+			return;
+		}
+		const promptsService = accessor.get(IPromptsService);
+		const viewsService = accessor.get(IViewsService);
+		const uri = extractURI(context);
+		const promptType = context.promptType as PromptsType | undefined;
+		if (!promptType) {
+			return;
+		}
+
+		const disabled = promptsService.getDisabledPromptFiles(promptType);
+		disabled.delete(uri);
+		promptsService.setDisabledPromptFiles(promptType, disabled);
+
+		const view = viewsService.getActiveViewWithId<AICustomizationViewPane>(AI_CUSTOMIZATION_VIEW_ID);
+		view?.refresh();
+	}
+});
+
+// Context menu: Disable (shown when item is enabled)
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable") },
+	group: '4_toggle',
+	order: 1,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+});
+
+// Context menu: Enable (shown when item is disabled)
+MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable") },
+	group: '4_toggle',
+	order: 1,
+	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
 });
 
 //#endregion

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -241,6 +241,7 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
 		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AICustomizationItemTypeContextKey.key, PromptsType.skill),
 	),
 });
 
@@ -252,6 +253,7 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
 		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AICustomizationItemTypeContextKey.key, PromptsType.skill),
 	),
 });
 
@@ -263,6 +265,7 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
 		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AICustomizationItemTypeContextKey.key, PromptsType.skill),
 	),
 });
 
@@ -274,6 +277,7 @@ MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
 		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AICustomizationItemTypeContextKey.key, PromptsType.skill),
 	),
 });
 

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.ts
@@ -8,7 +8,7 @@ import { Action2, MenuRegistry, registerAction2 } from '../../../../platform/act
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { AICustomizationItemMenuId } from './aiCustomizationTreeView.js';
-import { AICustomizationItemDisabledContextKey, AICustomizationItemTypeContextKey, AICustomizationViewPane } from './aiCustomizationTreeViewViews.js';
+import { AICustomizationItemDisabledContextKey, AICustomizationItemStorageContextKey, AICustomizationItemTypeContextKey, AICustomizationViewPane } from './aiCustomizationTreeViewViews.js';
 import { PromptsType } from '../../../../workbench/contrib/chat/common/promptSyntax/promptTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -20,6 +20,7 @@ import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IPromptsService } from '../../../../workbench/contrib/chat/common/promptSyntax/service/promptsService.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
 import { AI_CUSTOMIZATION_VIEW_ID } from './aiCustomizationTreeView.js';
+import { BUILTIN_STORAGE } from '../../chat/common/builtinPromptsStorage.js';
 
 //#region Utilities
 
@@ -232,36 +233,48 @@ registerAction2(class extends Action2 {
 	}
 });
 
-// Context menu: Disable (shown when item is enabled)
+// Context menu: Disable (shown when builtin item is enabled)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable") },
 	group: '4_toggle',
 	order: 1,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+	),
 });
 
-// Context menu: Enable (shown when item is disabled)
+// Context menu: Enable (shown when builtin item is disabled)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable") },
 	group: '4_toggle',
 	order: 1,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+	),
 });
 
-// Inline hover: Disable (shown when item is enabled)
+// Inline hover: Disable (shown when builtin item is enabled)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: DISABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
 	group: 'inline',
 	order: 5,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, false),
+		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+	),
 });
 
-// Inline hover: Enable (shown when item is disabled)
+// Inline hover: Enable (shown when builtin item is disabled)
 MenuRegistry.appendMenuItem(AICustomizationItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
 	group: 'inline',
 	order: 5,
-	when: ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AICustomizationItemDisabledContextKey.key, true),
+		ContextKeyExpr.equals(AICustomizationItemStorageContextKey.key, BUILTIN_STORAGE),
+	),
 });
 
 //#endregion

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -54,6 +54,11 @@ export const AICustomizationIsEmptyContextKey = new RawContextKey<boolean>('aiCu
  */
 export const AICustomizationItemTypeContextKey = new RawContextKey<string>('aiCustomizationItemType', '');
 
+/**
+ * Context key indicating whether the current item is disabled.
+ */
+export const AICustomizationItemDisabledContextKey = new RawContextKey<boolean>('aiCustomizationItemDisabled', false);
+
 //#endregion
 
 //#region Tree Item Types
@@ -98,6 +103,7 @@ interface IAICustomizationFileItem {
 	readonly description?: string;
 	readonly storage: AICustomizationPromptsStorage;
 	readonly promptType: PromptsType;
+	readonly disabled: boolean;
 }
 
 /**
@@ -240,6 +246,9 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
 
 		templateData.name.textContent = item.name;
 
+		// Apply disabled styling
+		templateData.container.classList.toggle('disabled', item.disabled);
+
 		// Set tooltip with name and description
 		const tooltip = item.description ? `${item.name} - ${item.description}` : item.name;
 		templateData.container.title = tooltip;
@@ -255,6 +264,7 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
 		// Create scoped context key service with item type for when-clause filtering
 		const overlay = this.contextKeyService.createOverlay([
 			[AICustomizationItemTypeContextKey.key, item.promptType],
+			[AICustomizationItemDisabledContextKey.key, item.disabled],
 		]);
 
 		// Create menu and extract inline actions
@@ -513,6 +523,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 	 */
 	private async getFilesForStorageAndType(storage: AICustomizationPromptsStorage, promptType: PromptsType): Promise<IAICustomizationFileItem[]> {
 		const cached = this.cache.get(promptType);
+		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
 
 		// For skills, use the cached skills data
 		if (promptType === PromptsType.skill) {
@@ -530,6 +541,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 						description: skill.description,
 						storage: skill.storage,
 						promptType,
+						disabled: disabledUris.has(skill.uri),
 					};
 				});
 		}
@@ -544,6 +556,7 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 			description: item.description,
 			storage: item.storage,
 			promptType,
+			disabled: disabledUris.has(item.uri),
 		}));
 	}
 }
@@ -566,6 +579,7 @@ export class AICustomizationViewPane extends ViewPane {
 	// Context keys for controlling menu visibility and welcome content
 	private readonly isEmptyContextKey: IContextKey<boolean>;
 	private readonly itemTypeContextKey: IContextKey<string>;
+	private readonly itemDisabledContextKey: IContextKey<boolean>;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -590,6 +604,7 @@ export class AICustomizationViewPane extends ViewPane {
 		// Initialize context keys
 		this.isEmptyContextKey = AICustomizationIsEmptyContextKey.bindTo(contextKeyService);
 		this.itemTypeContextKey = AICustomizationItemTypeContextKey.bindTo(contextKeyService);
+		this.itemDisabledContextKey = AICustomizationItemDisabledContextKey.bindTo(contextKeyService);
 
 		// Subscribe to prompt service events to refresh tree
 		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
@@ -648,10 +663,13 @@ export class AICustomizationViewPane extends ViewPane {
 						if (element.type === 'group') {
 							return element.label;
 						}
-						// For files, include description if available
-						return element.description
+						// For files, include description and disabled state
+						const nameAndDesc = element.description
 							? localize('fileAriaLabel', "{0}, {1}", element.name, element.description)
 							: element.name;
+						return element.disabled
+							? localize('fileAriaLabelDisabled', "{0}, disabled", nameAndDesc)
+							: nameAndDesc;
 					},
 					getWidgetAriaLabel: () => localize('aiCustomizationTree', "Chat Customization Items"),
 				},
@@ -729,14 +747,16 @@ export class AICustomizationViewPane extends ViewPane {
 
 		const element = e.element;
 
-		// Set context key for the item type so menu items can use `when` clauses
+		// Set context keys for the item so menu items can use `when` clauses
 		this.itemTypeContextKey.set(element.promptType);
+		this.itemDisabledContextKey.set(element.disabled);
 
 		// Get menu actions from the menu service
 		const context = {
 			uri: element.uri.toString(),
 			name: element.name,
 			promptType: element.promptType,
+			disabled: element.disabled,
 		};
 		const menu = this.menuService.getMenuActions(AICustomizationItemMenuId, this.contextKeyService, { arg: context, shouldForwardArgs: true });
 		const { secondary } = getContextMenuActions(menu, 'inline');
@@ -748,8 +768,9 @@ export class AICustomizationViewPane extends ViewPane {
 				getActions: () => secondary,
 				getActionsContext: () => context,
 				onHide: () => {
-					// Clear the context key when menu closes
+					// Clear the context keys when menu closes
 					this.itemTypeContextKey.reset();
+					this.itemDisabledContextKey.reset();
 				},
 			});
 		}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -59,6 +59,11 @@ export const AICustomizationItemTypeContextKey = new RawContextKey<string>('aiCu
  */
 export const AICustomizationItemDisabledContextKey = new RawContextKey<boolean>('aiCustomizationItemDisabled', false);
 
+/**
+ * Context key for the current item's storage type in context menus.
+ */
+export const AICustomizationItemStorageContextKey = new RawContextKey<string>('aiCustomizationItemStorage', '');
+
 //#endregion
 
 //#region Tree Item Types
@@ -265,6 +270,7 @@ class AICustomizationFileRenderer implements ITreeRenderer<IAICustomizationFileI
 		const overlay = this.contextKeyService.createOverlay([
 			[AICustomizationItemTypeContextKey.key, item.promptType],
 			[AICustomizationItemDisabledContextKey.key, item.disabled],
+			[AICustomizationItemStorageContextKey.key, item.storage],
 		]);
 
 		// Create menu and extract inline actions
@@ -580,6 +586,7 @@ export class AICustomizationViewPane extends ViewPane {
 	private readonly isEmptyContextKey: IContextKey<boolean>;
 	private readonly itemTypeContextKey: IContextKey<string>;
 	private readonly itemDisabledContextKey: IContextKey<boolean>;
+	private readonly itemStorageContextKey: IContextKey<string>;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -605,6 +612,7 @@ export class AICustomizationViewPane extends ViewPane {
 		this.isEmptyContextKey = AICustomizationIsEmptyContextKey.bindTo(contextKeyService);
 		this.itemTypeContextKey = AICustomizationItemTypeContextKey.bindTo(contextKeyService);
 		this.itemDisabledContextKey = AICustomizationItemDisabledContextKey.bindTo(contextKeyService);
+		this.itemStorageContextKey = AICustomizationItemStorageContextKey.bindTo(contextKeyService);
 
 		// Subscribe to prompt service events to refresh tree
 		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
@@ -750,6 +758,7 @@ export class AICustomizationViewPane extends ViewPane {
 		// Set context keys for the item so menu items can use `when` clauses
 		this.itemTypeContextKey.set(element.promptType);
 		this.itemDisabledContextKey.set(element.disabled);
+		this.itemStorageContextKey.set(element.storage);
 
 		// Get menu actions from the menu service
 		const context = {
@@ -771,6 +780,7 @@ export class AICustomizationViewPane extends ViewPane {
 					// Clear the context keys when menu closes
 					this.itemTypeContextKey.reset();
 					this.itemDisabledContextKey.reset();
+					this.itemStorageContextKey.reset();
 				},
 			});
 		}

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews.ts
@@ -531,12 +531,14 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 		const cached = this.cache.get(promptType);
 		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
 
-		// For skills, use the cached skills data
+		// For skills, use the cached skills data and merge in disabled skills
 		if (promptType === PromptsType.skill) {
 			const skills = cached?.skills || [];
 			const filtered = skills.filter(skill => skill.storage === storage);
-			return filtered
+			const seenUris = new Set<string>();
+			const result: IAICustomizationFileItem[] = filtered
 				.map(skill => {
+					seenUris.add(skill.uri.toString());
 					// Use skill name from frontmatter, or fallback to parent folder name
 					const skillName = skill.name || basename(dirname(skill.uri)) || basename(skill.uri);
 					return {
@@ -550,6 +552,27 @@ class UnifiedAICustomizationDataSource implements IAsyncDataSource<RootElement, 
 						disabled: disabledUris.has(skill.uri),
 					};
 				});
+
+			// Include disabled skills not already in the enabled list
+			if (disabledUris.size > 0) {
+				const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, CancellationToken.None);
+				for (const file of allSkillFiles) {
+					if (file.storage === storage && !seenUris.has(file.uri.toString()) && disabledUris.has(file.uri)) {
+						result.push({
+							type: 'file' as const,
+							id: file.uri.toString(),
+							uri: file.uri,
+							name: file.name || basename(dirname(file.uri)) || basename(file.uri),
+							description: file.description,
+							storage: file.storage,
+							promptType,
+							disabled: true,
+						});
+					}
+				}
+			}
+
+			return result;
 		}
 
 		// Use cached files data (already fetched in getStorageGroups)

--- a/src/vs/sessions/contrib/aiCustomizationTreeView/browser/media/aiCustomizationTreeView.css
+++ b/src/vs/sessions/contrib/aiCustomizationTreeView/browser/media/aiCustomizationTreeView.css
@@ -103,6 +103,11 @@
 	white-space: nowrap;
 }
 
+/* Disabled items */
+.ai-customization-view .ai-customization-tree-item.disabled {
+	opacity: 0.5;
+}
+
 /* Empty state */
 .ai-customization-view .empty-message {
 	padding: 10px;

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -155,6 +155,8 @@ export class AgenticPromptsService extends PromptsService {
 			uri: s.uri,
 			storage: BUILTIN_STORAGE,
 			type: PromptsType.skill,
+			name: s.name,
+			description: s.description,
 		}));
 	}
 

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -211,11 +211,8 @@ export class AgenticPromptsService extends PromptsService {
 			}
 		}
 
-		// Filter out overridden and disabled built-in items
-		const disabledFiles = this.getDisabledPromptFiles(type);
 		const nonOverridden = builtinItems.filter(
 			p => !overriddenNames.has(type === PromptsType.skill ? basename(dirname(p.uri)) : getCleanPromptName(p.uri))
-				&& !disabledFiles.has(p.uri)
 		);
 		// Built-in items use BUILTIN_STORAGE ('builtin') which is not in the
 		// core IPromptPath union but is handled by the sessions UI layer.

--- a/src/vs/sessions/contrib/chat/browser/promptsService.ts
+++ b/src/vs/sessions/contrib/chat/browser/promptsService.ts
@@ -175,7 +175,8 @@ export class AgenticPromptsService extends PromptsService {
 
 		// Collect names already present from other sources
 		const existingNames = new Set(baseResult.map(s => s.name));
-		const nonOverridden = builtinSkills.filter(s => !existingNames.has(s.name));
+		const disabledSkills = this.getDisabledPromptFiles(PromptsType.skill);
+		const nonOverridden = builtinSkills.filter(s => !existingNames.has(s.name) && !disabledSkills.has(s.uri));
 		if (nonOverridden.length === 0) {
 			return baseResult;
 		}
@@ -210,8 +211,11 @@ export class AgenticPromptsService extends PromptsService {
 			}
 		}
 
+		// Filter out overridden and disabled built-in items
+		const disabledFiles = this.getDisabledPromptFiles(type);
 		const nonOverridden = builtinItems.filter(
 			p => !overriddenNames.has(type === PromptsType.skill ? basename(dirname(p.uri)) : getCleanPromptName(p.uri))
+				&& !disabledFiles.has(p.uri)
 		);
 		// Built-in items use BUILTIN_STORAGE ('builtin') which is not in the
 		// core IPromptPath union but is handled by the sessions UI layer.

--- a/src/vs/sessions/contrib/chat/common/builtinPromptsStorage.ts
+++ b/src/vs/sessions/contrib/chat/common/builtinPromptsStorage.ts
@@ -25,4 +25,6 @@ export interface IBuiltinPromptPath {
 	readonly uri: URI;
 	readonly storage: AICustomizationPromptsStorage;
 	readonly type: PromptsType;
+	readonly name?: string;
+	readonly description?: string;
 }

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -28,7 +28,7 @@ import { AgentSessionProviders, getAgentSessionProvider } from '../../contrib/ch
 import { AddDynamicVariableAction, IAddDynamicVariableContext } from '../../contrib/chat/browser/attachments/chatDynamicVariables.js';
 import { IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../contrib/chat/common/participants/chatAgents.js';
 import { IPromptFileContext, IPromptsService } from '../../contrib/chat/common/promptSyntax/service/promptsService.js';
-import { isValidPromptType, PromptsType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
+import { isValidPromptType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IChatModel } from '../../contrib/chat/common/model/chatModel.js';
 import { ChatRequestAgentPart } from '../../contrib/chat/common/requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../../contrib/chat/common/requestParser/chatRequestParser.js';
@@ -203,10 +203,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	private async _pushSkills(): Promise<void> {
 		try {
 			const skills = await this._promptsService.findAgentSkills(CancellationToken.None) ?? [];
-			const disabledSkills = this._promptsService.getDisabledPromptFiles(PromptsType.skill);
-			const dtos: ISkillDto[] = skills
-				.filter(skill => !disabledSkills.has(skill.uri))
-				.map(skill => ({ uri: skill.uri }));
+			const dtos: ISkillDto[] = skills.map(skill => ({ uri: skill.uri }));
 			this._proxy.$acceptSkills(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push skills to extension host', error);

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -28,7 +28,7 @@ import { AgentSessionProviders, getAgentSessionProvider } from '../../contrib/ch
 import { AddDynamicVariableAction, IAddDynamicVariableContext } from '../../contrib/chat/browser/attachments/chatDynamicVariables.js';
 import { IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentRequest, IChatAgentService } from '../../contrib/chat/common/participants/chatAgents.js';
 import { IPromptFileContext, IPromptsService } from '../../contrib/chat/common/promptSyntax/service/promptsService.js';
-import { isValidPromptType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
+import { isValidPromptType, PromptsType } from '../../contrib/chat/common/promptSyntax/promptTypes.js';
 import { IChatModel } from '../../contrib/chat/common/model/chatModel.js';
 import { ChatRequestAgentPart } from '../../contrib/chat/common/requestParser/chatParserTypes.js';
 import { ChatRequestParser } from '../../contrib/chat/common/requestParser/chatRequestParser.js';
@@ -203,7 +203,10 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	private async _pushSkills(): Promise<void> {
 		try {
 			const skills = await this._promptsService.findAgentSkills(CancellationToken.None) ?? [];
-			const dtos: ISkillDto[] = skills.map(skill => ({ uri: skill.uri }));
+			const disabledSkills = this._promptsService.getDisabledPromptFiles(PromptsType.skill);
+			const dtos: ISkillDto[] = skills
+				.filter(skill => !disabledSkills.has(skill.uri))
+				.map(skill => ({ uri: skill.uri }));
 			this._proxy.$acceptSkills(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push skills to extension host', error);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -566,9 +566,12 @@ export class AICustomizationListWidget extends Disposable {
 						if (entry.type === 'group-header') {
 							return localize('groupAriaLabel', "{0}, {1} items, {2}", entry.label, entry.count, entry.collapsed ? localize('collapsed', "collapsed") : localize('expanded', "expanded"));
 						}
-						return entry.item.description
+						const nameAndDesc = entry.item.description
 							? localize('itemAriaLabel', "{0}, {1}", entry.item.name, entry.item.description)
 							: entry.item.name;
+						return entry.item.disabled
+							? localize('itemAriaLabelDisabled', "{0}, disabled", nameAndDesc)
+							: nameAndDesc;
 					},
 					getWidgetAriaLabel: () => localize('listAriaLabel', "Chat Customizations"),
 				},

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -13,6 +13,7 @@ import { autorun } from '../../../../../base/common/observable.js';
 import { basename, dirname, isEqualOrParent } from '../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ResourceSet } from '../../../../../base/common/map.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { localize } from '../../../../../nls.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -949,11 +950,13 @@ export class AICustomizationListWidget extends Disposable {
 				});
 			}
 		} else if (promptType === PromptsType.skill) {
-			// Use findAgentSkills which has parsed name/description from frontmatter
+			// Use findAgentSkills for enabled skills (has parsed name/description from frontmatter)
 			const skills = await this.promptsService.findAgentSkills(CancellationToken.None);
+			const seenUris = new ResourceSet();
 			for (const skill of skills || []) {
 				const filename = basename(skill.uri);
 				const skillName = skill.name || basename(dirname(skill.uri)) || filename;
+				seenUris.add(skill.uri);
 				items.push({
 					id: skill.uri.toString(),
 					uri: skill.uri,
@@ -962,8 +965,27 @@ export class AICustomizationListWidget extends Disposable {
 					description: skill.description,
 					storage: skill.storage,
 					promptType,
-					disabled: disabledUris.has(skill.uri),
+					disabled: false,
 				});
+			}
+			// Also include disabled skills from the raw file list
+			if (disabledUris.size > 0) {
+				const allSkillFiles = await this.promptsService.listPromptFiles(PromptsType.skill, CancellationToken.None);
+				for (const file of allSkillFiles) {
+					if (!seenUris.has(file.uri) && disabledUris.has(file.uri)) {
+						const filename = basename(file.uri);
+						items.push({
+							id: file.uri.toString(),
+							uri: file.uri,
+							name: file.name || basename(dirname(file.uri)) || filename,
+							filename,
+							description: file.description,
+							storage: file.storage,
+							promptType,
+							disabled: true,
+						});
+					}
+				}
 			}
 		} else if (promptType === PromptsType.prompt) {
 			// Use getPromptSlashCommands which has parsed name/description from frontmatter

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -22,7 +22,7 @@ import { IPromptsService, PromptsStorage, IPromptPath } from '../../common/promp
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
 import { AGENT_MD_FILENAME } from '../../common/promptSyntax/config/promptFileLocations.js';
 import { agentIcon, instructionsIcon, promptIcon, skillIcon, hookIcon, userIcon, workspaceIcon, extensionIcon, pluginIcon, builtinIcon } from './aiCustomizationIcons.js';
-import { AI_CUSTOMIZATION_ITEM_STORAGE_KEY, AI_CUSTOMIZATION_ITEM_TYPE_KEY, AI_CUSTOMIZATION_ITEM_URI_KEY, AICustomizationManagementItemMenuId, AICustomizationManagementSection, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
+import { AI_CUSTOMIZATION_ITEM_DISABLED_KEY, AI_CUSTOMIZATION_ITEM_STORAGE_KEY, AI_CUSTOMIZATION_ITEM_TYPE_KEY, AI_CUSTOMIZATION_ITEM_URI_KEY, AICustomizationManagementItemMenuId, AICustomizationManagementSection, BUILTIN_STORAGE } from './aiCustomizationManagement.js';
 import { InputBox } from '../../../../../base/browser/ui/inputbox/inputBox.js';
 import { defaultButtonStyles, defaultInputBoxStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { Delayer } from '../../../../../base/common/async.js';
@@ -88,6 +88,7 @@ export interface IAICustomizationListItem {
 	readonly description?: string;
 	readonly storage: PromptsStorage;
 	readonly promptType: PromptsType;
+	readonly disabled: boolean;
 	/** When set, overrides `storage` for display grouping purposes. */
 	readonly groupKey?: string;
 	nameMatches?: IMatch[];
@@ -310,6 +311,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			};
 		}));
 
+		// Apply disabled styling
+		templateData.container.classList.toggle('disabled', element.disabled);
+
 		// Name with highlights — nameMatches are pre-computed against the formatted display name
 		const displayName = formatDisplayName(element.name);
 		templateData.nameLabel.set(displayName, element.nameMatches);
@@ -359,6 +363,7 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			[AI_CUSTOMIZATION_ITEM_TYPE_KEY, element.promptType],
 			[AI_CUSTOMIZATION_ITEM_STORAGE_KEY, element.storage],
 			[AI_CUSTOMIZATION_ITEM_URI_KEY, element.uri.toString()],
+			[AI_CUSTOMIZATION_ITEM_DISABLED_KEY, element.disabled],
 		]);
 
 		const menu = templateData.elementDisposables.add(
@@ -591,6 +596,8 @@ export class AICustomizationListWidget extends Disposable {
 		// Subscribe to prompt service changes
 		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
 		this._register(this.promptsService.onDidChangeSlashCommands(() => this.refresh()));
+		this._register(this.promptsService.onDidChangeSkills(() => this.refresh()));
+		this._register(this.promptsService.onDidChangeInstructions(() => this.refresh()));
 
 		// Refresh on file deletions so the list updates after inline delete actions
 		this._register(this.fileService.onDidFilesChange(e => {
@@ -636,6 +643,7 @@ export class AICustomizationListWidget extends Disposable {
 			[AI_CUSTOMIZATION_ITEM_TYPE_KEY, item.promptType],
 			[AI_CUSTOMIZATION_ITEM_STORAGE_KEY, item.storage],
 			[AI_CUSTOMIZATION_ITEM_URI_KEY, item.uri.toString()],
+			[AI_CUSTOMIZATION_ITEM_DISABLED_KEY, item.disabled],
 		]);
 
 		// Get menu actions, excluding inline actions to avoid duplicates
@@ -921,6 +929,7 @@ export class AICustomizationListWidget extends Disposable {
 	private async fetchItemsForSection(section: AICustomizationManagementSection): Promise<IAICustomizationListItem[]> {
 		const promptType = sectionToPromptType(section);
 		const items: IAICustomizationListItem[] = [];
+		const disabledUris = this.promptsService.getDisabledPromptFiles(promptType);
 
 
 		if (promptType === PromptsType.agent) {
@@ -936,6 +945,7 @@ export class AICustomizationListWidget extends Disposable {
 					description: agent.description,
 					storage: agent.source.storage,
 					promptType,
+					disabled: disabledUris.has(agent.uri),
 				});
 			}
 		} else if (promptType === PromptsType.skill) {
@@ -952,6 +962,7 @@ export class AICustomizationListWidget extends Disposable {
 					description: skill.description,
 					storage: skill.storage,
 					promptType,
+					disabled: disabledUris.has(skill.uri),
 				});
 			}
 		} else if (promptType === PromptsType.prompt) {
@@ -971,6 +982,7 @@ export class AICustomizationListWidget extends Disposable {
 					description: command.description,
 					storage: command.promptPath.storage,
 					promptType,
+					disabled: disabledUris.has(command.promptPath.uri),
 				});
 			}
 		} else if (promptType === PromptsType.hook) {
@@ -1003,6 +1015,7 @@ export class AICustomizationListWidget extends Disposable {
 									description: truncatedCmd || localize('hookUnset', "(unset)"),
 									storage: hookFile.storage,
 									promptType,
+									disabled: disabledUris.has(hookFile.uri),
 								});
 							}
 						}
@@ -1020,6 +1033,7 @@ export class AICustomizationListWidget extends Disposable {
 						filename,
 						storage: hookFile.storage,
 						promptType,
+						disabled: disabledUris.has(hookFile.uri),
 					});
 				}
 			}
@@ -1050,6 +1064,7 @@ export class AICustomizationListWidget extends Disposable {
 							storage: agent.source.storage,
 							groupKey: 'agents',
 							promptType,
+							disabled: disabledUris.has(agent.uri),
 						});
 					}
 				}
@@ -1096,6 +1111,7 @@ export class AICustomizationListWidget extends Disposable {
 					description: item.description,
 					storage: item.storage,
 					promptType,
+					disabled: disabledUris.has(item.uri),
 				};
 			};
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -598,7 +598,6 @@ export class AICustomizationListWidget extends Disposable {
 		this._register(this.promptsService.onDidChangeCustomAgents(() => this.refresh()));
 		this._register(this.promptsService.onDidChangeSlashCommands(() => this.refresh()));
 		this._register(this.promptsService.onDidChangeSkills(() => this.refresh()));
-		this._register(this.promptsService.onDidChangeInstructions(() => this.refresh()));
 
 		// Refresh on file deletions so the list updates after inline delete actions
 		this._register(this.fileService.onDidFilesChange(e => {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -493,6 +493,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_TYPE_KEY, PromptsType.skill),
 	),
 });
 
@@ -504,6 +505,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_TYPE_KEY, PromptsType.skill),
 	),
 });
 
@@ -515,6 +517,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_TYPE_KEY, PromptsType.skill),
 	),
 });
 
@@ -526,6 +529,7 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	when: ContextKeyExpr.and(
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
 		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_TYPE_KEY, PromptsType.skill),
 	),
 });
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -20,6 +20,7 @@ import { AICustomizationManagementEditorInput } from './aiCustomizationManagemen
 import {
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_ID,
 	AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID,
+	AI_CUSTOMIZATION_ITEM_DISABLED_KEY,
 	AI_CUSTOMIZATION_ITEM_STORAGE_KEY,
 	AI_CUSTOMIZATION_ITEM_TYPE_KEY,
 	AI_CUSTOMIZATION_ITEM_URI_KEY,
@@ -33,7 +34,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { PromptsType } from '../../common/promptSyntax/promptTypes.js';
-import { PromptsStorage } from '../../common/promptSyntax/service/promptsService.js';
+import { PromptsStorage, IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 import { IAICustomizationWorkspaceService } from '../../common/aiCustomizationWorkspaceService.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ChatConfiguration } from '../../common/constants.js';
@@ -434,6 +435,70 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	group: '4_modify',
 	order: 1,
 	when: WHEN_ITEM_IS_PLUGIN,
+});
+
+// Disable item action
+const DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID = 'aiCustomizationManagement.disableItem';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID,
+			title: localize2('disable', "Disable"),
+			icon: Codicon.eyeClosed,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
+		const promptsService = accessor.get(IPromptsService);
+		const uri = extractURI(context);
+		const promptType = extractPromptType(context);
+		if (!promptType) {
+			return;
+		}
+
+		const disabled = promptsService.getDisabledPromptFiles(promptType);
+		disabled.add(uri);
+		promptsService.setDisabledPromptFiles(promptType, disabled);
+	}
+});
+
+// Enable item action
+const ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID = 'aiCustomizationManagement.enableItem';
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID,
+			title: localize2('enable', "Enable"),
+			icon: Codicon.eye,
+		});
+	}
+	async run(accessor: ServicesAccessor, context: AICustomizationContext): Promise<void> {
+		const promptsService = accessor.get(IPromptsService);
+		const uri = extractURI(context);
+		const promptType = extractPromptType(context);
+		if (!promptType) {
+			return;
+		}
+
+		const disabled = promptsService.getDisabledPromptFiles(promptType);
+		disabled.delete(uri);
+		promptsService.setDisabledPromptFiles(promptType, disabled);
+	}
+});
+
+// Context menu: Disable (shown when item is enabled)
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable") },
+	group: '5_toggle',
+	order: 1,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+});
+
+// Context menu: Enable (shown when item is disabled)
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable") },
+	group: '5_toggle',
+	order: 1,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -485,36 +485,48 @@ registerAction2(class extends Action2 {
 	}
 });
 
-// Context menu: Disable (shown when item is enabled)
+// Context menu: Disable (shown when builtin item is enabled)
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable") },
 	group: '5_toggle',
 	order: 1,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+	),
 });
 
-// Context menu: Enable (shown when item is disabled)
+// Context menu: Enable (shown when builtin item is disabled)
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable") },
 	group: '5_toggle',
 	order: 1,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+	),
 });
 
-// Inline hover: Disable (shown when item is enabled)
+// Inline hover: Disable (shown when builtin item is enabled)
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
 	group: 'inline',
 	order: 5,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+	),
 });
 
-// Inline hover: Enable (shown when item is disabled)
+// Inline hover: Enable (shown when builtin item is disabled)
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
 	group: 'inline',
 	order: 5,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+		ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_STORAGE_KEY, BUILTIN_STORAGE),
+	),
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -354,6 +354,20 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 });
 
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+});
+
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+});
+
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
 	group: 'inline',
 	order: 10,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.contribution.ts
@@ -354,20 +354,6 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 });
 
 MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
-	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
-	group: 'inline',
-	order: 5,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
-});
-
-MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
-	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
-	group: 'inline',
-	order: 5,
-	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
-});
-
-MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: DELETE_AI_CUSTOMIZATION_ID, title: localize('delete', "Delete"), icon: Codicon.trash },
 	group: 'inline',
 	order: 10,
@@ -512,6 +498,22 @@ MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
 	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable") },
 	group: '5_toggle',
 	order: 1,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
+});
+
+// Inline hover: Disable (shown when item is enabled)
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: DISABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('disable', "Disable"), icon: Codicon.eyeClosed },
+	group: 'inline',
+	order: 5,
+	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, false),
+});
+
+// Inline hover: Enable (shown when item is disabled)
+MenuRegistry.appendMenuItem(AICustomizationManagementItemMenuId, {
+	command: { id: ENABLE_AI_CUSTOMIZATION_MGMT_ITEM_ID, title: localize('enable', "Enable"), icon: Codicon.eye },
+	group: 'inline',
+	order: 5,
 	when: ContextKeyExpr.equals(AI_CUSTOMIZATION_ITEM_DISABLED_KEY, true),
 });
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagement.ts
@@ -88,6 +88,11 @@ export const AI_CUSTOMIZATION_ITEM_STORAGE_KEY = 'aiCustomizationManagementItemS
 export const AI_CUSTOMIZATION_ITEM_URI_KEY = 'aiCustomizationManagementItemUri';
 
 /**
+ * Context key indicating whether the item is disabled.
+ */
+export const AI_CUSTOMIZATION_ITEM_DISABLED_KEY = 'aiCustomizationManagementItemDisabled';
+
+/**
  * Storage key for persisting the selected section.
  */
 export const AI_CUSTOMIZATION_MANAGEMENT_SELECTED_SECTION_KEY = 'aiCustomizationManagement.selectedSection';

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -417,6 +417,10 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
+.ai-customization-list-item.disabled {
+	opacity: 0.5;
+}
+
 .ai-customization-list-item .item-left {
 	display: flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1245,7 +1245,9 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 	public async getInstructionFiles(token: CancellationToken, sessionResource?: URI): Promise<readonly IPromptPath[]> {
 		const sw = StopWatch.create();
-		const result = await this.listPromptFiles(PromptsType.instructions, token);
+		const allFiles = await this.listPromptFiles(PromptsType.instructions, token);
+		const disabledInstructions = this.getDisabledPromptFiles(PromptsType.instructions);
+		const result = allFiles.filter(p => !disabledInstructions.has(p.uri));
 		if (sessionResource) {
 			const elapsed = sw.elapsed();
 			void this.getInstructionsDiscoveryInfo(token).catch(() => undefined).then(discoveryInfo => {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1245,9 +1245,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 	public async getInstructionFiles(token: CancellationToken, sessionResource?: URI): Promise<readonly IPromptPath[]> {
 		const sw = StopWatch.create();
-		const allFiles = await this.listPromptFiles(PromptsType.instructions, token);
-		const disabledInstructions = this.getDisabledPromptFiles(PromptsType.instructions);
-		const result = allFiles.filter(p => !disabledInstructions.has(p.uri));
+		const result = await this.listPromptFiles(PromptsType.instructions, token);
 		if (sessionResource) {
 			const elapsed = sw.elapsed();
 			void this.getInstructionsDiscoveryInfo(token).catch(() => undefined).then(discoveryInfo => {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1014,10 +1014,6 @@ export class PromptsService extends Disposable implements IPromptsService {
 		} else if (type === PromptsType.skill) {
 			this.cachedSkills.refresh();
 			this.cachedSlashCommands.refresh();
-		} else if (type === PromptsType.prompt) {
-			this.cachedSlashCommands.refresh();
-		} else if (type === PromptsType.instructions) {
-			this._onDidChangeInstructions.fire();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -601,12 +601,11 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 	private async computePromptSlashCommands(token: CancellationToken): Promise<readonly IChatPromptSlashCommand[]> {
 		const promptFiles = await this.listPromptFiles(PromptsType.prompt, token);
-		const disabledPrompts = this.getDisabledPromptFiles(PromptsType.prompt);
 		const useAgentSkills = this.configurationService.getValue(PromptsConfig.USE_AGENT_SKILLS);
 		const skills = useAgentSkills ? await this.listPromptFiles(PromptsType.skill, token) : [];
 		const disabledSkills = this.getDisabledPromptFiles(PromptsType.skill);
 		const slashCommandFiles = [
-			...promptFiles.filter(p => !disabledPrompts.has(p.uri)),
+			...promptFiles,
 			...skills.filter(s => !disabledSkills.has(s.uri)),
 		];
 		const details = await Promise.all(slashCommandFiles.map(async promptPath => {
@@ -1014,6 +1013,7 @@ export class PromptsService extends Disposable implements IPromptsService {
 			this.cachedCustomAgents.refresh();
 		} else if (type === PromptsType.skill) {
 			this.cachedSkills.refresh();
+			this.cachedSlashCommands.refresh();
 		} else if (type === PromptsType.prompt) {
 			this.cachedSlashCommands.refresh();
 		} else if (type === PromptsType.instructions) {

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1007,6 +1007,12 @@ export class PromptsService extends Disposable implements IPromptsService {
 		this.storageService.store(this.disabledPromptsStorageKeyPrefix + type, JSON.stringify(disabled), StorageScope.PROFILE, StorageTarget.USER);
 		if (type === PromptsType.agent) {
 			this.cachedCustomAgents.refresh();
+		} else if (type === PromptsType.skill) {
+			this.cachedSkills.refresh();
+		} else if (type === PromptsType.prompt) {
+			this.cachedSlashCommands.refresh();
+		} else if (type === PromptsType.instructions) {
+			this._onDidChangeInstructions.fire();
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -601,9 +601,14 @@ export class PromptsService extends Disposable implements IPromptsService {
 
 	private async computePromptSlashCommands(token: CancellationToken): Promise<readonly IChatPromptSlashCommand[]> {
 		const promptFiles = await this.listPromptFiles(PromptsType.prompt, token);
+		const disabledPrompts = this.getDisabledPromptFiles(PromptsType.prompt);
 		const useAgentSkills = this.configurationService.getValue(PromptsConfig.USE_AGENT_SKILLS);
 		const skills = useAgentSkills ? await this.listPromptFiles(PromptsType.skill, token) : [];
-		const slashCommandFiles = [...promptFiles, ...skills];
+		const disabledSkills = this.getDisabledPromptFiles(PromptsType.skill);
+		const slashCommandFiles = [
+			...promptFiles.filter(p => !disabledPrompts.has(p.uri)),
+			...skills.filter(s => !disabledSkills.has(s.uri)),
+		];
 		const details = await Promise.all(slashCommandFiles.map(async promptPath => {
 			try {
 				const parsedPromptFile = await this.parseNew(promptPath.uri, token);


### PR DESCRIPTION
Built-in skills (shipped with the Sessions app) can auto-run via the LLM, but users had no way to opt out. This adds a disable/enable toggle so users can grey out and unregister individual built-in skills.

### Approach

**UI toggle** — Adds Disable/Enable actions to both the management editor list and the sessions sidebar tree view. The toggle appears as an inline hover icon (eye/eye-closed) and in the right-click context menu, scoped to built-in skills only (`storage === builtin && promptType === skill`). Disabled items render at 50% opacity with a `.disabled` CSS class.

**Unregistration** — Disabled built-in skills are filtered at their registration points:
- `AgenticPromptsService.findAgentSkills()` — where built-ins are appended to the skill list
- `computePromptSlashCommands()` — so `/skill-name` completions disappear

**Infrastructure reuse** — Leverages the existing `IPromptsService.getDisabledPromptFiles()`/`setDisabledPromptFiles()` storage (profile-scoped, per-type `ResourceSet`). Extended `setDisabledPromptFiles()` to refresh `cachedSkills` + `cachedSlashCommands` for skills, so the toggle takes effect immediately without reload.

**`listPromptFiles()` stays unfiltered** — The raw file listing still returns disabled items so the UI can show them greyed out for re-enabling.

### How to test
1. Open the Sessions app → Chat Customizations editor → Skills section
2. Hover a built-in skill → eye-closed icon appears → click to disable
3. Skill greys out, typing `/` no longer shows it as a completion
4. Right-click → Enable to re-enable
5. Non-builtin items and non-skill types should NOT show the toggle