### PR TITLE
Sessions: Remove titlebar shadow in agent sessions

### DIFF
--- a/src/vs/sessions/browser/parts/media/titlebarpart.css
+++ b/src/vs/sessions/browser/parts/media/titlebarpart.css
@@ -109,6 +109,11 @@
 	display: none !important;
 }
 
+/* Remove the titlebar shadow in agent sessions */
+.agent-sessions-workbench.monaco-workbench .part.titlebar {
+	box-shadow: none;
+}
+
 /* macOS native: the spacer uses window-controls-container but should not block dragging */
 .agent-sessions-workbench.mac .part.titlebar .window-controls-container {
 	-webkit-app-region: drag;


### PR DESCRIPTION
Remove the titlebar shadow in agent sessions to improve visual clarity. Test by launching an agent session and verifying the absence of the shadow in the titlebar.

