### PR TITLE
Fix CI status widget header label vertical alignment

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
@@ -40,6 +40,7 @@
 
 .ci-status-widget-title .monaco-icon-label {
 	width: 100%;
+	height: 18px;
 }
 
 .ci-status-widget-title .monaco-icon-label-container,

--- a/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/ciStatusWidget.css
@@ -32,6 +32,8 @@
 /* Title - single line, overflow ellipsis */
 .ci-status-widget-title {
 	flex: 1;
+	display: flex;
+	align-items: center;
 	overflow: hidden;
 	color: var(--vscode-foreground);
 }


### PR DESCRIPTION
The CI status widget header label (icon + text) was not vertically centered like the collapse/expand chevron.

The twistie element already had `display: flex; align-items: center;` but the title element lacked these properties, causing its inner `monaco-icon-label` content to be misaligned.

**Fix:** Add `display: flex; align-items: center;` to `.ci-status-widget-title` to match the twistie's vertical alignment.