### PR TITLE
Add model picker telemetry for admin/upgrade links and Other Models toggles

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -64,10 +64,6 @@ export interface IActionListItem<T> {
 	readonly label?: string;
 	readonly description?: string | IMarkdownString;
 	/**
-	 * Optional callback invoked when a markdown link inside the description is activated.
-	 */
-	readonly onDescriptionLinkActivated?: () => void;
-	/**
 	 * Optional hover configuration shown when focusing/hovering over the item.
 	 */
 	readonly hover?: IActionListItemHover;
@@ -197,6 +193,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 		private readonly _onRemoveItem: ((item: IActionListItem<T>) => void) | undefined,
 		private readonly _onSubmenuIndicatorHover: ((element: IActionListItem<T>, indicator: HTMLElement, disposables: DisposableStore) => void) | undefined,
 		private _hasAnySubmenuActions: boolean,
+		private readonly _descriptionActionHandler: ((uri: URI, item: IActionListItem<T>) => void) | undefined,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 	) { }
@@ -288,8 +285,8 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 			} else {
 				const rendered = renderMarkdown(element.description, {
 					actionHandler: (content: string) => {
-						element.onDescriptionLinkActivated?.();
-						this._openerService.open(URI.parse(content), { allowCommands: true });
+						const uri = URI.parse(content);
+						this._descriptionActionHandler?.(uri, element) ?? this._openerService.open(uri, { allowCommands: true });
 					}
 				});
 				data.elementDisposables.add(rendered);
@@ -410,6 +407,12 @@ export interface IActionListOptions {
 	readonly minWidth?: number;
 
 	/**
+	 * Optional markdown link action handler for item descriptions.
+	 * When unset, links open via the opener service with command links allowed.
+	 */
+	readonly descriptionActionHandler?: (uri: URI, item: IActionListItem<unknown>) => void;
+
+	/**
 	 * Optional callback fired when a section's collapsed state changes.
 	 */
 	readonly onDidToggleSection?: (section: string, collapsed: boolean) => void;
@@ -528,7 +531,7 @@ export class ActionListWidget<T> extends Disposable {
 		const hasAnySubmenuActions = items.some(item => !!item.submenuActions?.length);
 
 		this._list = this._register(new List(user, this.domNode, virtualDelegate, [
-			new ActionItemRenderer<T>(preview, (item) => this._removeItem(item), (element, indicator, disposables) => this._wireSubmenuIndicator(element, indicator, disposables), hasAnySubmenuActions, this._keybindingService, this._openerService),
+			new ActionItemRenderer<T>(preview, (item) => this._removeItem(item), (element, indicator, disposables) => this._wireSubmenuIndicator(element, indicator, disposables), hasAnySubmenuActions, this._options?.descriptionActionHandler, this._keybindingService, this._openerService),
 			new HeaderRenderer(),
 			new SeparatorRenderer(),
 		], {

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -64,6 +64,10 @@ export interface IActionListItem<T> {
 	readonly label?: string;
 	readonly description?: string | IMarkdownString;
 	/**
+	 * Optional callback invoked when a markdown link inside the description is activated.
+	 */
+	readonly onDescriptionLinkActivated?: () => void;
+	/**
 	 * Optional hover configuration shown when focusing/hovering over the item.
 	 */
 	readonly hover?: IActionListItemHover;
@@ -284,6 +288,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 			} else {
 				const rendered = renderMarkdown(element.description, {
 					actionHandler: (content: string) => {
+						element.onDescriptionLinkActivated?.();
 						this._openerService.open(URI.parse(content), { allowCommands: true });
 					}
 				});
@@ -403,6 +408,11 @@ export interface IActionListOptions {
 	 * Minimum width for the action list.
 	 */
 	readonly minWidth?: number;
+
+	/**
+	 * Optional callback fired when a section's collapsed state changes.
+	 */
+	readonly onDidToggleSection?: (section: string, collapsed: boolean) => void;
 
 	/**
 	 * When true, descriptions are rendered as subtext below the title
@@ -638,6 +648,7 @@ export class ActionListWidget<T> extends Disposable {
 		} else {
 			this._collapsedSections.add(section);
 		}
+		this._options?.onDidToggleSection?.(section, this._collapsedSections.has(section));
 		this._applyFilter();
 	}
 

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -286,7 +286,11 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 				const rendered = renderMarkdown(element.description, {
 					actionHandler: (content: string) => {
 						const uri = URI.parse(content);
-						this._linkHandler?.(uri, element) ?? this._openerService.open(uri, { allowCommands: true });
+						if (this._linkHandler) {
+							this._linkHandler(uri, element);
+						} else {
+							void this._openerService.open(uri, { allowCommands: true });
+						}
 					}
 				});
 				data.elementDisposables.add(rendered);

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -193,7 +193,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 		private readonly _onRemoveItem: ((item: IActionListItem<T>) => void) | undefined,
 		private readonly _onSubmenuIndicatorHover: ((element: IActionListItem<T>, indicator: HTMLElement, disposables: DisposableStore) => void) | undefined,
 		private _hasAnySubmenuActions: boolean,
-		private readonly _descriptionActionHandler: ((uri: URI, item: IActionListItem<T>) => void) | undefined,
+		private readonly _linkHandler: ((uri: URI, item: IActionListItem<T>) => void) | undefined,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 	) { }
@@ -286,7 +286,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 				const rendered = renderMarkdown(element.description, {
 					actionHandler: (content: string) => {
 						const uri = URI.parse(content);
-						this._descriptionActionHandler?.(uri, element) ?? this._openerService.open(uri, { allowCommands: true });
+						this._linkHandler?.(uri, element) ?? this._openerService.open(uri, { allowCommands: true });
 					}
 				});
 				data.elementDisposables.add(rendered);
@@ -407,10 +407,10 @@ export interface IActionListOptions {
 	readonly minWidth?: number;
 
 	/**
-	 * Optional markdown link action handler for item descriptions.
+	 * Optional handler for markdown links activated in item descriptions or hovers.
 	 * When unset, links open via the opener service with command links allowed.
 	 */
-	readonly descriptionActionHandler?: (uri: URI, item: IActionListItem<unknown>) => void;
+	readonly linkHandler?: (uri: URI, item: IActionListItem<unknown>) => void;
 
 	/**
 	 * Optional callback fired when a section's collapsed state changes.
@@ -531,7 +531,7 @@ export class ActionListWidget<T> extends Disposable {
 		const hasAnySubmenuActions = items.some(item => !!item.submenuActions?.length);
 
 		this._list = this._register(new List(user, this.domNode, virtualDelegate, [
-			new ActionItemRenderer<T>(preview, (item) => this._removeItem(item), (element, indicator, disposables) => this._wireSubmenuIndicator(element, indicator, disposables), hasAnySubmenuActions, this._options?.descriptionActionHandler, this._keybindingService, this._openerService),
+			new ActionItemRenderer<T>(preview, (item) => this._removeItem(item), (element, indicator, disposables) => this._wireSubmenuIndicator(element, indicator, disposables), hasAnySubmenuActions, this._options?.linkHandler, this._keybindingService, this._openerService),
 			new HeaderRenderer(),
 			new SeparatorRenderer(),
 		], {
@@ -1176,10 +1176,14 @@ export class ActionListWidget<T> extends Disposable {
 		}
 
 		const markdown = typeof element.hover!.content === 'string' ? new MarkdownString(element.hover!.content) : element.hover!.content;
+		const linkHandler = this._options?.linkHandler;
 		this._hover.value = this._hoverService.showDelayedHover({
 			content: markdown ?? '',
 			target: rowElement,
 			additionalClasses: ['action-widget-hover'],
+			linkHandler: linkHandler ? (url: string) => {
+				linkHandler(URI.parse(url), element);
+			} : undefined,
 			position: {
 				hoverPosition: HoverPosition.LEFT,
 				forcePosition: false,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -79,7 +79,7 @@ type ChatModelChangeEvent = {
 type ChatModelPickerInteraction = 'disabledModelContactAdminClicked' | 'premiumModelUpgradePlanClicked' | 'otherModelsExpanded' | 'otherModelsCollapsed';
 
 type ChatModelPickerInteractionClassification = {
-	owner: 'lramos15';
+	owner: 'sandy081';
 	comment: 'Reporting interactions in the chat model picker';
 	interaction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model picker interaction that occurred' };
 };

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -74,6 +74,18 @@ type ChatModelChangeEvent = {
 	toModel: string | TelemetryTrustedValue<string>;
 };
 
+type ChatModelPickerInteraction = 'disabledModelContactAdminClicked' | 'premiumModelUpgradePlanClicked' | 'otherModelsExpanded' | 'otherModelsCollapsed';
+
+type ChatModelPickerInteractionClassification = {
+	owner: 'lramos15';
+	comment: 'Reporting interactions in the chat model picker';
+	interaction: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The model picker interaction that occurred' };
+};
+
+type ChatModelPickerInteractionEvent = {
+	interaction: ChatModelPickerInteraction;
+};
+
 function createModelItem(
 	action: IActionWidgetDropdownAction & { section?: string },
 	model?: ILanguageModelChatMetadataAndIdentifier,
@@ -199,6 +211,7 @@ export function buildModelPickerItems(
 	showFeatured: boolean,
 	hoverPosition?: IHoverPositionOptions,
 	languageModelsService?: ILanguageModelsService,
+	onModelPickerInteraction?: (interaction: ChatModelPickerInteraction) => void,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
 	if (models.length === 0) {
@@ -340,7 +353,7 @@ export function buildModelPickerItems(
 					if (item.kind === 'available') {
 						items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect, languageModelsService!), item.model, hoverPosition, languageModelsService));
 					} else {
-						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, undefined, hoverPosition));
+						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, undefined, hoverPosition, onModelPickerInteraction));
 					}
 				}
 			}
@@ -389,7 +402,7 @@ export function buildModelPickerItems(
 				for (const model of otherModels) {
 					const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
 					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other, hoverPosition));
+						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other, hoverPosition, onModelPickerInteraction));
 					} else {
 						items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, languageModelsService!, ModelPickerSection.Other), model, hoverPosition, languageModelsService));
 					}
@@ -453,6 +466,7 @@ function createUnavailableModelItem(
 	updateStateType: StateType,
 	section?: string,
 	hoverPosition?: IHoverPositionOptions,
+	onModelPickerInteraction?: (interaction: ChatModelPickerInteraction) => void,
 ): IActionListItem<IActionWidgetDropdownAction> {
 	let description: string | MarkdownString | undefined;
 
@@ -497,6 +511,13 @@ function createUnavailableModelItem(
 		className: 'chat-model-picker-unavailable',
 		section,
 		hover: { content: hoverContent, position: hoverPosition },
+		onDescriptionLinkActivated: () => {
+			if (reason === 'upgrade') {
+				onModelPickerInteraction?.('premiumModelUpgradePlanClicked');
+			} else if (reason === 'admin') {
+				onModelPickerInteraction?.('disabledModelContactAdminClicked');
+			}
+		}
 	};
 }
 
@@ -632,6 +653,9 @@ export class ModelPickerWidget extends Disposable {
 		const controlModelsForTier = isPro ? manifest.paid : manifest.free;
 		const canShowManageModelsAction = this._delegate.showManageModelsAction() && shouldShowManageModelsAction(this._entitlementService);
 		const manageModelsAction = canShowManageModelsAction ? createManageModelsAction(this._commandService) : undefined;
+		const logModelPickerInteraction = (interaction: ChatModelPickerInteraction) => {
+			this._telemetryService.publicLog2<ChatModelPickerInteractionEvent, ChatModelPickerInteractionClassification>('chat.modelPickerInteraction', { interaction });
+		};
 		const items = buildModelPickerItems(
 			models,
 			this._selectedModel?.identifier,
@@ -648,6 +672,7 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.showFeatured(),
 			this._hoverPosition,
 			this._languageModelsService,
+			logModelPickerInteraction,
 		);
 
 		const listOptions = {
@@ -656,6 +681,11 @@ export class ModelPickerWidget extends Disposable {
 			filterActions: showFilter && manageModelsAction ? [manageModelsAction] : undefined,
 			focusFilterOnOpen: true,
 			collapsedByDefault: new Set([ModelPickerSection.Other]),
+			onDidToggleSection: (section: string, collapsed: boolean) => {
+				if (section === ModelPickerSection.Other) {
+					logModelPickerInteraction(collapsed ? 'otherModelsCollapsed' : 'otherModelsExpanded');
+				}
+			},
 			minWidth: 200,
 		};
 		const previouslyFocusedElement = dom.getActiveElement();

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -30,6 +30,7 @@ import { IModelControlEntry, ILanguageModelChatMetadataAndIdentifier, ILanguageM
 import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../../../services/chat/common/chatEntitlementService.js';
 import * as semver from '../../../../../../base/common/semver/semver.js';
 import { IModelPickerDelegate } from './modelPickerActionItem.js';
+import { IUriIdentityService } from '../../../../../../platform/uriIdentity/common/uriIdentity.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
 
 function isVersionAtLeast(current: string, required: string): boolean {
@@ -557,6 +558,7 @@ export class ModelPickerWidget extends Disposable {
 		@IProductService private readonly _productService: IProductService,
 		@IChatEntitlementService private readonly _entitlementService: IChatEntitlementService,
 		@IUpdateService private readonly _updateService: IUpdateService,
+		@IUriIdentityService private readonly _uriIdentityService: IUriIdentityService,
 	) {
 		super();
 
@@ -683,7 +685,7 @@ export class ModelPickerWidget extends Disposable {
 			linkHandler: (uri: URI) => {
 				if (uri.scheme === 'command' && uri.path === 'workbench.action.chat.upgradePlan') {
 					logModelPickerInteraction('premiumModelUpgradePlanClicked');
-				} else if (manageSettingsUrl && uri.toString().startsWith(manageSettingsUrl)) {
+				} else if (manageSettingsUrl && this._uriIdentityService.extUri.isEqual(uri, URI.parse(manageSettingsUrl))) {
 					logModelPickerInteraction('disabledModelContactAdminClicked');
 				}
 				void this._openerService.open(uri, { allowCommands: true });

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -679,7 +679,7 @@ export class ModelPickerWidget extends Disposable {
 					logModelPickerInteraction(collapsed ? 'otherModelsCollapsed' : 'otherModelsExpanded');
 				}
 			},
-			descriptionActionHandler: (uri: URI, item: IActionListItem<unknown>) => {
+			linkHandler: (uri: URI, item: IActionListItem<unknown>) => {
 				if (uri.scheme === 'command' && uri.path === 'workbench.action.chat.upgradePlan') {
 					logModelPickerInteraction('premiumModelUpgradePlanClicked');
 				} else if (item.className === 'chat-model-picker-unavailable') {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -650,6 +650,7 @@ export class ModelPickerWidget extends Disposable {
 		const logModelPickerInteraction = (interaction: ChatModelPickerInteraction) => {
 			this._telemetryService.publicLog2<ChatModelPickerInteractionEvent, ChatModelPickerInteractionClassification>('chat.modelPickerInteraction', { interaction });
 		};
+		const manageSettingsUrl = this._productService.defaultChatAgent?.manageSettingsUrl;
 		const items = buildModelPickerItems(
 			models,
 			this._selectedModel?.identifier,
@@ -658,7 +659,7 @@ export class ModelPickerWidget extends Disposable {
 			this._productService.version,
 			this._updateService.state.type,
 			onSelect,
-			this._productService.defaultChatAgent?.manageSettingsUrl,
+			manageSettingsUrl,
 			this._delegate.useGroupedModelPicker(),
 			!showFilter ? manageModelsAction : undefined,
 			this._entitlementService,
@@ -679,10 +680,10 @@ export class ModelPickerWidget extends Disposable {
 					logModelPickerInteraction(collapsed ? 'otherModelsCollapsed' : 'otherModelsExpanded');
 				}
 			},
-			linkHandler: (uri: URI, item: IActionListItem<unknown>) => {
+			linkHandler: (uri: URI) => {
 				if (uri.scheme === 'command' && uri.path === 'workbench.action.chat.upgradePlan') {
 					logModelPickerInteraction('premiumModelUpgradePlanClicked');
-				} else if (item.disabled && uri.scheme !== 'command') {
+				} else if (manageSettingsUrl && uri.toString().startsWith(manageSettingsUrl)) {
 					logModelPickerInteraction('disabledModelContactAdminClicked');
 				}
 				void this._openerService.open(uri, { allowCommands: true });

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -14,12 +14,14 @@ import { KeyCode } from '../../../../../../base/common/keyCodes.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { localize } from '../../../../../../nls.js';
 import { ActionListItemKind, IActionListItem } from '../../../../../../platform/actionWidget/browser/actionList.js';
 import { IHoverPositionOptions } from '../../../../../../base/browser/ui/hover/hover.js';
 import { IActionWidgetService } from '../../../../../../platform/actionWidget/browser/actionWidget.js';
 import { IActionWidgetDropdownAction } from '../../../../../../platform/actionWidget/browser/actionWidgetDropdown.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IOpenerService } from '../../../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
@@ -211,7 +213,6 @@ export function buildModelPickerItems(
 	showFeatured: boolean,
 	hoverPosition?: IHoverPositionOptions,
 	languageModelsService?: ILanguageModelsService,
-	onModelPickerInteraction?: (interaction: ChatModelPickerInteraction) => void,
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
 	if (models.length === 0) {
@@ -353,7 +354,7 @@ export function buildModelPickerItems(
 					if (item.kind === 'available') {
 						items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect, languageModelsService!), item.model, hoverPosition, languageModelsService));
 					} else {
-						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, undefined, hoverPosition, onModelPickerInteraction));
+						items.push(createUnavailableModelItem(item.id, item.entry, item.reason, manageSettingsUrl, updateStateType, undefined, hoverPosition));
 					}
 				}
 			}
@@ -402,7 +403,7 @@ export function buildModelPickerItems(
 				for (const model of otherModels) {
 					const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
 					if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other, hoverPosition, onModelPickerInteraction));
+						items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other, hoverPosition));
 					} else {
 						items.push(createModelItem(createModelAction(model, selectedModelId, onSelect, languageModelsService!, ModelPickerSection.Other), model, hoverPosition, languageModelsService));
 					}
@@ -466,7 +467,6 @@ function createUnavailableModelItem(
 	updateStateType: StateType,
 	section?: string,
 	hoverPosition?: IHoverPositionOptions,
-	onModelPickerInteraction?: (interaction: ChatModelPickerInteraction) => void,
 ): IActionListItem<IActionWidgetDropdownAction> {
 	let description: string | MarkdownString | undefined;
 
@@ -511,13 +511,6 @@ function createUnavailableModelItem(
 		className: 'chat-model-picker-unavailable',
 		section,
 		hover: { content: hoverContent, position: hoverPosition },
-		onDescriptionLinkActivated: () => {
-			if (reason === 'upgrade') {
-				onModelPickerInteraction?.('premiumModelUpgradePlanClicked');
-			} else if (reason === 'admin') {
-				onModelPickerInteraction?.('disabledModelContactAdminClicked');
-			}
-		}
 	};
 }
 
@@ -558,6 +551,7 @@ export class ModelPickerWidget extends Disposable {
 		private readonly _hoverPosition: IHoverPositionOptions | undefined,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@ICommandService private readonly _commandService: ICommandService,
+		@IOpenerService private readonly _openerService: IOpenerService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ILanguageModelsService private readonly _languageModelsService: ILanguageModelsService,
 		@IProductService private readonly _productService: IProductService,
@@ -672,7 +666,6 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.showFeatured(),
 			this._hoverPosition,
 			this._languageModelsService,
-			logModelPickerInteraction,
 		);
 
 		const listOptions = {
@@ -685,6 +678,14 @@ export class ModelPickerWidget extends Disposable {
 				if (section === ModelPickerSection.Other) {
 					logModelPickerInteraction(collapsed ? 'otherModelsCollapsed' : 'otherModelsExpanded');
 				}
+			},
+			descriptionActionHandler: (uri: URI, item: IActionListItem<unknown>) => {
+				if (uri.scheme === 'command' && uri.path === 'workbench.action.chat.upgradePlan') {
+					logModelPickerInteraction('premiumModelUpgradePlanClicked');
+				} else if (item.className === 'chat-model-picker-unavailable') {
+					logModelPickerInteraction('disabledModelContactAdminClicked');
+				}
+				void this._openerService.open(uri, { allowCommands: true });
 			},
 			minWidth: 200,
 		};

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -682,7 +682,7 @@ export class ModelPickerWidget extends Disposable {
 			linkHandler: (uri: URI, item: IActionListItem<unknown>) => {
 				if (uri.scheme === 'command' && uri.path === 'workbench.action.chat.upgradePlan') {
 					logModelPickerInteraction('premiumModelUpgradePlanClicked');
-				} else if (item.className === 'chat-model-picker-unavailable') {
+				} else if (item.disabled && uri.scheme !== 'command') {
 					logModelPickerInteraction('disabledModelContactAdminClicked');
 				}
 				void this._openerService.open(uri, { allowCommands: true });


### PR DESCRIPTION
## Summary
- add model picker telemetry for:
  - clicking **Contact your admin** on unavailable/admin-gated models
  - clicking **Upgrade** on premium/upgrade-gated models
  - expanding/collapsing the **Other Models** section
- emit telemetry from `chatModelPicker.ts` via typed `publicLog2` event `chat.modelPickerInteraction`
- extend action widget list options with a generic `linkHandler` used for markdown links in both item descriptions and hovers
- extend action list options with `onDidToggleSection` callback and use it to track Other Models section expand/collapse
- use `IUriIdentityService.extUri.isEqual` to identify admin links against `manageSettingsUrl`

## Validation
- `npm run -s compile-check-ts-native`

Ref #297183