### PR TITLE
fix: force re-render markdown cell on re-execution to refresh broken images

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2815,6 +2815,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			offset: cellTop + top,
 			visible: true,
 			metadata: cell.metadata,
+			forceRefresh: true,
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1354,7 +1354,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			return this.createMarkupPreview(newContent);
 		}
 
-		const sameContent = newContent.content === entry.content;
+		const sameContent = newContent.content === entry.content && !newContent.forceRefresh;
 		const sameMetadata = (equals(newContent.metadata, entry.metadata));
 		if (!sameContent || !sameMetadata || !entry.visible) {
 			this._sendMessageToWebview({

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -365,6 +365,7 @@ export interface IMarkupCellInitialization {
 	offset: number;
 	visible: boolean;
 	metadata: NotebookCellMetadata;
+	forceRefresh?: boolean;
 }
 
 export interface IInitializeMarkupCells {


### PR DESCRIPTION
Fixes #151151

## Problem
When a markdown cell is re-executed without changing its content, images 
that were previously broken (e.g. the file didn't exist yet) remain broken 
even after the referenced file is created. This happens because 
`showMarkupPreview` skips sending a re-render message to the webview when 
content is identical to the cached version.

## Fix
Added a `forceRefresh` flag to `IMarkupCellInitialization`. When set, the 
`sameContent` check is bypassed and the webview always re-renders the cell. 
The flag is passed as `true` from `createMarkupPreview` in 
`notebookEditorWidget.ts`, which is called on every cell execution.

## Testing
- All existing notebook, markup, and markdown unit tests pass.
- Manual repro: create a markdown cell with `<img src="myimg.png">`, execute 
  it (broken image appears), create the file, re-execute — image now renders 
  correctly without needing to edit the cell.