### PR TITLE
Fix non-hardcoded meta commands not working with kitty keyboard, Fish

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1131,7 +1131,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 
 			// Skip processing by xterm.js of keyboard events that resolve to commands defined in
-			// the commandsToSkipShell setting, or that use the Meta/Super modifier (Cmd on macOS).
+			// the commandsToSkipShell setting, or that use the Meta.
 			// The metaKey check is needed because when a shell like fish enables the kitty
 			// keyboard protocol, xterm.js encodes Meta-modified keys as CSI u sequences and
 			// consumes them via preventDefault. The (non-kitty) traditional xterm.js handler already skips

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1131,10 +1131,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			}
 
 			// Skip processing by xterm.js of keyboard events that resolve to commands defined in
-			// the commandsToSkipShell setting. Ensure sendKeybindingsToShell is respected here
-			// which will disable this special handling and always opt to send the keystroke to the
-			// shell process
-			if (!this._terminalConfigurationService.config.sendKeybindingsToShell && resolveResult.kind === ResultKind.KbFound && resolveResult.commandId && this._skipTerminalCommands.some(k => k === resolveResult.commandId)) {
+			// the commandsToSkipShell setting, or that use the Meta/Super modifier (Cmd on macOS).
+			// The metaKey check is needed because when a shell like fish enables the kitty
+			// keyboard protocol, xterm.js encodes Meta-modified keys as CSI u sequences and
+			// consumes them via preventDefault. The (non-kitty) traditional xterm.js handler already skips
+			// Meta keys so they bubble up naturally, but the kitty handler does not.
+			if (!this._terminalConfigurationService.config.sendKeybindingsToShell && resolveResult.kind === ResultKind.KbFound && resolveResult.commandId && (event.metaKey || this._skipTerminalCommands.some(k => k === resolveResult.commandId))) {
 				event.preventDefault();
 				return false;
 			}

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -14,6 +14,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ResultKind } from '../../../../../platform/keybinding/common/keybindingResolver.js';
 import { TerminalCapability, type ICwdDetectionCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
 import { GeneralShellType, ITerminalChildProcess, ITerminalProfile, TitleEventSource, type IShellLaunchConfig, type ITerminalBackend, type ITerminalProcessOptions } from '../../../../../platform/terminal/common/terminal.js';
@@ -136,6 +137,7 @@ suite('Workbench - TerminalInstance', () => {
 							fastScrollSensitivity: 2,
 							mouseWheelScrollSensitivity: 1,
 							unicodeVersion: '6',
+							commandsToSkipShell: [],
 							shellIntegration: {
 								enabled: true
 							}
@@ -249,6 +251,35 @@ suite('Workbench - TerminalInstance', () => {
 
 			strictEqual(writes.length, 1);
 			strictEqual(writes[0].replace(/\x1b/g, '\\x1b').replace(/\r/g, '\\r'), '\\x1b[200~echo hello\\rworld\\x1b[201~\\r');
+		});
+
+		test('custom key event handler should intercept Meta-modified keys that resolve to a command when sendKeybindingsToShell is disabled', async () => {
+			const instance = await createTerminalInstance();
+			const keybindingService = instance['_keybindingService'];
+			const originalSoftDispatch = keybindingService.softDispatch;
+			// Simulate Cmd+= resolving to zoomIn. This command is deliberately NOT in
+			// DEFAULT_COMMANDS_TO_SKIP_SHELL, so only the event.metaKey check can intercept it.
+			keybindingService.softDispatch = () => ({ kind: ResultKind.KbFound, commandId: 'workbench.action.zoomIn', commandArgs: undefined, isBubble: false });
+
+			// Capture the inline handler by intercepting its registration on xterm.raw,
+			// then attach + show the terminal so the handler gets registered.
+			let capturedHandler: ((e: KeyboardEvent) => boolean) | undefined;
+			instance.xterm!.raw.attachCustomKeyEventHandler = handler => { capturedHandler = handler; };
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+			instance.attachToElement(container);
+			instance.setVisible(true);
+
+			const event = new KeyboardEvent('keydown', { key: '=', metaKey: true, cancelable: true });
+			try {
+				deepStrictEqual(
+					{ result: capturedHandler?.(event), defaultPrevented: event.defaultPrevented },
+					{ result: false, defaultPrevented: true }
+				);
+			} finally {
+				keybindingService.softDispatch = originalSoftDispatch;
+				container.remove();
+			}
 		});
 	});
 	suite('parseExitResult', () => {


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/303118 


I think when you press command shortcut in terminal, VS Code checks if the command is in hardcoded skip list: https://github.com/microsoft/vscode/blob/a1254fd4c266b86ea1a605a8e8d3f08b7a4b24a4/src/vs/workbench/contrib/terminal/common/terminal.ts#L497 

If its like cmd+shift+p , vscode correctly intercepts it. 

If not(meaning not in the above list) like cmd+w or zoom (cmd+), vscode lets xterm handle it. 
* With the non-kitty scenarios, xterm would produce no output for these and event would bubble back up to vscode naturally.

I think with Kitty case with fish enabling KB protocol at prompt, xterm's kitty handler encodes these non-hardcoded command key as csi sequences -> sends to fish (which just ignores it), and then VS Code never see it. 

Video after my PR: 
https://github.com/user-attachments/assets/390c4b65-96fd-4027-bc4d-695285309dfb


This is really easy to test, just need to launch fish from mac and try things like cmd + (zoom in) or cmd+ shift+ w, with kitty keyboard protocol enabled. 
