### PR TITLE
Add inline badge to customization list items for context instructions

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -184,6 +184,10 @@ Prompt files bundled with the Sessions app live in `src/vs/sessions/prompts/`. T
 | Instructions | `listPromptFiles()` + `listAgentInstructions()` | Includes AGENTS.md, CLAUDE.md etc. |
 | Hooks | `listPromptFiles()` | Individual hooks parsed via `parseHooksFromFile()` |
 
+### Item Badges
+
+`IAICustomizationListItem.badge` is an optional string that renders as a small inline tag next to the item name (same visual style as the MCP "Bridged" badge). Used by context instructions to show "always added" or "context matching '{pattern}'" without baking metadata into the display name. The badge text is also included in search filtering.
+
 ### Debug Panel
 
 Toggle via Command Palette: "Toggle Customizations Debug Panel". Shows a 4-stage pipeline view:

--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -186,7 +186,7 @@ Prompt files bundled with the Sessions app live in `src/vs/sessions/prompts/`. T
 
 ### Item Badges
 
-`IAICustomizationListItem.badge` is an optional string that renders as a small inline tag next to the item name (same visual style as the MCP "Bridged" badge). Used by context instructions to show "always added" or "context matching '{pattern}'" without baking metadata into the display name. The badge text is also included in search filtering.
+`IAICustomizationListItem.badge` is an optional string that renders as a small inline tag next to the item name (same visual style as the MCP "Bridged" badge). For context instructions, this badge shows the raw `applyTo` pattern (e.g. a glob like `**/*.ts`), while the tooltip (`badgeTooltip`) explains the behavior. The badge text is also included in search filtering.
 
 ### Debug Panel
 

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -337,7 +337,7 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			const uriLabel = this.labelService.getUriLabel(element.uri, { relative: false });
 			let content = `${element.name}\n${uriLabel}`;
 			if (element.badgeTooltip) {
-				content += `\n${element.badgeTooltip}`;
+				content += `\n\n${element.badgeTooltip}`;
 			}
 			const plugin = element.pluginUri && this.agentPluginService.plugins.get().find(p => isEqual(p.uri, element.pluginUri));
 			if (plugin) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -99,6 +99,8 @@ export interface IAICustomizationListItem {
 	readonly pluginUri?: URI;
 	/** When set, overrides the formatted name for display. */
 	readonly displayName?: string;
+	/** When set, shows a small inline badge next to the item name. */
+	readonly badge?: string;
 	/** When set, overrides the default prompt-type icon. */
 	readonly typeIcon?: ThemeIcon;
 	nameMatches?: IMatch[];
@@ -152,6 +154,7 @@ interface IAICustomizationItemTemplateData {
 	readonly actionBar: ActionBar;
 	readonly typeIcon: HTMLElement;
 	readonly nameLabel: HighlightedLabel;
+	readonly badge: HTMLElement;
 	readonly description: HighlightedLabel;
 	readonly disposables: DisposableStore;
 	readonly elementDisposables: DisposableStore;
@@ -294,7 +297,9 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		const leftSection = DOM.append(container, $('.item-left'));
 		const typeIcon = DOM.append(leftSection, $('.item-type-icon'));
 		const textContainer = DOM.append(leftSection, $('.item-text'));
-		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(textContainer, $('.item-name'))));
+		const nameRow = DOM.append(textContainer, $('.item-name-row'));
+		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(nameRow, $('.item-name'))));
+		const badge = DOM.append(nameRow, $('.item-badge'));
 		const description = disposables.add(new HighlightedLabel(DOM.append(textContainer, $('.item-description'))));
 
 		// Right section for actions (hover-visible)
@@ -309,6 +314,7 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 			actionBar,
 			typeIcon,
 			nameLabel,
+			badge,
 			description,
 			disposables,
 			elementDisposables,
@@ -346,6 +352,15 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		// Name with highlights — nameMatches are pre-computed against the formatted display name
 		const displayName = element.displayName ?? formatDisplayName(element.name);
 		templateData.nameLabel.set(displayName, element.nameMatches);
+
+		// Optional inline badge (e.g. "always added", "context matching '*.ts'")
+		if (element.badge) {
+			templateData.badge.textContent = element.badge;
+			templateData.badge.style.display = '';
+		} else {
+			templateData.badge.textContent = '';
+			templateData.badge.style.display = 'none';
+		}
 
 		// Hooks show shell commands here, so keep the full text instead of truncating to the first sentence.
 		const secondaryText = getCustomizationSecondaryText(element.description, element.filename, element.promptType);
@@ -1259,7 +1274,7 @@ export class AICustomizationListWidget extends Disposable {
 
 				if (applyTo !== undefined) {
 					// Context instruction
-					const suffix = applyTo === '**'
+					const badge = applyTo === '**'
 						? localize('alwaysAdded', "always added", applyTo)
 						: localize('onContext', "context matching '{0}'", applyTo);
 					items.push({
@@ -1267,7 +1282,8 @@ export class AICustomizationListWidget extends Disposable {
 						uri: item.uri,
 						name: friendlyName,
 						filename: this.labelService.getUriLabel(item.uri, { relative: true }),
-						displayName: `${friendlyName} - ${suffix}`,
+						displayName: friendlyName,
+						badge,
 						description: description,
 						storage: item.storage,
 						promptType,
@@ -1382,8 +1398,9 @@ export class AICustomizationListWidget extends Disposable {
 				const nameMatches = matchesContiguousSubString(query, displayName);
 				const descriptionMatches = item.description ? matchesContiguousSubString(query, item.description) : null;
 				const filenameMatches = matchesContiguousSubString(query, item.filename);
+				const badgeMatches = item.badge ? matchesContiguousSubString(query, item.badge) : null;
 
-				if (nameMatches || descriptionMatches || filenameMatches) {
+				if (nameMatches || descriptionMatches || filenameMatches || badgeMatches) {
 					matchedItems.push({
 						...item,
 						nameMatches: nameMatches || undefined,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -41,6 +41,7 @@ import { IAICustomizationWorkspaceService, applyStorageSourceFilter } from '../.
 import { Action, Separator } from '../../../../../base/common/actions.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
+import { getDefaultHoverDelegate } from '../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { generateCustomizationDebugReport } from './aiCustomizationDebugPanel.js';
@@ -101,6 +102,8 @@ export interface IAICustomizationListItem {
 	readonly displayName?: string;
 	/** When set, shows a small inline badge next to the item name. */
 	readonly badge?: string;
+	/** Tooltip shown when hovering the badge. */
+	readonly badgeTooltip?: string;
 	/** When set, overrides the default prompt-type icon. */
 	readonly typeIcon?: ThemeIcon;
 	nameMatches?: IMatch[];
@@ -353,10 +356,17 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		const displayName = element.displayName ?? formatDisplayName(element.name);
 		templateData.nameLabel.set(displayName, element.nameMatches);
 
-		// Optional inline badge (e.g. "always added", "context matching '*.ts'")
+		// Optional inline badge (e.g. "always added", "*.ts")
 		if (element.badge) {
 			templateData.badge.textContent = element.badge;
 			templateData.badge.style.display = '';
+			if (element.badgeTooltip) {
+				templateData.elementDisposables.add(this.hoverService.setupManagedHover(
+					getDefaultHoverDelegate('mouse'),
+					templateData.badge,
+					element.badgeTooltip,
+				));
+			}
 		} else {
 			templateData.badge.textContent = '';
 			templateData.badge.style.display = 'none';
@@ -1275,8 +1285,11 @@ export class AICustomizationListWidget extends Disposable {
 				if (applyTo !== undefined) {
 					// Context instruction
 					const badge = applyTo === '**'
-						? localize('alwaysAdded', "always added", applyTo)
-						: localize('onContext', "context matching '{0}'", applyTo);
+						? localize('alwaysAdded', "always added")
+						: applyTo;
+					const badgeTooltip = applyTo === '**'
+						? localize('alwaysAddedTooltip', "This instruction is automatically included in every interaction.")
+						: localize('onContextTooltip', "This instruction is automatically included when files matching '{0}' are in context.", applyTo);
 					items.push({
 						id: item.uri.toString(),
 						uri: item.uri,
@@ -1284,6 +1297,7 @@ export class AICustomizationListWidget extends Disposable {
 						filename: this.labelService.getUriLabel(item.uri, { relative: true }),
 						displayName: friendlyName,
 						badge,
+						badgeTooltip,
 						description: description,
 						storage: item.storage,
 						promptType,

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -332,10 +332,13 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		templateData.typeIcon.className = 'item-type-icon';
 		templateData.typeIcon.classList.add(...ThemeIcon.asClassNameArray(element.typeIcon ?? promptTypeToIcon(element.promptType)));
 
-		// Hover tooltip: name + full path + plugin source
+		// Hover tooltip: name + full path + badge context + plugin source
 		templateData.elementDisposables.add(this.hoverService.setupDelayedHover(templateData.container, () => {
 			const uriLabel = this.labelService.getUriLabel(element.uri, { relative: false });
 			let content = `${element.name}\n${uriLabel}`;
+			if (element.badgeTooltip) {
+				content += `\n${element.badgeTooltip}`;
+			}
 			const plugin = element.pluginUri && this.agentPluginService.plugins.get().find(p => isEqual(p.uri, element.pluginUri));
 			if (plugin) {
 				content += `\n${localize('fromPlugin', "Plugin: {0}", plugin.label)}`;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget.ts
@@ -302,7 +302,7 @@ class AICustomizationItemRenderer implements IListRenderer<IFileItemEntry, IAICu
 		const textContainer = DOM.append(leftSection, $('.item-text'));
 		const nameRow = DOM.append(textContainer, $('.item-name-row'));
 		const nameLabel = disposables.add(new HighlightedLabel(DOM.append(nameRow, $('.item-name'))));
-		const badge = DOM.append(nameRow, $('.item-badge'));
+		const badge = DOM.append(nameRow, $('.inline-badge.item-badge'));
 		const description = disposables.add(new HighlightedLabel(DOM.append(textContainer, $('.item-description'))));
 
 		// Right section for actions (hover-visible)

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -146,7 +146,7 @@ class McpServerItemRenderer implements IListRenderer<IMcpServerItemEntry | IMcpB
 		const nameRow = DOM.append(details, $('.mcp-server-name-row'));
 		const name = DOM.append(nameRow, $('.mcp-server-name'));
 
-		const bridgedBadge = DOM.append(nameRow, $('.mcp-bridged-badge'));
+		const bridgedBadge = DOM.append(nameRow, $('.inline-badge.mcp-bridged-badge'));
 		bridgedBadge.textContent = localize('bridged', "Bridged");
 
 		const description = DOM.append(details, $('.mcp-server-description'));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -503,8 +503,6 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	line-height: 18px;
-	min-width: 0;
-	flex: 1 1 auto;
 }
 
 .ai-customization-list-item .item-description {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -452,14 +452,8 @@
 	opacity: 0.6;
 }
 
-/* MCP bridged badge — shown inline next to the server name */
-.mcp-server-item .mcp-server-name-row {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-}
-
-.mcp-server-item .mcp-bridged-badge {
+/* Shared inline badge style — used by MCP "Bridged" badge and item badges */
+.inline-badge {
 	flex-shrink: 0;
 	font-size: 10px;
 	padding: 0 4px;
@@ -468,6 +462,13 @@
 	background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
 	white-space: nowrap;
 	line-height: 16px;
+}
+
+/* MCP bridged badge — shown inline next to the server name */
+.mcp-server-item .mcp-server-name-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .ai-customization-list-item .item-type-icon {
@@ -502,17 +503,8 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	line-height: 18px;
-}
-
-.ai-customization-list-item .item-badge {
-	flex-shrink: 0;
-	font-size: 10px;
-	padding: 0 4px;
-	border-radius: 3px;
-	color: var(--vscode-descriptionForeground);
-	background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
-	white-space: nowrap;
-	line-height: 16px;
+	min-width: 0;
+	flex: 1 1 auto;
 }
 
 .ai-customization-list-item .item-description {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/media/aiCustomizationManagement.css
@@ -489,12 +489,30 @@
 	min-width: 0;
 }
 
+.ai-customization-list-item .item-name-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	overflow: hidden;
+}
+
 .ai-customization-list-item .item-name {
 	font-size: 13px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	line-height: 18px;
+}
+
+.ai-customization-list-item .item-badge {
+	flex-shrink: 0;
+	font-size: 10px;
+	padding: 0 4px;
+	border-radius: 3px;
+	color: var(--vscode-descriptionForeground);
+	background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+	white-space: nowrap;
+	line-height: 16px;
 }
 
 .ai-customization-list-item .item-description {


### PR DESCRIPTION
## Summary

Instructions with `applyTo` patterns previously baked context info into the display name string (e.g. `"Name - context matching '*.ts'"`). This PR replaces that with a visual inline badge — the same style used for the MCP "Bridged" badge — making it cleaner and more scannable.

## Changes

**Generic badge support on `IAICustomizationListItem`:**
- `badge?: string` — small inline tag rendered next to the item name
- `badgeTooltip?: string` — hover tooltip explaining the badge
- Badge text is included in search filtering
- DOM: `.item-name` is now wrapped in a `.item-name-row` flex container with a `.item-badge` sibling

**Instructions usage:**
- `applyTo: '**'` → badge shows **"always added"**, tooltip: "This instruction is automatically included in every interaction."
- `applyTo: 'src/auth/**'` → badge shows **`src/auth/**`**, tooltip: "This instruction is automatically included when files matching 'src/auth/**' are in context."

**CSS:** `.item-badge` matches the existing `.mcp-bridged-badge` visual style (small rounded tag, `descriptionForeground` color, `toolbar-hoverBackground` background).

**Spec:** Updated `AI_CUSTOMIZATIONS.md` with "Item Badges" section.

## Testing
- TypeScript compilation ✅
- Layering check ✅
- Hygiene pre-commit hook ✅
- Component explorer screenshots verified in both dark and light themes