### PR TITLE
component explorer fixture for chat customization tabs

### DIFF
--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -32,7 +32,7 @@ import '../../../../platform/theme/common/colors/listColors.js';
 // ============================================================================
 
 const defaultFilter: IStorageSourceFilter = {
-	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension],
+	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.plugin, PromptsStorage.extension],
 };
 
 interface IFixtureInstructionFile {

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -16,7 +16,7 @@ import { IWorkspace, IWorkspaceContextService } from '../../../../platform/works
 import { IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
 import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor } from '../../../contrib/chat/common/customizationHarnessService.js';
 import { PromptsType } from '../../../contrib/chat/common/promptSyntax/promptTypes.js';
-import { IPromptsService, IResolvedAgentFile, AgentFileType, PromptsStorage } from '../../../contrib/chat/common/promptSyntax/service/promptsService.js';
+import { IPromptsService, IResolvedAgentFile, AgentFileType, PromptsStorage, IPromptPath, IExtensionPromptPath } from '../../../contrib/chat/common/promptSyntax/service/promptsService.js';
 import { AICustomizationManagementSection } from '../../../contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
 import { AICustomizationListWidget } from '../../../contrib/chat/browser/aiCustomization/aiCustomizationListWidget.js';
 import { IPathService } from '../../../services/path/common/pathService.js';
@@ -36,11 +36,7 @@ const defaultFilter: IStorageSourceFilter = {
 };
 
 interface IFixtureInstructionFile {
-	readonly uri: URI;
-	readonly storage: PromptsStorage;
-	readonly type: PromptsType;
-	readonly name?: string;
-	readonly description?: string;
+	readonly promptPath: IPromptPath;
 	/** If set, this instruction file has an applyTo pattern (on-demand). */
 	readonly applyTo?: string;
 }
@@ -53,14 +49,7 @@ function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], a
 		override getDisabledPromptFiles(): ResourceSet { return new ResourceSet(); }
 		override async listPromptFiles(type: PromptsType) {
 			if (type === PromptsType.instructions) {
-				return instructionFiles.map(f => ({
-					uri: f.uri,
-					storage: f.storage,
-					type: f.type,
-					name: f.name,
-					description: f.description,
-					applyTo: f.applyTo,
-				}));
+				return instructionFiles.map(f => f.promptPath);
 			}
 			return [];
 		}
@@ -167,14 +156,14 @@ export default defineThemedFixtureGroup({ path: 'chat/' }, {
 		labels: { kind: 'screenshot' },
 		render: ctx => renderInstructionsTab(ctx, [
 			// Always-active instructions (no applyTo)
-			{ uri: URI.file('/workspace/.github/instructions/coding-standards.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Coding Standards', description: 'Repository-wide coding standards' },
-			{ uri: URI.file('/home/dev/.copilot/instructions/my-style.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'My Style', description: 'Personal coding style preferences' },
+			{ promptPath: { uri: URI.file('/workspace/.github/instructions/coding-standards.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Coding Standards', description: 'Repository-wide coding standards' } },
+			{ promptPath: { uri: URI.file('/home/dev/.copilot/instructions/my-style.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'My Style', description: 'Personal coding style preferences' } },
 			// Always-included instruction (applyTo: **)
-			{ uri: URI.file('/workspace/.github/instructions/general-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'General Guidelines', description: 'General development guidelines', applyTo: '**' },
+			{ promptPath: { uri: URI.file('/workspace/.github/instructions/general-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'General Guidelines', description: 'General development guidelines' }, applyTo: '**' },
 			// On-demand instructions (with applyTo pattern)
-			{ uri: URI.file('/workspace/.github/instructions/testing-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Testing Guidelines', description: 'Testing best practices', applyTo: '**/*.test.ts' },
-			{ uri: URI.file('/workspace/.github/instructions/security-review.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Security Review', description: 'Security review checklist', applyTo: 'src/auth/**' },
-			{ uri: URI.file('/home/dev/.copilot/instructions/typescript-rules.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'TypeScript Rules', description: 'TypeScript conventions', applyTo: '**/*.ts' },
+			{ promptPath: { uri: URI.file('/workspace/.github/instructions/testing-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Testing Guidelines', description: 'Testing best practices' }, applyTo: '**/*.test.ts' },
+			{ promptPath: { uri: URI.file('/workspace/.github/instructions/security-review.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Security Review', description: 'Security review checklist' }, applyTo: 'src/auth/**' },
+			{ promptPath: { uri: URI.file('/home/dev/.copilot/instructions/typescript-rules.instructions.md'), storage: PromptsStorage.extension, type: PromptsType.instructions, name: 'TypeScript Rules', description: 'TypeScript conventions', extension: undefined!, source: undefined! } satisfies IExtensionPromptPath, applyTo: '**/*.ts' },
 		], [
 			// Agent instruction files (AGENTS.md, copilot-instructions.md)
 			{ uri: URI.file('/workspace/AGENTS.md'), realPath: undefined, type: AgentFileType.agentsMd },

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
-import { ResourceMap, ResourceSet } from '../../../../base/common/map.js';
+import { ResourceSet } from '../../../../base/common/map.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { URI } from '../../../../base/common/uri.js';
 import { mock } from '../../../../base/test/common/mock.js';
@@ -46,14 +46,6 @@ interface IFixtureInstructionFile {
 }
 
 function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], agentInstructionFiles: IResolvedAgentFile[] = []): IPromptsService {
-	// Build a map from URI to applyTo for parseNew
-	const applyToMap = new ResourceMap<string | undefined>();
-	const descriptionMap = new ResourceMap<string | undefined>();
-	for (const file of instructionFiles) {
-		applyToMap.set(file.uri, file.applyTo);
-		descriptionMap.set(file.uri, file.description);
-	}
-
 	return new class extends mock<IPromptsService>() {
 		override readonly onDidChangeCustomAgents = Event.None;
 		override readonly onDidChangeSlashCommands = Event.None;
@@ -74,13 +66,7 @@ function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], a
 		override async listAgentInstructions() { return agentInstructionFiles; }
 		override async getCustomAgents() { return []; }
 		override async parseNew(uri: URI, _token: CancellationToken): Promise<ParsedPromptFile> {
-			const applyTo = applyToMap.get(uri);
-			const description = descriptionMap.get(uri);
-			const header = {
-				get applyTo() { return applyTo; },
-				get description() { return description; },
-			};
-			return new ParsedPromptFile(uri, header as never);
+			return new ParsedPromptFile(uri);
 		}
 	}();
 }

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { Event } from '../../../../base/common/event.js';
+import { ResourceMap, ResourceSet } from '../../../../base/common/map.js';
+import { observableValue } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
+import { mock } from '../../../../base/test/common/mock.js';
+import { IContextMenuService, IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { IListService, ListService } from '../../../../platform/list/browser/listService.js';
+import { IWorkspace, IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
+import { IAICustomizationWorkspaceService, IStorageSourceFilter } from '../../../contrib/chat/common/aiCustomizationWorkspaceService.js';
+import { CustomizationHarness, ICustomizationHarnessService, IHarnessDescriptor, createVSCodeHarnessDescriptor } from '../../../contrib/chat/common/customizationHarnessService.js';
+import { PromptsType } from '../../../contrib/chat/common/promptSyntax/promptTypes.js';
+import { IPromptsService, IResolvedAgentFile, AgentFileType, PromptsStorage } from '../../../contrib/chat/common/promptSyntax/service/promptsService.js';
+import { AICustomizationManagementSection } from '../../../contrib/chat/browser/aiCustomization/aiCustomizationManagement.js';
+import { AICustomizationListWidget } from '../../../contrib/chat/browser/aiCustomization/aiCustomizationListWidget.js';
+import { IPathService } from '../../../services/path/common/pathService.js';
+import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from './fixtureUtils.js';
+import { ParsedPromptFile } from '../../../contrib/chat/common/promptSyntax/promptFileParser.js';
+
+// Ensure color registrations are loaded
+import '../../../../platform/theme/common/colors/inputColors.js';
+import '../../../../platform/theme/common/colors/listColors.js';
+
+// ============================================================================
+// Mock helpers
+// ============================================================================
+
+const defaultFilter: IStorageSourceFilter = {
+	sources: [PromptsStorage.local, PromptsStorage.user, PromptsStorage.extension],
+};
+
+interface IFixtureInstructionFile {
+	readonly uri: URI;
+	readonly storage: PromptsStorage;
+	readonly type: PromptsType;
+	readonly name?: string;
+	readonly description?: string;
+	/** If set, this instruction file has an applyTo pattern (on-demand). */
+	readonly applyTo?: string;
+}
+
+function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], agentInstructionFiles: IResolvedAgentFile[] = []): IPromptsService {
+	// Build a map from URI to applyTo for parseNew
+	const applyToMap = new ResourceMap<string | undefined>();
+	const descriptionMap = new ResourceMap<string | undefined>();
+	for (const file of instructionFiles) {
+		applyToMap.set(file.uri, file.applyTo);
+		descriptionMap.set(file.uri, file.description);
+	}
+
+	return new class extends mock<IPromptsService>() {
+		override readonly onDidChangeCustomAgents = Event.None;
+		override readonly onDidChangeSlashCommands = Event.None;
+		override readonly onDidChangeSkills = Event.None;
+		override getDisabledPromptFiles(): ResourceSet { return new ResourceSet(); }
+		override async listPromptFiles(type: PromptsType) {
+			if (type === PromptsType.instructions) {
+				return instructionFiles.map(f => ({
+					uri: f.uri,
+					storage: f.storage as PromptsStorage.local,
+					type: f.type,
+					name: f.name,
+					description: f.description,
+				}));
+			}
+			return [];
+		}
+		override async listAgentInstructions() { return agentInstructionFiles; }
+		override async getCustomAgents() { return []; }
+		override async parseNew(uri: URI, _token: CancellationToken): Promise<ParsedPromptFile> {
+			const applyTo = applyToMap.get(uri);
+			const description = descriptionMap.get(uri);
+			const header = {
+				get applyTo() { return applyTo; },
+				get description() { return description; },
+			};
+			return new ParsedPromptFile(uri, header as never);
+		}
+	}();
+}
+
+function createMockWorkspaceService(): IAICustomizationWorkspaceService {
+	const activeProjectRoot = observableValue<URI | undefined>('mockActiveProjectRoot', URI.file('/workspace'));
+	return new class extends mock<IAICustomizationWorkspaceService>() {
+		override readonly isSessionsWindow = false;
+		override readonly activeProjectRoot = activeProjectRoot;
+		override readonly hasOverrideProjectRoot = observableValue('hasOverride', false);
+		override getActiveProjectRoot() { return URI.file('/workspace'); }
+		override getStorageSourceFilter() { return defaultFilter; }
+	}();
+}
+
+function createMockHarnessService(): ICustomizationHarnessService {
+	const descriptor = createVSCodeHarnessDescriptor([PromptsStorage.extension]);
+	return new class extends mock<ICustomizationHarnessService>() {
+		override readonly activeHarness = observableValue('activeHarness', CustomizationHarness.VSCode);
+		override readonly availableHarnesses = observableValue<readonly IHarnessDescriptor[]>('harnesses', [descriptor]);
+		override getStorageSourceFilter() { return defaultFilter; }
+		override getActiveDescriptor() { return descriptor; }
+	}();
+}
+
+function createMockWorkspaceContextService(): IWorkspaceContextService {
+	return new class extends mock<IWorkspaceContextService>() {
+		override readonly onDidChangeWorkspaceFolders = Event.None;
+		override getWorkspace(): IWorkspace {
+			return { id: 'test', folders: [] };
+		}
+	}();
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+async function renderInstructionsTab(ctx: ComponentFixtureContext, instructionFiles: IFixtureInstructionFile[], agentInstructionFiles: IResolvedAgentFile[] = []): Promise<void> {
+	const width = 500;
+	const height = 400;
+	ctx.container.style.width = `${width}px`;
+	ctx.container.style.height = `${height}px`;
+
+	const contextMenuService = new class extends mock<IContextMenuService>() {
+		override onDidShowContextMenu = Event.None;
+		override onDidHideContextMenu = Event.None;
+		override showContextMenu(): void { }
+	};
+
+	const contextViewService = new class extends mock<IContextViewService>() {
+		override anchorAlignment = 0;
+		override showContextView() { return { close: () => { } }; }
+		override hideContextView(): void { }
+		override getContextViewElement(): HTMLElement { return ctx.container; }
+		override layout(): void { }
+	};
+
+	const instantiationService = createEditorServices(ctx.disposableStore, {
+		colorTheme: ctx.theme,
+		additionalServices: (reg) => {
+			reg.defineInstance(IContextMenuService, contextMenuService);
+			reg.defineInstance(IContextViewService, contextViewService);
+			registerWorkbenchServices(reg);
+			reg.define(IListService, ListService);
+			reg.defineInstance(IPromptsService, createMockPromptsService(instructionFiles, agentInstructionFiles));
+			reg.defineInstance(IAICustomizationWorkspaceService, createMockWorkspaceService());
+			reg.defineInstance(ICustomizationHarnessService, createMockHarnessService());
+			reg.defineInstance(IWorkspaceContextService, createMockWorkspaceContextService());
+			reg.defineInstance(IFileService, new class extends mock<IFileService>() {
+				override readonly onDidFilesChange = Event.None;
+			}());
+			reg.defineInstance(IPathService, new class extends mock<IPathService>() {
+				override readonly defaultUriScheme = 'file';
+				override userHome(): URI;
+				override userHome(): Promise<URI>;
+				override userHome(): URI | Promise<URI> { return URI.file('/home/dev'); }
+			}());
+		},
+	});
+
+	const widget = ctx.disposableStore.add(
+		instantiationService.createInstance(AICustomizationListWidget)
+	);
+	ctx.container.appendChild(widget.element);
+	await widget.setSection(AICustomizationManagementSection.Instructions);
+	widget.layout(height, width);
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export default defineThemedFixtureGroup({ path: 'chat/' }, {
+
+	InstructionsTabWithItems: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderInstructionsTab(ctx, [
+			// Always-active instructions (no applyTo)
+			{ uri: URI.file('/workspace/.github/instructions/coding-standards.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Coding Standards', description: 'Repository-wide coding standards' },
+			{ uri: URI.file('/home/dev/.copilot/instructions/my-style.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'My Style', description: 'Personal coding style preferences' },
+			// Always-included instruction (applyTo: **)
+			{ uri: URI.file('/workspace/.github/instructions/general-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'General Guidelines', description: 'General development guidelines', applyTo: '**' },
+			// On-demand instructions (with applyTo pattern)
+			{ uri: URI.file('/workspace/.github/instructions/testing-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Testing Guidelines', description: 'Testing best practices', applyTo: '**/*.test.ts' },
+			{ uri: URI.file('/workspace/.github/instructions/security-review.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Security Review', description: 'Security review checklist', applyTo: 'src/auth/**' },
+			{ uri: URI.file('/home/dev/.copilot/instructions/typescript-rules.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'Typescript Rules', description: 'TypeScript conventions', applyTo: '**/*.ts' },
+		], [
+			// Agent instruction files (AGENTS.md, copilot-instructions.md)
+			{ uri: URI.file('/workspace/AGENTS.md'), realPath: undefined, type: AgentFileType.agentsMd },
+			{ uri: URI.file('/workspace/.github/copilot-instructions.md'), realPath: undefined, type: AgentFileType.copilotInstructionsMd },
+		]),
+	}),
+
+	InstructionsTabEmpty: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderInstructionsTab(ctx, []),
+	}),
+});

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -173,7 +173,7 @@ export default defineThemedFixtureGroup({ path: 'chat/' }, {
 			// On-demand instructions (with applyTo pattern)
 			{ uri: URI.file('/workspace/.github/instructions/testing-guidelines.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Testing Guidelines', description: 'Testing best practices', applyTo: '**/*.test.ts' },
 			{ uri: URI.file('/workspace/.github/instructions/security-review.instructions.md'), storage: PromptsStorage.local, type: PromptsType.instructions, name: 'Security Review', description: 'Security review checklist', applyTo: 'src/auth/**' },
-			{ uri: URI.file('/home/dev/.copilot/instructions/typescript-rules.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'Typescript Rules', description: 'TypeScript conventions', applyTo: '**/*.ts' },
+			{ uri: URI.file('/home/dev/.copilot/instructions/typescript-rules.instructions.md'), storage: PromptsStorage.user, type: PromptsType.instructions, name: 'TypeScript Rules', description: 'TypeScript conventions', applyTo: '**/*.ts' },
 		], [
 			// Agent instruction files (AGENTS.md, copilot-instructions.md)
 			{ uri: URI.file('/workspace/AGENTS.md'), realPath: undefined, type: AgentFileType.agentsMd },

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationListWidget.fixture.ts
@@ -55,10 +55,11 @@ function createMockPromptsService(instructionFiles: IFixtureInstructionFile[], a
 			if (type === PromptsType.instructions) {
 				return instructionFiles.map(f => ({
 					uri: f.uri,
-					storage: f.storage as PromptsStorage.local,
+					storage: f.storage,
 					type: f.type,
 					name: f.name,
 					description: f.description,
+					applyTo: f.applyTo,
 				}));
 			}
 			return [];


### PR DESCRIPTION
Adds a component explorer fixture for the instruction chat customization tab.

To run use the `Component Explorer` launch config

FYI @joshspicer 

<img width="821" height="547" alt="image" src="https://github.com/user-attachments/assets/70017fc6-c22d-47a6-b578-7de7bd5aedd9" />
