### PR TITLE
Fix operator precedence in timeline pageSize calculation

### DIFF
--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -328,7 +328,7 @@ export class TimelinePane extends ViewPane {
 		let pageSize = this.configurationService.getValue<number | null | undefined>('timeline.pageSize');
 		if (pageSize === undefined || pageSize === null) {
 			// If we are paging when scrolling, then add an extra item to the end to make sure the "Load more" item is out of view
-			pageSize = Math.max(20, Math.floor((this.tree?.renderHeight ?? 0 / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
+			pageSize = Math.max(20, Math.floor(((this.tree?.renderHeight ?? 0) / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
 		}
 		return pageSize;
 	}


### PR DESCRIPTION
Fixes #303257

## Bug

In `TimelinePane.pageSize`, the nullish coalescing operator (`??`) has lower precedence than division (`/`), causing `renderHeight` (pixels) to be used directly as the page size instead of `renderHeight / ItemHeight` (items).

### Current code

```typescript
pageSize = Math.max(20, Math.floor((this.tree?.renderHeight ?? 0 / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
```

JavaScript parses this as `this.tree?.renderHeight ?? (0 / ItemHeight)` because `/` binds tighter than `??`.

When the tree exists (the common case), `renderHeight` is a pixel value (e.g., 500). Without the division by `ItemHeight` (22), the computed page size is ~499 instead of the intended ~22. This causes a ~24x over-fetch on every timeline load and "Load more" action.

### Fix

Add parentheses to enforce the intended grouping:

```typescript
pageSize = Math.max(20, Math.floor(((this.tree?.renderHeight ?? 0) / ItemHeight) + (this.pageOnScroll ? 1 : -1)));
```

### Verification

```js
const ItemHeight = 22, renderHeight = 500;

// Buggy:  renderHeight ?? (0 / ItemHeight)  => 500  =>  pageSize = 499
// Fixed:  (renderHeight ?? 0) / ItemHeight   => 22.7 =>  pageSize = 21
```

When the tree is null/undefined, both produce `pageSize = 20` (via `Math.max`), so the fallback path is unaffected.