### PR TITLE
Fix duplicated condition in accessibility signal property change detection

### DIFF
--- a/src/vs/workbench/contrib/accessibilitySignals/browser/editorTextPropertySignalsContribution.ts
+++ b/src/vs/workbench/contrib/accessibilitySignals/browser/editorTextPropertySignalsContribution.ts
@@ -149,7 +149,7 @@ export class EditorTextPropertySignalsContribution extends Disposable implements
 					const newValueAtPosition = s.source.isPresentAtPosition(args.position, reader);
 					const newValueOnLine = s.source.isPresentOnLine(args.position.lineNumber, reader);
 
-					if (lastValueAtPosition !== undefined && lastValueAtPosition !== undefined) {
+					if (lastValueAtPosition !== undefined && lastValueOnLine !== undefined) {
 						if (!lastValueAtPosition && newValueAtPosition) {
 							trigger(s.property, s.source, 'positional');
 						}


### PR DESCRIPTION
Fixes #303602

The condition on line 152 checked `lastValueAtPosition !== undefined` twice instead of also checking `lastValueOnLine !== undefined`. This guard is meant to skip the initial `autorun` call when both values are still `undefined`. Because only one variable was checked, the guard did not properly protect against `lastValueOnLine` being `undefined`.

**Before:** `if (lastValueAtPosition !== undefined && lastValueAtPosition !== undefined)`
**After:** `if (lastValueAtPosition !== undefined && lastValueOnLine !== undefined)`