### PR TITLE
fix: stale status after file changes in large repositories

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -3109,8 +3109,14 @@ export class Repository implements Disposable {
 		}
 
 		if (!this.operations.isIdle()) {
-			this.logger.trace('[Repository][onFileChange] Skip running git status because an operation is running.');
-			return;
+			// Skip if a write operation is running — it will call updateModelState() when it
+			// completes, picking up any file changes. However, Status and Refresh *are*
+			// updateModelState(), so a file change during their execution can produce a stale
+			// snapshot. In that case, fall through and schedule a follow-up refresh.
+			if (!this.operations.isRunning(OperationKind.Status) && !this.operations.isRunning(OperationKind.Refresh)) {
+				this.logger.trace('[Repository][onFileChange] Skip running git status because an operation is running.');
+				return;
+			}
 		}
 
 		this.eventuallyUpdateWhenIdleAndWait();


### PR DESCRIPTION
This fixes a bug where the Source Control panel wouldn't update after editing files.
Only manual updates would trigger `git status` as observed in the Git extension output.
Before the fix only `git check-ignore` was going off on file edits, but it was never followed by `git status`.
After the fix `git status` goes off as expected and file changes are shown in the Source Control panel.

Closest related issue I found is:
* https://github.com/microsoft/vscode/issues/233129

This bug started appearing for me after 1.104.3. 
I didn't manage to dig up why it started after that version, but with the help of copilot I managed to at least fix it.

This was happening to me on the following platform using the `visual-studio-code-bin` AUR package
```
Linux krynju-g14 6.17.9-arch1-1 #1 SMP PREEMPT_DYNAMIC Mon, 24 Nov 2025 15:21:09 +0000 x86_64 GNU/Linux
```


Below is a summary produced by copilot: 

# Git: Fix stale status after file changes in large repositories

## How to reproduce

1. Open a repository with more than `git.statusLimit` files (default: 10 000) containing a known large folder (e.g. `node_modules`).
2. Observe `git check-ignore` being called in the Git output log.
3. While `git check-ignore` is running, create or modify a file in the repository.
4. **Before fix:** The Source Control view does not update to reflect the change.
5. **After fix:** A follow-up `git status` is scheduled and the view updates correctly.


## Problem

In repositories that hit the file status limit (`git.statusLimit`), the Git extension would silently miss file change events, causing the Source Control view to become stale and not reflect the true state of the working tree.

### Root cause

When the file status limit is exceeded, `getStatus()` calls `findKnownHugeFolderPathsToIgnore()`, which spawns a `git check-ignore` process. This call happens *inside* `updateModelState()`, which itself runs while the `Status` operation is still registered as active in the `OperationManager`.

The `Status` operation is marked `readOnly: false` (correctly, since it mutates model state), so `OperationManager.isIdle()` returns `false` for its entire duration — including the trailing `git check-ignore` call. Any file system change event fired during that window would hit the following guard in `onFileChange`:

```ts
if (!this.operations.isIdle()) {
    this.logger.trace('[Repository][onFileChange] Skip running git status because an operation is running.');
    return;  // ← event silently dropped
}
```

The event was dropped without rescheduling. Once `Status` completed, no further refresh was triggered, leaving the model stale.

This bug has been latent since January 2019 (when `findKnownHugeFolderPathsToIgnore` was introduced), but only manifests in repos that exceed `git.statusLimit` — typically large monorepos or repos containing `node_modules` or similar large directories.

### Why the blanket "skip when not idle" guard exists

The guard is intentional and correct for write operations (Commit, Push, Pull, Checkout, etc.): those operations call `updateModelState()` themselves upon completion, so any file changes that occurred during the operation will be captured naturally. Scheduling a redundant refresh would be wasteful.

However, `Status` and `Refresh` *are* `updateModelState()` — they have no write phase. A file change that occurs after `git status` has already returned its snapshot (but before the operation completes) will not be picked up by the current run. Without a follow-up refresh, the model is left permanently stale.

## Fix

In `onFileChange`, when `isIdle()` returns `false`, additionally check whether only a `Status` or `Refresh` operation is running. If so, fall through and schedule a follow-up refresh anyway. The refresh is debounced (1 s) and gated by `whenIdleAndFocused()`, so it will wait until the current `Status`/`Refresh` completes before running — eliminating both redundant work and the stale snapshot.

```ts
if (!this.operations.isIdle()) {
    // Skip if a write operation is running — it will call updateModelState() when it
    // completes, picking up any file changes. However, Status and Refresh *are*
    // updateModelState(), so a file change during their execution can produce a stale
    // snapshot. In that case, fall through and schedule a follow-up refresh.
    if (!this.operations.isRunning(OperationKind.Status) && !this.operations.isRunning(OperationKind.Refresh)) {
        this.logger.trace('[Repository][onFileChange] Skip running git status because an operation is running.');
        return;
    }
}

this.eventuallyUpdateWhenIdleAndWait();
```



