### PR TITLE
Restructure agent sessions filter menu with sort and group radios

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -23,7 +23,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { AgentSessionsControl } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsControl.js';
-import { AgentSessionsFilter, AgentSessionsGrouping } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.js';
+import { AgentSessionsFilter, AgentSessionsGrouping, AgentSessionsSorting } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.js';
 import { AgentSessionProviders } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessions.js';
 import { ISessionsManagementService, IsNewChatSessionContext } from './sessionsManagementService.js';
 import { Action2, ISubmenuItem, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -41,8 +41,11 @@ import { IHostService } from '../../../../workbench/services/host/browser/host.j
 const $ = DOM.$;
 export const SessionsViewId = 'agentic.workbench.view.sessionsView';
 const SessionsViewFilterSubMenu = new MenuId('AgentSessionsViewFilterSubMenu');
-const IsGroupedByRepositoryContext = new RawContextKey<boolean>('sessionsView.isGroupedByRepository', true);
+const SessionsViewFilterFilterSubMenu = new MenuId('AgentSessionsViewFilterFilterSubMenu');
+const SessionsViewGroupingContext = new RawContextKey<string>('sessionsView.grouping', AgentSessionsGrouping.Repository);
+const SessionsViewSortingContext = new RawContextKey<string>('sessionsView.sorting', AgentSessionsSorting.Created);
 const GROUPING_STORAGE_KEY = 'agentSessions.grouping';
+const SORTING_STORAGE_KEY = 'agentSessions.sorting';
 
 export class AgenticSessionsViewPane extends ViewPane {
 
@@ -50,7 +53,9 @@ export class AgenticSessionsViewPane extends ViewPane {
 	private sessionsControlContainer: HTMLElement | undefined;
 	sessionsControl: AgentSessionsControl | undefined;
 	private currentGrouping: AgentSessionsGrouping = AgentSessionsGrouping.Repository;
-	private isGroupedByRepoKey: ReturnType<typeof IsGroupedByRepositoryContext.bindTo> | undefined;
+	private currentSorting: AgentSessionsSorting = AgentSessionsSorting.Created;
+	private groupingContextKey: ReturnType<typeof SessionsViewGroupingContext.bindTo> | undefined;
+	private sortingContextKey: ReturnType<typeof SessionsViewSortingContext.bindTo> | undefined;
 
 	constructor(
 		options: IViewPaneOptions,
@@ -71,14 +76,22 @@ export class AgenticSessionsViewPane extends ViewPane {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
 		// Restore persisted grouping
-		const stored = this.storageService.get(GROUPING_STORAGE_KEY, StorageScope.PROFILE);
-		if (stored && Object.values(AgentSessionsGrouping).includes(stored as AgentSessionsGrouping)) {
-			this.currentGrouping = stored as AgentSessionsGrouping;
+		const storedGrouping = this.storageService.get(GROUPING_STORAGE_KEY, StorageScope.PROFILE);
+		if (storedGrouping && Object.values(AgentSessionsGrouping).includes(storedGrouping as AgentSessionsGrouping)) {
+			this.currentGrouping = storedGrouping as AgentSessionsGrouping;
 		}
 
-		// Ensure the view-title context reflects the restored grouping immediately
-		this.isGroupedByRepoKey = IsGroupedByRepositoryContext.bindTo(contextKeyService);
-		this.isGroupedByRepoKey.set(this.currentGrouping === AgentSessionsGrouping.Repository);
+		// Restore persisted sorting
+		const storedSorting = this.storageService.get(SORTING_STORAGE_KEY, StorageScope.PROFILE);
+		if (storedSorting && Object.values(AgentSessionsSorting).includes(storedSorting as AgentSessionsSorting)) {
+			this.currentSorting = storedSorting as AgentSessionsSorting;
+		}
+
+		// Ensure context keys reflect restored state immediately
+		this.groupingContextKey = SessionsViewGroupingContext.bindTo(contextKeyService);
+		this.groupingContextKey.set(this.currentGrouping);
+		this.sortingContextKey = SessionsViewSortingContext.bindTo(contextKeyService);
+		this.sortingContextKey.set(this.currentSorting);
 	}
 
 	protected override renderBody(parent: HTMLElement): void {
@@ -105,14 +118,11 @@ export class AgenticSessionsViewPane extends ViewPane {
 	private createControls(parent: HTMLElement): void {
 		const sessionsContainer = DOM.append(parent, $('.agent-sessions-container'));
 
-		// Track grouping state via context key for the toggle button
-		const isGroupedByRepoKey = this.isGroupedByRepoKey = IsGroupedByRepositoryContext.bindTo(this.contextKeyService);
-		isGroupedByRepoKey.set(this.currentGrouping === AgentSessionsGrouping.Repository);
-
-		// Sessions Filter (actions go to view title bar via menu registration)
+		// Sessions Filter (actions go to the nested filter submenu)
 		const sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
-			filterMenuId: SessionsViewFilterSubMenu,
+			filterMenuId: SessionsViewFilterFilterSubMenu,
 			groupResults: () => this.currentGrouping,
+			sortResults: () => this.currentSorting,
 			allowedProviders: [AgentSessionProviders.Background, AgentSessionProviders.Cloud],
 			providerLabelOverrides: new Map([
 				[AgentSessionProviders.Background, localize('chat.session.providerLabel.background', "Copilot CLI")],
@@ -233,17 +243,26 @@ export class AgenticSessionsViewPane extends ViewPane {
 		this.sessionsControl?.openFind();
 	}
 
-	toggleGroupByRepository(): void {
-		if (this.currentGrouping === AgentSessionsGrouping.Repository) {
-			this.currentGrouping = AgentSessionsGrouping.Date;
-		} else {
-			this.currentGrouping = AgentSessionsGrouping.Repository;
+	setGrouping(grouping: AgentSessionsGrouping): void {
+		if (this.currentGrouping === grouping) {
+			return;
 		}
 
+		this.currentGrouping = grouping;
 		this.storageService.store(GROUPING_STORAGE_KEY, this.currentGrouping, StorageScope.PROFILE, StorageTarget.USER);
-		this.isGroupedByRepoKey?.set(this.currentGrouping === AgentSessionsGrouping.Repository);
-		// TODO @osortega: Unsure if this is going to be annoying or helpful so that you can quickly see the active sessions
+		this.groupingContextKey?.set(this.currentGrouping);
 		this.sessionsControl?.resetSectionCollapseState();
+		this.sessionsControl?.update();
+	}
+
+	setSorting(sorting: AgentSessionsSorting): void {
+		if (this.currentSorting === sorting) {
+			return;
+		}
+
+		this.currentSorting = sorting;
+		this.storageService.store(SORTING_STORAGE_KEY, this.currentSorting, StorageScope.PROFILE, StorageTarget.USER);
+		this.sortingContextKey?.set(this.currentSorting);
 		this.sessionsControl?.update();
 	}
 }
@@ -291,16 +310,25 @@ MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
 	when: ContextKeyExpr.equals('view', SessionsViewId)
 } satisfies ISubmenuItem);
 
-registerAction2(class GroupByRepositoryAction extends Action2 {
+// Nest the filter toggles (providers, statuses, properties, reset) inside a "Filter" submenu
+MenuRegistry.appendMenuItem(SessionsViewFilterSubMenu, {
+	submenu: SessionsViewFilterFilterSubMenu,
+	title: localize2('filter', "Filter"),
+	group: '1_filter',
+	order: 0,
+} satisfies ISubmenuItem);
+
+// Sort By: Created Date (radio)
+registerAction2(class SortByCreatedAction extends Action2 {
 	constructor() {
 		super({
-			id: 'sessionsView.groupByRepository',
-			title: localize2('groupByRepository', "Group by Project"),
+			id: 'sessionsView.sortByCreated',
+			title: localize2('sortByCreated', "Created Date"),
 			category: SessionsCategories.Sessions,
-			toggled: IsGroupedByRepositoryContext,
+			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Created),
 			menu: [{
 				id: SessionsViewFilterSubMenu,
-				group: 'grouping',
+				group: '2_sort',
 				order: 0,
 			}]
 		});
@@ -309,7 +337,76 @@ registerAction2(class GroupByRepositoryAction extends Action2 {
 	override run(accessor: ServicesAccessor) {
 		const viewsService = accessor.get(IViewsService);
 		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
-		view?.toggleGroupByRepository();
+		view?.setSorting(AgentSessionsSorting.Created);
+	}
+});
+
+// Sort By: Updated Date (radio)
+registerAction2(class SortByUpdatedAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.sortByUpdated',
+			title: localize2('sortByUpdated', "Updated Date"),
+			category: SessionsCategories.Sessions,
+			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Updated),
+			menu: [{
+				id: SessionsViewFilterSubMenu,
+				group: '2_sort',
+				order: 1,
+			}]
+		});
+	}
+
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
+		view?.setSorting(AgentSessionsSorting.Updated);
+	}
+});
+
+// Group By: Project (radio)
+registerAction2(class GroupByProjectAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.groupByProject',
+			title: localize2('groupByProject', "Project"),
+			category: SessionsCategories.Sessions,
+			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Repository),
+			menu: [{
+				id: SessionsViewFilterSubMenu,
+				group: '3_group',
+				order: 0,
+			}]
+		});
+	}
+
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
+		view?.setGrouping(AgentSessionsGrouping.Repository);
+	}
+});
+
+// Group By: Time (radio)
+registerAction2(class GroupByTimeAction extends Action2 {
+	constructor() {
+		super({
+			id: 'sessionsView.groupByTime',
+			title: localize2('groupByTime', "Time"),
+			category: SessionsCategories.Sessions,
+			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Date),
+			menu: [{
+				id: SessionsViewFilterSubMenu,
+				group: '3_group',
+				order: 1,
+			}]
+		});
+	}
+
+	override run(accessor: ServicesAccessor) {
+		const viewsService = accessor.get(IViewsService);
+		const view = viewsService.getViewWithId<AgenticSessionsViewPane>(SessionsViewId);
+		view?.setGrouping(AgentSessionsGrouping.Date);
 	}
 });
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -8,7 +8,7 @@ import * as DOM from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { autorun } from '../../../../base/common/observable.js';
-import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { EditorsVisibleContext } from '../../../../workbench/common/contextkeys.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -54,8 +54,8 @@ export class AgenticSessionsViewPane extends ViewPane {
 	sessionsControl: AgentSessionsControl | undefined;
 	private currentGrouping: AgentSessionsGrouping = AgentSessionsGrouping.Repository;
 	private currentSorting: AgentSessionsSorting = AgentSessionsSorting.Created;
-	private groupingContextKey: ReturnType<typeof SessionsViewGroupingContext.bindTo> | undefined;
-	private sortingContextKey: ReturnType<typeof SessionsViewSortingContext.bindTo> | undefined;
+	private groupingContextKey: IContextKey | undefined;
+	private sortingContextKey: IContextKey | undefined;
 
 	constructor(
 		options: IViewPaneOptions,

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -41,7 +41,7 @@ import { IHostService } from '../../../../workbench/services/host/browser/host.j
 const $ = DOM.$;
 export const SessionsViewId = 'agentic.workbench.view.sessionsView';
 const SessionsViewFilterSubMenu = new MenuId('AgentSessionsViewFilterSubMenu');
-const SessionsViewFilterFilterSubMenu = new MenuId('AgentSessionsViewFilterFilterSubMenu');
+const SessionsViewFilterOptionsSubMenu = new MenuId('AgentSessionsViewFilterOptionsSubMenu');
 const SessionsViewGroupingContext = new RawContextKey<string>('sessionsView.grouping', AgentSessionsGrouping.Repository);
 const SessionsViewSortingContext = new RawContextKey<string>('sessionsView.sorting', AgentSessionsSorting.Created);
 const GROUPING_STORAGE_KEY = 'agentSessions.grouping';
@@ -120,7 +120,7 @@ export class AgenticSessionsViewPane extends ViewPane {
 
 		// Sessions Filter (actions go to the nested filter submenu)
 		const sessionsFilter = this._register(this.instantiationService.createInstance(AgentSessionsFilter, {
-			filterMenuId: SessionsViewFilterFilterSubMenu,
+			filterMenuId: SessionsViewFilterOptionsSubMenu,
 			groupResults: () => this.currentGrouping,
 			sortResults: () => this.currentSorting,
 			allowedProviders: [AgentSessionProviders.Background, AgentSessionProviders.Cloud],
@@ -312,7 +312,7 @@ MenuRegistry.appendMenuItem(MenuId.ViewTitle, {
 
 // Nest the filter toggles (providers, statuses, properties, reset) inside a "Filter" submenu
 MenuRegistry.appendMenuItem(SessionsViewFilterSubMenu, {
-	submenu: SessionsViewFilterFilterSubMenu,
+	submenu: SessionsViewFilterOptionsSubMenu,
 	title: localize2('filter', "Filter"),
 	group: '1_filter',
 	order: 0,

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -323,7 +323,7 @@ registerAction2(class SortByCreatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByCreated',
-			title: localize2('sortByCreated', "Created Date"),
+			title: localize2('sortByCreated', "Sort by: Created Date"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Created),
 			menu: [{
@@ -346,7 +346,7 @@ registerAction2(class SortByUpdatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByUpdated',
-			title: localize2('sortByUpdated', "Updated Date"),
+			title: localize2('sortByUpdated', "Sort by: Updated Date"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Updated),
 			menu: [{
@@ -369,7 +369,7 @@ registerAction2(class GroupByProjectAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.groupByProject',
-			title: localize2('groupByProject', "Project"),
+			title: localize2('groupByProject', "Group by: Project"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Repository),
 			menu: [{
@@ -392,7 +392,7 @@ registerAction2(class GroupByTimeAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.groupByTime',
-			title: localize2('groupByTime', "Time"),
+			title: localize2('groupByTime', "Group by: Time"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Date),
 			menu: [{

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -323,7 +323,7 @@ registerAction2(class SortByCreatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByCreated',
-			title: localize2('sortByCreated', "Sort by Created Date"),
+			title: localize2('sortByCreated', "Sort by Created"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Created),
 			menu: [{
@@ -346,7 +346,7 @@ registerAction2(class SortByUpdatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByUpdated',
-			title: localize2('sortByUpdated', "Sort by Updated Date"),
+			title: localize2('sortByUpdated', "Sort by Updated"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Updated),
 			menu: [{

--- a/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts
@@ -323,7 +323,7 @@ registerAction2(class SortByCreatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByCreated',
-			title: localize2('sortByCreated', "Sort by: Created Date"),
+			title: localize2('sortByCreated', "Sort by Created Date"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Created),
 			menu: [{
@@ -346,7 +346,7 @@ registerAction2(class SortByUpdatedAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.sortByUpdated',
-			title: localize2('sortByUpdated', "Sort by: Updated Date"),
+			title: localize2('sortByUpdated', "Sort by Updated Date"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewSortingContext.key, AgentSessionsSorting.Updated),
 			menu: [{
@@ -369,7 +369,7 @@ registerAction2(class GroupByProjectAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.groupByProject',
-			title: localize2('groupByProject', "Group by: Project"),
+			title: localize2('groupByProject', "Group by Project"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Repository),
 			menu: [{
@@ -392,7 +392,7 @@ registerAction2(class GroupByTimeAction extends Action2 {
 	constructor() {
 		super({
 			id: 'sessionsView.groupByTime',
-			title: localize2('groupByTime', "Group by: Time"),
+			title: localize2('groupByTime', "Group by Time"),
 			category: SessionsCategories.Sessions,
 			toggled: ContextKeyExpr.equals(SessionsViewGroupingContext.key, AgentSessionsGrouping.Date),
 			menu: [{

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -252,7 +252,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 			return false;
 		};
 
-		const sorter = new AgentSessionsSorter();
+		const sorter = new AgentSessionsSorter(() => this.options.filter.sortResults?.() ?? AgentSessionsSorting.Created);
 		const approvalModel = this.options.enableApprovalRow ? this._register(this.instantiationService.createInstance(AgentSessionApprovalModel)) : undefined;
 		const activeSessionResource = observableValue<URI | undefined>(this, undefined);
 		const sessionRenderer = this._register(this.instantiationService.createInstance(AgentSessionRenderer, {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl.ts
@@ -14,7 +14,7 @@ import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { localize } from '../../../../../nls.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, IMarshalledAgentSessionContext, isAgentSession, isAgentSessionSection } from './agentSessionsModel.js';
 import { AgentSessionListItem, AgentSessionRenderer, AgentSessionsAccessibilityProvider, AgentSessionsCompressionDelegate, AgentSessionsDataSource, AgentSessionsDragAndDrop, AgentSessionsIdentityProvider, AgentSessionsKeyboardNavigationLabelProvider, AgentSessionsListDelegate, AgentSessionSectionRenderer, AgentSessionSectionLabels, AgentSessionsSorter, getRepositoryName, IAgentSessionsFilter } from './agentSessionsViewer.js';
-import { AgentSessionsGrouping } from './agentSessionsFilter.js';
+import { AgentSessionsGrouping, AgentSessionsSorting } from './agentSessionsFilter.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { FuzzyScore } from '../../../../../base/common/filters.js';
 import { IMenuService, MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -258,6 +258,7 @@ export class AgentSessionsControl extends Disposable implements IAgentSessionsCo
 		const sessionRenderer = this._register(this.instantiationService.createInstance(AgentSessionRenderer, {
 			...this.options,
 			isGroupedByRepository: () => this.options.filter.groupResults?.() === AgentSessionsGrouping.Repository,
+			isSortedByUpdated: () => this.options.filter.sortResults?.() === AgentSessionsSorting.Updated,
 		}, approvalModel, activeSessionResource));
 		const sessionFilter = this._register(new AgentSessionsDataSource(this.options.filter, sorter));
 		const list = this.sessionsList = this._register(this.instantiationService.createInstance(WorkbenchCompressibleAsyncDataTree,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -21,6 +21,11 @@ export enum AgentSessionsGrouping {
 	Repository = 'repository'
 }
 
+export enum AgentSessionsSorting {
+	Created = 'created',
+	Updated = 'updated'
+}
+
 export interface IAgentSessionsFilterOptions extends Partial<IAgentSessionsFilter> {
 
 	readonly filterMenuId?: MenuId;
@@ -41,6 +46,7 @@ export interface IAgentSessionsFilterOptions extends Partial<IAgentSessionsFilte
 	notifyResults?(count: number): void;
 
 	readonly groupResults?: () => AgentSessionsGrouping | undefined;
+	readonly sortResults?: () => AgentSessionsSorting | undefined;
 
 	overrideExclude?(session: IAgentSession): boolean | undefined;
 }
@@ -61,6 +67,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 
 	readonly limitResults = () => this.options.limitResults?.();
 	readonly groupResults = () => this.options.groupResults?.();
+	readonly sortResults = () => this.options.sortResults?.();
 
 	private excludes = DEFAULT_EXCLUDES;
 	private isStoringExcludes = false;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsFilter.ts
@@ -286,7 +286,7 @@ export class AgentSessionsFilter extends Disposable implements Required<IAgentSe
 			constructor() {
 				super({
 					id: `agentSessions.filter.resetExcludes.${menuId.id.toLowerCase()}`,
-					title: localize('agentSessions.filter.reset', "Reset Filter"),
+					title: localize('agentSessions.filter.reset', "Reset"),
 					menu: {
 						id: menuId,
 						group: '4_reset',

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -1148,7 +1148,7 @@ export function groupAgentSessionsByDate(sessions: IAgentSession[], sortBy?: Age
 			pinnedSessions.push(session);
 		} else {
 			const sessionTime = sortBy === AgentSessionsSorting.Updated
-				? session.timing.lastRequestStarted ?? session.timing.created
+				? session.timing.lastRequestEnded ?? session.timing.created
 				: session.timing.created;
 			if (sessionTime >= startOfToday) {
 				todaySessions.push(session);
@@ -1271,8 +1271,8 @@ export class AgentSessionsSorter implements ITreeSorter<IAgentSession> {
 
 		// Sort by time
 		const useUpdated = this.sortBy === AgentSessionsSorting.Updated || prioritizeActiveSessions;
-		const timeA = useUpdated ? sessionA.timing.lastRequestStarted ?? sessionA.timing.created : sessionA.timing.created;
-		const timeB = useUpdated ? sessionB.timing.lastRequestStarted ?? sessionB.timing.created : sessionB.timing.created;
+		const timeA = useUpdated ? sessionA.timing.lastRequestEnded ?? sessionA.timing.created : sessionA.timing.created;
+		const timeB = useUpdated ? sessionB.timing.lastRequestEnded ?? sessionB.timing.created : sessionB.timing.created;
 		return timeB - timeA;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -42,7 +42,7 @@ import { renderAsPlaintext } from '../../../../../base/browser/markdownRenderer.
 import { MarkdownString, IMarkdownString } from '../../../../../base/common/htmlContent.js';
 import { AgentSessionHoverWidget } from './agentSessionHoverWidget.js';
 import { AgentSessionProviders } from './agentSessions.js';
-import { AgentSessionsGrouping } from './agentSessionsFilter.js';
+import { AgentSessionsGrouping, AgentSessionsSorting } from './agentSessionsFilter.js';
 import { autorun, IObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { Button } from '../../../../../base/browser/ui/button/button.js';
@@ -722,6 +722,12 @@ export interface IAgentSessionsFilter {
 	readonly groupResults?: () => AgentSessionsGrouping | undefined;
 
 	/**
+	 * The field to sort sessions by.
+	 * Defaults to created date when undefined.
+	 */
+	readonly sortResults?: () => AgentSessionsSorting | undefined;
+
+	/**
 	 * A callback to notify the filter about the number of
 	 * results after filtering.
 	 */
@@ -784,6 +790,11 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 		// Sessions model
 		if (isAgentSessionsModel(element)) {
+
+			// Sync sort preference to sorter
+			if (this.sorter instanceof AgentSessionsSorter) {
+				this.sorter.sortBy = this.filter?.sortResults?.() ?? AgentSessionsSorting.Created;
+			}
 
 			// Apply filter if configured
 			let filteredSessions = element.sessions.filter(session => !this.filter?.exclude(session));
@@ -878,7 +889,8 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 	private groupSessionsByDate(sortedSessions: IAgentSession[]): AgentSessionListItem[] {
 		const result: AgentSessionListItem[] = [];
-		const groupedSessions = groupAgentSessionsByDate(sortedSessions);
+		const sortBy = this.filter?.sortResults?.();
+		const groupedSessions = groupAgentSessionsByDate(sortedSessions, sortBy);
 
 		for (const { sessions, section, label } of groupedSessions.values()) {
 			if (sessions.length === 0) {
@@ -1116,7 +1128,7 @@ export const AgentSessionSectionLabels = {
 const DAY_THRESHOLD = 24 * 60 * 60 * 1000;
 const WEEK_THRESHOLD = 7 * DAY_THRESHOLD;
 
-export function groupAgentSessionsByDate(sessions: IAgentSession[]): Map<AgentSessionSection, IAgentSessionSection> {
+export function groupAgentSessionsByDate(sessions: IAgentSession[], sortBy?: AgentSessionsSorting): Map<AgentSessionSection, IAgentSessionSection> {
 	const now = Date.now();
 	const startOfToday = new Date(now).setHours(0, 0, 0, 0);
 	const startOfYesterday = startOfToday - DAY_THRESHOLD;
@@ -1135,7 +1147,9 @@ export function groupAgentSessionsByDate(sessions: IAgentSession[]): Map<AgentSe
 		} else if (session.isPinned()) {
 			pinnedSessions.push(session);
 		} else {
-			const sessionTime = session.timing.created;
+			const sessionTime = sortBy === AgentSessionsSorting.Updated
+				? session.timing.lastRequestStarted ?? session.timing.created
+				: session.timing.created;
 			if (sessionTime >= startOfToday) {
 				todaySessions.push(session);
 			} else if (sessionTime >= startOfYesterday) {
@@ -1216,6 +1230,8 @@ export class AgentSessionsCompressionDelegate implements ITreeCompressionDelegat
 
 export class AgentSessionsSorter implements ITreeSorter<IAgentSession> {
 
+	sortBy: AgentSessionsSorting = AgentSessionsSorting.Created;
+
 	compare(sessionA: IAgentSession, sessionB: IAgentSession, prioritizeActiveSessions = false): number {
 
 		// Special sorting if enabled
@@ -1254,8 +1270,9 @@ export class AgentSessionsSorter implements ITreeSorter<IAgentSession> {
 		}
 
 		// Sort by time
-		const timeA = prioritizeActiveSessions ? sessionA.timing.lastRequestStarted ?? sessionA.timing.created : sessionA.timing.created;
-		const timeB = prioritizeActiveSessions ? sessionB.timing.lastRequestStarted ?? sessionB.timing.created : sessionB.timing.created;
+		const useUpdated = this.sortBy === AgentSessionsSorting.Updated || prioritizeActiveSessions;
+		const timeA = useUpdated ? sessionA.timing.lastRequestStarted ?? sessionA.timing.created : sessionA.timing.created;
+		const timeB = useUpdated ? sessionB.timing.lastRequestStarted ?? sessionB.timing.created : sessionB.timing.created;
 		return timeB - timeA;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -794,11 +794,6 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		// Sessions model
 		if (isAgentSessionsModel(element)) {
 
-			// Sync sort preference to sorter
-			if (this.sorter instanceof AgentSessionsSorter) {
-				this.sorter.sortBy = this.filter?.sortResults?.() ?? AgentSessionsSorting.Created;
-			}
-
 			// Apply filter if configured
 			let filteredSessions = element.sessions.filter(session => !this.filter?.exclude(session));
 
@@ -1233,7 +1228,11 @@ export class AgentSessionsCompressionDelegate implements ITreeCompressionDelegat
 
 export class AgentSessionsSorter implements ITreeSorter<IAgentSession> {
 
-	sortBy: AgentSessionsSorting = AgentSessionsSorting.Created;
+	private readonly getSortBy: () => AgentSessionsSorting;
+
+	constructor(getSortBy?: () => AgentSessionsSorting) {
+		this.getSortBy = getSortBy ?? (() => AgentSessionsSorting.Created);
+	}
 
 	compare(sessionA: IAgentSession, sessionB: IAgentSession, prioritizeActiveSessions = false): number {
 
@@ -1273,9 +1272,17 @@ export class AgentSessionsSorter implements ITreeSorter<IAgentSession> {
 		}
 
 		// Sort by time
-		const useUpdated = this.sortBy === AgentSessionsSorting.Updated || prioritizeActiveSessions;
-		const timeA = useUpdated ? sessionA.timing.lastRequestEnded ?? sessionA.timing.created : sessionA.timing.created;
-		const timeB = useUpdated ? sessionB.timing.lastRequestEnded ?? sessionB.timing.created : sessionB.timing.created;
+		const sortBy = this.getSortBy();
+		const timeA = prioritizeActiveSessions
+			? sessionA.timing.lastRequestStarted ?? sessionA.timing.created
+			: sortBy === AgentSessionsSorting.Updated
+				? sessionA.timing.lastRequestEnded ?? sessionA.timing.created
+				: sessionA.timing.created;
+		const timeB = prioritizeActiveSessions
+			? sessionB.timing.lastRequestStarted ?? sessionB.timing.created
+			: sortBy === AgentSessionsSorting.Updated
+				? sessionB.timing.lastRequestEnded ?? sessionB.timing.created
+				: sessionB.timing.created;
 		return timeB - timeA;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -88,6 +88,7 @@ interface IAgentSessionItemTemplate {
 export interface IAgentSessionRendererOptions {
 	readonly disableHover?: boolean;
 	getHoverPosition(): HoverPosition;
+
 	isGroupedByRepository?(): boolean;
 	isSortedByUpdated?(): boolean;
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -89,6 +89,7 @@ export interface IAgentSessionRendererOptions {
 	readonly disableHover?: boolean;
 	getHoverPosition(): HoverPosition;
 	isGroupedByRepository?(): boolean;
+	isSortedByUpdated?(): boolean;
 }
 
 export class AgentSessionRenderer extends Disposable implements ICompressibleTreeRenderer<IAgentSession, FuzzyScore, IAgentSessionItemTemplate> {
@@ -414,7 +415,9 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			}
 
 			if (!timeLabel) {
-				const date = session.timing.created;
+				const date = this.options.isSortedByUpdated?.()
+					? session.timing.lastRequestEnded ?? session.timing.created
+					: session.timing.created;
 				const seconds = Math.round((new Date().getTime() - date) / 1000);
 				if (seconds < 60) {
 					timeLabel = localize('secondsDuration', "now");

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -1142,9 +1142,9 @@ suite('AgentSessionsSorter', () => {
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session active', 'Session archived']);
 	});
 
-	test('prioritizeActive: uses lastRequestEnded for time sorting', () => {
+	test('prioritizeActive: uses lastRequestStarted for time sorting', () => {
 		const sorter = new AgentSessionsSorter();
-		const recentlyActive = createSession({ id: 'recent-active', created: 1000, lastRequestEnded: 5000 });
+		const recentlyActive = createSession({ id: 'recent-active', created: 1000, lastRequestStarted: 5000 });
 		const recentlyCreated = createSession({ id: 'recent-created', created: 3000 });
 
 		const sorted = [recentlyCreated, recentlyActive].sort((a, b) => sorter.compare(a, b, true));
@@ -1170,8 +1170,7 @@ suite('AgentSessionsSorter', () => {
 	});
 
 	test('sortBy Created: sorts by creation time regardless of lastRequestEnded', () => {
-		const sorter = new AgentSessionsSorter();
-		sorter.sortBy = AgentSessionsSorting.Created;
+		const sorter = new AgentSessionsSorter(() => AgentSessionsSorting.Created);
 		const olderCreated = createSession({ id: 'older', created: 1000, lastRequestEnded: 5000 });
 		const newerCreated = createSession({ id: 'newer', created: 3000, lastRequestEnded: 2000 });
 
@@ -1180,8 +1179,7 @@ suite('AgentSessionsSorter', () => {
 	});
 
 	test('sortBy Updated: sorts by lastRequestEnded', () => {
-		const sorter = new AgentSessionsSorter();
-		sorter.sortBy = AgentSessionsSorting.Updated;
+		const sorter = new AgentSessionsSorter(() => AgentSessionsSorting.Updated);
 		const recentlyUpdated = createSession({ id: 'updated', created: 1000, lastRequestEnded: 5000 });
 		const recentlyCreated = createSession({ id: 'created', created: 3000, lastRequestEnded: 2000 });
 
@@ -1190,8 +1188,7 @@ suite('AgentSessionsSorter', () => {
 	});
 
 	test('sortBy Updated: falls back to created when lastRequestEnded is undefined', () => {
-		const sorter = new AgentSessionsSorter();
-		sorter.sortBy = AgentSessionsSorting.Updated;
+		const sorter = new AgentSessionsSorter(() => AgentSessionsSorting.Updated);
 		const withRequest = createSession({ id: 'with-request', created: 1000, lastRequestEnded: 3000 });
 		const withoutRequest = createSession({ id: 'no-request', created: 4000 });
 

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -1070,6 +1070,7 @@ suite('AgentSessionsSorter', () => {
 		isPinned: boolean;
 		created: number;
 		lastRequestStarted: number;
+		lastRequestEnded: number;
 	}>): IAgentSession {
 		const now = Date.now();
 		return {
@@ -1081,7 +1082,7 @@ suite('AgentSessionsSorter', () => {
 			icon: Codicon.terminal,
 			timing: {
 				created: overrides.created ?? now,
-				lastRequestEnded: undefined,
+				lastRequestEnded: overrides.lastRequestEnded,
 				lastRequestStarted: overrides.lastRequestStarted,
 			},
 			changes: undefined,
@@ -1141,9 +1142,9 @@ suite('AgentSessionsSorter', () => {
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session active', 'Session archived']);
 	});
 
-	test('prioritizeActive: uses lastRequestStarted for time sorting', () => {
+	test('prioritizeActive: uses lastRequestEnded for time sorting', () => {
 		const sorter = new AgentSessionsSorter();
-		const recentlyActive = createSession({ id: 'recent-active', created: 1000, lastRequestStarted: 5000 });
+		const recentlyActive = createSession({ id: 'recent-active', created: 1000, lastRequestEnded: 5000 });
 		const recentlyCreated = createSession({ id: 'recent-created', created: 3000 });
 
 		const sorted = [recentlyCreated, recentlyActive].sort((a, b) => sorter.compare(a, b, true));
@@ -1168,30 +1169,30 @@ suite('AgentSessionsSorter', () => {
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session regular', 'Session archived-pinned']);
 	});
 
-	test('sortBy Created: sorts by creation time regardless of lastRequestStarted', () => {
+	test('sortBy Created: sorts by creation time regardless of lastRequestEnded', () => {
 		const sorter = new AgentSessionsSorter();
 		sorter.sortBy = AgentSessionsSorting.Created;
-		const olderCreated = createSession({ id: 'older', created: 1000, lastRequestStarted: 5000 });
-		const newerCreated = createSession({ id: 'newer', created: 3000, lastRequestStarted: 2000 });
+		const olderCreated = createSession({ id: 'older', created: 1000, lastRequestEnded: 5000 });
+		const newerCreated = createSession({ id: 'newer', created: 3000, lastRequestEnded: 2000 });
 
 		const sorted = [olderCreated, newerCreated].sort((a, b) => sorter.compare(a, b));
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session newer', 'Session older']);
 	});
 
-	test('sortBy Updated: sorts by lastRequestStarted', () => {
+	test('sortBy Updated: sorts by lastRequestEnded', () => {
 		const sorter = new AgentSessionsSorter();
 		sorter.sortBy = AgentSessionsSorting.Updated;
-		const recentlyUpdated = createSession({ id: 'updated', created: 1000, lastRequestStarted: 5000 });
-		const recentlyCreated = createSession({ id: 'created', created: 3000, lastRequestStarted: 2000 });
+		const recentlyUpdated = createSession({ id: 'updated', created: 1000, lastRequestEnded: 5000 });
+		const recentlyCreated = createSession({ id: 'created', created: 3000, lastRequestEnded: 2000 });
 
 		const sorted = [recentlyCreated, recentlyUpdated].sort((a, b) => sorter.compare(a, b));
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session updated', 'Session created']);
 	});
 
-	test('sortBy Updated: falls back to created when lastRequestStarted is undefined', () => {
+	test('sortBy Updated: falls back to created when lastRequestEnded is undefined', () => {
 		const sorter = new AgentSessionsSorter();
 		sorter.sortBy = AgentSessionsSorting.Updated;
-		const withRequest = createSession({ id: 'with-request', created: 1000, lastRequestStarted: 3000 });
+		const withRequest = createSession({ id: 'with-request', created: 1000, lastRequestEnded: 3000 });
 		const withoutRequest = createSession({ id: 'no-request', created: 4000 });
 
 		const sorted = [withRequest, withoutRequest].sort((a, b) => sorter.compare(a, b));
@@ -1208,7 +1209,7 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		isArchived: boolean;
 		isPinned: boolean;
 		created: number;
-		lastRequestStarted: number;
+		lastRequestEnded: number;
 	}>): IAgentSession {
 		return {
 			providerType: 'test',
@@ -1219,8 +1220,8 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 			icon: Codicon.terminal,
 			timing: {
 				created: overrides.created ?? Date.now(),
-				lastRequestEnded: undefined,
-				lastRequestStarted: overrides.lastRequestStarted,
+				lastRequestEnded: overrides.lastRequestEnded,
+				lastRequestStarted: undefined,
 			},
 			changes: undefined,
 			metadata: undefined,
@@ -1238,7 +1239,7 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		const now = Date.now();
 		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
 
-		const oldSession = createSession({ id: 'old', created: tenDaysAgo, lastRequestStarted: now });
+		const oldSession = createSession({ id: 'old', created: tenDaysAgo, lastRequestEnded: now });
 
 		const grouped = groupAgentSessionsByDate([oldSession]);
 		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
@@ -1252,7 +1253,7 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		const now = Date.now();
 		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
 
-		const oldButUpdated = createSession({ id: 'old-updated', created: tenDaysAgo, lastRequestStarted: now });
+		const oldButUpdated = createSession({ id: 'old-updated', created: tenDaysAgo, lastRequestEnded: now });
 
 		const grouped = groupAgentSessionsByDate([oldButUpdated], AgentSessionsSorting.Updated);
 		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
@@ -1262,7 +1263,7 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		assert.deepStrictEqual(olderSessions.length, 0);
 	});
 
-	test('Updated: falls back to created when lastRequestStarted is undefined', () => {
+	test('Updated: falls back to created when lastRequestEnded is undefined', () => {
 		const now = Date.now();
 		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
 
@@ -1280,8 +1281,8 @@ suite('groupAgentSessionsByDate with sortBy', () => {
 		const now = Date.now();
 		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
 
-		const pinnedOld = createSession({ id: 'pinned', created: tenDaysAgo, lastRequestStarted: now, isPinned: true });
-		const archivedOld = createSession({ id: 'archived', created: tenDaysAgo, lastRequestStarted: now, isArchived: true });
+		const pinnedOld = createSession({ id: 'pinned', created: tenDaysAgo, lastRequestEnded: now, isPinned: true });
+		const archivedOld = createSession({ id: 'archived', created: tenDaysAgo, lastRequestEnded: now, isArchived: true });
 
 		const grouped = groupAgentSessionsByDate([pinnedOld, archivedOld], AgentSessionsSorting.Updated);
 		const pinnedSessions = grouped.get(AgentSessionSection.Pinned)!.sessions;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -6,7 +6,7 @@
 import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter } from '../../../browser/agentSessions/agentSessionsViewer.js';
+import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate } from '../../../browser/agentSessions/agentSessionsViewer.js';
 import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSessionSection } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
@@ -1196,5 +1196,100 @@ suite('AgentSessionsSorter', () => {
 
 		const sorted = [withRequest, withoutRequest].sort((a, b) => sorter.compare(a, b));
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session no-request', 'Session with-request']);
+	});
+});
+
+suite('groupAgentSessionsByDate with sortBy', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createSession(overrides: Partial<{
+		id: string;
+		isArchived: boolean;
+		isPinned: boolean;
+		created: number;
+		lastRequestStarted: number;
+	}>): IAgentSession {
+		return {
+			providerType: 'test',
+			providerLabel: 'Test',
+			resource: URI.parse(`test://session/${overrides.id ?? 'default'}`),
+			status: ChatSessionStatus.Completed,
+			label: `Session ${overrides.id ?? 'default'}`,
+			icon: Codicon.terminal,
+			timing: {
+				created: overrides.created ?? Date.now(),
+				lastRequestEnded: undefined,
+				lastRequestStarted: overrides.lastRequestStarted,
+			},
+			changes: undefined,
+			metadata: undefined,
+			isArchived: () => overrides.isArchived ?? false,
+			setArchived: () => { },
+			isPinned: () => overrides.isPinned ?? false,
+			setPinned: () => { },
+			isRead: () => true,
+			isMarkedUnread: () => false,
+			setRead: () => { },
+		};
+	}
+
+	test('default (Created): buckets by created time', () => {
+		const now = Date.now();
+		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+
+		const oldSession = createSession({ id: 'old', created: tenDaysAgo, lastRequestStarted: now });
+
+		const grouped = groupAgentSessionsByDate([oldSession]);
+		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
+		const olderSessions = grouped.get(AgentSessionSection.Older)!.sessions;
+
+		assert.deepStrictEqual(todaySessions.length, 0);
+		assert.deepStrictEqual(olderSessions.length, 1);
+	});
+
+	test('Updated: session created long ago but recently updated goes into Today', () => {
+		const now = Date.now();
+		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+
+		const oldButUpdated = createSession({ id: 'old-updated', created: tenDaysAgo, lastRequestStarted: now });
+
+		const grouped = groupAgentSessionsByDate([oldButUpdated], AgentSessionsSorting.Updated);
+		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
+		const olderSessions = grouped.get(AgentSessionSection.Older)!.sessions;
+
+		assert.deepStrictEqual(todaySessions.length, 1);
+		assert.deepStrictEqual(olderSessions.length, 0);
+	});
+
+	test('Updated: falls back to created when lastRequestStarted is undefined', () => {
+		const now = Date.now();
+		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+
+		const oldNoUpdate = createSession({ id: 'old-no-update', created: tenDaysAgo });
+
+		const grouped = groupAgentSessionsByDate([oldNoUpdate], AgentSessionsSorting.Updated);
+		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
+		const olderSessions = grouped.get(AgentSessionSection.Older)!.sessions;
+
+		assert.deepStrictEqual(todaySessions.length, 0);
+		assert.deepStrictEqual(olderSessions.length, 1);
+	});
+
+	test('Updated: pinned and archived sessions are not affected by sortBy', () => {
+		const now = Date.now();
+		const tenDaysAgo = now - 10 * 24 * 60 * 60 * 1000;
+
+		const pinnedOld = createSession({ id: 'pinned', created: tenDaysAgo, lastRequestStarted: now, isPinned: true });
+		const archivedOld = createSession({ id: 'archived', created: tenDaysAgo, lastRequestStarted: now, isArchived: true });
+
+		const grouped = groupAgentSessionsByDate([pinnedOld, archivedOld], AgentSessionsSorting.Updated);
+		const pinnedSessions = grouped.get(AgentSessionSection.Pinned)!.sessions;
+		const archivedSessions = grouped.get(AgentSessionSection.Archived)!.sessions;
+		const todaySessions = grouped.get(AgentSessionSection.Today)!.sessions;
+
+		assert.deepStrictEqual(pinnedSessions.length, 1);
+		assert.deepStrictEqual(archivedSessions.length, 1);
+		assert.deepStrictEqual(todaySessions.length, 0);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -12,7 +12,7 @@ import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { AgentSessionsGrouping } from '../../../browser/agentSessions/agentSessionsFilter.js';
+import { AgentSessionsGrouping, AgentSessionsSorting } from '../../../browser/agentSessions/agentSessionsFilter.js';
 
 suite('sessionDateFromNow', () => {
 
@@ -1166,5 +1166,35 @@ suite('AgentSessionsSorter', () => {
 
 		const sorted = [archivedPinned, regular].sort((a, b) => sorter.compare(a, b));
 		assert.deepStrictEqual(sorted.map(s => s.label), ['Session regular', 'Session archived-pinned']);
+	});
+
+	test('sortBy Created: sorts by creation time regardless of lastRequestStarted', () => {
+		const sorter = new AgentSessionsSorter();
+		sorter.sortBy = AgentSessionsSorting.Created;
+		const olderCreated = createSession({ id: 'older', created: 1000, lastRequestStarted: 5000 });
+		const newerCreated = createSession({ id: 'newer', created: 3000, lastRequestStarted: 2000 });
+
+		const sorted = [olderCreated, newerCreated].sort((a, b) => sorter.compare(a, b));
+		assert.deepStrictEqual(sorted.map(s => s.label), ['Session newer', 'Session older']);
+	});
+
+	test('sortBy Updated: sorts by lastRequestStarted', () => {
+		const sorter = new AgentSessionsSorter();
+		sorter.sortBy = AgentSessionsSorting.Updated;
+		const recentlyUpdated = createSession({ id: 'updated', created: 1000, lastRequestStarted: 5000 });
+		const recentlyCreated = createSession({ id: 'created', created: 3000, lastRequestStarted: 2000 });
+
+		const sorted = [recentlyCreated, recentlyUpdated].sort((a, b) => sorter.compare(a, b));
+		assert.deepStrictEqual(sorted.map(s => s.label), ['Session updated', 'Session created']);
+	});
+
+	test('sortBy Updated: falls back to created when lastRequestStarted is undefined', () => {
+		const sorter = new AgentSessionsSorter();
+		sorter.sortBy = AgentSessionsSorting.Updated;
+		const withRequest = createSession({ id: 'with-request', created: 1000, lastRequestStarted: 3000 });
+		const withoutRequest = createSession({ id: 'no-request', created: 4000 });
+
+		const sorted = [withRequest, withoutRequest].sort((a, b) => sorter.compare(a, b));
+		assert.deepStrictEqual(sorted.map(s => s.label), ['Session no-request', 'Session with-request']);
 	});
 });


### PR DESCRIPTION
Restructures the agent sessions settings gear menu into a proper configuration menu:

## Menu Structure
```
Settings gear menu:
├── Filter ▸ (submenu with providers, statuses, properties, reset)
├── Sort by Created Date (radio)
├── Sort by Updated Date (radio)
├── Group by Project (radio)
└── Group by Time (radio)
```

## Changes

- **Filter submenu**: Moved all filter toggles (providers, statuses, properties, reset) into a nested "Filter" submenu to declutter the top-level menu
- **Sort radios**: Added "Sort by Created Date" / "Sort by Updated Date" radio options. When sorting by updated date, sessions are ordered by `lastRequestStarted` (falling back to `created`). Date grouping buckets also respect the sort field.
- **Group radios**: Replaced the old "Group by Project" toggle with proper radio options: "Group by Project" / "Group by Time"
- **Persistence**: Both sort and group preferences are persisted to storage and restored on load
- **Tests**: Added tests for the new `sortBy` property on `AgentSessionsSorter`
