### PR TITLE
Fix confirmOnKill 'always' to confirm even without child processes

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -433,9 +433,9 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	async safeDisposeTerminal(instance: ITerminalInstance): Promise<void> {
 		// Confirm on kill in the editor is handled by the editor input
+		const confirmOnKill = this._terminalConfigurationService.config.confirmOnKill;
 		if (instance.target !== TerminalLocation.Editor &&
-			instance.hasChildProcesses &&
-			(this._terminalConfigurationService.config.confirmOnKill === 'panel' || this._terminalConfigurationService.config.confirmOnKill === 'always')) {
+			(confirmOnKill === 'always' || (instance.hasChildProcesses && confirmOnKill === 'panel'))) {
 			const veto = await this._showTerminalCloseConfirmation(true);
 			if (veto) {
 				return;


### PR DESCRIPTION
## Summary

- `terminal.integrated.confirmOnKill` set to `'always'` now shows the confirmation dialog even when the terminal has no running child processes
- Previously, `'always'` still required `hasChildProcesses` to be true, making it behave identically to `'panel'` for idle terminals
- `'panel'` retains the existing behavior (only confirms when child processes are running)

## The problem

When a user sets `terminal.integrated.confirmOnKill` to `'always'`, they expect a confirmation dialog **every time** a terminal is killed. However, the current implementation checks `instance.hasChildProcesses` before showing the dialog regardless of the setting. This means clicking the trash icon on an idle terminal (e.g., a shell with no commands running) immediately kills it without confirmation.

## The fix

Restructured the condition in `safeDisposeTerminal` so that:
- `'always'` → always shows confirmation (no `hasChildProcesses` check)
- `'panel'` → shows confirmation only when child processes are running (existing behavior preserved)

**Before:**
```typescript
if (instance.target !== TerminalLocation.Editor &&
    instance.hasChildProcesses &&
    (confirmOnKill === 'panel' || confirmOnKill === 'always')) {
```

**After:**
```typescript
const confirmOnKill = this._terminalConfigurationService.config.confirmOnKill;
if (instance.target !== TerminalLocation.Editor &&
    (confirmOnKill === 'always' || (instance.hasChildProcesses && confirmOnKill === 'panel'))) {
```

## Test plan

- [ ] Set `terminal.integrated.confirmOnKill` to `'always'`
- [ ] Open a terminal (idle, no commands running)
- [ ] Click the trash icon in the terminal tab list → confirmation dialog should appear
- [ ] Run a command (e.g., `sleep 100`) and click trash → confirmation dialog should appear
- [ ] Set `confirmOnKill` to `'panel'` and repeat with idle terminal → no confirmation (existing behavior)
- [ ] Set `confirmOnKill` to `'panel'` and repeat with running process → confirmation dialog should appear
- [ ] Set `confirmOnKill` to `'never'` → no confirmation in any case