### PR TITLE
fix: update chat slash commands to include GitHub Copilot targets and enhance attachment handling

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -76,7 +76,6 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
 		}, async () => {
 			await commandService.executeCommand(OpenModelPickerAction.ID);
 		}));
@@ -200,7 +199,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 				sortText: 'z1_autoApprove',
 				executeImmediately: true,
 				silent: true,
-				locations: [ChatAgentLocation.Chat]
+				locations: [ChatAgentLocation.Chat],
+				targets: [Target.VSCode, Target.GitHubCopilot]
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -210,7 +210,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 				sortText: 'z1_disableAutoApprove',
 				executeImmediately: true,
 				silent: true,
-				locations: [ChatAgentLocation.Chat]
+				locations: [ChatAgentLocation.Chat],
+				targets: [Target.VSCode, Target.GitHubCopilot]
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -220,7 +221,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 				sortText: 'z1_yolo',
 				executeImmediately: true,
 				silent: true,
-				locations: [ChatAgentLocation.Chat]
+				locations: [ChatAgentLocation.Chat],
+				targets: [Target.VSCode, Target.GitHubCopilot]
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -230,7 +232,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 				sortText: 'z1_disableYolo',
 				executeImmediately: true,
 				silent: true,
-				locations: [ChatAgentLocation.Chat]
+				locations: [ChatAgentLocation.Chat],
+				targets: [Target.VSCode, Target.GitHubCopilot]
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -241,7 +244,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 					sortText: 'z1_autopilot',
 					executeImmediately: true,
 					silent: true,
-					locations: [ChatAgentLocation.Chat]
+					locations: [ChatAgentLocation.Chat],
+					targets: [Target.VSCode, Target.GitHubCopilot]
 				}, async (_prompt, _progress, _history, _location, sessionResource) => {
 					setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Autopilot);
 				}));
@@ -251,7 +255,8 @@ export class ChatSlashCommandsContribution extends Disposable {
 					sortText: 'z1_exitAutopilot',
 					executeImmediately: true,
 					silent: true,
-					locations: [ChatAgentLocation.Chat]
+					locations: [ChatAgentLocation.Chat],
+					targets: [Target.VSCode, Target.GitHubCopilot]
 				}, async (_prompt, _progress, _history, _location, sessionResource) => {
 					setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 				}));

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -104,9 +104,6 @@ class SlashCommandCompletions extends Disposable {
 
 				let customAgentTarget: Target | undefined = undefined;
 				if (widget.lockedAgentId) {
-					if (!widget.attachmentCapabilities.supportsPromptAttachments) {
-						return null;
-					}
 					const sessionResource = widget.viewModel.model.sessionResource;
 					const ctx = sessionResource && chatService.getChatSessionFromInternalUri(sessionResource);
 					customAgentTarget = (ctx ? chatSessionsService.getCustomAgentTargetForSessionType(getChatSessionType(sessionResource)) : undefined) ?? Target.Undefined;
@@ -137,6 +134,12 @@ class SlashCommandCompletions extends Disposable {
 				return {
 					suggestions: slashCommands
 						.filter(c => {
+							// execute immediately commands are client-side only... so they're not "attaching anything"
+							// so this check can be scoped to when the command _does_ attach something before
+							// checking if the widget supports attachments at all
+							if (!c.silent && !widget.attachmentCapabilities.supportsPromptAttachments) {
+								return false;
+							}
 							if (c.when && !widget.scopedContextKeyService.contextMatchesRules(c.when)) {
 								return false;
 							}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -134,7 +134,7 @@ class SlashCommandCompletions extends Disposable {
 				return {
 					suggestions: slashCommands
 						.filter(c => {
-							// execute immediately commands are client-side only... so they're not "attaching anything"
+							// silent commands are client-side only... so they're not "attaching anything"
 							// so this check can be scoped to when the command _does_ attach something before
 							// checking if the widget supports attachments at all
 							if (!c.silent && !widget.attachmentCapabilities.supportsPromptAttachments) {

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -224,9 +224,13 @@ export class ChatRequestParser {
 		}
 
 		const capabilities = context?.attachmentCapabilities ?? usedAgent?.capabilities ?? context?.attachmentCapabilities;
-		if (!usedAgent || capabilities?.supportsPromptAttachments) {
-			const slashCommands = this.slashCommandService.getCommands(location, context?.mode ?? ChatModeKind.Ask);
-			const slashCommand = slashCommands.find(c => c.command === command);
+		const slashCommands = this.slashCommandService.getCommands(location, context?.mode ?? ChatModeKind.Ask);
+		const slashCommand = slashCommands.find(c => c.command === command);
+		// If there is no agent, we allow any slash command.
+		// If there is an agent, we let
+		// * silent ones go through since they are only UI-facing and don't influence chat history
+		// * slash commands that support prompt attachments, since those are meant to be used in conjunction with an agent and we can assume the agent can handle them.
+		if (!usedAgent || slashCommand?.silent || capabilities?.supportsPromptAttachments) {
 			if (slashCommand) {
 				// Valid standalone slash command
 				return new ChatRequestSlashCommandPart(slashRange, slashEditorRange, slashCommand);

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -223,7 +223,7 @@ export class ChatRequestParser {
 			}
 		}
 
-		const capabilities = context?.attachmentCapabilities ?? usedAgent?.capabilities ?? context?.attachmentCapabilities;
+		const capabilities = context?.attachmentCapabilities ?? usedAgent?.capabilities;
 		const slashCommands = this.slashCommandService.getCommands(location, context?.mode ?? ChatModeKind.Ask);
 		const slashCommand = slashCommands.find(c => c.command === command);
 		// If there is no agent, we allow any slash command.

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_non-silent_slash_command_with_agent_and_no_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_non-silent_slash_command_with_agent_and_no_supportsPromptAttachments.0.snap
@@ -1,0 +1,54 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 16
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 17
+      },
+      text: " /fix this",
+      kind: "text"
+    }
+  ],
+  text: "@agent /fix this"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_silent_slash_command_with_agent_and_no_supportsPromptAttachments.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/__snapshots__/ChatRequestParser_silent_slash_command_with_agent_and_no_supportsPromptAttachments.0.snap
@@ -1,0 +1,71 @@
+{
+  parts: [
+    {
+      range: {
+        start: 0,
+        endExclusive: 6
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 7
+      },
+      agent: {
+        id: "agent",
+        name: "agent",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
+        extensionVersion: undefined,
+        publisherDisplayName: "",
+        extensionDisplayName: "",
+        extensionPublisherId: "",
+        locations: [ "panel" ],
+        modes: [ "ask" ],
+        metadata: {  },
+        slashCommands: [
+          {
+            name: "subCommand",
+            description: ""
+          }
+        ],
+        disambiguation: [  ]
+      },
+      kind: "agent"
+    },
+    {
+      range: {
+        start: 6,
+        endExclusive: 7
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 7,
+        endLineNumber: 1,
+        endColumn: 8
+      },
+      text: " ",
+      kind: "text"
+    },
+    {
+      range: {
+        start: 7,
+        endExclusive: 13
+      },
+      editorRange: {
+        startLineNumber: 1,
+        startColumn: 8,
+        endLineNumber: 1,
+        endColumn: 14
+      },
+      slashCommand: {
+        command: "clear",
+        silent: true
+      },
+      kind: "slash"
+    }
+  ],
+  text: "@agent /clear"
+}

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -408,4 +408,36 @@ suite('ChatRequestParser', () => {
 		});
 		await assertSnapshot(result);
 	});
+
+	test('silent slash command with agent and no supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({ _serviceBrand: undefined, hasToolsAgent: false, onDidChangeAgents: Event.None });
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		instantiationService.stub(IChatAgentService, agentsService);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([{ command: 'clear', silent: true }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /clear', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: false }
+		});
+		await assertSnapshot(result);
+	});
+
+	test('non-silent slash command with agent and no supportsPromptAttachments', async () => {
+		const agentsService = mockObject<IChatAgentService>()({ _serviceBrand: undefined, hasToolsAgent: false, onDidChangeAgents: Event.None });
+		agentsService.getAgentsByName.returns([getAgentWithSlashCommands([{ name: 'subCommand', description: '' }])]);
+		instantiationService.stub(IChatAgentService, agentsService);
+
+		const slashCommandService = mockObject<IChatSlashCommandService>()({ _serviceBrand: undefined });
+		slashCommandService.getCommands.returns([{ command: 'fix' }]);
+		instantiationService.stub(IChatSlashCommandService, slashCommandService);
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, '@agent /fix this', undefined, {
+			attachmentCapabilities: { supportsPromptAttachments: false }
+		});
+		await assertSnapshot(result);
+	});
 });


### PR DESCRIPTION
This may not be the right way to handle this... but look, slash commands that are silent like `/clear`, `/fork`, `/debug`, `/models` are not attachments. They're simply another way to invoke a command simple as that.

This code originally gated those showing up in completions AND actually working (parser changes) on whether or not the chatSession supported PromptAttachments. This refactors that to allow silent commands to go through even if that's not defined.

2nd. This change then caused allllll these permissiony commands to show up for Claude even though that UX doesn't exist for Claude so I have hard coded the target only because the when clause is also hard coded here: https://github.com/microsoft/vscode/blob/5ce6509b44ef4567da385254af426dc6ca79deae/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts#L480

With these 2 changes, Claude gets a few more slash commands:
* `/clear`
* `/fork`
* `/debug`
* `/models` (and Copilot CLI gets this one too since I removed the hardcoded target)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
