### PR TITLE
Sessions: Add session count display to agent session sections

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -573,6 +573,7 @@ export function toStatusLabel(status: AgentSessionStatus): string {
 interface IAgentSessionSectionTemplate {
 	readonly container: HTMLElement;
 	readonly label: HTMLSpanElement;
+	readonly count: HTMLSpanElement;
 	readonly toolbar: MenuWorkbenchToolBar;
 	readonly contextKeyService: IContextKeyService;
 	readonly disposables: IDisposable;
@@ -596,6 +597,7 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 			'div.agent-session-section@container',
 			[
 				h('span.agent-session-section-label@label'),
+				h('span.agent-session-section-count@count'),
 				h('div.agent-session-section-toolbar@toolbar')
 			]
 		);
@@ -611,6 +613,7 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 		return {
 			container: elements.container,
 			label: elements.label,
+			count: elements.count,
 			toolbar,
 			contextKeyService,
 			disposables
@@ -621,6 +624,9 @@ export class AgentSessionSectionRenderer implements ICompressibleTreeRenderer<IA
 
 		// Label
 		template.label.textContent = element.element.label;
+
+		// Count
+		template.count.textContent = String(element.element.sessions.length);
 
 		// Toolbar
 		ChatContextKeys.agentSessionSection.bindTo(template.contextKeyService).set(element.element.section);
@@ -691,7 +697,7 @@ export class AgentSessionsAccessibilityProvider implements IListAccessibilityPro
 
 	getAriaLabel(element: AgentSessionListItem): string | null {
 		if (isAgentSessionSection(element)) {
-			return localize('agentSessionSectionAriaLabel', "{0} sessions section", element.label);
+			return localize('agentSessionSectionAriaLabel', "{0} sessions section, {1} sessions", element.label, element.sessions.length);
 		}
 
 		return localize('agentSessionItemAriaLabel', "{0} session {1} ({2}), created {3}", element.providerLabel, element.label, toStatusLabel(element.status), new Date(element.timing.created).toLocaleString());

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -318,6 +318,11 @@
 			flex: 1;
 		}
 
+		.agent-session-section-count {
+			opacity: 0.7;
+			margin-right: 4px;
+		}
+
 		.agent-session-section-toolbar {
 			/* for the absolute positioning of the toolbar below */
 			position: relative;
@@ -330,6 +335,11 @@
 				display: none;
 			}
 		}
+	}
+
+	.monaco-list-row:hover .agent-session-section .agent-session-section-count,
+	.monaco-list-row.focused:not(.selected) .agent-session-section .agent-session-section-count {
+		display: none;
 	}
 
 	.monaco-list-row:hover .agent-session-section .agent-session-section-toolbar,


### PR DESCRIPTION
Introduce a display for the session count in the agent session sections. This enhancement improves visibility of the number of sessions associated with each section. Update the accessibility label to reflect the session count for better screen reader support. Adjust CSS for proper styling of the new count display. Testing involves verifying the session count appears correctly in the UI and is announced by screen readers.

