### PR TITLE
Add inlineChat.askInChat setting to toggle Ask in Chat vs Inline Chat

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -11,7 +11,7 @@ import { EmbeddedDiffEditorWidget } from '../../../../editor/browser/widget/diff
 import { EmbeddedCodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/embeddedCodeEditorWidget.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { InlineChatController, InlineChatRunOptions } from './inlineChatController.js';
-import { ACTION_ACCEPT_CHANGES, ACTION_ASK_IN_CHAT, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_POSSIBLE, ACTION_START, CTX_INLINE_CHAT_V2_ENABLED, CTX_INLINE_CHAT_V1_ENABLED, CTX_HOVER_MODE, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_PENDING_CONFIRMATION, CTX_INLINE_CHAT_TERMINATED, InlineChatConfigKeys, CTX_FIX_DIAGNOSTICS_ENABLED, CTX_INLINE_CHAT_AFFORDANCE_VISIBLE } from '../common/inlineChat.js';
+import { ACTION_ACCEPT_CHANGES, ACTION_ASK_IN_CHAT, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_POSSIBLE, ACTION_START, CTX_INLINE_CHAT_V2_ENABLED, CTX_INLINE_CHAT_V1_ENABLED, CTX_HOVER_MODE, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_PENDING_CONFIRMATION, CTX_INLINE_CHAT_TERMINATED, InlineChatConfigKeys, CTX_FIX_DIAGNOSTICS_ENABLED, CTX_INLINE_CHAT_AFFORDANCE_VISIBLE, CTX_ASK_IN_CHAT_ENABLED } from '../common/inlineChat.js';
 import { ctxHasEditorModification, ctxHasRequestInProgress } from '../../chat/browser/chatEditing/chatEditingEditorContextKeys.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, IAction2Options, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
@@ -53,7 +53,7 @@ export class StartSessionAction extends Action2 {
 			shortTitle: localize2('runShort', 'Inline Chat'),
 			category: AbstractInlineChatAction.category,
 			f1: true,
-			precondition: ContextKeyExpr.and(inlineChatContextKey, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+			precondition: ContextKeyExpr.and(inlineChatContextKey, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())),
 			keybinding: {
 				when: EditorContextKeys.focus,
 				weight: KeybindingWeight.WorkbenchContrib,
@@ -64,7 +64,7 @@ export class StartSessionAction extends Action2 {
 				id: MenuId.EditorContext,
 				group: '1_chat',
 				order: 3,
-				when: inlineChatContextKey
+				when: ContextKeyExpr.and(inlineChatContextKey, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate()))
 			}, {
 				id: MenuId.ChatTitleBarMenu,
 				group: 'a_open',
@@ -130,7 +130,7 @@ export class StartSessionAction extends Action2 {
 MenuRegistry.appendMenuItem(MenuId.InlineChatEditorAffordance, {
 	group: '0_chat',
 	order: 1,
-	when: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasNonEmptySelection, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), ChatEntitlementContextKeys.Setup.hidden.negate()),
+	when: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasNonEmptySelection, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate()), ChatEntitlementContextKeys.Setup.hidden.negate()),
 	command: {
 		id: ACTION_START,
 		title: localize('editCode', "Ask for Edits"),
@@ -449,9 +449,9 @@ export class SubmitInlineChatInputAction extends AbstractInlineChatAction {
 			id: 'inlineChat.submitInput',
 			title: localize2('submitInput', "Send"),
 			icon: Codicon.send,
-			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_INPUT_HAS_TEXT, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())),
 			keybinding: {
-				when: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+				when: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())),
 				weight: KeybindingWeight.EditorCore + 10,
 				primary: KeyCode.Enter
 			},
@@ -459,7 +459,7 @@ export class SubmitInlineChatInputAction extends AbstractInlineChatAction {
 				id: MenuId.InlineChatInput,
 				group: '0_main',
 				order: 1,
-				when: CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()
+				when: ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())
 			}]
 		});
 	}
@@ -502,7 +502,7 @@ export class AskInChatAction extends EditorAction2 {
 			title: localize2('askInChat', 'Ask in Chat'),
 			category: AbstractInlineChatAction.category,
 			f1: true,
-			precondition: ContextKeyExpr.and(inlineChatContextKey, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT),
+			precondition: ContextKeyExpr.and(inlineChatContextKey, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED),
 			keybinding: {
 				when: EditorContextKeys.focus,
 				weight: KeybindingWeight.WorkbenchContrib,
@@ -513,12 +513,12 @@ export class AskInChatAction extends EditorAction2 {
 				id: MenuId.EditorContext,
 				group: '1_chat',
 				order: 3,
-				when: ContextKeyExpr.and(inlineChatContextKey, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT)
+				when: ContextKeyExpr.and(inlineChatContextKey, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED)
 			}, {
 				id: MenuId.InlineChatEditorAffordance,
 				group: '0_chat',
 				order: 1,
-				when: ContextKeyExpr.and(EditorContextKeys.hasNonEmptySelection, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT)
+				when: ContextKeyExpr.and(EditorContextKeys.hasNonEmptySelection, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED)
 			}]
 		});
 	}
@@ -564,9 +564,9 @@ export class QueueInChatAction extends AbstractInlineChatAction {
 			id: 'inlineChat.queueInChat',
 			title: localize2('queueInChat', "Queue in Chat"),
 			icon: Codicon.arrowUp,
-			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_INPUT_HAS_TEXT, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED),
 			keybinding: {
-				when: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT),
+				when: ContextKeyExpr.and(CTX_INLINE_CHAT_INPUT_WIDGET_FOCUSED, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED),
 				weight: KeybindingWeight.EditorCore + 10,
 				primary: KeyCode.Enter
 			},
@@ -574,7 +574,7 @@ export class QueueInChatAction extends AbstractInlineChatAction {
 				id: MenuId.InlineChatInput,
 				group: '0_main',
 				order: 1,
-				when: CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT,
+				when: ContextKeyExpr.and(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT, CTX_ASK_IN_CHAT_ENABLED),
 			}]
 		});
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -55,7 +55,11 @@ export class StartSessionAction extends Action2 {
 			f1: true,
 			precondition: ContextKeyExpr.and(inlineChatContextKey, ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())),
 			keybinding: {
-				when: EditorContextKeys.focus,
+				when: ContextKeyExpr.and(
+					EditorContextKeys.focus,
+					inlineChatContextKey,
+					ContextKeyExpr.or(CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate(), CTX_ASK_IN_CHAT_ENABLED.negate())
+				),
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyI
 			},

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -22,6 +22,7 @@ export const enum InlineChatConfigKeys {
 	Affordance = 'inlineChat.affordance',
 	RenderMode = 'inlineChat.renderMode',
 	FixDiagnostics = 'inlineChat.fixDiagnostics',
+	AskInChat = 'inlineChat.askInChat',
 }
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
@@ -87,7 +88,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				mode: 'auto'
 			},
 			tags: ['experimental']
-		}
+		},
+		[InlineChatConfigKeys.AskInChat]: {
+			description: localize('askInChat', "Controls whether files in a chat editing session use Ask in Chat instead of Inline Chat."),
+			default: true,
+			type: 'boolean',
+		},
 	}
 });
 
@@ -138,6 +144,7 @@ export const CTX_INLINE_CHAT_V2_ENABLED = ContextKeyExpr.or(
 
 export const CTX_HOVER_MODE = ContextKeyExpr.equals('config.inlineChat.renderMode', 'hover');
 export const CTX_FIX_DIAGNOSTICS_ENABLED = ContextKeyExpr.equals('config.inlineChat.fixDiagnostics', true);
+export const CTX_ASK_IN_CHAT_ENABLED = ContextKeyExpr.equals('config.inlineChat.askInChat', true);
 
 // --- (selected) action identifier
 


### PR DESCRIPTION
Adds a new `inlineChat.askInChat` boolean setting (default: `true`) that controls whether Cmd+I / Ctrl+I in a file belonging to a chat editing session opens Ask in Chat or regular Inline Chat.

When enabled (default): behavior is unchanged - the keybinding triggers Ask in Chat for chat-owned files.
When disabled: the keybinding always opens regular Inline Chat, even for chat-owned files.

Fixes #300439