### PR TITLE
Browser Quick Open / Tab Management

### DIFF
--- a/src/vs/platform/browserView/common/browserView.ts
+++ b/src/vs/platform/browserView/common/browserView.ts
@@ -12,6 +12,7 @@ const commandPrefix = 'workbench.action.browser';
 export enum BrowserViewCommandId {
 	Open = `${commandPrefix}.open`,
 	NewTab = `${commandPrefix}.newTab`,
+	QuickOpen = `${commandPrefix}.quickOpen`,
 	GoBack = `${commandPrefix}.goBack`,
 	GoForward = `${commandPrefix}.goForward`,
 	Reload = `${commandPrefix}.reload`,

--- a/src/vs/platform/browserView/common/browserView.ts
+++ b/src/vs/platform/browserView/common/browserView.ts
@@ -10,22 +10,37 @@ import { localize } from '../../../nls.js';
 
 const commandPrefix = 'workbench.action.browser';
 export enum BrowserViewCommandId {
+	// Tab management
 	Open = `${commandPrefix}.open`,
 	NewTab = `${commandPrefix}.newTab`,
 	QuickOpen = `${commandPrefix}.quickOpen`,
+	CloseAll = `${commandPrefix}.closeAll`,
+	CloseAllInGroup = `${commandPrefix}.closeAllInGroup`,
+
+	// Navigation
 	GoBack = `${commandPrefix}.goBack`,
 	GoForward = `${commandPrefix}.goForward`,
 	Reload = `${commandPrefix}.reload`,
 	HardReload = `${commandPrefix}.hardReload`,
+
+	// Editor actions
 	FocusUrlInput = `${commandPrefix}.focusUrlInput`,
+	OpenExternal = `${commandPrefix}.openExternal`,
+	OpenSettings = `${commandPrefix}.openSettings`,
+
+	// Chat actions
 	AddElementToChat = `${commandPrefix}.addElementToChat`,
 	AddConsoleLogsToChat = `${commandPrefix}.addConsoleLogsToChat`,
+
+	// Dev Tools
 	ToggleDevTools = `${commandPrefix}.toggleDevTools`,
-	OpenExternal = `${commandPrefix}.openExternal`,
+
+	// Storage
 	ClearGlobalStorage = `${commandPrefix}.clearGlobalStorage`,
 	ClearWorkspaceStorage = `${commandPrefix}.clearWorkspaceStorage`,
 	ClearEphemeralStorage = `${commandPrefix}.clearEphemeralStorage`,
-	OpenSettings = `${commandPrefix}.openSettings`,
+
+	// Find in page
 	ShowFind = `${commandPrefix}.showFind`,
 	HideFind = `${commandPrefix}.hideFind`,
 	FindNext = `${commandPrefix}.findNext`,

--- a/src/vs/platform/browserView/common/browserViewTelemetry.ts
+++ b/src/vs/platform/browserView/common/browserViewTelemetry.ts
@@ -17,6 +17,10 @@ export type IntegratedBrowserOpenSource =
 	/** Opened via the "Open Integrated Browser" command with a URL argument.
 	 * This typically means another extension or component invoked the command programmatically. */
 	| 'commandWithUrl'
+	/** Opened via the quick open feature with no initial URL. */
+	| 'quickOpenWithoutUrl'
+	/** Opened via the quick open feature with an initial URL. */
+	| 'quickOpenWithUrl'
 	/** Opened via the "New Tab" command from an existing tab. */
 	| 'newTabCommand'
 	/** Opened via the localhost link opener when the `workbench.browser.openLocalhostLinks` setting

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserEditor.ts
@@ -507,6 +507,14 @@ export class BrowserEditor extends EditorPane {
 		})));
 	}
 
+	override focus(): void {
+		if (this._model?.url && !this._model.error) {
+			void this._model.focus();
+		} else {
+			this.focusUrlInput();
+		}
+	}
+
 	override async setInput(input: BrowserEditorInput, options: IEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
 		await super.setInput(input, options, context, token);
 		if (token.isCancellationRequested) {
@@ -540,18 +548,6 @@ export class BrowserEditor extends EditorPane {
 			certificateError: this._model.certificateError
 		});
 		this.setBackgroundImage(this._model.screenshot);
-
-		if (!options?.preserveFocus) {
-			setTimeout(() => {
-				if (this._model === model) {
-					if (this._model.url) {
-						this._browserContainer.focus();
-					} else {
-						this.focusUrlInput();
-					}
-				}
-			}, 0);
-		}
 
 		// Start / stop screenshots when the model visibility changes
 		this._inputDisposables.add(this._model.onDidChangeVisibility(() => this.doScreenshot()));

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -36,6 +36,7 @@ import { logBrowserOpen } from '../../../../platform/browserView/common/browserV
 // Register actions and browser features
 import './browserViewActions.js';
 import './features/browserEditorChatFeatures.js';
+import './features/browserQuickOpenFeature.js';
 import './features/browserEditorZoomFeature.js';
 
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -11,7 +11,6 @@ import { EditorExtensions, IEditorFactoryRegistry } from '../../../common/editor
 import { BrowserEditor } from './browserEditor.js';
 import { BrowserEditorInput, BrowserEditorSerializer } from '../common/browserEditorInput.js';
 import { BrowserViewUri } from '../../../../platform/browserView/common/browserViewUri.js';
-import { generateUuid } from '../../../../base/common/uuid.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { registerSingleton, InstantiationType } from '../../../../platform/instantiation/common/extensions.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
@@ -23,15 +22,6 @@ import { IBrowserViewCDPService, IBrowserViewWorkbenchService } from '../common/
 import { BrowserViewWorkbenchService } from './browserViewWorkbenchService.js';
 import { BrowserViewCDPService } from './browserViewCDPService.js';
 import { BrowserViewStorageScope } from '../../../../platform/browserView/common/browserView.js';
-import { IExternalOpener, IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { isLocalhostAuthority } from '../../../../platform/url/common/trustedDomains.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
-import { URI } from '../../../../base/common/uri.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { logBrowserOpen } from '../../../../platform/browserView/common/browserViewTelemetry.js';
 
 // Register actions and browser features
 import './browserViewActions.js';
@@ -104,79 +94,12 @@ class BrowserEditorResolverContribution implements IWorkbenchContribution {
 
 registerWorkbenchContribution2(BrowserEditorResolverContribution.ID, BrowserEditorResolverContribution, WorkbenchPhase.BlockStartup);
 
-/**
- * Opens localhost URLs in the Integrated Browser when the setting is enabled.
- */
-class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchContribution, IExternalOpener {
-	static readonly ID = 'workbench.contrib.localhostLinkOpener';
-
-	constructor(
-		@IOpenerService openerService: IOpenerService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IEditorService private readonly editorService: IEditorService,
-		@ITelemetryService private readonly telemetryService: ITelemetryService
-	) {
-		super();
-
-		this._register(openerService.registerExternalOpener(this));
-	}
-
-	async openExternal(href: string, _ctx: { sourceUri: URI; preferredOpenerId?: string }, _token: CancellationToken): Promise<boolean> {
-		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
-			return false;
-		}
-
-		try {
-			const parsed = new URL(href);
-			if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-				return false;
-			}
-			if (!isLocalhostAuthority(parsed.host)) {
-				return false;
-			}
-		} catch {
-			return false;
-		}
-
-		logBrowserOpen(this.telemetryService, 'localhostLinkOpener');
-
-		const browserUri = BrowserViewUri.forId(generateUuid());
-		await this.editorService.openEditor({ resource: browserUri, options: { pinned: true, viewState: { url: href } } });
-		return true;
-	}
-}
-
-registerWorkbenchContribution2(LocalhostLinkOpenerContribution.ID, LocalhostLinkOpenerContribution, WorkbenchPhase.BlockStartup);
-
 registerSingleton(IBrowserViewWorkbenchService, BrowserViewWorkbenchService, InstantiationType.Delayed);
 registerSingleton(IBrowserViewCDPService, BrowserViewCDPService, InstantiationType.Delayed);
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...workbenchConfigurationNodeBase,
 	properties: {
-		'workbench.browser.showInTitleBar': {
-			type: ['boolean', 'string'],
-			enum: [true, false, 'whenOpen'],
-			enumDescriptions: [
-				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.true' }, 'The button is always shown in the title bar.'),
-				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.false' }, 'The button is never shown in the title bar.'),
-				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.whenOpen' }, 'The button is shown in the title bar when a browser editor is open.')
-			],
-			default: 'whenOpen',
-			experiment: { mode: 'startup' },
-			description: localize(
-				{ comment: ['This is the description for a setting.'], key: 'browser.showInTitleBar' },
-				'Controls whether the Integrated Browser button is shown in the title bar.'
-			)
-		},
-		'workbench.browser.openLocalhostLinks': {
-			type: 'boolean',
-			default: false,
-			markdownDescription: localize(
-				{ comment: ['This is the description for a setting.'], key: 'browser.openLocalhostLinks' },
-				'When enabled, localhost links from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.'
-			)
-		},
 		'workbench.browser.dataStorage': {
 			type: 'string',
 			enum: [

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserView.contribution.ts
@@ -36,8 +36,8 @@ import { logBrowserOpen } from '../../../../platform/browserView/common/browserV
 // Register actions and browser features
 import './browserViewActions.js';
 import './features/browserEditorChatFeatures.js';
-import './features/browserQuickOpenFeature.js';
 import './features/browserEditorZoomFeature.js';
+import './features/browserTabManagementFeatures.js';
 
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(
@@ -155,8 +155,14 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	...workbenchConfigurationNodeBase,
 	properties: {
 		'workbench.browser.showInTitleBar': {
-			type: 'boolean',
-			default: false,
+			type: ['boolean', 'string'],
+			enum: [true, false, 'whenOpen'],
+			enumDescriptions: [
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.true' }, 'The button is always shown in the title bar.'),
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.false' }, 'The button is never shown in the title bar.'),
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.whenOpen' }, 'The button is shown in the title bar when a browser editor is open.')
+			],
+			default: 'whenOpen',
 			experiment: { mode: 'startup' },
 			description: localize(
 				{ comment: ['This is the description for a setting.'], key: 'browser.showInTitleBar' },

--- a/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/browserViewActions.ts
@@ -3,25 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize, localize2 } from '../../../../nls.js';
+import { localize2 } from '../../../../nls.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, registerAction2, MenuId } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
-import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { BrowserEditor, CONTEXT_BROWSER_CAN_GO_BACK, CONTEXT_BROWSER_CAN_GO_FORWARD, CONTEXT_BROWSER_DEVTOOLS_OPEN, CONTEXT_BROWSER_FOCUSED, CONTEXT_BROWSER_HAS_ERROR, CONTEXT_BROWSER_HAS_URL, CONTEXT_BROWSER_STORAGE_SCOPE, CONTEXT_BROWSER_FIND_WIDGET_FOCUSED, CONTEXT_BROWSER_FIND_WIDGET_VISIBLE } from './browserEditor.js';
-import { BrowserViewUri } from '../../../../platform/browserView/common/browserViewUri.js';
-import { generateUuid } from '../../../../base/common/uuid.js';
 import { IBrowserViewWorkbenchService } from '../common/browserView.js';
 import { BrowserViewCommandId, BrowserViewStorageScope } from '../../../../platform/browserView/common/browserView.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
-import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { logBrowserOpen } from '../../../../platform/browserView/common/browserViewTelemetry.js';
 import { BrowserEditorInput } from '../common/browserEditorInput.js';
-import { ToggleTitleBarConfigAction } from '../../../browser/parts/titlebar/titlebarActions.js';
 
 // Context key expression to check if browser editor is active
 export const BROWSER_EDITOR_ACTIVE = ContextKeyExpr.equals('activeEditor', BrowserEditorInput.EDITOR_ID);
@@ -32,80 +27,6 @@ export enum BrowserActionGroup {
 	Zoom = '2_zoom',
 	Page = '3_page',
 	Settings = '4_settings'
-}
-
-interface IOpenBrowserOptions {
-	url?: string;
-	openToSide?: boolean;
-}
-
-class OpenIntegratedBrowserAction extends Action2 {
-	constructor() {
-		super({
-			id: BrowserViewCommandId.Open,
-			title: localize2('browser.openAction', "Open Integrated Browser"),
-			category: BrowserActionCategory,
-			icon: Codicon.globe,
-			f1: true,
-			menu: {
-				id: MenuId.TitleBar,
-				group: 'navigation',
-				order: 10,
-				when: ContextKeyExpr.equals('config.workbench.browser.showInTitleBar', true)
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor, urlOrOptions?: string | IOpenBrowserOptions): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-		const telemetryService = accessor.get(ITelemetryService);
-
-		// Parse arguments
-		const options = typeof urlOrOptions === 'string' ? { url: urlOrOptions } : (urlOrOptions ?? {});
-		const resource = BrowserViewUri.forId(generateUuid());
-		const group = options.openToSide ? SIDE_GROUP : ACTIVE_GROUP;
-
-		logBrowserOpen(telemetryService, options.url ? 'commandWithUrl' : 'commandWithoutUrl');
-
-		const editorPane = await editorService.openEditor({ resource, options: { viewState: { url: options.url } } }, group);
-
-		// Lock the group when opening to the side
-		if (options.openToSide && editorPane?.group) {
-			editorPane.group.lock(true);
-		}
-	}
-}
-
-class NewTabAction extends Action2 {
-	constructor() {
-		super({
-			id: BrowserViewCommandId.NewTab,
-			title: localize2('browser.newTabAction', "New Tab"),
-			category: BrowserActionCategory,
-			f1: true,
-			precondition: BROWSER_EDITOR_ACTIVE,
-			menu: {
-				id: MenuId.BrowserActionsToolbar,
-				group: BrowserActionGroup.Tabs,
-				order: 1,
-			},
-			// When already in a browser, Ctrl/Cmd + T opens a new tab
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over search actions
-				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
-			}
-		});
-	}
-
-	async run(accessor: ServicesAccessor, _browserEditor = accessor.get(IEditorService).activeEditorPane): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-		const telemetryService = accessor.get(ITelemetryService);
-		const resource = BrowserViewUri.forId(generateUuid());
-
-		logBrowserOpen(telemetryService, 'newTabCommand');
-
-		await editorService.openEditor({ resource });
-	}
 }
 
 class GoBackAction extends Action2 {
@@ -549,8 +470,6 @@ class BrowserFindPreviousAction extends Action2 {
 }
 
 // Register actions
-registerAction2(OpenIntegratedBrowserAction);
-registerAction2(NewTabAction);
 registerAction2(GoBackAction);
 registerAction2(GoForwardAction);
 registerAction2(ReloadAction);
@@ -566,9 +485,3 @@ registerAction2(ShowBrowserFindAction);
 registerAction2(HideBrowserFindAction);
 registerAction2(BrowserFindNextAction);
 registerAction2(BrowserFindPreviousAction);
-
-registerAction2(class ToggleBrowserTitleBarButton extends ToggleTitleBarConfigAction {
-	constructor() {
-		super('workbench.browser.showInTitleBar', localize('toggle.browser', 'Integrated Browser'), localize('toggle.browserDescription', "Toggle visibility of the Integrated Browser button in title bar"), 8);
-	}
-});

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserQuickOpenFeature.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserQuickOpenFeature.ts
@@ -1,0 +1,276 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../../../nls.js';
+import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { ServicesAccessor, IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeyMod, KeyCode } from '../../../../../base/common/keyCodes.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { IEditorGroupsService, GroupsOrder } from '../../../../services/editor/common/editorGroupsService.js';
+import { GroupIdentifier } from '../../../../common/editor.js';
+import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPickSeparator, QuickInputButtonLocation } from '../../../../../platform/quickinput/common/quickInput.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { ThemeIcon } from '../../../../../base/common/themables.js';
+import { BrowserViewUri } from '../../../../../platform/browserView/common/browserViewUri.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { BrowserEditorInput } from '../../common/browserEditorInput.js';
+import { BrowserActionCategory } from '../browserViewActions.js';
+import { logBrowserOpen } from '../../../../../platform/browserView/common/browserViewTelemetry.js';
+import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+
+interface IBrowserQuickPickItem extends IQuickPickItem {
+	groupId: GroupIdentifier;
+	editor: BrowserEditorInput;
+}
+
+const closeButtonItem: IQuickInputButton = {
+	iconClass: ThemeIcon.asClassName(Codicon.close),
+	tooltip: localize('browser.closeTab', "Close")
+};
+
+const closeAllButtonItem: IQuickInputButton = {
+	iconClass: ThemeIcon.asClassName(Codicon.closeAll),
+	tooltip: localize('browser.closeAllTabs', "Close All"),
+	location: QuickInputButtonLocation.Inline
+};
+
+const IP_ADDRESS_PATTERN = /^(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/;
+const URL_LIKE_PATTERN = /^[\w-]+(\.[\w-]+)+(\/\S*)?$/;
+const LOCALHOST_PATTERN = /^localhost:\d+(\/\S*)?$/;
+
+/**
+ * Checks if the input looks like a URL and returns the full URL with protocol,
+ * or `undefined` if it doesn't look like a URL.
+ */
+function tryParseAsUrl(value: string): string | undefined {
+	value = value.trim();
+	if (!value) {
+		return undefined;
+	}
+
+	// Already has a protocol
+	if (/^https?:\/\//i.test(value)) {
+		return value;
+	}
+
+	// localhost or IP address default to http
+	if (LOCALHOST_PATTERN.test(value) || IP_ADDRESS_PATTERN.test(value)) {
+		return `http://${value}`;
+	}
+
+	// foo.bar style domains default to https
+	if (URL_LIKE_PATTERN.test(value)) {
+		return `https://${value}`;
+	}
+
+	return undefined;
+}
+
+/**
+ * Manages a quick pick that lists all open browser tabs grouped by editor group,
+ * with close buttons, live updates, and an always-visible "New Integrated Browser Tab" entry.
+ */
+class BrowserTabQuickPick extends Disposable {
+
+	private readonly _quickPick;
+	private readonly _itemListeners = this._register(new DisposableStore());
+	private _resolvedUrl: string | undefined;
+
+	private readonly _openUrlPick: IBrowserQuickPickItem = {
+		groupId: -1,
+		editor: undefined!,
+		label: '',
+		iconClass: ThemeIcon.asClassName(Codicon.globe),
+		alwaysShow: true,
+	};
+
+	private readonly _openNewTabPick: IBrowserQuickPickItem = {
+		groupId: -1,
+		editor: undefined!,
+		label: localize('browser.openNewTab', "New Integrated Browser Tab"),
+		iconClass: ThemeIcon.asClassName(Codicon.add),
+		alwaysShow: true,
+	};
+
+	constructor(
+		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly _editorGroupsService: IEditorGroupsService,
+		@IQuickInputService quickInputService: IQuickInputService,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super();
+
+		this._quickPick = this._register(quickInputService.createQuickPick<IBrowserQuickPickItem>({ useSeparators: true }));
+		this._quickPick.placeholder = localize('browser.quickOpenPlaceholder', "Select a browser tab or enter a URL");
+		this._quickPick.matchOnDescription = true;
+		this._quickPick.sortByLabel = false;
+		this._quickPick.buttons = [closeAllButtonItem];
+
+		this._register(this._quickPick.onDidChangeValue(value => {
+			this._resolvedUrl = tryParseAsUrl(value);
+			if (this._resolvedUrl) {
+				this._openUrlPick.label = localize('browser.openUrl', "Open {0} in New Tab", this._resolvedUrl);
+			}
+			this._buildItems();
+		}));
+
+		this._register(this._quickPick.onDidTriggerItemButton(async ({ item }) => {
+			if (!item.editor) {
+				return;
+			}
+			const group = this._editorGroupsService.getGroup(item.groupId);
+			if (group) {
+				await group.closeEditor(item.editor, {
+					preserveFocus: true // Don't shift focus so the quickpick doesn't close
+				});
+			}
+		}));
+
+		this._register(this._quickPick.onDidTriggerButton(async () => {
+			for (const group of this._editorGroupsService.getGroups(GroupsOrder.GRID_APPEARANCE)) {
+				const browserEditors = group.editors.filter((e): e is BrowserEditorInput => e instanceof BrowserEditorInput);
+				if (browserEditors.length > 0) {
+					await group.closeEditors(browserEditors, {
+						preserveFocus: true // Don't shift focus so the quickpick doesn't close
+					});
+				}
+			}
+		}));
+
+		this._register(this._quickPick.onDidAccept(async () => {
+			const [selected] = this._quickPick.selectedItems;
+			if (!selected) {
+				return;
+			}
+			if (selected === this._openNewTabPick) {
+				logBrowserOpen(telemetryService, 'quickOpenWithoutUrl');
+				await this._editorService.openEditor({
+					resource: BrowserViewUri.forId(generateUuid()),
+				});
+			} else if (selected === this._openUrlPick && this._resolvedUrl) {
+				logBrowserOpen(telemetryService, 'quickOpenWithUrl');
+				await this._editorService.openEditor({
+					resource: BrowserViewUri.forId(generateUuid()),
+					options: { viewState: { url: this._resolvedUrl } },
+				});
+			} else {
+				await this._editorService.openEditor(selected.editor, selected.groupId);
+			}
+		}));
+
+		this._register(this._quickPick.onDidHide(() => this.dispose()));
+	}
+
+	show(): void {
+		this._buildItems();
+
+		// Pre-select the currently active browser editor
+		const activeEditor = this._editorService.activeEditor;
+		if (activeEditor instanceof BrowserEditorInput) {
+			const activePick = (this._quickPick.items as readonly (IBrowserQuickPickItem | IQuickPickSeparator)[])
+				.find((item): item is IBrowserQuickPickItem => item.type !== 'separator' && item.editor === activeEditor);
+			if (activePick) {
+				this._quickPick.activeItems = [activePick];
+			}
+		}
+
+		this._quickPick.show();
+	}
+
+	private _buildItems(): void {
+		this._itemListeners.clear();
+
+		// Remember which editor was active so we can restore selection
+		const activeEditor = this._quickPick.activeItems[0]?.editor;
+
+		const picks: (IBrowserQuickPickItem | IQuickPickSeparator)[] = [];
+		const groups = this._editorGroupsService.getGroups(GroupsOrder.GRID_APPEARANCE);
+
+		const groupsWithBrowserEditors = groups
+			.map(group => ({ group, browserEditors: group.editors.filter((e): e is BrowserEditorInput => e instanceof BrowserEditorInput) }))
+			.filter(({ browserEditors }) => browserEditors.length > 0);
+		const multipleGroups = groupsWithBrowserEditors.length > 1;
+
+		// Build a map of group ID to aria label for screen readers
+		const mapGroupIdToGroupAriaLabel = new Map<GroupIdentifier, string>();
+		for (const { group } of groupsWithBrowserEditors) {
+			mapGroupIdToGroupAriaLabel.set(group.id, group.ariaLabel);
+		}
+
+		let newActivePick: IBrowserQuickPickItem | undefined;
+
+		for (const { group, browserEditors } of groupsWithBrowserEditors) {
+			if (multipleGroups) {
+				picks.push({ type: 'separator', label: group.label });
+			}
+			for (const editor of browserEditors) {
+				const icon = editor.getIcon();
+				const description = editor.getDescription();
+				const nameAndDescription = description ? `${editor.getName()} ${description}` : editor.getName();
+				const pick: IBrowserQuickPickItem = {
+					groupId: group.id,
+					editor,
+					label: editor.getName(),
+					ariaLabel: multipleGroups
+						? localize('browserEntryAriaLabelWithGroup', "{0}, {1}", nameAndDescription, mapGroupIdToGroupAriaLabel.get(group.id))
+						: nameAndDescription,
+					description,
+					buttons: [closeButtonItem],
+					italic: !group.isPinned(editor),
+				};
+				if (icon instanceof URI) {
+					pick.iconPath = { dark: icon };
+				} else if (icon) {
+					pick.iconClass = ThemeIcon.asClassName(icon);
+				}
+				picks.push(pick);
+
+				if (editor === activeEditor) {
+					newActivePick = pick;
+				}
+
+				this._itemListeners.add(editor.onDidChangeLabel(() => this._buildItems()));
+			}
+			this._itemListeners.add(group.onDidModelChange(() => this._buildItems()));
+		}
+
+		picks.push({ type: 'separator' });
+		if (this._resolvedUrl) {
+			picks.push(this._openUrlPick);
+		}
+		picks.push(this._openNewTabPick);
+
+		this._quickPick.keepScrollPosition = true;
+		this._quickPick.items = picks;
+		if (newActivePick) {
+			this._quickPick.activeItems = [newActivePick];
+		}
+	}
+}
+
+class QuickOpenBrowserAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.browser.quickOpen',
+			title: localize2('browser.quickOpenAction', "Quick Open Browser Tab..."),
+			category: BrowserActionCategory,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const picker = accessor.get(IInstantiationService).createInstance(BrowserTabQuickPick);
+		picker.show();
+	}
+}
+
+registerAction2(QuickOpenBrowserAction);

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../../nls.js';
-import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor, IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyMod, KeyCode } from '../../../../../base/common/keyCodes.js';
-import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroupsService, GroupsOrder } from '../../../../services/editor/common/editorGroupsService.js';
 import { GroupIdentifier } from '../../../../common/editor.js';
-import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPickSeparator, QuickInputButtonLocation } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPickSeparator, QuickInputButtonLocation, IQuickPick } from '../../../../../platform/quickinput/common/quickInput.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
@@ -19,9 +19,15 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { BrowserViewUri } from '../../../../../platform/browserView/common/browserViewUri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { BrowserEditorInput } from '../../common/browserEditorInput.js';
-import { BrowserActionCategory } from '../browserViewActions.js';
+import { BROWSER_EDITOR_ACTIVE, BrowserActionCategory, BrowserActionGroup } from '../browserViewActions.js';
 import { logBrowserOpen } from '../../../../../platform/browserView/common/browserViewTelemetry.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
+import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
+import { BrowserViewCommandId } from '../../../../../platform/browserView/common/browserView.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
+import { ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
+
+export const CONTEXT_BROWSER_EDITOR_OPEN = new RawContextKey<boolean>('browserEditorOpen', false, localize('browser.editorOpen', "Whether any browser editor is currently open"));
 
 interface IBrowserQuickPickItem extends IQuickPickItem {
 	groupId: GroupIdentifier;
@@ -40,8 +46,8 @@ const closeAllButtonItem: IQuickInputButton = {
 };
 
 const IP_ADDRESS_PATTERN = /^(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/;
-const URL_LIKE_PATTERN = /^[\w-]+(\.[\w-]+)+(\/\S*)?$/;
-const LOCALHOST_PATTERN = /^localhost:\d+(\/\S*)?$/;
+const URL_LIKE_PATTERN = /^[\w-]+(\.[\w-]+)+(:\d+)?(\/\S*)?$/;
+const LOCALHOST_PATTERN = /^localhost(:\d+)?(\/\S*)?$/;
 
 /**
  * Checks if the input looks like a URL and returns the full URL with protocol,
@@ -77,7 +83,7 @@ function tryParseAsUrl(value: string): string | undefined {
  */
 class BrowserTabQuickPick extends Disposable {
 
-	private readonly _quickPick;
+	private readonly _quickPick: IQuickPick<IBrowserQuickPickItem, { useSeparators: true }>;
 	private readonly _itemListeners = this._register(new DisposableStore());
 	private _resolvedUrl: string | undefined;
 
@@ -255,14 +261,24 @@ class BrowserTabQuickPick extends Disposable {
 
 class QuickOpenBrowserAction extends Action2 {
 	constructor() {
+		const neverShowInTitleBar = ContextKeyExpr.equals('config.workbench.browser.showInTitleBar', false);
 		super({
-			id: 'workbench.action.browser.quickOpen',
+			id: BrowserViewCommandId.QuickOpen,
 			title: localize2('browser.quickOpenAction', "Quick Open Browser Tab..."),
+			icon: Codicon.globe,
 			category: BrowserActionCategory,
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+				win: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA },
+				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA },
+				// On Linux, Ctrl+Shift+A is mapped to editor block comments. Don't set a keybinding to avoid conflicts.
+			},
+			menu: {
+				id: MenuId.TitleBar,
+				group: 'navigation',
+				order: 10,
+				when: ContextKeyExpr.and(CONTEXT_BROWSER_EDITOR_OPEN, neverShowInTitleBar.negate()),
 			}
 		});
 	}
@@ -273,4 +289,123 @@ class QuickOpenBrowserAction extends Action2 {
 	}
 }
 
+interface IOpenBrowserOptions {
+	url?: string;
+	openToSide?: boolean;
+}
+
+class OpenIntegratedBrowserAction extends Action2 {
+	constructor() {
+		super({
+			id: BrowserViewCommandId.Open,
+			title: localize2('browser.openAction', "Open Integrated Browser"),
+			category: BrowserActionCategory,
+			icon: Codicon.globe,
+			f1: true,
+			menu: {
+				id: MenuId.TitleBar,
+				group: 'navigation',
+				order: 10,
+				when: ContextKeyExpr.and(
+					// This is a hack to work around `true` just testing for truthiness of the key. It works since `1 == true` in JS.
+					ContextKeyExpr.equals('config.workbench.browser.showInTitleBar', 1),
+					CONTEXT_BROWSER_EDITOR_OPEN.negate()
+				)
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor, urlOrOptions?: string | IOpenBrowserOptions): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const telemetryService = accessor.get(ITelemetryService);
+
+		// Parse arguments
+		const options = typeof urlOrOptions === 'string' ? { url: urlOrOptions } : (urlOrOptions ?? {});
+		const resource = BrowserViewUri.forId(generateUuid());
+		const group = options.openToSide ? SIDE_GROUP : ACTIVE_GROUP;
+
+		logBrowserOpen(telemetryService, options.url ? 'commandWithUrl' : 'commandWithoutUrl');
+
+		const editorPane = await editorService.openEditor({ resource, options: { viewState: { url: options.url } } }, group);
+
+		// Lock the group when opening to the side
+		if (options.openToSide && editorPane?.group) {
+			editorPane.group.lock(true);
+		}
+	}
+}
+
+class NewTabAction extends Action2 {
+	constructor() {
+		super({
+			id: BrowserViewCommandId.NewTab,
+			title: localize2('browser.newTabAction', "New Tab"),
+			category: BrowserActionCategory,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
+			menu: {
+				id: MenuId.BrowserActionsToolbar,
+				group: BrowserActionGroup.Tabs,
+				order: 1,
+			},
+			// When already in a browser, Ctrl/Cmd + T opens a new tab
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib + 50, // Priority over search actions
+				primary: KeyMod.CtrlCmd | KeyCode.KeyT,
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor, _browserEditor = accessor.get(IEditorService).activeEditorPane): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const telemetryService = accessor.get(ITelemetryService);
+		const resource = BrowserViewUri.forId(generateUuid());
+
+		logBrowserOpen(telemetryService, 'newTabCommand');
+
+		await editorService.openEditor({ resource });
+	}
+}
+
 registerAction2(QuickOpenBrowserAction);
+registerAction2(OpenIntegratedBrowserAction);
+registerAction2(NewTabAction);
+
+registerAction2(class ToggleBrowserTitleBarButton extends ToggleTitleBarConfigAction {
+	constructor() {
+		super('workbench.browser.showInTitleBar', localize('toggle.browser', 'Integrated Browser'), localize('toggle.browserDescription', "Toggle visibility of the Integrated Browser button in title bar"), 8);
+	}
+});
+
+/**
+ * Tracks whether any browser editor is open across all editor groups and
+ * keeps the `browserEditorOpen` context key in sync.
+ */
+class BrowserEditorOpenContextKeyContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.browserEditorOpenContextKey';
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IEditorService editorService: IEditorService,
+	) {
+		super();
+
+		const contextKey = CONTEXT_BROWSER_EDITOR_OPEN.bindTo(contextKeyService);
+		const update = () => contextKey.set(editorService.editors.some(e => e instanceof BrowserEditorInput));
+
+		update();
+
+		this._register(editorService.onWillOpenEditor(e => {
+			if (e.editor instanceof BrowserEditorInput) {
+				contextKey.set(true);
+			}
+		}));
+		this._register(editorService.onDidCloseEditor(e => {
+			if (e.editor instanceof BrowserEditorInput) {
+				update();
+			}
+		}));
+	}
+}
+
+registerWorkbenchContribution2(BrowserEditorOpenContextKeyContribution.ID, BrowserEditorOpenContextKeyContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
+++ b/src/vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from '../../../../../nls.js';
-import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor, IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyMod, KeyCode } from '../../../../../base/common/keyCodes.js';
 import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { IEditorGroupsService, GroupsOrder } from '../../../../services/editor/common/editorGroupsService.js';
-import { GroupIdentifier } from '../../../../common/editor.js';
+import { EditorsOrder, GroupIdentifier } from '../../../../common/editor.js';
 import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPickSeparator, QuickInputButtonLocation, IQuickPick } from '../../../../../platform/quickinput/common/quickInput.js';
 import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
@@ -25,7 +25,14 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { BrowserViewCommandId } from '../../../../../platform/browserView/common/browserView.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../common/contributions.js';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
+import { workbenchConfigurationNodeBase } from '../../../../common/configuration.js';
+import { IExternalOpener, IOpenerService } from '../../../../../platform/opener/common/opener.js';
+import { isLocalhostAuthority } from '../../../../../platform/url/common/trustedDomains.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { ToggleTitleBarConfigAction } from '../../../../browser/parts/titlebar/titlebarActions.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
 
 export const CONTEXT_BROWSER_EDITOR_OPEN = new RawContextKey<boolean>('browserEditorOpen', false, localize('browser.editorOpen', "Whether any browser editor is currently open"));
 
@@ -45,37 +52,6 @@ const closeAllButtonItem: IQuickInputButton = {
 	location: QuickInputButtonLocation.Inline
 };
 
-const IP_ADDRESS_PATTERN = /^(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/|$)/;
-const URL_LIKE_PATTERN = /^[\w-]+(\.[\w-]+)+(:\d+)?(\/\S*)?$/;
-const LOCALHOST_PATTERN = /^localhost(:\d+)?(\/\S*)?$/;
-
-/**
- * Checks if the input looks like a URL and returns the full URL with protocol,
- * or `undefined` if it doesn't look like a URL.
- */
-function tryParseAsUrl(value: string): string | undefined {
-	value = value.trim();
-	if (!value) {
-		return undefined;
-	}
-
-	// Already has a protocol
-	if (/^https?:\/\//i.test(value)) {
-		return value;
-	}
-
-	// localhost or IP address default to http
-	if (LOCALHOST_PATTERN.test(value) || IP_ADDRESS_PATTERN.test(value)) {
-		return `http://${value}`;
-	}
-
-	// foo.bar style domains default to https
-	if (URL_LIKE_PATTERN.test(value)) {
-		return `https://${value}`;
-	}
-
-	return undefined;
-}
 
 /**
  * Manages a quick pick that lists all open browser tabs grouped by editor group,
@@ -85,15 +61,6 @@ class BrowserTabQuickPick extends Disposable {
 
 	private readonly _quickPick: IQuickPick<IBrowserQuickPickItem, { useSeparators: true }>;
 	private readonly _itemListeners = this._register(new DisposableStore());
-	private _resolvedUrl: string | undefined;
-
-	private readonly _openUrlPick: IBrowserQuickPickItem = {
-		groupId: -1,
-		editor: undefined!,
-		label: '',
-		iconClass: ThemeIcon.asClassName(Codicon.globe),
-		alwaysShow: true,
-	};
 
 	private readonly _openNewTabPick: IBrowserQuickPickItem = {
 		groupId: -1,
@@ -116,14 +83,6 @@ class BrowserTabQuickPick extends Disposable {
 		this._quickPick.matchOnDescription = true;
 		this._quickPick.sortByLabel = false;
 		this._quickPick.buttons = [closeAllButtonItem];
-
-		this._register(this._quickPick.onDidChangeValue(value => {
-			this._resolvedUrl = tryParseAsUrl(value);
-			if (this._resolvedUrl) {
-				this._openUrlPick.label = localize('browser.openUrl', "Open {0} in New Tab", this._resolvedUrl);
-			}
-			this._buildItems();
-		}));
 
 		this._register(this._quickPick.onDidTriggerItemButton(async ({ item }) => {
 			if (!item.editor) {
@@ -157,12 +116,6 @@ class BrowserTabQuickPick extends Disposable {
 				logBrowserOpen(telemetryService, 'quickOpenWithoutUrl');
 				await this._editorService.openEditor({
 					resource: BrowserViewUri.forId(generateUuid()),
-				});
-			} else if (selected === this._openUrlPick && this._resolvedUrl) {
-				logBrowserOpen(telemetryService, 'quickOpenWithUrl');
-				await this._editorService.openEditor({
-					resource: BrowserViewUri.forId(generateUuid()),
-					options: { viewState: { url: this._resolvedUrl } },
 				});
 			} else {
 				await this._editorService.openEditor(selected.editor, selected.groupId);
@@ -246,9 +199,6 @@ class BrowserTabQuickPick extends Disposable {
 		}
 
 		picks.push({ type: 'separator' });
-		if (this._resolvedUrl) {
-			picks.push(this._openUrlPick);
-		}
 		picks.push(this._openNewTabPick);
 
 		this._quickPick.keepScrollPosition = true;
@@ -270,9 +220,10 @@ class QuickOpenBrowserAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				win: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA },
-				mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA },
-				// On Linux, Ctrl+Shift+A is mapped to editor block comments. Don't set a keybinding to avoid conflicts.
+				// Note: on Linux this conflicts with the "toggle block comment" keybinding.
+				//       it's not as problem at the moment becase oh the `when`, but worth noting for the future.
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA,
+				when: BROWSER_EDITOR_ACTIVE
 			},
 			menu: {
 				id: MenuId.TitleBar,
@@ -367,9 +318,61 @@ class NewTabAction extends Action2 {
 	}
 }
 
+class CloseAllBrowserTabsAction extends Action2 {
+	constructor() {
+		super({
+			id: BrowserViewCommandId.CloseAll,
+			title: localize2('browser.closeAll', "Close All Browser Tabs"),
+			category: BrowserActionCategory,
+			f1: true,
+			precondition: CONTEXT_BROWSER_EDITOR_OPEN,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorGroupsService = accessor.get(IEditorGroupsService);
+		for (const group of editorGroupsService.getGroups(GroupsOrder.GRID_APPEARANCE)) {
+			const browserEditors = group.getEditors(EditorsOrder.SEQUENTIAL).filter((e): e is BrowserEditorInput => e instanceof BrowserEditorInput);
+			if (browserEditors.length > 0) {
+				await group.closeEditors(browserEditors);
+			}
+		}
+	}
+}
+
+class CloseAllBrowserTabsInGroupAction extends Action2 {
+	constructor() {
+		super({
+			id: BrowserViewCommandId.CloseAllInGroup,
+			title: localize2('browser.closeAllInGroup', "Close All Browser Tabs in Group"),
+			category: BrowserActionCategory,
+			f1: true,
+			precondition: BROWSER_EDITOR_ACTIVE,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorGroupsService = accessor.get(IEditorGroupsService);
+		const editorService = accessor.get(IEditorService);
+		const group = editorGroupsService.getGroup(editorService.activeEditorPane?.group?.id ?? editorGroupsService.activeGroup.id);
+		if (!group) {
+			return;
+		}
+		const browserEditors = group.getEditors(EditorsOrder.SEQUENTIAL).filter((e): e is BrowserEditorInput => e instanceof BrowserEditorInput);
+		if (browserEditors.length > 0) {
+			await group.closeEditors(browserEditors);
+		}
+	}
+}
+
+// Register as "Close All Browser Tabs" action in editor title menu to align with the regular "Close All" action
+MenuRegistry.appendMenuItem(MenuId.EditorTitleContext, { command: { id: BrowserViewCommandId.CloseAllInGroup, title: localize('browser.closeAllInGroupShort', "Close All Browser Tabs") }, group: '1_close', order: 55, when: BROWSER_EDITOR_ACTIVE });
+
 registerAction2(QuickOpenBrowserAction);
 registerAction2(OpenIntegratedBrowserAction);
 registerAction2(NewTabAction);
+registerAction2(CloseAllBrowserTabsAction);
+registerAction2(CloseAllBrowserTabsInGroupAction);
 
 registerAction2(class ToggleBrowserTitleBarButton extends ToggleTitleBarConfigAction {
 	constructor() {
@@ -409,3 +412,76 @@ class BrowserEditorOpenContextKeyContribution extends Disposable implements IWor
 }
 
 registerWorkbenchContribution2(BrowserEditorOpenContextKeyContribution.ID, BrowserEditorOpenContextKeyContribution, WorkbenchPhase.AfterRestored);
+
+/**
+ * Opens localhost URLs in the Integrated Browser when the setting is enabled.
+ */
+class LocalhostLinkOpenerContribution extends Disposable implements IWorkbenchContribution, IExternalOpener {
+	static readonly ID = 'workbench.contrib.localhostLinkOpener';
+
+	constructor(
+		@IOpenerService openerService: IOpenerService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IEditorService private readonly editorService: IEditorService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService
+	) {
+		super();
+
+		this._register(openerService.registerExternalOpener(this));
+	}
+
+	async openExternal(href: string, _ctx: { sourceUri: URI; preferredOpenerId?: string }, _token: CancellationToken): Promise<boolean> {
+		if (!this.configurationService.getValue<boolean>('workbench.browser.openLocalhostLinks')) {
+			return false;
+		}
+
+		try {
+			const parsed = new URL(href);
+			if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+				return false;
+			}
+			if (!isLocalhostAuthority(parsed.host)) {
+				return false;
+			}
+		} catch {
+			return false;
+		}
+
+		logBrowserOpen(this.telemetryService, 'localhostLinkOpener');
+
+		const browserUri = BrowserViewUri.forId(generateUuid());
+		await this.editorService.openEditor({ resource: browserUri, options: { pinned: true, viewState: { url: href } } });
+		return true;
+	}
+}
+
+registerWorkbenchContribution2(LocalhostLinkOpenerContribution.ID, LocalhostLinkOpenerContribution, WorkbenchPhase.BlockStartup);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...workbenchConfigurationNodeBase,
+	properties: {
+		'workbench.browser.showInTitleBar': {
+			type: ['boolean', 'string'],
+			enum: [true, false, 'whenOpen'],
+			enumDescriptions: [
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.true' }, 'The button is always shown in the title bar.'),
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.false' }, 'The button is never shown in the title bar.'),
+				localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'browser.showInTitleBar.whenOpen' }, 'The button is shown in the title bar when a browser editor is open.')
+			],
+			default: 'whenOpen',
+			experiment: { mode: 'startup' },
+			description: localize(
+				{ comment: ['This is the description for a setting.'], key: 'browser.showInTitleBar' },
+				'Controls whether the Integrated Browser button is shown in the title bar.'
+			)
+		},
+		'workbench.browser.openLocalhostLinks': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				{ comment: ['This is the description for a setting.'], key: 'browser.openLocalhostLinks' },
+				'When enabled, localhost links from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.'
+			)
+		}
+	}
+});


### PR DESCRIPTION
`Ctrl/Cmd + Shift + A` when a browser is active (same shortcut as Chrome / Edge).

https://github.com/user-attachments/assets/41a44d0a-c226-4ead-8d8d-087167bd12bb

Also updates the browser button in the title bar to default to show when a browser is already open. Clicking when there is an existing browser will trigger the quick open picker:
<img width="302" height="58" alt="image" src="https://github.com/user-attachments/assets/eaea921e-56d0-4dc3-b80e-71660c702f1d" />

Also adds commands to close all browsers (in one group or everywhere):
<img width="377" height="183" alt="image" src="https://github.com/user-attachments/assets/71f73144-9fa9-403c-954d-b95f4317cabc" />
<img width="318" height="88" alt="image" src="https://github.com/user-attachments/assets/f43024ea-6afb-4349-83a7-f0c1d49c4f0b" />


Closes #302161
Closes #299861