### PR TITLE
Update toolSpecificData for UI re-rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -862,6 +862,12 @@ export class Response extends AbstractResponse implements IDisposable {
 		);
 
 		if (existingInvocation) {
+			// Update toolSpecificData before completing so that the UI re-render
+			// triggered by didExecuteTool already sees the latest data (e.g.
+			// terminalCommandOutput).
+			if (progress.toolSpecificData !== undefined) {
+				existingInvocation.toolSpecificData = progress.toolSpecificData;
+			}
 			if (progress.isComplete) {
 				existingInvocation.didExecuteTool({
 					content: [],
@@ -869,9 +875,6 @@ export class Response extends AbstractResponse implements IDisposable {
 					toolResultError: progress.errorMessage,
 					toolResultDetails: progress.resultDetails
 				});
-			}
-			if (progress.toolSpecificData !== undefined) {
-				existingInvocation.toolSpecificData = progress.toolSpecificData;
 			}
 			return;
 		}


### PR DESCRIPTION
Ensure that the UI re-renders with the latest tool-specific data before completing the invocation. This change updates the `toolSpecificData` to reflect the most current information during the execution process.

Fixes https://github.com/microsoft/vscode/issues/302200