### PR TITLE
Improve parsing robustness of os-release files

### DIFF
--- a/src/vs/base/node/osReleaseInfo.ts
+++ b/src/vs/base/node/osReleaseInfo.ts
@@ -47,12 +47,13 @@ export async function getOSReleaseInfo(errorLogger: (error: string | Error) => v
 		};
 
 		for await (const line of readLines({ input: handle.createReadStream(), crlfDelay: Infinity })) {
-			if (!line.includes('=')) {
+			const equalsIndex = line.indexOf('=');
+			if (equalsIndex === -1) {
 				continue;
 			}
-			const key = line.split('=')[0].toUpperCase().trim();
+			const key = line.substring(0, equalsIndex).toUpperCase().trim();
 			if (osReleaseKeys.has(key)) {
-				const value = line.split('=')[1].replace(/"/g, '').toLowerCase().trim();
+				const value = line.substring(equalsIndex + 1).replace(/"/g, '').toLowerCase().trim();
 				if (key === 'ID' || key === 'DISTRIB_ID') {
 					releaseInfo.id = value;
 				} else if (key === 'ID_LIKE') {


### PR DESCRIPTION
The current parser uses `line.split('=')[1]` to extract values. However, the `os-release` specification (and general shell-like assignment files) allows values to contain `=` characters. Using `split('=')[1]` would only capture a portion of such values.

This PR switches to using `line.indexOf('=')` to split the string precisely once at the first delimiter, ensuring the full value is captured. It also improves efficiency by avoiding multiple split operations.