### PR TITLE
Mark PR review comments as converted when added to agent feedback

### DIFF
--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachment.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachment.ts
@@ -69,6 +69,7 @@ export class AgentFeedbackAttachmentContribution extends Disposable {
 				range: f.range,
 				codeSelection: f.codeSelection,
 				diffHunks: f.diffHunks,
+				sourcePRReviewCommentId: f.sourcePRReviewCommentId,
 			})),
 			value,
 		};
@@ -91,6 +92,9 @@ export class AgentFeedbackAttachmentContribution extends Disposable {
 				: `${item.range.startLineNumber}-${item.range.endLineNumber}`;
 
 			let part = `[${fileName}:${lineRef}]`;
+			if (item.sourcePRReviewCommentId) {
+				part += `\n(PR review comment, thread ID: ${item.sourcePRReviewCommentId} — resolve this thread when addressed)`;
+			}
 			if (item.codeSelection) {
 				part += `\nSelection:\n\`\`\`\n${item.codeSelection}\n\`\`\``;
 			}

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution.ts
@@ -410,6 +410,10 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			return;
 		}
 
+		const sourcePRReviewCommentId = comment.source === SessionEditorCommentSource.PRReview
+			? comment.sourceId
+			: undefined;
+
 		const feedback = this._agentFeedbackService.addFeedback(
 			this._sessionResource,
 			comment.resourceUri,
@@ -417,10 +421,13 @@ export class AgentFeedbackEditorWidget extends Disposable implements IOverlayWid
 			comment.text,
 			comment.suggestion,
 			createAgentFeedbackContext(this._editor, this._codeEditorService, comment.resourceUri, comment.range),
+			sourcePRReviewCommentId,
 		);
 		this._agentFeedbackService.setNavigationAnchor(this._sessionResource, toSessionEditorCommentId(SessionEditorCommentSource.AgentFeedback, feedback.id));
 		if (comment.source === SessionEditorCommentSource.CodeReview) {
 			this._codeReviewService.removeComment(this._sessionResource, comment.sourceId);
+		} else if (comment.source === SessionEditorCommentSource.PRReview) {
+			this._codeReviewService.markPRReviewCommentConverted(this._sessionResource, comment.sourceId);
 		}
 	}
 

--- a/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
+++ b/src/vs/sessions/contrib/agentFeedback/browser/agentFeedbackService.ts
@@ -32,6 +32,8 @@ export interface IAgentFeedback {
 	readonly suggestion?: ICodeReviewSuggestion;
 	readonly codeSelection?: string;
 	readonly diffHunks?: string;
+	/** When this feedback was converted from a PR review comment, the original thread ID. */
+	readonly sourcePRReviewCommentId?: string;
 }
 
 export interface INavigableSessionComment {
@@ -61,7 +63,7 @@ export interface IAgentFeedbackService {
 	/**
 	 * Add a feedback item for the given session.
 	 */
-	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext): IAgentFeedback;
+	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string): IAgentFeedback;
 
 	/**
 	 * Remove a single feedback item.
@@ -115,7 +117,7 @@ export interface IAgentFeedbackService {
 	 * Add a feedback item and then submit the feedback. Waits for the
 	 * attachment to be updated in the chat widget before submitting.
 	 */
-	addFeedbackAndSubmit(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext): Promise<void>;
+	addFeedbackAndSubmit(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string): Promise<void>;
 }
 
 // --- Implementation -----------------------------------------------------------
@@ -146,7 +148,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		super();
 	}
 
-	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext): IAgentFeedback {
+	addFeedback(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string): IAgentFeedback {
 		const key = sessionResource.toString();
 		let feedbackItems = this._feedbackBySession.get(key);
 		if (!feedbackItems) {
@@ -163,6 +165,7 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 			suggestion,
 			codeSelection: context?.codeSelection,
 			diffHunks: context?.diffHunks,
+			sourcePRReviewCommentId,
 		};
 
 		// Insert at the correct sorted position.
@@ -443,8 +446,8 @@ export class AgentFeedbackService extends Disposable implements IAgentFeedbackSe
 		this._onDidChangeFeedback.fire({ sessionResource, feedbackItems: [] });
 	}
 
-	async addFeedbackAndSubmit(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext): Promise<void> {
-		this.addFeedback(sessionResource, resourceUri, range, text, suggestion, context);
+	async addFeedbackAndSubmit(sessionResource: URI, resourceUri: URI, range: IRange, text: string, suggestion?: ICodeReviewSuggestion, context?: IAgentFeedbackContext, sourcePRReviewCommentId?: string): Promise<void> {
+		this.addFeedback(sessionResource, resourceUri, range, text, suggestion, context, sourcePRReviewCommentId);
 
 		// Wait for the attachment contribution to update the chat widget's attachment model
 		const widget = this._chatWidgetService.getWidgetBySessionResource(sessionResource);

--- a/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
+++ b/src/vs/sessions/contrib/codeReview/browser/codeReviewService.ts
@@ -201,6 +201,13 @@ export interface ICodeReviewService {
 	 * Resolve a PR review thread on GitHub and remove it from local state.
 	 */
 	resolvePRReviewThread(sessionResource: URI, threadId: string): Promise<void>;
+
+	/**
+	 * Mark a PR review comment as locally converted to agent feedback.
+	 * The comment is hidden from the PR review state until the session is
+	 * cleaned up.
+	 */
+	markPRReviewCommentConverted(sessionResource: URI, commentId: string): void;
 }
 
 // --- Storage Types -----------------------------------------------------------
@@ -301,6 +308,8 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 
 	private readonly _reviewsBySession = new Map<string, ISessionReviewData>();
 	private readonly _prReviewBySession = new Map<string, IPRSessionReviewData>();
+	/** PR review comment IDs that have been converted to agent feedback (per session). */
+	private readonly _convertedPRCommentsBySession = new Map<string, Set<string>>();
 
 	constructor(
 		@ICommandService private readonly _commandService: ICommandService,
@@ -610,6 +619,26 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 		}
 	}
 
+	markPRReviewCommentConverted(sessionResource: URI, commentId: string): void {
+		const key = sessionResource.toString();
+		let converted = this._convertedPRCommentsBySession.get(key);
+		if (!converted) {
+			converted = new Set();
+			this._convertedPRCommentsBySession.set(key, converted);
+		}
+		converted.add(commentId);
+
+		// Immediately filter the comment from the observable PR review state
+		const data = this._prReviewBySession.get(key);
+		if (data) {
+			const currentState = data.state.get();
+			if (currentState.kind === PRReviewStateKind.Loaded) {
+				const filtered = currentState.comments.filter(c => c.id !== commentId);
+				data.state.set({ kind: PRReviewStateKind.Loaded, comments: filtered }, undefined);
+			}
+		}
+	}
+
 	private _getOrCreatePRReviewData(sessionResource: URI): IPRSessionReviewData {
 		const key = sessionResource.toString();
 		let data = this._prReviewBySession.get(key);
@@ -643,10 +672,15 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 		// Watch the PR model's review threads and map to local state
 		data.disposables.add(autorun(reader => {
 			const threads = prModel.reviewThreads.read(reader);
+			const converted = this._convertedPRCommentsBySession.get(sessionResource.toString());
 			const comments: IPRReviewComment[] = [];
 
 			for (const thread of threads) {
 				if (thread.isResolved) {
+					continue;
+				}
+				const threadId = String(thread.id);
+				if (converted?.has(threadId)) {
 					continue;
 				}
 				const fileUri = this._sessionsManagementService.resolveSessionFileUri(sessionResource, thread.path);
@@ -677,6 +711,7 @@ export class CodeReviewService extends Disposable implements ICodeReviewService 
 
 	private _disposePRReview(sessionResource: URI): void {
 		const key = sessionResource.toString();
+		this._convertedPRCommentsBySession.delete(key);
 		const data = this._prReviewBySession.get(key);
 		if (data) {
 			data.disposables.dispose();

--- a/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
+++ b/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
@@ -307,6 +307,8 @@ export interface IAgentFeedbackVariableEntry extends IBaseChatRequestVariableEnt
 		readonly range: IRange;
 		readonly codeSelection?: string;
 		readonly diffHunks?: string;
+		/** When this item was converted from a PR review comment, the original thread ID. */
+		readonly sourcePRReviewCommentId?: string;
 	}>;
 }
 


### PR DESCRIPTION
## Summary

When a PR review comment is converted to agent feedback in the agent sessions editor widget, it now gets locally marked as "converted" and immediately hides from the feedback widget. This marking survives PR poll refreshes so the comment stays hidden.

Additionally, the attachment variable entry now carries the source PR review comment thread ID, and the stringified value sent to the LLM mentions that the feedback originated from a PR comment with its thread ID so it can be resolved when addressed.

## Changes

| File | Change |
|------|--------|
| `codeReviewService.ts` | Added `markPRReviewCommentConverted()` — tracks converted IDs per session, filters from PR review observable state, and filters during poll rebuilds. Cleans up on session dispose. |
| `agentFeedbackService.ts` | Added optional `sourcePRReviewCommentId` to `IAgentFeedback` interface and `addFeedback()`/`addFeedbackAndSubmit()` methods |
| `chatVariableEntries.ts` | Extended `IAgentFeedbackVariableEntry.feedbackItems` with optional `sourcePRReviewCommentId` |
| `agentFeedbackEditorWidgetContribution.ts` | On convert from PRReview source: calls `markPRReviewCommentConverted` and passes source thread ID to `addFeedback` |
| `agentFeedbackAttachment.ts` | Passes `sourcePRReviewCommentId` through to variable entry; enriches stringified LLM value with PR comment origin and thread ID |

## Testing

- TypeScript compilation passes (`compile-check-ts-native`)
- Hygiene pre-commit hook passes