### PR TITLE
Agent Debug panel: Fix Copilot CLI sessions not appearing until the second message was sent

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -30,6 +30,7 @@ import { ChatAgentLocation } from '../../contrib/chat/common/constants.js';
 import { IChatModel } from '../../contrib/chat/common/model/chatModel.js';
 import { isUntitledChatSession } from '../../contrib/chat/common/model/chatUri.js';
 import { IChatAgentRequest } from '../../contrib/chat/common/participants/chatAgents.js';
+import { IChatDebugService } from '../../contrib/chat/common/chatDebugService.js';
 import { IChatArtifactsService } from '../../contrib/chat/common/tools/chatArtifactsService.js';
 import { IChatTodoListService } from '../../contrib/chat/common/tools/chatTodoListService.js';
 import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
@@ -445,6 +446,7 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService,
 		@IChatTodoListService private readonly _chatTodoListService: IChatTodoListService,
 		@IChatArtifactsService private readonly _chatArtifactsService: IChatArtifactsService,
+		@IChatDebugService private readonly _chatDebugService: IChatDebugService,
 		@IDialogService private readonly _dialogService: IDialogService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
@@ -574,6 +576,16 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 
 			// Migrate artifacts from old session to new session
 			this._chatArtifactsService.migrateArtifacts(originalResource, modifiedResource);
+
+			// Eagerly invoke debug providers for Copilot CLI sessions so the real
+			// session appears in the debug panel immediately after the untitled →
+			// real swap. Without this, the untitled session is filtered out (it
+			// only has a "Load Hooks" event) and the real session has no events
+			// until someone navigates to it — which can't happen because it's
+			// not listed.
+			if (chatSessionType === 'copilotcli') {
+				this._chatDebugService.invokeProviders(modifiedResource);
+			}
 
 			// Find the group containing the original editor
 			const originalGroup =

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -584,7 +584,9 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 			// until someone navigates to it — which can't happen because it's
 			// not listed.
 			if (chatSessionType === 'copilotcli') {
-				this._chatDebugService.invokeProviders(modifiedResource);
+				// Fire-and-forget: don't block the editor swap. Errors are
+				// handled internally by invokeProviders via onUnexpectedError.
+				this._chatDebugService.invokeProviders(modifiedResource).catch(() => { /* handled internally */ });
 			}
 
 			// Find the group containing the original editor


### PR DESCRIPTION
Eagerly invoke debug providers for the new Copilot CLI session resource during the untitled→real session commit, so the session appears in the Agent Debug Logs panel immediately after the first message instead of requiring a second message. The fix is a single invokeProviders call scoped to copilotcli sessions in $onDidCommitChatSessionItem.