### PR TITLE
Sessions: remove diff changes from title

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -77,18 +77,4 @@
 	flex-shrink: 0;
 }
 
-/* Changes summary */
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-changes {
-	display: flex;
-	align-items: center;
-	flex-shrink: 0;
-	gap: 3px;
-}
 
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-changes-added {
-	color: var(--vscode-gitDecoration-addedResourceForeground);
-}
-
-.command-center .agent-sessions-titlebar-container .agent-sessions-titlebar-changes-removed {
-	color: var(--vscode-gitDecoration-deletedResourceForeground);
-}

--- a/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget.ts
@@ -19,7 +19,7 @@ import { IMenuService, MenuId, MenuRegistry, SubmenuItemAction } from '../../../
 import { IContextKeyService, ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { ChatContextKeys } from '../../../../workbench/contrib/chat/common/actions/chatContextKeys.js';
-import { IMarshalledAgentSessionContext, getAgentChangesSummary, hasValidDiff } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
+import { IMarshalledAgentSessionContext } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
 import { Menus } from '../../../browser/menus.js';
 import { IWorkbenchContribution } from '../../../../workbench/common/contributions.js';
@@ -128,10 +128,8 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 			const label = this._getActiveSessionLabel();
 			const icon = this._getActiveSessionIcon();
 			const repoLabel = this._getRepositoryLabel();
-			const changesSummary = this._getChangesSummary();
-
 			// Build a render-state key from all displayed data
-			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}|${changesSummary?.insertions ?? ''}|${changesSummary?.deletions ?? ''}`;
+			const renderState = `${icon?.id ?? ''}|${label}|${repoLabel ?? ''}`;
 
 			// Skip re-render if state hasn't changed
 			if (this._lastRenderState === renderState) {
@@ -174,25 +172,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 				const repoEl = $('span.agent-sessions-titlebar-repo');
 				repoEl.textContent = repoLabel;
 				centerGroup.appendChild(repoEl);
-			}
-
-			// Changes summary shown next to the repo
-			if (changesSummary) {
-				const separator2 = $('span.agent-sessions-titlebar-separator');
-				separator2.textContent = '\u00B7';
-				centerGroup.appendChild(separator2);
-
-				const changesEl = $('span.agent-sessions-titlebar-changes');
-
-				const addedEl = $('span.agent-sessions-titlebar-changes-added');
-				addedEl.textContent = `+${changesSummary.insertions}`;
-				changesEl.appendChild(addedEl);
-
-				const removedEl = $('span.agent-sessions-titlebar-changes-removed');
-				removedEl.textContent = `-${changesSummary.deletions}`;
-				changesEl.appendChild(removedEl);
-
-				centerGroup.appendChild(changesEl);
 			}
 
 			sessionPill.appendChild(centerGroup);
@@ -361,24 +340,6 @@ export class SessionsTitleBarWidget extends BaseActionViewItem {
 		});
 
 		menu.dispose();
-	}
-
-	/**
-	 * Get the changes summary for the active session.
-	 */
-	private _getChangesSummary(): { insertions: number; deletions: number } | undefined {
-		const activeSession = this.activeSessionService.getActiveSession();
-		if (!activeSession) {
-			return undefined;
-		}
-
-		const agentSession = this.agentSessionsService.getSession(activeSession.resource);
-		const changes = agentSession?.changes;
-		if (!changes || !hasValidDiff(changes)) {
-			return undefined;
-		}
-
-		return getAgentChangesSummary(changes);
 	}
 
 	private _showSessionsPicker(): void {


### PR DESCRIPTION
## Summary

Remove diff changes indicators from the Agent Sessions title bar widget so the title only shows session identity information.

## Changes

- Remove changes summary rendering (`+insertions`, `-deletions`) from `SessionsTitleBarWidget`
- Remove changes summary from render state key
- Remove `_getChangesSummary()` method and related diff helper imports
- Remove now-unused CSS rules for titlebar changes summary

## Validation

- `npm run compile-check-ts-native` passed