### PR TITLE
fix(terminal): avoid auto bracketed paste for non-executed control sequences

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1345,9 +1345,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	async sendText(text: string, shouldExecute: boolean, bracketedPasteMode?: boolean): Promise<void> {
-		// Apply bracketed paste sequences if the terminal has the mode enabled, this will prevent
-		// the text from triggering keybindings and ensure new lines are handled properly
-		if (bracketedPasteMode && this.xterm?.raw.modes.bracketedPasteMode) {
+		// Use bracketed paste when explicitly requested or when executing multiline text (when supported by the shell).
+		// This avoids shell keybinding/line-editing handling for pasted multiline input while preserving
+		// the original behavior of non-executed control sequences such as '\r'.
+		if ((bracketedPasteMode || (shouldExecute && /[\r\n]/.test(text))) && this.xterm?.raw.modes.bracketedPasteMode) {
 			text = `\x1b[200~${text}\x1b[201~`;
 		}
 

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { deepStrictEqual, strictEqual } from 'assert';
+import { timeout } from '../../../../../base/common/async.js';
 import { Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../../base/common/network.js';
@@ -123,7 +124,8 @@ suite('Workbench - TerminalInstance', () => {
 
 	suite('TerminalInstance', () => {
 		let terminalInstance: ITerminalInstance;
-		test('should create an instance of TerminalInstance with env from default profile', async () => {
+
+		async function createTerminalInstance(): Promise<TerminalInstance> {
 			const instantiationService = workbenchInstantiationService({
 				configurationService: () => new TestConfigurationService({
 					files: {},
@@ -134,7 +136,6 @@ suite('Workbench - TerminalInstance', () => {
 							fastScrollSensitivity: 2,
 							mouseWheelScrollSensitivity: 1,
 							unicodeVersion: '6',
-							commandsToSkipShell: [],
 							shellIntegration: {
 								enabled: true
 							}
@@ -147,9 +148,63 @@ suite('Workbench - TerminalInstance', () => {
 			instantiationService.stub(IEnvironmentVariableService, store.add(instantiationService.createInstance(EnvironmentVariableService)));
 			instantiationService.stub(ITerminalInstanceService, store.add(new TestTerminalInstanceService()));
 			instantiationService.stub(ITerminalService, { setNextCommandId: async () => { } } as Partial<ITerminalService>);
-			terminalInstance = store.add(instantiationService.createInstance(TerminalInstance, terminalShellTypeContextKey, {}));
-			// //Wait for the teminalInstance._xtermReadyPromise to resolve
-			await new Promise(resolve => setTimeout(resolve, 100));
+			const instance = store.add(instantiationService.createInstance(TerminalInstance, terminalShellTypeContextKey, {}));
+			await instance.xtermReadyPromise;
+			return instance;
+		}
+
+		async function waitForShellLaunchConfigEnv(instance: ITerminalInstance): Promise<void> {
+			for (let i = 0; i < 50; i++) {
+				if (instance.shellLaunchConfig.env) {
+					return;
+				}
+				await timeout(0);
+			}
+
+			throw new Error('Timed out waiting for shell launch config env');
+		}
+
+		async function captureWritesWithBracketedPasteMode(instance: TerminalInstance, callback: () => Promise<void>): Promise<string[]> {
+			const writes: string[] = [];
+			const processManager = (instance as unknown as { _processManager: { write(data: string): Promise<void> } })._processManager;
+			const originalWrite = processManager.write;
+			const originalXterm = instance.xterm!;
+			const testRaw = Object.create(originalXterm.raw) as typeof originalXterm.raw;
+			Object.defineProperty(testRaw, 'modes', {
+				value: {
+					...originalXterm.raw.modes,
+					bracketedPasteMode: true
+				},
+				configurable: true
+			});
+			const testXterm = Object.create(originalXterm) as typeof originalXterm;
+			Object.defineProperty(testXterm, 'raw', {
+				value: testRaw,
+				configurable: true
+			});
+			Object.defineProperty(testXterm, 'scrollToBottom', {
+				value: () => { },
+				configurable: true
+			});
+
+			processManager.write = async (data: string) => {
+				writes.push(data);
+			};
+			instance.xterm = testXterm;
+
+			try {
+				await callback();
+			} finally {
+				processManager.write = originalWrite;
+				instance.xterm = originalXterm;
+			}
+
+			return writes;
+		}
+
+		test('should create an instance of TerminalInstance with env from default profile', async () => {
+			terminalInstance = await createTerminalInstance();
+			await waitForShellLaunchConfigEnv(terminalInstance);
 			deepStrictEqual(terminalInstance.shellLaunchConfig.env, { TEST: 'TEST' });
 		});
 
@@ -192,6 +247,26 @@ suite('Workbench - TerminalInstance', () => {
 
 			// Verify that the task name is preserved
 			strictEqual(taskTerminal.title, 'Test Task Name', 'Task terminal should preserve API-set title');
+		});
+
+		test('should use bracketed paste mode for multiline executed text when available', async () => {
+			const instance = await createTerminalInstance();
+			const writes = await captureWritesWithBracketedPasteMode(instance, async () => {
+				await instance.sendText('echo hello\nworld', true);
+			});
+
+			strictEqual(writes.length, 1);
+			strictEqual(writes[0].replace(/\x1b/g, '\\x1b').replace(/\r/g, '\\r'), '\\x1b[200~echo hello\\rworld\\x1b[201~\\r');
+		});
+
+		test('should not use bracketed paste mode for non-executed carriage return input', async () => {
+			const instance = await createTerminalInstance();
+			const writes = await captureWritesWithBracketedPasteMode(instance, async () => {
+				await instance.sendText('\r', false);
+			});
+
+			strictEqual(writes.length, 1);
+			strictEqual(writes[0].replace(/\x1b/g, '\\x1b').replace(/\r/g, '\\r'), '\\r');
 		});
 	});
 	suite('parseExitResult', () => {


### PR DESCRIPTION
PR #302526 introduced automatic bracketed paste for any text containing `\r` or `\n`. This unintentionally changed the behavior of `sendText(text, false)` for control sequences such as `\u000D`, which could previously be sent as raw keystrokes via the `workbench.action.terminal.sendSequence` command to simulate Enter.

This patch restores the original behavior by applying automatic bracketed paste only when:

- explicitly requested via `bracketedPasteMode`, or
- the text is multiline *and* `shouldExecute` is true

This preserves the multiline execution fix while keeping non-executed control sequences raw.

A regression test is included to verify that `sendText('\r', false)` sends a plain `\r` to the pty instead of wrapping it in bracketed paste.

Fixes #303665

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
