### PR TITLE
Collapse inactive repo sections in agent sessions view

### DIFF
--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -4,7 +4,7 @@
 		"sessionStart": [
 			{
 				"type": "command",
-				"bash": ""
+				"bash": "nvm use && npm i"
 			}
 		],
 		"sessionEnd": [

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -4,7 +4,7 @@
 		"sessionStart": [
 			{
 				"type": "command",
-				"bash": "nvm use && npm i"
+				"bash": ""
 			}
 		],
 		"sessionEnd": [

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -238,6 +238,7 @@ export class AgenticSessionsViewPane extends ViewPane {
 
 		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
 		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
+		// TODO: Unsure if this is going to be annoying or helpful so that you can quickly see the active sessions
 		this.sessionsControl?.resetSectionCollapseState();
 		this.sessionsControl?.update();
 	}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -238,6 +238,7 @@ export class AgenticSessionsViewPane extends ViewPane {
 
 		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
 		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
+		this.sessionsControl?.resetSectionCollapseState();
 		this.sessionsControl?.update();
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -238,7 +238,7 @@ export class AgenticSessionsViewPane extends ViewPane {
 
 		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
 		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
-		// TODO: Unsure if this is going to be annoying or helpful so that you can quickly see the active sessions
+		// TODO @osortega: Unsure if this is going to be annoying or helpful so that you can quickly see the active sessions
 		this.sessionsControl?.resetSectionCollapseState();
 		this.sessionsControl?.update();
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessions.ts
@@ -171,6 +171,8 @@ export interface IAgentSessionsControl {
 
 	clearFocus(): void;
 	hasFocusOrSelection(): boolean;
+
+	resetSectionCollapseState(): void;
 }
 
 export const agentSessionReadIndicatorForeground = registerColor(

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -13,7 +13,7 @@ import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, IMarshalledAgentSessionContext, isAgentSession, isAgentSessionSection } from './agentSessionsModel.js';
-import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionsSorter, getRepositoryName, IAgentSessionsFilter } from './agentSessionsViewer.js';
+import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionSectionLabels, AgentSessionsSorter, getRepositoryName, IAgentSessionsFilter } from './agentSessionsViewer.js';
 import { AgentSessionsGrouping } from './agentSessionsFilter.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
@@ -81,7 +81,6 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	private sessionsList: WorkbenchCompressibleAsyncDataTree<IAgentSessionsModel, AgentSessionListItem, FuzzyScore> | undefined;
 	private static readonly RECENT_SESSIONS_FOR_EXPAND = 5;
-	private static readonly UNKNOWN_REPOSITORY_LABEL = localize('agentSessions.noRepository', "Other");
 
 	private sessionsListFindIsOpen = false;
 	private _isProgrammaticCollapseChange = false;
@@ -398,7 +397,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 		for (const session of sessions) {
 			const name = getRepositoryName(session);
-			this._recentRepositoryLabels.add(name ?? AgentSessionsControl.UNKNOWN_REPOSITORY_LABEL);
+			this._recentRepositoryLabels.add(name ?? AgentSessionSectionLabels[AgentSessionSection.Repository]);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -218,6 +218,10 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		this.storageService.store(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, JSON.stringify(state), StorageScope.PROFILE, StorageTarget.USER);
 	}
 
+	resetSectionCollapseState(): void {
+		this.storageService.remove(AgentSessionsControl.SECTION_COLLAPSE_STATE_KEY, StorageScope.PROFILE);
+	}
+
 	private createList(container: HTMLElement): void {
 		const collapseByDefault = (element: unknown) => {
 			if (isAgentSessionSection(element)) {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -13,7 +13,7 @@ import { StandardKeyboardEvent } from '../../../../../base/browser/keyboardEvent
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, IMarshalledAgentSessionContext, isAgentSession, isAgentSessionSection } from './agentSessionsModel.js';
-import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionsSorter, IAgentSessionsFilter } from './agentSessionsViewer.js';
+import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionsSorter, getRepositoryName, IAgentSessionsFilter } from './agentSessionsViewer.js';
 import { AgentSessionsGrouping } from './agentSessionsFilter.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
@@ -80,8 +80,11 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 	private emptyFilterMessage: HTMLElement | undefined;
 
 	private sessionsList: WorkbenchCompressibleAsyncDataTree<IAgentSessionsModel, AgentSessionListItem, FuzzyScore> | undefined;
+	private static readonly RECENT_SESSIONS_FOR_EXPAND = 5;
+
 	private sessionsListFindIsOpen = false;
 	private _isProgrammaticCollapseChange = false;
+	private readonly _recentRepositoryLabels = new Set<string>();
 
 	private readonly updateSessionsListThrottler = this._register(new Throttler());
 
@@ -238,6 +241,9 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 					if (element.section === AgentSessionSection.Yesterday && this.hasTodaySessions()) {
 						return true; // Also collapse Yesterday when there are sessions from Today
 					}
+					if (element.section === AgentSessionSection.Repository && !this._recentRepositoryLabels.has(element.label)) {
+						return true; // Collapse repository sections that don't contain recent sessions
+					}
 				}
 			}
 
@@ -305,6 +311,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			}
 		}));
 
+		this.computeRecentRepositoryLabels();
 		list.setInput(model);
 
 		this._register(list.onDidOpen(e => this.openAgentSession(e)));
@@ -374,6 +381,22 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			!session.isArchived() &&
 			session.timing.created >= startOfToday
 		);
+	}
+
+	private computeRecentRepositoryLabels(): void {
+		this._recentRepositoryLabels.clear();
+
+		const sessions = this.agentSessionsService.model.sessions
+			.filter(s => !s.isArchived() && !s.isPinned())
+			.sort((a, b) => b.timing.created - a.timing.created)
+			.slice(0, AgentSessionsControl.RECENT_SESSIONS_FOR_EXPAND);
+
+		for (const session of sessions) {
+			const name = getRepositoryName(session);
+			if (name) {
+				this._recentRepositoryLabels.add(name);
+			}
+		}
 	}
 
 	private async openAgentSession(e: IOpenEvent<AgentSessionListItem | undefined>): Promise<void> {
@@ -511,6 +534,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	async update(): Promise<void> {
 		return this.updateSessionsListThrottler.queue(async () => {
+			this.computeRecentRepositoryLabels();
 			await this.sessionsList?.updateChildren();
 
 			this._onDidUpdate.fire();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -81,6 +81,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 	private sessionsList: WorkbenchCompressibleAsyncDataTree<IAgentSessionsModel, AgentSessionListItem, FuzzyScore> | undefined;
 	private static readonly RECENT_SESSIONS_FOR_EXPAND = 5;
+	private static readonly UNKNOWN_REPOSITORY_LABEL = localize('agentSessions.noRepository', "Other");
 
 	private sessionsListFindIsOpen = false;
 	private _isProgrammaticCollapseChange = false;
@@ -397,9 +398,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 
 		for (const session of sessions) {
 			const name = getRepositoryName(session);
-			if (name) {
-				this._recentRepositoryLabels.add(name);
-			}
+			this._recentRepositoryLabels.add(name ?? AgentSessionsControl.UNKNOWN_REPOSITORY_LABEL);
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -899,7 +899,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		const pinnedSessions: IAgentSession[] = [];
 		const archivedSessions: IAgentSession[] = [];
 		const unknownKey = '\x00unknown';
-		const unknownLabel = localize('agentSessions.noRepository', "Other");
+		const unknownLabel = AgentSessionSectionLabels[AgentSessionSection.Repository];
 
 		for (const session of sortedSessions) {
 			if (session.isArchived()) {
@@ -937,11 +937,23 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			});
 		}
 
-		for (const [, { label, sessions }] of repoMap) {
+		for (const [repoId, { label, sessions }] of repoMap) {
+			if (repoId === unknownKey) {
+				continue; // "Other" group is added after all named repos
+			}
 			result.push({
 				section: AgentSessionSection.Repository,
 				label,
 				sessions,
+			});
+		}
+
+		const unknownGroup = repoMap.get(unknownKey);
+		if (unknownGroup) {
+			result.push({
+				section: AgentSessionSection.Repository,
+				label: unknownGroup.label,
+				sessions: unknownGroup.sessions,
 			});
 		}
 
@@ -1112,6 +1124,7 @@ export const AgentSessionSectionLabels = {
 	[AgentSessionSection.Older]: localize('agentSessions.olderSection', "Older"),
 	[AgentSessionSection.Archived]: localize('agentSessions.archivedSection', "Archived"),
 	[AgentSessionSection.More]: localize('agentSessions.moreSection', "More"),
+	[AgentSessionSection.Repository]: localize('agentSessions.noRepository', "Other"),
 };
 
 const DAY_THRESHOLD = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
When grouped by repository, only sections containing one of the 5 most recent sessions are expanded by default — all other repo sections start collapsed. This helps users focus on active work.

## Changes

**`agentSessionsControl.ts`**
- Added `computeRecentRepositoryLabels()` — computes the set of repository labels that contain the 5 most recent sessions (by `timing.created`)
- Called before `setInput` (initial render) and before `updateChildren` (on updates)
- Extended `collapseByDefault` to collapse `Repository` sections whose label isn't in the recent set (when `collapseOlderSections` is enabled)
- Added `resetSectionCollapseState()` — clears persisted section collapse preferences

**`agentSessions.ts`**
- Added `resetSectionCollapseState()` to the `IAgentSessionsControl` interface

**`sessionsViewPane.ts`**
- Calls `resetSectionCollapseState()` when toggling between date/repo grouping, so fresh defaults apply to the new grouping mode

## Behavior
- Saved user collapse/expand preferences still take priority
- When switching grouping modes, persisted collapse state is reset so defaults apply cleanly
- Pinned and Archived sections retain their existing collapse behavior