### PR TITLE
Fix `get_terminal_output` Invalid ID Handling and Clarify Background Terminal ID Contract

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -16,7 +16,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get the output of a terminal command previously started with ${TerminalToolId.RunInTerminal}`,
+	modelDescription: `Get the output of a background terminal command previously started with ${TerminalToolId.RunInTerminal}. The id must be the exact opaque value returned by ${TerminalToolId.RunInTerminal} when isBackground=true; terminal names, labels, and integers are not valid ids.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -24,7 +24,8 @@ export const GetTerminalOutputToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: 'The ID of the terminal to check.'
+				description: `The ID of the background terminal to check (returned by ${TerminalToolId.RunInTerminal} when isBackground=true). This must be the exact opaque id returned by that tool; terminal names, labels, or integers are invalid.`,
+				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 			},
 		},
 		required: [
@@ -47,10 +48,20 @@ export class GetTerminalOutputTool extends Disposable implements IToolImpl {
 
 	async invoke(invocation: IToolInvocation, _countTokens: CountTokensCallback, _progress: ToolProgress, token: CancellationToken): Promise<IToolResult> {
 		const args = invocation.parameters as IGetTerminalOutputInputParams;
+		const execution = RunInTerminalTool.getExecution(args.id);
+		if (!execution) {
+			return {
+				content: [{
+					kind: 'text',
+					value: `Error: No active terminal execution found with ID ${args.id}. The ID must be the exact value returned by ${TerminalToolId.RunInTerminal} for a background command.`
+				}]
+			};
+		}
+
 		return {
 			content: [{
 				kind: 'text',
-				value: `Output of terminal ${args.id}:\n${RunInTerminalTool.getBackgroundOutput(args.id)}`
+				value: `Output of terminal ${args.id}:\n${execution.getOutput()}`
 			}]
 		};
 	}

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/getTerminalOutputTool.ts
@@ -16,7 +16,7 @@ export const GetTerminalOutputToolData: IToolData = {
 	toolReferenceName: 'getTerminalOutput',
 	legacyToolReferenceFullNames: ['runCommands/getTerminalOutput'],
 	displayName: localize('getTerminalOutputTool.displayName', 'Get Terminal Output'),
-	modelDescription: `Get the output of a background terminal command previously started with ${TerminalToolId.RunInTerminal}. The id must be the exact opaque value returned by ${TerminalToolId.RunInTerminal} when isBackground=true; terminal names, labels, and integers are not valid ids.`,
+	modelDescription: `Get the output of a background terminal command previously started with ${TerminalToolId.RunInTerminal}. The ID must be the exact opaque value returned by ${TerminalToolId.RunInTerminal} when isBackground=true; terminal names, labels, and integers are not valid IDs.`,
 	icon: Codicon.terminal,
 	source: ToolDataSource.Internal,
 	inputSchema: {
@@ -24,7 +24,7 @@ export const GetTerminalOutputToolData: IToolData = {
 		properties: {
 			id: {
 				type: 'string',
-				description: `The ID of the background terminal to check (returned by ${TerminalToolId.RunInTerminal} when isBackground=true). This must be the exact opaque id returned by that tool; terminal names, labels, or integers are invalid.`,
+				description: `The ID of the background terminal to check (returned by ${TerminalToolId.RunInTerminal} when isBackground=true). This must be the exact opaque ID returned by that tool; terminal names, labels, or integers are invalid.`,
 				pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 			},
 		},

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -49,7 +49,7 @@ suite('GetTerminalOutputTool', () => {
 	test('tool description documents opaque terminal ids', () => {
 		const idProperty = GetTerminalOutputToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
 		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque value'));
-		assert.ok(idProperty?.description?.includes('exact opaque id returned by that tool'));
+		assert.ok(/exact opaque id returned by that tool/i.test(idProperty?.description ?? ''));
 		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -14,6 +14,8 @@ import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js
 
 suite('GetTerminalOutputTool', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	const UNKNOWN_TERMINAL_ID = '123e4567-e89b-12d3-a456-426614174000';
+	const KNOWN_TERMINAL_ID = '123e4567-e89b-12d3-a456-426614174001';
 	let tool: GetTerminalOutputTool;
 	let originalGetExecution: typeof RunInTerminalTool.getExecution;
 
@@ -57,7 +59,7 @@ suite('GetTerminalOutputTool', () => {
 		RunInTerminalTool.getExecution = () => undefined;
 
 		const result = await tool.invoke(
-			createInvocation('pwsh'),
+			createInvocation(UNKNOWN_TERMINAL_ID),
 			async () => 0,
 			{ report: () => { } },
 			CancellationToken.None,
@@ -74,7 +76,7 @@ suite('GetTerminalOutputTool', () => {
 		RunInTerminalTool.getExecution = () => createMockExecution('line1\nline2');
 
 		const result = await tool.invoke(
-			createInvocation('abc'),
+			createInvocation(KNOWN_TERMINAL_ID),
 			async () => 0,
 			{ report: () => { } },
 			CancellationToken.None,
@@ -83,7 +85,7 @@ suite('GetTerminalOutputTool', () => {
 		assert.strictEqual(result.content.length, 1);
 		assert.strictEqual(result.content[0].kind, 'text');
 		const value = (result.content[0] as { value: string }).value;
-		assert.ok(value.includes('Output of terminal abc:'));
+		assert.ok(value.includes(`Output of terminal ${KNOWN_TERMINAL_ID}:`));
 		assert.ok(value.includes('line1\nline2'));
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/getTerminalOutputTool.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { GetTerminalOutputTool, GetTerminalOutputToolData } from '../../browser/tools/getTerminalOutputTool.js';
+import { RunInTerminalTool, type IActiveTerminalExecution } from '../../browser/tools/runInTerminalTool.js';
+import type { IToolInvocation } from '../../../../chat/common/tools/languageModelToolsService.js';
+import type { ITerminalExecuteStrategyResult } from '../../browser/executeStrategy/executeStrategy.js';
+import type { ITerminalInstance } from '../../../../terminal/browser/terminal.js';
+
+suite('GetTerminalOutputTool', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let tool: GetTerminalOutputTool;
+	let originalGetExecution: typeof RunInTerminalTool.getExecution;
+
+	setup(() => {
+		tool = store.add(new GetTerminalOutputTool());
+		originalGetExecution = RunInTerminalTool.getExecution;
+	});
+
+	teardown(() => {
+		RunInTerminalTool.getExecution = originalGetExecution;
+	});
+
+	function createInvocation(id: string): IToolInvocation {
+		return {
+			parameters: { id },
+			callId: 'test-call',
+			context: { sessionId: 'test-session' },
+			toolId: 'get_terminal_output',
+			tokenBudget: 1000,
+			isComplete: () => false,
+			isCancellationRequested: false,
+		} as unknown as IToolInvocation;
+	}
+
+	function createMockExecution(output: string): IActiveTerminalExecution {
+		return {
+			completionPromise: Promise.resolve({ output } as ITerminalExecuteStrategyResult),
+			instance: {} as ITerminalInstance,
+			getOutput: () => output,
+		};
+	}
+
+	test('tool description documents opaque terminal ids', () => {
+		const idProperty = GetTerminalOutputToolData.inputSchema?.properties?.id as { description?: string; pattern?: string } | undefined;
+		assert.ok(GetTerminalOutputToolData.modelDescription.includes('exact opaque value'));
+		assert.ok(idProperty?.description?.includes('exact opaque id returned by that tool'));
+		assert.ok(idProperty?.pattern?.includes('[0-9a-fA-F]{8}'));
+	});
+
+	test('returns explicit error for unknown terminal id', async () => {
+		RunInTerminalTool.getExecution = () => undefined;
+
+		const result = await tool.invoke(
+			createInvocation('pwsh'),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		assert.strictEqual(result.content.length, 1);
+		assert.strictEqual(result.content[0].kind, 'text');
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('No active terminal execution found'));
+		assert.ok(value.includes('exact value returned by run_in_terminal'));
+	});
+
+	test('returns output for active terminal id', async () => {
+		RunInTerminalTool.getExecution = () => createMockExecution('line1\nline2');
+
+		const result = await tool.invoke(
+			createInvocation('abc'),
+			async () => 0,
+			{ report: () => { } },
+			CancellationToken.None,
+		);
+
+		assert.strictEqual(result.content.length, 1);
+		assert.strictEqual(result.content[0].kind, 'text');
+		const value = (result.content[0] as { value: string }).value;
+		assert.ok(value.includes('Output of terminal abc:'));
+		assert.ok(value.includes('line1\nline2'));
+	});
+});


### PR DESCRIPTION
fix #298433

1. Makes it clear that `GetTerminalOutputTool` is for checking the output of background terminals.
2. Prevents repeated bad id guesses by giving better instructions.
3. Makes failures understandable and recoverable when an invalid id is used.
4. Reduces agent looping/spinning caused by unclear invalid terminal id failures.

cc @tyriar