### PR TITLE
stabilize worktreeCreated run actions by waiting for worktree readiness

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -8,6 +8,7 @@ import { autorun, IObservable, observableValue, transaction } from '../../../../
 import { joinPath, dirname, isEqual } from '../../../../base/common/resources.js';
 import { parse } from '../../../../base/common/jsonc.js';
 import { isMacintosh, isWindows } from '../../../../base/common/platform.js';
+import { timeout } from '../../../../base/common/async.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -126,12 +127,16 @@ export class SessionsConfigurationService extends Disposable implements ISession
 
 	private static readonly _PINNED_TASK_LABELS_KEY = 'agentSessions.pinnedTaskLabels';
 	private static readonly _SUPPORTED_TASK_TYPES = new Set(['shell', 'npm']);
+	private static readonly _RUN_ON_WORKTREE_CREATED_DELAY_MS = 250;
+	private static readonly _WORKTREE_AVAILABILITY_TIMEOUT_MS = 5000;
+	private static readonly _WORKTREE_AVAILABILITY_POLL_MS = 100;
 
 	private readonly _sessionTasks = observableValue<readonly ISessionTaskWithTarget[]>(this, []);
 	private readonly _fileWatcher = this._register(new MutableDisposable());
 	/** Maps `cwd.toString() + command` to the terminal `instanceId`. */
 	private readonly _taskTerminals = new Map<string, number>();
 	private readonly _knownSessionWorktrees = new Map<string, string | undefined>();
+	private readonly _worktreeTaskRunIds = new Map<string, number>();
 	private readonly _pinnedTaskLabels: Map<string, string>;
 	private readonly _pinnedTaskObservables = new Map<string, ReturnType<typeof observableValue<string | undefined>>>();
 
@@ -496,7 +501,54 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			return;
 		}
 
-		void this._runWorktreeCreatedTasks(session);
+		const runId = (this._worktreeTaskRunIds.get(sessionKey) ?? 0) + 1;
+		this._worktreeTaskRunIds.set(sessionKey, runId);
+		void this._runWorktreeCreatedTasksWhenReady(session.resource.toString(), currentWorktree, runId);
+	}
+
+	private async _runWorktreeCreatedTasksWhenReady(sessionKey: string, worktree: string, runId: number): Promise<void> {
+		await timeout(SessionsConfigurationService._RUN_ON_WORKTREE_CREATED_DELAY_MS);
+		if (!this._isCurrentWorktreeRun(sessionKey, worktree, runId)) {
+			return;
+		}
+
+		const activeSession = this._sessionsManagementService.getActiveSession();
+		if (!activeSession || activeSession.resource.toString() !== sessionKey || activeSession.worktree?.toString() !== worktree) {
+			return;
+		}
+
+		const worktreeUri = activeSession.worktree;
+		if (!worktreeUri) {
+			return;
+		}
+
+		const available = await this._waitForWorktreeAvailability(worktreeUri, sessionKey, worktree, runId);
+		if (!available) {
+			return;
+		}
+
+		await this._runWorktreeCreatedTasks(activeSession);
+	}
+
+	private async _waitForWorktreeAvailability(worktree: URI, sessionKey: string, worktreeKey: string, runId: number): Promise<boolean> {
+		const deadline = Date.now() + SessionsConfigurationService._WORKTREE_AVAILABILITY_TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			if (!this._isCurrentWorktreeRun(sessionKey, worktreeKey, runId)) {
+				return false;
+			}
+
+			if (await this._fileService.exists(worktree)) {
+				return true;
+			}
+
+			await timeout(SessionsConfigurationService._WORKTREE_AVAILABILITY_POLL_MS);
+		}
+
+		return false;
+	}
+
+	private _isCurrentWorktreeRun(sessionKey: string, worktree: string, runId: number): boolean {
+		return this._worktreeTaskRunIds.get(sessionKey) === runId && this._knownSessionWorktrees.get(sessionKey) === worktree;
 	}
 
 	private async _runWorktreeCreatedTasks(session: IActiveSessionItem): Promise<void> {

--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -527,7 +527,18 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			return;
 		}
 
-		await this._runWorktreeCreatedTasks(activeSession);
+		// Final staleness check after waiting for worktree availability to ensure
+		// that the active session/worktree has not changed during the await.
+		if (!this._isCurrentWorktreeRun(sessionKey, worktree, runId)) {
+			return;
+		}
+
+		const latestSession = this._sessionsManagementService.getActiveSession();
+		if (!latestSession || latestSession.resource.toString() !== sessionKey || latestSession.worktree?.toString() !== worktree) {
+			return;
+		}
+
+		await this._runWorktreeCreatedTasks(latestSession);
 	}
 
 	private async _waitForWorktreeAvailability(worktree: URI, sessionKey: string, worktreeKey: string, runId: number): Promise<boolean> {

--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -512,7 +512,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			return;
 		}
 
-		const activeSession = this._sessionsManagementService.getActiveSession();
+		const activeSession = this._sessionsManagementService.activeSession.get();
 		if (!activeSession || activeSession.resource.toString() !== sessionKey || activeSession.worktree?.toString() !== worktree) {
 			return;
 		}
@@ -533,7 +533,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 			return;
 		}
 
-		const latestSession = this._sessionsManagementService.getActiveSession();
+		const latestSession = this._sessionsManagementService.activeSession.get();
 		if (!latestSession || latestSession.resource.toString() !== sessionKey || latestSession.worktree?.toString() !== worktree) {
 			return;
 		}

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -59,6 +59,7 @@ suite('SessionsConfigurationService', () => {
 	let storageService: InMemoryStorageService;
 	let readFileCalls: URI[];
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSessionItem | undefined>>;
+	let existingUris: Set<string>;
 
 	const userSettingsUri = URI.parse('file:///user/settings.json');
 	const repoUri = URI.parse('file:///repo');
@@ -71,6 +72,7 @@ suite('SessionsConfigurationService', () => {
 		sentCommands = [];
 		committedFiles = [];
 		readFileCalls = [];
+		existingUris = new Set([repoUri.toString(), worktreeUri.toString()]);
 
 		const instantiationService = store.add(new TestInstantiationService());
 		activeSessionObs = observableValue('activeSession', undefined);
@@ -83,6 +85,9 @@ suite('SessionsConfigurationService', () => {
 					throw new Error('file not found');
 				}
 				return { value: VSBuffer.fromString(content) } as IFileContent;
+			}
+			override async exists(resource: URI): Promise<boolean> {
+				return existingUris.has(resource.toString());
 			}
 			override watch() { return { dispose() { } }; }
 			override onDidFilesChange: any = () => ({ dispose() { } });
@@ -704,13 +709,41 @@ suite('SessionsConfigurationService', () => {
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
-		await new Promise(r => setTimeout(r, 10));
+		await new Promise(r => setTimeout(r, 20));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: worktreeUri }), resource: sessionResource }, undefined);
-		await new Promise(r => setTimeout(r, 10));
+		await new Promise(r => setTimeout(r, 350));
 
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'npm run build');
+	});
+
+	test('runs worktreeCreated task only for latest worktree when worktree changes quickly', async () => {
+		const sessionResource = URI.parse('file:///session-worktree-switch');
+		const wt1 = URI.parse('file:///worktree1');
+		const wt2 = URI.parse('file:///worktree2');
+		existingUris.add(wt1.toString());
+		existingUris.add(wt2.toString());
+
+		fileContents.set(URI.parse('file:///worktree1/.vscode/tasks.json').toString(), tasksJsonContent([
+			{ label: 'init1', type: 'shell', command: 'echo wt1', inSessions: true, runOptions: { runOn: 'worktreeCreated' } },
+		]));
+		fileContents.set(URI.parse('file:///worktree2/.vscode/tasks.json').toString(), tasksJsonContent([
+			{ label: 'init2', type: 'shell', command: 'echo wt2', inSessions: true, runOptions: { runOn: 'worktreeCreated' } },
+		]));
+		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
+		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
+
+		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
+		await new Promise(r => setTimeout(r, 20));
+
+		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt1 }), resource: sessionResource }, undefined);
+		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt2 }), resource: sessionResource }, undefined);
+
+		await new Promise(r => setTimeout(r, 350));
+
+		assert.strictEqual(sentCommands.length, 1);
+		assert.strictEqual(sentCommands[0].command, 'echo wt2');
 	});
 
 });

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -18,6 +18,7 @@ import { IActiveSessionItem, ISessionsManagementService } from '../../../session
 import { INonSessionTaskEntry, ISessionsConfigurationService, SessionsConfigurationService, ITaskEntry } from '../../browser/sessionsConfigurationService.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { observableValue } from '../../../../../base/common/observable.js';
+import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 
 function makeSession(opts: { repository?: URI; worktree?: URI } = {}): IActiveSessionItem {
 	return {
@@ -698,7 +699,7 @@ suite('SessionsConfigurationService', () => {
 		assert.strictEqual(createdTerminals.length, 2, 'should create two terminals for different worktrees');
 	});
 
-	test('runs worktreeCreated session tasks when a session gains a worktree', async () => {
+	test('runs worktreeCreated session tasks when a session gains a worktree', runWithFakedTimers(async scheduler => {
 		const sessionResource = URI.parse('file:///session-worktree-created');
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
@@ -709,16 +710,16 @@ suite('SessionsConfigurationService', () => {
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
-		await new Promise(r => setTimeout(r, 20));
+		await scheduler.tick(20);
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: worktreeUri }), resource: sessionResource }, undefined);
-		await new Promise(r => setTimeout(r, 350));
+		await scheduler.tick(350);
 
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'npm run build');
-	});
+	}));
 
-	test('runs worktreeCreated task only for latest worktree when worktree changes quickly', async () => {
+	test('runs worktreeCreated task only for latest worktree when worktree changes quickly', runWithFakedTimers(async scheduler => {
 		const sessionResource = URI.parse('file:///session-worktree-switch');
 		const wt1 = URI.parse('file:///worktree1');
 		const wt2 = URI.parse('file:///worktree2');
@@ -735,15 +736,15 @@ suite('SessionsConfigurationService', () => {
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
-		await new Promise(r => setTimeout(r, 20));
+		await scheduler.tick(20);
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt1 }), resource: sessionResource }, undefined);
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt2 }), resource: sessionResource }, undefined);
 
-		await new Promise(r => setTimeout(r, 350));
+		await scheduler.tick(350);
 
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'echo wt2');
-	});
+	}));
 
 });

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -18,7 +18,6 @@ import { IActiveSessionItem, ISessionsManagementService } from '../../../session
 import { INonSessionTaskEntry, ISessionsConfigurationService, SessionsConfigurationService, ITaskEntry } from '../../browser/sessionsConfigurationService.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { observableValue } from '../../../../../base/common/observable.js';
-import { runWithFakedTimers } from '../../../../../base/test/common/timeTravelScheduler.js';
 
 function makeSession(opts: { repository?: URI; worktree?: URI } = {}): IActiveSessionItem {
 	return {
@@ -699,7 +698,7 @@ suite('SessionsConfigurationService', () => {
 		assert.strictEqual(createdTerminals.length, 2, 'should create two terminals for different worktrees');
 	});
 
-	test('runs worktreeCreated session tasks when a session gains a worktree', runWithFakedTimers(async scheduler => {
+	test('runs worktreeCreated session tasks when a session gains a worktree', async () => {
 		const sessionResource = URI.parse('file:///session-worktree-created');
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
@@ -710,16 +709,16 @@ suite('SessionsConfigurationService', () => {
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
-		await scheduler.tick(20);
+		await new Promise(r => setTimeout(r, 20));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: worktreeUri }), resource: sessionResource }, undefined);
-		await scheduler.tick(350);
+		await new Promise(r => setTimeout(r, 350));
 
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'npm run build');
-	}));
+	});
 
-	test('runs worktreeCreated task only for latest worktree when worktree changes quickly', runWithFakedTimers(async scheduler => {
+	test('runs worktreeCreated task only for latest worktree when worktree changes quickly', async () => {
 		const sessionResource = URI.parse('file:///session-worktree-switch');
 		const wt1 = URI.parse('file:///worktree1');
 		const wt2 = URI.parse('file:///worktree2');
@@ -736,15 +735,15 @@ suite('SessionsConfigurationService', () => {
 		fileContents.set(userTasksUri.toString(), tasksJsonContent([]));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri }), resource: sessionResource }, undefined);
-		await scheduler.tick(20);
+		await new Promise(r => setTimeout(r, 20));
 
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt1 }), resource: sessionResource }, undefined);
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: wt2 }), resource: sessionResource }, undefined);
 
-		await scheduler.tick(350);
+		await new Promise(r => setTimeout(r, 350));
 
 		assert.strictEqual(sentCommands.length, 1);
 		assert.strictEqual(sentCommands[0].command, 'echo wt2');
-	}));
+	});
 
 });


### PR DESCRIPTION
potential fix for #302546

I could not get the task to run when new worktree was created. I also could not select Copilot CLI - it was stuck on cloud. Thus, this could use some testing.

Root cause appears to be a cwd timing race at worktree transition boundaries. `runOn: "worktreeCreated"` actions were triggered immediately off the `activeSession.worktree` metadata change, which is an early signal and can arrive before the underlying worktree path is fully readable. In that window, Task execution is especially vulnerable because the Tasks engine resolves the folder and launches immediately (`Executing task in folder ...`). If the cwd is still transient, `bun install` fails with `CouldntReadCurrentDirectory` (emitted by `bun`, not VS Code).

This also explains why “same command in terminal” can succeed: the regular terminal path is typically exercised later (manual open/focus/type/click delay), after session/worktree state has stabilized. So this is primarily an event-timing/orchestration issue, not a command-content issue.

Fix: make `worktreeCreated` auto-runs race-safe by delaying slightly, cancelling stale pending runs when worktree changes again, re-validating active session/worktree right before execution, and waiting for worktree availability before launching run actions.