### PR TITLE
feat: add context key expressions for slash command visibility

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -12,6 +12,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IChatAgentService } from '../common/participants/chatAgents.js';
+import { ChatContextKeys } from '../common/actions/chatContextKeys.js';
 import { IChatSlashCommandService } from '../common/participants/chatSlashCommands.js';
 import { IChatService } from '../common/chatService/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel } from '../common/constants.js';
@@ -28,6 +29,7 @@ import { IChatWidgetService } from './chat.js';
 import { agentSlashCommandToMarkdown, agentToMarkdown } from './widget/chatContentParts/chatMarkdownDecorationsRenderer.js';
 import { Target } from '../common/promptSyntax/promptTypes.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 
 export class ChatSlashCommandsContribution extends Disposable {
 
@@ -163,7 +165,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode, Target.GitHubCopilot]
+			when: ContextKeyExpr.or(
+				ChatContextKeys.lockedToCodingAgent.negate(),
+				ChatContextKeys.chatSessionSupportsFork
+			),
 		}, async (_prompt, _progress, _history, _location, sessionResource) => {
 			await commandService.executeCommand('workbench.action.chat.forkConversation', sessionResource);
 		}));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -137,6 +137,9 @@ class SlashCommandCompletions extends Disposable {
 				return {
 					suggestions: slashCommands
 						.filter(c => {
+							if (c.when && !widget.scopedContextKeyService.contextMatchesRules(c.when)) {
+								return false;
+							}
 							if (!widget.lockedAgentId) {
 								return true;
 							}
@@ -192,19 +195,21 @@ class SlashCommandCompletions extends Disposable {
 				}
 
 				return {
-					suggestions: slashCommands.map((c, i): CompletionItem => {
-						const withSlash = `${chatSubcommandLeader}${c.command}`;
-						return {
-							label: { label: withSlash, description: c.detail },
-							insertText: c.executeImmediately ? '' : `${withSlash} `,
-							documentation: c.detail,
-							range,
-							filterText: `${chatAgentLeader}${c.command}`,
-							sortText: c.sortText ?? 'z'.repeat(i + 1),
-							kind: CompletionItemKind.Text, // The icons are disabled here anyway,
-							command: c.executeImmediately ? { id: ChatSubmitAction.ID, title: withSlash, arguments: [{ widget, inputValue: `${withSlash} ` } satisfies IChatExecuteActionContext] } : undefined,
-						};
-					})
+					suggestions: slashCommands
+						.filter(c => !c.when || widget.scopedContextKeyService.contextMatchesRules(c.when))
+						.map((c, i): CompletionItem => {
+							const withSlash = `${chatSubcommandLeader}${c.command}`;
+							return {
+								label: { label: withSlash, description: c.detail },
+								insertText: c.executeImmediately ? '' : `${withSlash} `,
+								documentation: c.detail,
+								range,
+								filterText: `${chatAgentLeader}${c.command}`,
+								sortText: c.sortText ?? 'z'.repeat(i + 1),
+								kind: CompletionItemKind.Text, // The icons are disabled here anyway,
+								command: c.executeImmediately ? { id: ChatSubmitAction.ID, title: withSlash, arguments: [{ widget, inputValue: `${withSlash} ` } satisfies IChatExecuteActionContext] } : undefined,
+							};
+						})
 				};
 			}
 		}));

--- a/src/vs/workbench/contrib/chat/common/participants/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatSlashCommands.ts
@@ -6,6 +6,7 @@
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable, IDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
+import { ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IProgress } from '../../../../../platform/progress/common/progress.js';
 import { IChatMessage } from '../languageModels.js';
@@ -39,6 +40,12 @@ export interface IChatSlashData {
 	locations: ChatAgentLocation[];
 	modes?: ChatModeKind[];
 	targets?: Target[];
+
+	/**
+	 * Optional context key expression that controls visibility of this command.
+	 * When set, the command is only shown if the expression evaluates to true.
+	 */
+	when?: ContextKeyExpression;
 }
 
 export interface IChatSlashFragment {


### PR DESCRIPTION
This is how we should be registering slash commands - when clauses, not hard coded targets.

It would be a good exercise to apply when clauses to the rest of these in the future.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
