### PR TITLE
Handle empty results in Git revList

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3133,7 +3133,12 @@ export class Repository {
 			return [];
 		}
 
-		return result.stdout.trim().split('\n');
+		const stdout = result.stdout.trim();
+		if (!stdout) {
+			return [];
+		}
+
+		return stdout.split('\n');
 	}
 
 	async revParse(ref: string): Promise<string | undefined> {


### PR DESCRIPTION
When `git rev-list` returns no results, `stdout.trim()` is an empty string. Calling `.split('\n')` on an empty string in JavaScript results in `['']` (an array containing one empty string) rather than an empty array `[]`.

This PR adds a check to return an empty array if the output is empty, preventing downstream code from processing an empty string as a valid commit hash.