### PR TITLE
event: classify listener leak errors as dominated or popular

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -1029,7 +1029,8 @@ class LeakageMonitor {
 			console.warn(message);
 			console.warn(topStack);
 
-			const error = new ListenerLeakError(message, topStack);
+			const kind = topCount / listenerCount > 0.3 ? 'dominated' : 'popular';
+			const error = new ListenerLeakError(kind, message, topStack);
 			this._errorHandler(error);
 		}
 
@@ -1077,8 +1078,8 @@ export class ListenerLeakError extends Error {
 	 * `message` so that all leak errors group under the same title in telemetry.
 	 */
 	readonly details: string;
-	constructor(details: string, stack: string) {
-		super('potential listener LEAK detected');
+	constructor(kind: 'dominated' | 'popular', details: string, stack: string) {
+		super(`potential listener LEAK detected, ${kind}`);
 		this.name = 'ListenerLeakError';
 		this.details = details;
 		this.stack = stack;
@@ -1091,11 +1092,11 @@ export class ListenerRefusalError extends Error {
 	/**
 	 * The detailed message including listener count and most frequent stack.
 	 * Available locally for debugging but intentionally not used as the error
-	 * `message` so that all refusal errors group under the same title in telemetry.
+	 * `message` so that all leak errors group under the same title in telemetry.
 	 */
 	readonly details: string;
-	constructor(details: string, stack: string) {
-		super('potential listener LEAK detected (REFUSED to add)');
+	constructor(kind: 'dominated' | 'popular', details: string, stack: string) {
+		super(`potential listener LEAK detected, ${kind} (REFUSED to add)`);
 		this.name = 'ListenerRefusalError';
 		this.details = details;
 		this.stack = stack;
@@ -1235,7 +1236,8 @@ export class Emitter<T> {
 				console.warn(message);
 
 				const tuple = this._leakageMon.getMostFrequentStack() ?? ['UNKNOWN stack', -1];
-				const error = new ListenerRefusalError(`${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0]);
+				const kind = tuple[1] / this._size > 0.3 ? 'dominated' : 'popular';
+				const error = new ListenerRefusalError(kind, `${message}. HINT: Stack shows most frequent listener (${tuple[1]}-times)`, tuple[0]);
 				const errorHandler = this._options?.onListenerError || onUnexpectedError;
 				errorHandler(error);
 


### PR DESCRIPTION
This builds on the earlier change (4363457) that made `ListenerLeakError` and `ListenerRefusalError` messages generic so that error telemetry groups them under a single title instead of producing N unique entries.

The downside was losing the signal about **why** the leak is happening. This PR restores that by classifying each leak as one of two kinds:

- **`dominated`** (ratio > 30%) - The most frequent stack accounts for more than 30% of all listeners. This strongly indicates a real leak where the same code path keeps subscribing without disposing.
- **`popular`** (ratio <= 30%) - Many different callers subscribe to the same emitter. This is a design issue (overly popular emitter) rather than a disposal bug.

The classification is appended to the error message (e.g. `potential listener LEAK detected, dominated`), keeping telemetry grouping to just 2 variants per error class while preserving actionable diagnostic information.