### PR TITLE
Mark chat.artifacts.enabled setting as experimental instead of preview

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -509,7 +509,7 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			description: nls.localize('chat.artifacts.enabled', "Controls whether the artifacts view is available in chat."),
 			type: 'boolean',
-			tags: ['preview']
+			tags: ['experimental']
 		},
 		'chat.undoRequests.restoreInput': {
 			default: true,


### PR DESCRIPTION
Change the `chat.artifacts.enabled` configuration tag from `preview` to `experimental` to better reflect the feature's maturity level.