### PR TITLE
editor hover: add MenuId for marker hover status bar actions

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -139,6 +139,7 @@
 .monaco-hover .hover-row.status-bar .actions .action-container .action .icon {
 	padding-right: 4px;
 	vertical-align: middle;
+	font-size: inherit;
 }
 
 .monaco-hover .hover-row.status-bar .actions .action-container a {

--- a/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
@@ -22,6 +22,8 @@ import { CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSour
 import { MarkerController, NextMarkerAction } from '../../gotoError/browser/gotoError.js';
 import { HoverAnchor, HoverAnchorType, IEditorHoverParticipant, IEditorHoverRenderContext, IHoverPart, IRenderedHoverPart, IRenderedHoverParts, RenderedHoverParts } from './hoverTypes.js';
 import * as nls from '../../../../nls.js';
+import { IMenuService, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ITextEditorOptions } from '../../../../platform/editor/common/editor.js';
 import { IMarker, IMarkerData, MarkerSeverity } from '../../../../platform/markers/common/markers.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
@@ -65,6 +67,8 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 		@IMarkerDecorationsService private readonly _markerDecorationsService: IMarkerDecorationsService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
+		@IMenuService private readonly _menuService: IMenuService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 	) { }
 
 	public computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[]): MarkerHover[] {
@@ -206,12 +210,38 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 			}
 		}
 
+		// Menu-contributed actions (e.g. fix with inline chat)
+		const menuActions: MenuItemAction[] = [];
+		for (const [, actions] of this._menuService.getMenuActions(MenuId.MarkerHoverStatusBar, this._contextKeyService)) {
+			for (const action of actions) {
+				if (action instanceof MenuItemAction && action.enabled) {
+					menuActions.push(action);
+				}
+			}
+		}
+		const renderMenuActions = () => {
+			for (const action of menuActions) {
+				context.statusBar.addAction({
+					label: action.label,
+					commandId: action.id,
+					iconClass: action.class,
+					run: () => {
+						context.hide();
+						this._editor.setSelection(Range.lift(markerHover.range));
+						action.run();
+					}
+				});
+			}
+		};
+
 		if (!this._editor.getOption(EditorOption.readOnly)) {
 			const quickfixPlaceholderElement = context.statusBar.append($('div'));
 			if (this.recentMarkerCodeActionsInfo) {
 				if (IMarkerData.makeKey(this.recentMarkerCodeActionsInfo.marker) === IMarkerData.makeKey(markerHover.marker)) {
 					if (!this.recentMarkerCodeActionsInfo.hasCodeActions) {
-						quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");
+						if (menuActions.length === 0) {
+							quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");
+						}
 					}
 				} else {
 					this.recentMarkerCodeActionsInfo = undefined;
@@ -230,7 +260,12 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 
 				if (!this.recentMarkerCodeActionsInfo.hasCodeActions) {
 					actions.dispose();
-					quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");
+					if (menuActions.length === 0) {
+						quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");
+					} else {
+						quickfixPlaceholderElement.style.display = 'none';
+					}
+					renderMenuActions();
 					return;
 				}
 				quickfixPlaceholderElement.style.display = 'none';
@@ -274,13 +309,18 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 					});
 				}
 
+				renderMenuActions();
+
 				// Notify that the contents have changed given we added
 				// actions to the hover
 				// https://github.com/microsoft/vscode/issues/250424
 				context.onContentsChanged();
 
 			}, onUnexpectedError);
+		} else {
+			renderMenuActions();
 		}
+
 		return disposables;
 	}
 

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -309,6 +309,7 @@ export class MenuId {
 	static readonly ChatViewSessionTitleNavigationToolbar = new MenuId('ChatViewSessionTitleNavigationToolbar');
 	static readonly ChatViewSessionTitleToolbar = new MenuId('ChatViewSessionTitleToolbar');
 	static readonly ChatContextUsageActions = new MenuId('ChatContextUsageActions');
+	static readonly MarkerHoverStatusBar = new MenuId('MarkerHoverParticipant.StatusBar');
 
 	/**
 	 * Create or reuse a `MenuId` with the given identifier

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -254,6 +254,12 @@ export class FixDiagnosticsAction extends AbstractInlineChatAction {
 				group: '2_chat',
 				order: 1,
 				when: ContextKeyExpr.and(CTX_FIX_DIAGNOSTICS_ENABLED, EditorContextKeys.selectionHasDiagnostics, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+			}, {
+				id: MenuId.MarkerHoverStatusBar,
+				group: '1_fix',
+				order: 1,
+				when: ContextKeyExpr.and(CTX_FIX_DIAGNOSTICS_ENABLED, CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()),
+				precondition: null,
 			}]
 		});
 	}


### PR DESCRIPTION
This PR introduces a `MenuId.MarkerHoverStatusBar` so that workbench contributions (like inline chat's Fix action) can add actions to the marker hover status bar via the menu system.

## Changes

- **`MenuId.MarkerHoverStatusBar`** added to `actions.ts` - a new extension point for the marker hover status bar
- **`MarkerHoverParticipant`** queries this menu via `IMenuService.getMenuActions()` and renders enabled actions in the hover status bar, after Quick Fix actions
- **`FixDiagnosticsAction`** registers itself in the new menu with `precondition: null` (the hover already guarantees a diagnostic is present) and appropriate `when` guards (`CTX_FIX_DIAGNOSTICS_ENABLED`, `CTX_INLINE_CHAT_FILE_BELONGS_TO_CHAT.negate()`, plus `CTX_INLINE_CHAT_V2_ENABLED` auto-added by `AbstractInlineChatAction`)
- Before running a menu action, the editor selection is moved to the marker range so `attachDiagnostics` finds the correct diagnostic
- "No quick fixes available" message is suppressed when menu actions are present
- Icon `font-size: inherit` fix for hover status bar action icons
- Menu actions render on error rejection path too, so they are never lost

Fixes https://github.com/microsoft/vscode/issues/300857