### PR TITLE
fix(mcp): resolve env vars in agent plugin MCP server definitions

### DIFF
--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -233,6 +233,9 @@ export function convertBareEnvVarsToVsCodeSyntax(
 	def: IAgentPluginMcpServerDefinition,
 ): IAgentPluginMcpServerDefinition {
 	return cloneAndChange(def, (value) => {
+		if (URI.isUri(value)) {
+			return value;
+		}
 		if (typeof value === 'string') {
 			const replaced = value.replace(BARE_ENV_VAR_RE, '${env:$1}');
 			return replaced !== value ? replaced : undefined;

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -232,44 +232,13 @@ const BARE_ENV_VAR_RE = /\$\{(?![A-Za-z]+:)([A-Z_][A-Z0-9_]*)\}/g;
 export function convertBareEnvVarsToVsCodeSyntax(
 	def: IAgentPluginMcpServerDefinition,
 ): IAgentPluginMcpServerDefinition {
-	const convert = (s: string) => s.replace(BARE_ENV_VAR_RE, '${env:$1}');
-
-	const config = def.configuration;
-	let converted: IMcpServerConfiguration;
-
-	if (config.type === McpServerType.LOCAL) {
-		const local: Mutable<IMcpStdioServerConfiguration> = { ...config };
-		local.command = convert(local.command);
-		if (local.args) {
-			local.args = local.args.map(convert);
+	return cloneAndChange(def, (value) => {
+		if (typeof value === 'string') {
+			const replaced = value.replace(BARE_ENV_VAR_RE, '${env:$1}');
+			return replaced !== value ? replaced : undefined;
 		}
-		if (local.cwd) {
-			local.cwd = convert(local.cwd);
-		}
-		if (local.env) {
-			local.env = { ...local.env };
-			for (const [k, v] of Object.entries(local.env)) {
-				if (typeof v === 'string') {
-					local.env[k] = convert(v);
-				}
-			}
-		}
-		if (local.envFile) {
-			local.envFile = convert(local.envFile);
-		}
-		converted = local;
-	} else {
-		const remote: Mutable<IMcpRemoteServerConfiguration> = { ...config };
-		remote.url = convert(remote.url);
-		if (remote.headers) {
-			remote.headers = Object.fromEntries(
-				Object.entries(remote.headers).map(([k, v]) => [k, convert(v)])
-			);
-		}
-		converted = remote;
-	}
-
-	return { name: def.name, configuration: converted };
+		return undefined;
+	});
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -205,6 +205,74 @@ function interpolateMcpPluginRoot(
 }
 
 /**
+ * Regular expression matching bare `${VAR_NAME}` references that are NOT
+ * already using VS Code's `${env:VAR}` colon-delimited syntax. Only matches
+ * uppercase letters, digits, and underscores — the characters valid in POSIX
+ * environment variable names.
+ *
+ * Negative lookbehind ensures we skip tokens that already carry a namespace
+ * prefix (e.g. `${env:HOME}`, `${config:editor.fontSize}`).
+ */
+const BARE_ENV_VAR_RE = /\$\{(?![A-Za-z]+:)([A-Z_][A-Z0-9_]*)\}/g;
+
+/**
+ * Converts bare `${VAR}` environment-variable references found in MCP server
+ * definition strings to the VS Code `${env:VAR}` syntax so that the
+ * `configurationResolverService` can resolve them later in the pipeline.
+ *
+ * The MCP ecosystem (Claude Desktop, Copilot CLI) uses bare `${VAR}` to
+ * reference environment variables, while VS Code's resolver expects the
+ * `${env:VAR}` form. This function bridges that gap for all plugin-provided
+ * MCP server definitions.
+ *
+ * Only references whose name consists of uppercase letters, digits, and
+ * underscores are converted — this avoids transforming VS Code's own variable
+ * tokens (e.g. `${workspaceFolder}`) which use lowercase/camelCase names.
+ */
+export function convertBareEnvVarsToVsCodeSyntax(
+	def: IAgentPluginMcpServerDefinition,
+): IAgentPluginMcpServerDefinition {
+	const convert = (s: string) => s.replace(BARE_ENV_VAR_RE, '${env:$1}');
+
+	const config = def.configuration;
+	let converted: IMcpServerConfiguration;
+
+	if (config.type === McpServerType.LOCAL) {
+		const local: Mutable<IMcpStdioServerConfiguration> = { ...config };
+		local.command = convert(local.command);
+		if (local.args) {
+			local.args = local.args.map(convert);
+		}
+		if (local.cwd) {
+			local.cwd = convert(local.cwd);
+		}
+		if (local.env) {
+			local.env = { ...local.env };
+			for (const [k, v] of Object.entries(local.env)) {
+				if (typeof v === 'string') {
+					local.env[k] = convert(v);
+				}
+			}
+		}
+		if (local.envFile) {
+			local.envFile = convert(local.envFile);
+		}
+		converted = local;
+	} else {
+		const remote: Mutable<IMcpRemoteServerConfiguration> = { ...config };
+		remote.url = convert(remote.url);
+		if (remote.headers) {
+			remote.headers = Object.fromEntries(
+				Object.entries(remote.headers).map(([k, v]) => [k, convert(v)])
+			);
+		}
+		converted = remote;
+	}
+
+	return { name: def.name, configuration: converted };
+}
+
+/**
  * Shared hook-parsing logic for plugin formats that use the Claude/open-plugin
  * hook schema. Replaces `${token}` references in hook commands with the plugin
  * root path (shell-quoted when necessary), injects an environment variable, and
@@ -703,6 +771,7 @@ export abstract class AbstractAgentPluginDiscovery extends Disposable implements
 			if (adapter.pluginRootToken && adapter.pluginRootEnvVar) {
 				def = interpolateMcpPluginRoot(def, pluginFsPath, adapter.pluginRootToken, adapter.pluginRootEnvVar);
 			}
+			def = convertBareEnvVarsToVsCodeSyntax(def);
 			definitions.push(def);
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/plugins/convertBareEnvVarsToVsCodeSyntax.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/convertBareEnvVarsToVsCodeSyntax.test.ts
@@ -1,0 +1,233 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { IMcpRemoteServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
+import { convertBareEnvVarsToVsCodeSyntax } from '../../../common/plugins/agentPluginServiceImpl.js';
+
+suite('convertBareEnvVarsToVsCodeSyntax', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/** Helper to narrow the result configuration to a stdio server. */
+	function asStdio(result: ReturnType<typeof convertBareEnvVarsToVsCodeSyntax>): IMcpStdioServerConfiguration {
+		assert.strictEqual(result.configuration.type, McpServerType.LOCAL);
+		return result.configuration as IMcpStdioServerConfiguration;
+	}
+
+	/** Helper to narrow the result configuration to a remote server. */
+	function asRemote(result: ReturnType<typeof convertBareEnvVarsToVsCodeSyntax>): IMcpRemoteServerConfiguration {
+		assert.strictEqual(result.configuration.type, McpServerType.REMOTE);
+		return result.configuration as IMcpRemoteServerConfiguration;
+	}
+
+	suite('stdio (LOCAL) servers', () => {
+
+		test('converts bare ${VAR} in command to ${env:VAR}', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${MY_TOOL_PATH}/bin/server',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${env:MY_TOOL_PATH}/bin/server');
+		});
+
+		test('converts bare ${VAR} in args', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: 'node',
+					args: ['--token', '${ENTERPRISE_GITHUB_TOKEN}'],
+				},
+			}));
+			assert.deepStrictEqual(cfg.args, ['--token', '${env:ENTERPRISE_GITHUB_TOKEN}']);
+		});
+
+		test('converts bare ${VAR} in env values', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: 'server',
+					env: {
+						TOKEN: '${ENTERPRISE_GITHUB_TOKEN}',
+						STATIC: 'literal-value',
+					},
+				},
+			}));
+			assert.strictEqual(cfg.env!.TOKEN, '${env:ENTERPRISE_GITHUB_TOKEN}');
+			assert.strictEqual(cfg.env!.STATIC, 'literal-value');
+		});
+
+		test('converts bare ${VAR} in cwd', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: 'server',
+					cwd: '${PROJECT_DIR}/subdir',
+				},
+			}));
+			assert.strictEqual(cfg.cwd, '${env:PROJECT_DIR}/subdir');
+		});
+
+		test('converts bare ${VAR} in envFile', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: 'server',
+					envFile: '${HOME}/.env',
+				},
+			}));
+			assert.strictEqual(cfg.envFile, '${env:HOME}/.env');
+		});
+
+		test('does not convert already-namespaced ${env:VAR} references', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${env:ALREADY_RESOLVED}/bin/server',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${env:ALREADY_RESOLVED}/bin/server');
+		});
+
+		test('does not convert ${config:...} references', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${config:editor.fontSize}',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${config:editor.fontSize}');
+		});
+
+		test('does not convert lowercase/camelCase VS Code variable tokens', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${workspaceFolder}/server',
+					cwd: '${fileDirname}',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${workspaceFolder}/server');
+			assert.strictEqual(cfg.cwd, '${fileDirname}');
+		});
+
+		test('converts multiple bare ${VAR} references in a single string', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${BIN_DIR}/run --config ${CONFIG_DIR}/cfg.json',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${env:BIN_DIR}/run --config ${env:CONFIG_DIR}/cfg.json');
+		});
+
+		test('leaves strings without any ${VAR} unchanged', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '/usr/bin/server',
+					args: ['--port', '8080'],
+					env: { KEY: 'plain-value' },
+				},
+			}));
+			assert.strictEqual(cfg.command, '/usr/bin/server');
+			assert.deepStrictEqual(cfg.args, ['--port', '8080']);
+			assert.strictEqual(cfg.env!.KEY, 'plain-value');
+		});
+
+		test('preserves non-string env values (numbers and null)', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: 'server',
+					env: {
+						PORT: 3000,
+						UNSET: null,
+						TOKEN: '${MY_TOKEN}',
+					},
+				},
+			}));
+			assert.strictEqual(cfg.env!.PORT, 3000);
+			assert.strictEqual(cfg.env!.UNSET, null);
+			assert.strictEqual(cfg.env!.TOKEN, '${env:MY_TOKEN}');
+		});
+
+		test('converts underscore-prefixed variable names', () => {
+			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${_PRIVATE_BIN}/server',
+				},
+			}));
+			assert.strictEqual(cfg.command, '${env:_PRIVATE_BIN}/server');
+		});
+
+		test('preserves the definition name unchanged', () => {
+			const result = convertBareEnvVarsToVsCodeSyntax({
+				name: 'my-mcp-server',
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${MY_PATH}/server',
+				},
+			});
+			assert.strictEqual(result.name, 'my-mcp-server');
+		});
+	});
+
+	suite('remote (HTTP) servers', () => {
+
+		test('converts bare ${VAR} in url', () => {
+			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.REMOTE,
+					url: 'https://${API_HOST}/mcp',
+				},
+			}));
+			assert.strictEqual(cfg.url, 'https://${env:API_HOST}/mcp');
+		});
+
+		test('converts bare ${VAR} in header values', () => {
+			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.REMOTE,
+					url: 'https://example.com/mcp',
+					headers: {
+						Authorization: 'Bearer ${API_TOKEN}',
+						'X-Custom': 'static-value',
+					},
+				},
+			}));
+			assert.strictEqual(cfg.headers!.Authorization, 'Bearer ${env:API_TOKEN}');
+			assert.strictEqual(cfg.headers!['X-Custom'], 'static-value');
+		});
+
+		test('does not convert already-namespaced ${env:VAR} in url', () => {
+			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				configuration: {
+					type: McpServerType.REMOTE,
+					url: 'https://${env:API_HOST}/mcp',
+				},
+			}));
+			assert.strictEqual(cfg.url, 'https://${env:API_HOST}/mcp');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/chat/test/common/plugins/convertBareEnvVarsToVsCodeSyntax.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/plugins/convertBareEnvVarsToVsCodeSyntax.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { IMcpRemoteServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { convertBareEnvVarsToVsCodeSyntax } from '../../../common/plugins/agentPluginServiceImpl.js';
@@ -28,6 +29,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in command to ${env:VAR}', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${MY_TOOL_PATH}/bin/server',
@@ -39,6 +41,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in args', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: 'node',
@@ -51,6 +54,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in env values', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: 'server',
@@ -67,6 +71,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in cwd', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: 'server',
@@ -79,6 +84,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in envFile', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: 'server',
@@ -91,6 +97,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('does not convert already-namespaced ${env:VAR} references', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${env:ALREADY_RESOLVED}/bin/server',
@@ -102,6 +109,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('does not convert ${config:...} references', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${config:editor.fontSize}',
@@ -113,6 +121,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('does not convert lowercase/camelCase VS Code variable tokens', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${workspaceFolder}/server',
@@ -126,6 +135,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts multiple bare ${VAR} references in a single string', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${BIN_DIR}/run --config ${CONFIG_DIR}/cfg.json',
@@ -137,6 +147,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('leaves strings without any ${VAR} unchanged', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '/usr/bin/server',
@@ -152,6 +163,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('preserves non-string env values (numbers and null)', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: 'server',
@@ -170,6 +182,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts underscore-prefixed variable names', () => {
 			const cfg = asStdio(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${_PRIVATE_BIN}/server',
@@ -181,12 +194,27 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('preserves the definition name unchanged', () => {
 			const result = convertBareEnvVarsToVsCodeSyntax({
 				name: 'my-mcp-server',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.LOCAL,
 					command: '${MY_PATH}/server',
 				},
 			});
 			assert.strictEqual(result.name, 'my-mcp-server');
+		});
+
+		test('preserves uri as a URI instance', () => {
+			const input = URI.parse('file:///plugins/my-plugin');
+			const result = convertBareEnvVarsToVsCodeSyntax({
+				name: 'test',
+				uri: input,
+				configuration: {
+					type: McpServerType.LOCAL,
+					command: '${MY_PATH}/server',
+				},
+			});
+			assert.ok(URI.isUri(result.uri), 'uri must remain a URI instance');
+			assert.strictEqual(result.uri.toString(), input.toString());
 		});
 	});
 
@@ -195,6 +223,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in url', () => {
 			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.REMOTE,
 					url: 'https://${API_HOST}/mcp',
@@ -206,6 +235,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('converts bare ${VAR} in header values', () => {
 			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.REMOTE,
 					url: 'https://example.com/mcp',
@@ -222,6 +252,7 @@ suite('convertBareEnvVarsToVsCodeSyntax', () => {
 		test('does not convert already-namespaced ${env:VAR} in url', () => {
 			const cfg = asRemote(convertBareEnvVarsToVsCodeSyntax({
 				name: 'test',
+				uri: URI.parse('file:///test'),
 				configuration: {
 					type: McpServerType.REMOTE,
 					url: 'https://${env:API_HOST}/mcp',

--- a/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
+++ b/src/vs/workbench/contrib/mcp/common/discovery/pluginMcpDiscovery.ts
@@ -91,6 +91,7 @@ export class PluginMcpDiscovery extends Disposable implements IMcpDiscovery {
 			id: `${collectionId}.${name}`,
 			label: name,
 			launch,
+			variableReplacement: { target: ConfigurationTarget.USER },
 			cacheNonce: String(hash(launch)),
 		};
 	}


### PR DESCRIPTION
Agent plugin MCP servers did not resolve environment variable references because the resolution pipeline was skipped entirely (no variableReplacement was set) and the MCP-standard bare ${VAR} syntax is not recognized by VS Code's configuration resolver.

- Add variableReplacement to plugin server definitions so the resolution pipeline runs
- Convert bare ${VAR} references to ${env:VAR} at the plugin boundary so the resolver can look them up in process.env

Fixes #302579

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
