### PR TITLE
Mark many chat session related types as readonly

### DIFF
--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -31,6 +31,7 @@ import { IProcessEnvironment } from '../../base/common/platform.js';
 import { Registry } from '../../platform/registry/common/platform.js';
 import { InMemoryFileSystemProvider } from '../../platform/files/common/inMemoryFilesystemProvider.js';
 import { VSBuffer } from '../../base/common/buffer.js';
+import { isEqual } from '../../base/common/resources.js';
 
 /**
  * Mock files pre-seeded in the in-memory file system. These match the
@@ -279,13 +280,14 @@ class MockChatAgentContribution extends Disposable implements IWorkbenchContribu
 		}));
 
 		// Add or update session in list
-		const existing = this._sessionItems.find(s => s.resource.toString() === key);
-		let addedOrUpdated = existing ? { ...existing } : undefined;
+		const existingIndex = this._sessionItems.findIndex(s => isEqual(s.resource, resource));
+		let addedOrUpdated = existingIndex !== -1 ? { ...this._sessionItems[existingIndex] } : undefined;
 		if (addedOrUpdated) {
 			addedOrUpdated.timing = { ...addedOrUpdated.timing, lastRequestStarted: now, lastRequestEnded: now };
 			if (changes) {
 				addedOrUpdated.changes = changes;
 			}
+			this._sessionItems[existingIndex] = addedOrUpdated;
 		} else {
 			addedOrUpdated = {
 				resource,

--- a/src/vs/sessions/test/web.test.ts
+++ b/src/vs/sessions/test/web.test.ts
@@ -280,12 +280,11 @@ class MockChatAgentContribution extends Disposable implements IWorkbenchContribu
 
 		// Add or update session in list
 		const existing = this._sessionItems.find(s => s.resource.toString() === key);
-		let addedOrUpdated: IChatSessionItem | undefined = existing;
-		if (existing) {
-			existing.timing.lastRequestStarted = now;
-			existing.timing.lastRequestEnded = now;
+		let addedOrUpdated = existing ? { ...existing } : undefined;
+		if (addedOrUpdated) {
+			addedOrUpdated.timing = { ...addedOrUpdated.timing, lastRequestStarted: now, lastRequestEnded: now };
 			if (changes) {
-				existing.changes = changes;
+				addedOrUpdated.changes = changes;
 			}
 		} else {
 			addedOrUpdated = {

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -515,7 +515,8 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 		}
 
 		// We can still get stats if there is no model or if fetching from model failed
-		if (!item.changes || !model) {
+		let changes = revive<typeof item.changes>(item.changes);
+		if (!changes || !model) {
 			const stats = (await this._chatService.getMetadataForSession(uri))?.stats;
 			const diffs: IAgentSession['changes'] = {
 				files: stats?.fileCount || 0,
@@ -523,13 +524,13 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 				deletions: stats?.removed || 0
 			};
 			if (hasValidDiff(diffs)) {
-				item.changes = diffs;
+				changes = diffs;
 			}
 		}
 
 		return {
 			...item,
-			changes: revive(item.changes),
+			changes,
 			resource: uri,
 			iconPath: item.iconPath,
 			tooltip: item.tooltip ? this._reviveTooltip(item.tooltip) : undefined,
@@ -662,18 +663,20 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 	}
 
 	private async handleSessionModelOverrides(model: IChatModel, session: Dto<IChatSessionItem>): Promise<Dto<IChatSessionItem>> {
-		// Override desciription if there's an in-progress count
+		const outgoingSession = { ...session };
+
+		// Override description if there's an in-progress count
 		const inProgress = model.getRequests().filter(r => r.response && !r.response.isComplete);
 		if (inProgress.length) {
-			session.description = this._chatSessionsService.getInProgressSessionDescription(model);
+			outgoingSession.description = this._chatSessionsService.getInProgressSessionDescription(model);
 		}
 
 		// Override changes
 		// TODO: @osortega we don't really use statistics anymore, we need to clarify that in the API
-		if (!(session.changes instanceof Array)) {
+		if (!(outgoingSession.changes instanceof Array)) {
 			const modelStats = await awaitStatsForSession(model);
 			if (modelStats) {
-				session.changes = {
+				outgoingSession.changes = {
 					files: modelStats.fileCount,
 					insertions: modelStats.added,
 					deletions: modelStats.removed
@@ -683,10 +686,10 @@ export class MainThreadChatSessions extends Disposable implements MainThreadChat
 
 		// Override status if the models needs input
 		if (model.lastRequest?.response?.state === ResponseModelState.NeedsInput) {
-			session.status = ChatSessionStatus.NeedsInput;
+			outgoingSession.status = ChatSessionStatus.NeedsInput;
 		}
 
-		return session;
+		return outgoingSession;
 	}
 
 	private async _provideChatSessionContent(providerHandle: number, sessionResource: URI, token: CancellationToken): Promise<IChatSession> {

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1204,35 +1204,35 @@ export interface IChatCompleteResponse {
 }
 
 export interface IChatSessionStats {
-	fileCount: number;
-	added: number;
-	removed: number;
+	readonly fileCount: number;
+	readonly added: number;
+	readonly removed: number;
 }
 
 export type IChatSessionTiming = {
 	/**
 	 * Timestamp when the session was created in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 */
-	created: number;
+	readonly created: number;
 
 	/**
 	 * Timestamp when the most recent request started in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 *
 	 * Should be undefined if no requests have been made yet.
 	 */
-	lastRequestStarted: number | undefined;
+	readonly lastRequestStarted: number | undefined;
 
 	/**
 	 * Timestamp when the most recent request completed in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 *
 	 * Should be undefined if the most recent request is still in progress or if no requests have been made yet.
 	 */
-	lastRequestEnded: number | undefined;
+	readonly lastRequestEnded: number | undefined;
 };
 
 interface ILegacyChatSessionTiming {
-	startTime: number;
-	endTime?: number;
+	readonly startTime: number;
+	readonly endTime?: number;
 }
 
 export function convertLegacyChatSessionTiming(timing: IChatSessionTiming | ILegacyChatSessionTiming): IChatSessionTiming {

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -25,48 +25,48 @@ export const enum ChatSessionStatus {
 }
 
 export interface IChatSessionCommandContribution {
-	name: string;
-	description: string;
-	when?: string;
+	readonly name: string;
+	readonly description: string;
+	readonly when?: string;
 }
 
 export interface IChatSessionProviderOptionItem {
-	id: string;
-	name: string;
-	description?: string;
-	locked?: boolean;
-	icon?: ThemeIcon;
-	default?: boolean;
+	readonly id: string;
+	readonly name: string;
+	readonly description?: string;
+	readonly locked?: boolean;
+	readonly icon?: ThemeIcon;
+	readonly default?: boolean;
 	// [key: string]: any;
 }
 
 export interface IChatSessionProviderOptionGroupCommand {
-	command: string;
-	title: string;
-	tooltip?: string;
-	arguments?: unknown[];
+	readonly command: string;
+	readonly title: string;
+	readonly tooltip?: string;
+	readonly arguments?: readonly unknown[];
 }
 
 export interface IChatSessionProviderOptionGroup {
-	id: string;
-	name: string;
-	description?: string;
-	items: IChatSessionProviderOptionItem[];
-	searchable?: boolean;
-	onSearch?: (query: string, token: CancellationToken) => Thenable<IChatSessionProviderOptionItem[]>;
+	readonly id: string;
+	readonly name: string;
+	readonly description?: string;
+	readonly items: IChatSessionProviderOptionItem[];
+	readonly searchable?: boolean;
+	readonly onSearch?: (query: string, token: CancellationToken) => Thenable<IChatSessionProviderOptionItem[]>;
 	/**
 	 * A context key expression that controls visibility of this option group picker.
 	 * When specified, the picker is only visible when the expression evaluates to true.
 	 * The expression can reference other option group values via `chatSessionOption.<groupId>`.
 	 * Example: `"chatSessionOption.models == 'gpt-4'"`
 	 */
-	when?: string;
-	icon?: ThemeIcon;
+	readonly when?: string;
+	readonly icon?: ThemeIcon;
 	/**
 	 * Custom commands to show in the option group's picker UI.
 	 * These will be shown in a separate section at the end of the picker.
 	 */
-	commands?: IChatSessionProviderOptionGroupCommand[];
+	readonly commands?: IChatSessionProviderOptionGroupCommand[];
 }
 
 export interface IChatSessionsExtensionPoint {
@@ -107,28 +107,28 @@ export interface IChatSessionsExtensionPoint {
 }
 
 export interface IChatSessionItem {
-	resource: URI;
-	label: string;
-	iconPath?: ThemeIcon;
-	badge?: string | IMarkdownString;
-	description?: string | IMarkdownString;
-	status?: ChatSessionStatus;
-	tooltip?: string | IMarkdownString;
-	timing: IChatSessionTiming;
-	changes?: {
-		files: number;
-		insertions: number;
-		deletions: number;
+	readonly resource: URI;
+	readonly label: string;
+	readonly iconPath?: ThemeIcon;
+	readonly badge?: string | IMarkdownString;
+	readonly description?: string | IMarkdownString;
+	readonly status?: ChatSessionStatus;
+	readonly tooltip?: string | IMarkdownString;
+	readonly timing: IChatSessionTiming;
+	readonly changes?: {
+		readonly files: number;
+		readonly insertions: number;
+		readonly deletions: number;
 	} | readonly IChatSessionFileChange[] | readonly IChatSessionFileChange2[];
-	archived?: boolean;
-	metadata?: { readonly [key: string]: unknown };
+	readonly archived?: boolean;
+	readonly metadata?: { readonly [key: string]: unknown };
 }
 
 export interface IChatSessionFileChange {
-	modifiedUri: URI;
-	originalUri?: URI;
-	insertions: number;
-	deletions: number;
+	readonly modifiedUri: URI;
+	readonly originalUri?: URI;
+	readonly insertions: number;
+	readonly deletions: number;
 }
 
 export interface IChatSessionFileChange2 {
@@ -185,8 +185,8 @@ export interface IChatSession extends IDisposable {
 	 * Editing session transferred from a previously-untitled chat session in `onDidCommitChatSessionItem`.
 	 */
 	transferredState?: {
-		editingSession: IChatEditingSession | undefined;
-		inputState: ISerializableChatModelInputState | undefined;
+		readonly editingSession: IChatEditingSession | undefined;
+		readonly inputState: ISerializableChatModelInputState | undefined;
 	};
 
 	requestHandler?: (

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -51,7 +51,7 @@ export interface IChatSessionProviderOptionGroup {
 	readonly id: string;
 	readonly name: string;
 	readonly description?: string;
-	readonly items: IChatSessionProviderOptionItem[];
+	readonly items: readonly IChatSessionProviderOptionItem[];
 	readonly searchable?: boolean;
 	readonly onSearch?: (query: string, token: CancellationToken) => Thenable<IChatSessionProviderOptionItem[]>;
 	/**

--- a/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatSessionsService.ts
@@ -66,7 +66,7 @@ export interface IChatSessionProviderOptionGroup {
 	 * Custom commands to show in the option group's picker UI.
 	 * These will be shown in a separate section at the end of the picker.
 	 */
-	readonly commands?: IChatSessionProviderOptionGroupCommand[];
+	readonly commands?: readonly IChatSessionProviderOptionGroupCommand[];
 }
 
 export interface IChatSessionsExtensionPoint {


### PR DESCRIPTION
These types are generally expected to be immutable. This makes them easier to reason about too
