### PR TITLE
Option to allow-list command when offering to run outside of sandbox

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
@@ -45,6 +45,7 @@ export interface ICommandLineAnalyzerOptions {
 	treeSitterLanguage: TreeSitterCommandParserLanguage;
 	terminalToolSessionId: string;
 	chatSessionResource: URI | undefined;
+	requiresUnsandboxConfirmation?: boolean;
 }
 
 export interface ICommandLineAnalyzerResult {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineSandboxAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineSandboxAnalyzer.ts
@@ -22,7 +22,7 @@ export class CommandLineSandboxAnalyzer extends Disposable implements ICommandLi
 		}
 		return {
 			isAutoApproveAllowed: true,
-			forceAutoApproval: true,
+			forceAutoApproval: _options.requiresUnsandboxConfirmation ? false : true,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -610,6 +610,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			treeSitterLanguage: isPowerShell(shell, os) ? TreeSitterCommandParserLanguage.PowerShell : TreeSitterCommandParserLanguage.Bash,
 			terminalToolSessionId,
 			chatSessionResource,
+			requiresUnsandboxConfirmation,
 		};
 		const commandLineAnalyzerResults = await Promise.all(this._commandLineAnalyzers.map(e => e.analyze(commandLineAnalyzerOptions)));
 
@@ -625,7 +626,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		}
 
 		const analyzersIsAutoApproveAllowed = commandLineAnalyzerResults.every(e => e.isAutoApproveAllowed);
-		const customActions = !requiresUnsandboxConfirmation && isEligibleForAutoApproval() && analyzersIsAutoApproveAllowed ? commandLineAnalyzerResults.map(e => e.customActions ?? []).flat() : undefined;
+		const customActions = isEligibleForAutoApproval() && analyzersIsAutoApproveAllowed ? commandLineAnalyzerResults.map(e => e.customActions ?? []).flat() : undefined;
 
 		let shellType = basename(shell, '.exe');
 		if (shellType === 'powershell') {
@@ -766,7 +767,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			title: confirmationTitle,
 			message: confirmationMessage,
 			disclaimer,
-			allowAutoConfirm: requiresUnsandboxConfirmation ? false : undefined,
+			allowAutoConfirm: undefined,
 			terminalCustomActions: customActions,
 		} : undefined;
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -480,7 +480,6 @@ suite('RunInTerminalTool', () => {
 			}
 			ok(confirmationMessage.value.includes('Reason for leaving the sandbox: Needs network access outside the sandbox'));
 
-			strictEqual(result?.confirmationMessages?.disclaimer, undefined);
 			strictEqual(result?.confirmationMessages?.terminalCustomActions, undefined);
 		});
 	});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -467,7 +467,7 @@ suite('RunInTerminalTool', () => {
 			});
 
 			assertConfirmationRequired(result, 'Run `bash` command outside the sandbox?');
-			strictEqual(result?.confirmationMessages?.allowAutoConfirm, false);
+			strictEqual(result?.confirmationMessages?.allowAutoConfirm, undefined);
 			const terminalData = result?.toolSpecificData as IChatTerminalToolInvocationData;
 			strictEqual(terminalData.requestUnsandboxedExecution, true);
 			strictEqual(terminalData.requestUnsandboxedExecutionReason, 'Needs network access outside the sandbox');
@@ -480,7 +480,16 @@ suite('RunInTerminalTool', () => {
 			}
 			ok(confirmationMessage.value.includes('Reason for leaving the sandbox: Needs network access outside the sandbox'));
 
-			strictEqual(result?.confirmationMessages?.terminalCustomActions, undefined);
+			strictEqual(result?.confirmationMessages?.disclaimer, undefined);
+			const actions = result?.confirmationMessages?.terminalCustomActions;
+			ok(actions, 'Expected custom actions to be defined');
+			strictEqual(actions.length, 11);
+			ok(!isSeparator(actions[0]));
+			strictEqual(actions[0].label, 'Allow `echo …` in this Session');
+			ok(!isSeparator(actions[4]));
+			strictEqual(actions[4].label, 'Allow Exact Command Line in this Session');
+			ok(!isSeparator(actions[10]));
+			strictEqual(actions[10].label, 'Configure Auto Approve...');
 		});
 	});
 


### PR DESCRIPTION
fixes #303426
## Summary
- thread the unsandboxed confirmation requirement through terminal command-line analyzer options
- stop the sandbox analyzer from force auto-approving commands when explicit unsandboxed confirmation is required
- keep confirmation actions available in the terminal confirmation flow for these cases instead of suppressing them
- update the RunInTerminalTool test expectation to match the revised confirmation behavior

## Testing
- Not run in this update

## Notes
- the PR branch history was rewritten and force-pushed so the PR now contains a single commit