### PR TITLE
Fix quick diff false modifications on files with identical lines

### DIFF
--- a/src/vs/editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.ts
+++ b/src/vs/editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.ts
@@ -25,7 +25,7 @@ export class DefaultLinesDiffComputer implements ILinesDiffComputer {
 	private readonly myersDiffingAlgorithm = new MyersDiffAlgorithm();
 
 	computeDiff(originalLines: string[], modifiedLines: string[], options: ILinesDiffComputerOptions): LinesDiff {
-		if (originalLines.length <= 1 && equals(originalLines, modifiedLines, (a, b) => a === b)) {
+		if (equals(originalLines, modifiedLines, (a, b) => a === b)) {
 			return new LinesDiff([], [], false);
 		}
 

--- a/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffModel.ts
@@ -339,7 +339,11 @@ export class QuickDiffModel extends Disposable {
 			computeMoves: false, ignoreTrimWhitespace, maxComputationTimeMs
 		}, this.options.algorithm);
 
-		return { changes: result ? toLineChanges(DiffState.fromDiffResult(result)) : null, changes2: result?.changes ?? null };
+		if (!result || result.quitEarly) {
+			return { changes: null, changes2: null };
+		}
+
+		return { changes: toLineChanges(DiffState.fromDiffResult(result)), changes2: result.changes };
 	}
 
 	private getQuickDiffsPromise(): Promise<QuickDiff[]> {


### PR DESCRIPTION
Fixes #253704

When a file has many identical lines (400+), the diff algorithm's O(n^2) DP computation can exceed the 1000ms timeout. On timeout, `trivialTimedOut` returns a single diff covering the entire file, causing the gutter to show all lines as modified.

**Changes:**

- Extend the identity early-out in `DefaultLinesDiffComputer` to files of any size (was limited to <= 1 line), skipping the expensive DP computation for identical content
- Check `quitEarly` in `QuickDiffModel._diff()` and discard timed-out results instead of displaying incorrect decorations