### PR TITLE
Fix logic bug in ErrorHandler listener removal

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -50,7 +50,10 @@ export class ErrorHandler {
 	}
 
 	private _removeListener(listener: ErrorListenerCallback): void {
-		this.listeners.splice(this.listeners.indexOf(listener), 1);
+		const index = this.listeners.indexOf(listener);
+		if (index !== -1) {
+			this.listeners.splice(index, 1);
+		}
 	}
 
 	setUnexpectedErrorHandler(newUnexpectedErrorHandler: (e: any) => void): void {


### PR DESCRIPTION
Previously, `_removeListener` used:
```typescript
this.listeners.splice(this.listeners.indexOf(listener), 1);
```
If the listener was not found in the array, `indexOf` returns `-1`. In JavaScript, `splice(-1, 1)` removes the **last element** of the array. This means that attempting to remove a non-existent listener would accidentally remove the most recently added valid listener.

This PR adds a check to ensure the listener exists before attempting to remove it.