### PR TITLE
Agent debug log export: include session Id in filename and show success notification

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -14,6 +14,7 @@ import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contex
 import { IDialogService, IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { INotificationService, Severity } from '../../../../../platform/notification/common/notification.js';
+import { IOpenerService } from '../../../../../platform/opener/common/opener.js';
 import { ITelemetryService } from '../../../../../platform/telemetry/common/telemetry.js';
 import { ActiveEditorContext } from '../../../../common/contextkeys.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -25,6 +26,7 @@ import { CHAT_CATEGORY, CHAT_CONFIG_MENU_ID } from './chatActions.js';
 import { ChatDebugEditorInput } from '../chatDebug/chatDebugEditorInput.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { IChatDebugEditorOptions } from '../chatDebug/chatDebugTypes.js';
+import { LocalChatSessionUri } from '../../common/model/chatUri.js';
 
 /**
  * Registers the Open Agent Debug Logs and Show Agent Debug Logs actions.
@@ -127,6 +129,7 @@ export function registerChatOpenAgentDebugPanelAction() {
 			const fileDialogService = accessor.get(IFileDialogService);
 			const fileService = accessor.get(IFileService);
 			const notificationService = accessor.get(INotificationService);
+			const openerService = accessor.get(IOpenerService);
 			const telemetryService = accessor.get(ITelemetryService);
 
 			const sessionResource = chatDebugService.activeSessionResource;
@@ -135,7 +138,9 @@ export function registerChatOpenAgentDebugPanelAction() {
 				return;
 			}
 
-			const defaultUri = joinPath(await fileDialogService.defaultFilePath(), defaultDebugLogFileName);
+			const sessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
+			const exportFileName = sessionId ? `agent-debug-log-${sessionId}.json` : defaultDebugLogFileName;
+			const defaultUri = joinPath(await fileDialogService.defaultFilePath(), exportFileName);
 			const outputPath = await fileDialogService.showSaveDialog({ defaultUri, filters: debugLogFilters });
 			if (!outputPath) {
 				return;
@@ -152,6 +157,15 @@ export function registerChatOpenAgentDebugPanelAction() {
 			telemetryService.publicLog2<ChatDebugExportEvent, ChatDebugExportClassification>('chatDebugLogExported', {
 				fileSizeBytes: data.byteLength,
 			});
+
+			notificationService.prompt(
+				Severity.Info,
+				localize('chatDebugLog.exportSuccess', "Agent debug log exported successfully."),
+				[{
+					label: localize('chatDebugLog.openExportedFile', "Open File"),
+					run: () => openerService.open(outputPath)
+				}]
+			);
 		}
 	});
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatOpenAgentDebugPanelAction.ts
@@ -138,8 +138,10 @@ export function registerChatOpenAgentDebugPanelAction() {
 				return;
 			}
 
-			const sessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
-			const exportFileName = sessionId ? `agent-debug-log-${sessionId}.json` : defaultDebugLogFileName;
+			const localSessionId = LocalChatSessionUri.parseLocalSessionId(sessionResource);
+			const rawIdentifier = localSessionId ?? (sessionResource.path.replace(/^\//, '') || sessionResource.authority);
+			const sessionIdentifier = rawIdentifier?.replace(/[/\\:*?"<>|.]+/g, '_').replace(/^_+|_+$/g, '');
+			const exportFileName = sessionIdentifier ? `agent-debug-log-${sessionIdentifier}.json` : defaultDebugLogFileName;
 			const defaultUri = joinPath(await fileDialogService.defaultFilePath(), exportFileName);
 			const outputPath = await fileDialogService.showSaveDialog({ defaultUri, filters: debugLogFilters });
 			if (!outputPath) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/302213, https://github.com/microsoft/vscode/issues/302220

This PR improves the agent debug log export experience:

Session ID in filename: The export save dialog now suggests a unique filename that includes the session ID (e.g., agent-debug-log-b4b16957-3fa7-4508-8dd2-b4b438436105.json) instead of the generic agent-debug-log.json. Falls back to the generic name if no session ID is available.

Success notification with action: After a successful export, a notification is shown with an "Open File" action that opens the exported file in the editor.