### PR TITLE
inlineChat: use stepped resize for input widget width

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget.ts
@@ -163,9 +163,17 @@ export class InlineChatInputWidget extends Disposable {
 			const totalWidth = contentWidth.read(r) + editorPad + toolbarWidth.read(r);
 			const minWidth = 220;
 			const maxWidth = 600;
-			const clampedWidth = this._input.getOption(EditorOption.wordWrap) === 'on'
-				? maxWidth
-				: Math.max(minWidth, Math.min(totalWidth, maxWidth));
+			const midWidth = Math.round(maxWidth / 1.618);
+			let clampedWidth: number;
+			if (this._input.getOption(EditorOption.wordWrap) === 'on') {
+				clampedWidth = maxWidth;
+			} else if (totalWidth <= minWidth) {
+				clampedWidth = minWidth;
+			} else if (totalWidth <= midWidth) {
+				clampedWidth = midWidth;
+			} else {
+				clampedWidth = maxWidth;
+			}
 
 			const lineHeight = this._input.getOption(EditorOption.lineHeight);
 			const clampedHeight = Math.min(contentHeight.read(r), (3 * lineHeight));


### PR DESCRIPTION
This changes the inline chat input widget width to resize in discrete steps rather than continuously growing with content.

**Before:** The widget grew pixel-by-pixel from `minWidth` (220px) to `maxWidth` (600px) as the user typed, causing constant relayout.

**After:** The widget snaps between three sizes using the golden ratio:
- `minWidth` = 220px (initial)
- `midWidth` = ~371px (600 / 1.618)
- `maxWidth` = 600px (with word wrap enabled)

This reduces visual jitter by limiting the resize to at most two transitions instead of continuous growth.