### PR TITLE
Bug fix: Fix skill load regression 

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2776,11 +2776,18 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 */
 	private async _autoAttachInstructions({ attachedContext }: IChatRequestInputOptions): Promise<void> {
 		const contribution = this._lockedAgent ? this.chatSessionsService.getChatSessionContribution(this._lockedAgent.id) : undefined;
-		if (contribution?.autoAttachReferences === false) {
+
+		// For contributed session types, default to false for autoAttachReferences.
+		const isContributedSession = !!contribution;
+		const autoAttachEnabled = isContributedSession ?
+			contribution.autoAttachReferences === true : true;
+
+		if (!autoAttachEnabled) {
 			this.logService.debug(`ChatWidget#_autoAttachInstructions: skipped, autoAttachReferences is disabled`);
 			return;
 		}
-		this.logService.debug(`ChatWidget#_autoAttachInstructions: prompt files are always enabled`);
+
+		this.logService.debug(`ChatWidget#_autoAttachInstructions: prompt files are enabled`);
 		const enabledTools = this.input.currentModeKind === ChatModeKind.Agent ? this.input.selectedToolsModel.userSelectedTools.get() : undefined;
 		const enabledSubAgents = this.input.currentModeKind === ChatModeKind.Agent ? this.input.currentModeObs.get().agents?.get() : undefined;
 		const sessionResource = this._viewModel?.model.sessionResource;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2776,7 +2776,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	 */
 	private async _autoAttachInstructions({ attachedContext }: IChatRequestInputOptions): Promise<void> {
 		const contribution = this._lockedAgent ? this.chatSessionsService.getChatSessionContribution(this._lockedAgent.id) : undefined;
-		if (!contribution?.autoAttachReferences) {
+		if (contribution?.autoAttachReferences === false) {
 			this.logService.debug(`ChatWidget#_autoAttachInstructions: skipped, autoAttachReferences is disabled`);
 			return;
 		}


### PR DESCRIPTION
Fixes a regression introduced in #302508 where _autoAttachInstructions was silently skipped for all chat sessions without an explicit chatSessions extension point contribution (including the default local chat).

The check if (!contribution?.autoAttachReferences) treated undefined (no contribution registered) disabled all instruction, skill, agent, and slash command loading via ComputeAutomaticInstructions.collect(). Only hook loading was unaffected since getHooks() is called independently from chatServiceImpl.ts.