### PR TITLE
feat: add `chatPlugins` extension contribution point for agent plugins

### DIFF
--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -237,6 +237,7 @@ export interface IExtensionContributions {
 	readonly chatInstructions?: ReadonlyArray<IChatFileContribution>;
 	readonly chatAgents?: ReadonlyArray<IChatFileContribution>;
 	readonly chatSkills?: ReadonlyArray<IChatFileContribution>;
+	readonly chatPlugins?: ReadonlyArray<IChatFileContribution>;
 	readonly languageModelTools?: ReadonlyArray<IToolContribution>;
 	readonly languageModelToolSets?: ReadonlyArray<IToolSetContribution>;
 	readonly mcpServerDefinitionProviders?: ReadonlyArray<IMcpCollectionContribution>;

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -150,7 +150,7 @@ import './widget/input/editor/chatInputEditorContrib.js';
 import './widget/input/editor/chatInputEditorHover.js';
 import { LanguageModelToolsConfirmationService } from './tools/languageModelToolsConfirmationService.js';
 import { LanguageModelToolsService, globalAutoApproveDescription } from './tools/languageModelToolsService.js';
-import { AgentPluginService, ConfiguredAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
+import { AgentPluginService, ConfiguredAgentPluginDiscovery, ExtensionAgentPluginDiscovery, MarketplaceAgentPluginDiscovery } from '../common/plugins/agentPluginServiceImpl.js';
 import { IAgentPluginRepositoryService } from '../common/plugins/agentPluginRepositoryService.js';
 import { IPluginInstallService } from '../common/plugins/pluginInstallService.js';
 import { IPluginMarketplaceService, PluginMarketplaceService } from '../common/plugins/pluginMarketplaceService.js';
@@ -1888,6 +1888,7 @@ registerEditorFeature(ChatPasteProvidersFeature);
 
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(ConfiguredAgentPluginDiscovery));
 agentPluginDiscoveryRegistry.register(new SyncDescriptor(MarketplaceAgentPluginDiscovery));
+agentPluginDiscoveryRegistry.register(new SyncDescriptor(ExtensionAgentPluginDiscovery));
 
 registerSingleton(IChatResponseResourceFileSystemProvider, ChatResponseResourceFileSystemProvider, InstantiationType.Delayed);
 registerSingleton(IChatTransferService, ChatTransferService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/plugins/agentPluginServiceImpl.ts
@@ -22,14 +22,23 @@ import {
 import { escapeRegExpCharacters } from '../../../../../base/common/strings.js';
 import { hasKey, Mutable } from '../../../../../base/common/types.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ConfigurationTarget, getConfigValueInTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IMcpRemoteServerConfiguration, IMcpServerConfiguration, IMcpStdioServerConfiguration, McpServerType } from '../../../../../platform/mcp/common/mcpPlatformTypes.js';
 import { observableConfigValue } from '../../../../../platform/observable/common/platformObservableUtils.js';
 import { IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
+import { localize } from '../../../../../nls.js';
+import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { ExtensionIdentifier, IExtensionManifest } from '../../../../../platform/extensions/common/extensions.js';
+import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { Extensions, IExtensionFeaturesRegistry, IExtensionFeatureTableRenderer, IRenderedData, IRowData, ITableData } from '../../../../services/extensionManagement/common/extensionFeatures.js';
+import * as extensionsRegistry from '../../../../services/extensions/common/extensionsRegistry.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { ChatConfiguration } from '../constants.js';
 import { EnablementModel, IEnablementModel } from '../enablement.js';
@@ -1137,3 +1146,188 @@ export class MarketplaceAgentPluginDiscovery extends AbstractAgentPluginDiscover
 		return sources;
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Extension-contributed plugin discovery
+// ---------------------------------------------------------------------------
+
+interface IRawChatPluginContribution {
+	readonly path: string;
+	readonly when?: string;
+}
+
+const epPlugins = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawChatPluginContribution[]>({
+	extensionPoint: 'chatPlugins',
+	jsonSchema: {
+		description: localize('chatPlugins.schema.description', 'Contributes agent plugins for chat.'),
+		type: 'array',
+		items: {
+			additionalProperties: false,
+			type: 'object',
+			defaultSnippets: [{
+				body: {
+					path: './relative/path/to/plugin/',
+				}
+			}],
+			required: ['path'],
+			properties: {
+				path: {
+					description: localize('chatPlugins.property.path', 'Path to the agent plugin root directory relative to the extension root.'),
+					type: 'string'
+				},
+				when: {
+					description: localize('chatPlugins.property.when', '(Optional) A condition which must be true to enable this plugin.'),
+					type: 'string'
+				}
+			}
+		}
+	}
+});
+
+export class ExtensionAgentPluginDiscovery extends AbstractAgentPluginDiscovery {
+
+	private readonly _extensionPlugins = new Map<string, { uri: URI; when: ContextKeyExpression | undefined; extensionId: string }>();
+	private readonly _whenKeys = new Set<string>();
+
+	constructor(
+		@ICommandService private readonly _commandService: ICommandService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IDialogService private readonly _dialogService: IDialogService,
+		@IFileService fileService: IFileService,
+		@IPathService pathService: IPathService,
+		@ILogService logService: ILogService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super(fileService, pathService, logService, instantiationService);
+	}
+
+	public override start(enablementModel: IEnablementModel): void {
+		this._enablementModel = enablementModel;
+		const scheduler = this._register(new RunOnceScheduler(() => this._refreshPlugins(), 0));
+		this._register(this._contextKeyService.onDidChangeContext(e => {
+			if (e.affectsSome(this._whenKeys)) {
+				scheduler.schedule();
+			}
+		}));
+		epPlugins.setHandler((_extensions, delta) => {
+			for (const ext of delta.added) {
+				for (const raw of ext.value) {
+					if (!raw.path) {
+						ext.collector.error(localize('extension.plugin.missing.path', "Extension '{0}' cannot register a chatPlugins entry without a path.", ext.description.identifier.value));
+						continue;
+					}
+					const pluginUri = joinPath(ext.description.extensionLocation, raw.path);
+					if (!isEqualOrParent(pluginUri, ext.description.extensionLocation)) {
+						ext.collector.error(localize('extension.plugin.invalid.path', "Extension '{0}' chatPlugins entry '{1}' resolves outside the extension.", ext.description.identifier.value, raw.path));
+						continue;
+					}
+					let whenExpr: ContextKeyExpression | undefined;
+					if (raw.when) {
+						whenExpr = ContextKeyExpr.deserialize(raw.when);
+						if (!whenExpr) {
+							ext.collector.error(localize('extension.plugin.invalid.when', "Extension '{0}' chatPlugins entry '{1}' has an invalid when clause: '{2}'.", ext.description.identifier.value, raw.path, raw.when));
+							continue;
+						}
+					}
+					this._extensionPlugins.set(extensionPluginKey(ext.description.identifier, raw.path), { uri: pluginUri, when: whenExpr, extensionId: ext.description.identifier.value });
+				}
+			}
+			for (const ext of delta.removed) {
+				for (const raw of ext.value) {
+					this._extensionPlugins.delete(extensionPluginKey(ext.description.identifier, raw.path));
+				}
+			}
+			this._rebuildWhenKeys();
+			scheduler.schedule();
+		});
+	}
+
+	private _rebuildWhenKeys(): void {
+		this._whenKeys.clear();
+		for (const { when } of this._extensionPlugins.values()) {
+			if (when) {
+				for (const key of when.keys()) {
+					this._whenKeys.add(key);
+				}
+			}
+		}
+	}
+
+	protected override async _discoverPluginSources(): Promise<readonly IPluginSource[]> {
+		const sources: IPluginSource[] = [];
+		for (const [, entry] of this._extensionPlugins) {
+			if (entry.when && !this._contextKeyService.contextMatchesRules(entry.when)) {
+				continue;
+			}
+			let stat;
+			try {
+				stat = await this._fileService.resolve(entry.uri);
+			} catch {
+				this._logService.debug(`[ExtensionAgentPluginDiscovery] Could not resolve extension plugin path: ${entry.uri.toString()}`);
+				continue;
+			}
+			if (!stat.isDirectory) {
+				this._logService.debug(`[ExtensionAgentPluginDiscovery] Extension plugin path is not a directory: ${entry.uri.toString()}`);
+				continue;
+			}
+			sources.push({
+				uri: stat.resource,
+				fromMarketplace: undefined,
+				remove: () => this._promptUninstallExtension(entry.extensionId),
+			});
+		}
+		return sources;
+	}
+
+	private async _promptUninstallExtension(extensionId: string): Promise<void> {
+		const { confirmed } = await this._dialogService.confirm({
+			message: localize('uninstallExtensionForPlugin', "This plugin is provided by the extension '{0}'. Do you want to uninstall the extension?", extensionId),
+		});
+		if (confirmed) {
+			await this._commandService.executeCommand('workbench.extensions.uninstallExtension', extensionId);
+		}
+	}
+}
+
+function extensionPluginKey(extensionId: ExtensionIdentifier, path: string): string {
+	return `${extensionId.value}/${path}`;
+}
+
+class ChatPluginsDataRenderer extends Disposable implements IExtensionFeatureTableRenderer {
+	readonly type = 'table' as const;
+
+	shouldRender(manifest: IExtensionManifest): boolean {
+		return !!manifest.contributes?.chatPlugins?.length;
+	}
+
+	render(manifest: IExtensionManifest): IRenderedData<ITableData> {
+		const contributions = manifest.contributes?.chatPlugins ?? [];
+		if (!contributions.length) {
+			return { data: { headers: [], rows: [] }, dispose: () => { } };
+		}
+
+		const headers = [
+			localize('chatPluginsPath', "Path"),
+			localize('chatPluginsWhen', "When"),
+		];
+
+		const rows: IRowData[][] = contributions.map(d => [
+			d.path,
+			d.when ?? '-',
+		]);
+
+		return {
+			data: { headers, rows },
+			dispose: () => { }
+		};
+	}
+}
+
+Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).registerExtensionFeature({
+	id: 'chatPlugins',
+	label: localize('chatPlugins', "Chat Plugins"),
+	access: {
+		canToggle: false
+	},
+	renderer: new SyncDescriptor(ChatPluginsDataRenderer),
+});

--- a/src/vs/workbench/services/extensions/common/extensionPoints.json
+++ b/src/vs/workbench/services/extensions/common/extensionPoints.json
@@ -6,6 +6,7 @@
 	"chatInstructions",
 	"chatOutputRenderers",
 	"chatParticipants",
+	"chatPlugins",
 	"chatPromptFiles",
 	"chatSessions",
 	"chatSkills",


### PR DESCRIPTION
Extensions can now contribute agent plugins via the `chatPlugins` key in their package.json, following the same pattern as `chatSkills`.

Each entry points to a plugin root directory within the extension that is discovered by a new `ExtensionAgentPluginDiscovery` class, which plugs into the existing agent plugin discovery infrastructure.

- Registers `chatPlugins` extension point with JSON schema (path, when)
- Evaluates and reacts to `when` context key expressions
- Prompts to uninstall the providing extension on plugin removal

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
