### PR TITLE
Fix missing global flag in sanitizeId regex

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -752,7 +752,7 @@ export function inspectSetting(key: string, target: SettingsTarget, languageFilt
 }
 
 function sanitizeId(id: string): string {
-	return id.replace(/[\.\/]/, '_');
+	return id.replace(/[\.\/]/g, '_');
 }
 
 export function settingKeyToDisplayFormat(key: string, groupId: string = '', isLanguageTagSetting: boolean = false): { category: string; label: string } {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -751,7 +751,7 @@ export function inspectSetting(key: string, target: SettingsTarget, languageFilt
 	return { isConfigured, inspected, targetSelector, inspectedLanguageOverrides, languageSelector: languageFilter };
 }
 
-function sanitizeId(id: string): string {
+export function sanitizeId(id: string): string {
 	return id.replace(/[\.\/]/g, '_');
 }
 

--- a/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/settingsTreeModels.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { settingKeyToDisplayFormat, parseQuery, IParsedQuery } from '../../browser/settingsTreeModels.js';
+import { settingKeyToDisplayFormat, parseQuery, IParsedQuery, sanitizeId } from '../../browser/settingsTreeModels.js';
 
 suite('SettingsTree', () => {
 	test('settingKeyToDisplayFormat', () => {
@@ -327,6 +327,23 @@ suite('SettingsTree', () => {
 				idFilters: [],
 				languageFilter: 'cpp'
 			});
+	});
+
+	test('sanitizeId replaces all dots and slashes', () => {
+		assert.deepStrictEqual(
+			[
+				sanitizeId('root.editor.font.size'),
+				sanitizeId('group/subgroup/setting.key'),
+				sanitizeId('no-special-chars'),
+				sanitizeId('single.dot'),
+			],
+			[
+				'root_editor_font_size',
+				'group_subgroup_setting_key',
+				'no-special-chars',
+				'single_dot',
+			]
+		);
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
Fixes #303601

The `sanitizeId` regex was missing the `g` (global) flag, so `String.prototype.replace` only replaced the first occurrence of `.` or `/`. Since settings IDs contain multiple dots (e.g., `editor.font.size`), only the first one was being sanitized to `_`.

**Before:** `"root.editor.font.size"` -> `"root_editor.font.size"`
**After:** `"root.editor.font.size"` -> `"root_editor_font_size"`