### PR TITLE
Re-register run_in_terminal tool when sandbox settings change

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -76,11 +76,12 @@ class OutputLocationMigrationContribution extends Disposable implements IWorkben
 }
 registerWorkbenchContribution2(OutputLocationMigrationContribution.ID, OutputLocationMigrationContribution, WorkbenchPhase.Eventually);
 
-class ChatAgentToolsContribution extends Disposable implements IWorkbenchContribution {
+export class ChatAgentToolsContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'terminal.chatAgentTools';
 
 	private readonly _runInTerminalToolRegistration = this._register(new MutableDisposable<DisposableStore>());
+	private _runInTerminalToolRegistrationVersion = 0;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -154,8 +155,9 @@ class ChatAgentToolsContribution extends Disposable implements IWorkbenchContrib
 	private _runInTerminalTool: RunInTerminalTool | undefined;
 
 	private _registerRunInTerminalTool(): void {
+		const version = ++this._runInTerminalToolRegistrationVersion;
 		this._instantiationService.invokeFunction(createRunInTerminalToolData).then(runInTerminalToolData => {
-			if (this._store.isDisposed) {
+			if (this._store.isDisposed || version !== this._runInTerminalToolRegistrationVersion) {
 				return;
 			}
 			if (!this._runInTerminalTool) {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/terminal.chatAgentTools.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from '../../../../../base/common/codicons.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../base/common/lifecycle.js';
 import { isNumber } from '../../../../../base/common/types.js';
 import { localize } from '../../../../../nls.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -32,6 +32,7 @@ import { CreateAndRunTaskTool, CreateAndRunTaskToolData } from './tools/task/cre
 import { GetTaskOutputTool, GetTaskOutputToolData } from './tools/task/getTaskOutputTool.js';
 import { RunTaskTool, RunTaskToolData } from './tools/task/runTaskTool.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
+import { ITrustedDomainService } from '../../../url/common/trustedDomainService.js';
 import { ITerminalSandboxService, TerminalSandboxService } from '../common/terminalSandboxService.js';
 
 // #region Services
@@ -79,60 +80,96 @@ class ChatAgentToolsContribution extends Disposable implements IWorkbenchContrib
 
 	static readonly ID = 'terminal.chatAgentTools';
 
+	private readonly _runInTerminalToolRegistration = this._register(new MutableDisposable<DisposableStore>());
+
 	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-		@ILanguageModelToolsService toolsService: ILanguageModelToolsService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ILanguageModelToolsService private readonly _toolsService: ILanguageModelToolsService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ITrustedDomainService private readonly _trustedDomainService: ITrustedDomainService,
 	) {
 		super();
 
 		// #region Terminal
 
-		const confirmTerminalCommandTool = instantiationService.createInstance(ConfirmTerminalCommandTool);
-		this._register(toolsService.registerTool(ConfirmTerminalCommandToolData, confirmTerminalCommandTool));
-		const getTerminalOutputTool = instantiationService.createInstance(GetTerminalOutputTool);
-		this._register(toolsService.registerTool(GetTerminalOutputToolData, getTerminalOutputTool));
-		this._register(toolsService.executeToolSet.addTool(GetTerminalOutputToolData));
+		const confirmTerminalCommandTool = _instantiationService.createInstance(ConfirmTerminalCommandTool);
+		this._register(_toolsService.registerTool(ConfirmTerminalCommandToolData, confirmTerminalCommandTool));
+		const getTerminalOutputTool = _instantiationService.createInstance(GetTerminalOutputTool);
+		this._register(_toolsService.registerTool(GetTerminalOutputToolData, getTerminalOutputTool));
+		this._register(_toolsService.executeToolSet.addTool(GetTerminalOutputToolData));
 
-		const awaitTerminalTool = instantiationService.createInstance(AwaitTerminalTool);
-		this._register(toolsService.registerTool(AwaitTerminalToolData, awaitTerminalTool));
-		this._register(toolsService.executeToolSet.addTool(AwaitTerminalToolData));
+		const awaitTerminalTool = _instantiationService.createInstance(AwaitTerminalTool);
+		this._register(_toolsService.registerTool(AwaitTerminalToolData, awaitTerminalTool));
+		this._register(_toolsService.executeToolSet.addTool(AwaitTerminalToolData));
 
-		const killTerminalTool = instantiationService.createInstance(KillTerminalTool);
-		this._register(toolsService.registerTool(KillTerminalToolData, killTerminalTool));
-		this._register(toolsService.executeToolSet.addTool(KillTerminalToolData));
+		const killTerminalTool = _instantiationService.createInstance(KillTerminalTool);
+		this._register(_toolsService.registerTool(KillTerminalToolData, killTerminalTool));
+		this._register(_toolsService.executeToolSet.addTool(KillTerminalToolData));
 
-		instantiationService.invokeFunction(createRunInTerminalToolData).then(runInTerminalToolData => {
-			const runInTerminalTool = instantiationService.createInstance(RunInTerminalTool);
-			this._register(toolsService.registerTool(runInTerminalToolData, runInTerminalTool));
-			this._register(toolsService.executeToolSet.addTool(runInTerminalToolData));
-		});
+		this._registerRunInTerminalTool();
 
-		const getTerminalSelectionTool = instantiationService.createInstance(GetTerminalSelectionTool);
-		this._register(toolsService.registerTool(GetTerminalSelectionToolData, getTerminalSelectionTool));
+		const getTerminalSelectionTool = _instantiationService.createInstance(GetTerminalSelectionTool);
+		this._register(_toolsService.registerTool(GetTerminalSelectionToolData, getTerminalSelectionTool));
 
-		const getTerminalLastCommandTool = instantiationService.createInstance(GetTerminalLastCommandTool);
-		this._register(toolsService.registerTool(GetTerminalLastCommandToolData, getTerminalLastCommandTool));
+		const getTerminalLastCommandTool = _instantiationService.createInstance(GetTerminalLastCommandTool);
+		this._register(_toolsService.registerTool(GetTerminalLastCommandToolData, getTerminalLastCommandTool));
 
-		this._register(toolsService.readToolSet.addTool(GetTerminalSelectionToolData));
-		this._register(toolsService.readToolSet.addTool(GetTerminalLastCommandToolData));
+		this._register(_toolsService.readToolSet.addTool(GetTerminalSelectionToolData));
+		this._register(_toolsService.readToolSet.addTool(GetTerminalLastCommandToolData));
 
 		// #endregion
 
 		// #region Tasks
 
-		const runTaskTool = instantiationService.createInstance(RunTaskTool);
-		this._register(toolsService.registerTool(RunTaskToolData, runTaskTool));
+		const runTaskTool = _instantiationService.createInstance(RunTaskTool);
+		this._register(_toolsService.registerTool(RunTaskToolData, runTaskTool));
 
-		const getTaskOutputTool = instantiationService.createInstance(GetTaskOutputTool);
-		this._register(toolsService.registerTool(GetTaskOutputToolData, getTaskOutputTool));
+		const getTaskOutputTool = _instantiationService.createInstance(GetTaskOutputTool);
+		this._register(_toolsService.registerTool(GetTaskOutputToolData, getTaskOutputTool));
 
-		const createAndRunTaskTool = instantiationService.createInstance(CreateAndRunTaskTool);
-		this._register(toolsService.registerTool(CreateAndRunTaskToolData, createAndRunTaskTool));
-		this._register(toolsService.executeToolSet.addTool(RunTaskToolData));
-		this._register(toolsService.executeToolSet.addTool(CreateAndRunTaskToolData));
-		this._register(toolsService.readToolSet.addTool(GetTaskOutputToolData));
+		const createAndRunTaskTool = _instantiationService.createInstance(CreateAndRunTaskTool);
+		this._register(_toolsService.registerTool(CreateAndRunTaskToolData, createAndRunTaskTool));
+		this._register(_toolsService.executeToolSet.addTool(RunTaskToolData));
+		this._register(_toolsService.executeToolSet.addTool(CreateAndRunTaskToolData));
+		this._register(_toolsService.readToolSet.addTool(GetTaskOutputToolData));
 
 		// #endregion
+
+		// Re-register run_in_terminal tool when sandbox-related settings change,
+		// so the tool description and input schema stay in sync with the current
+		// sandbox state.
+		this._register(this._configurationService.onDidChangeConfiguration(e => {
+			if (
+				e.affectsConfiguration(TerminalChatAgentToolsSettingId.TerminalSandboxEnabled) ||
+				e.affectsConfiguration(TerminalChatAgentToolsSettingId.TerminalSandboxNetwork)
+			) {
+				this._registerRunInTerminalTool();
+			}
+		}));
+		this._register(this._trustedDomainService.onDidChangeTrustedDomains(() => {
+			this._registerRunInTerminalTool();
+		}));
+	}
+
+	private _runInTerminalTool: RunInTerminalTool | undefined;
+
+	private _registerRunInTerminalTool(): void {
+		this._instantiationService.invokeFunction(createRunInTerminalToolData).then(runInTerminalToolData => {
+			if (this._store.isDisposed) {
+				return;
+			}
+			if (!this._runInTerminalTool) {
+				this._runInTerminalTool = this._register(this._instantiationService.createInstance(RunInTerminalTool));
+			}
+			// Dispose old registration first so registerToolData doesn't throw
+			// "already registered" for the same tool ID.
+			this._runInTerminalToolRegistration.value = undefined;
+			const store = new DisposableStore();
+			store.add(this._toolsService.registerToolData(runInTerminalToolData));
+			store.add(this._toolsService.registerToolImplementation(runInTerminalToolData.id, this._runInTerminalTool));
+			store.add(this._toolsService.executeToolSet.addTool(runInTerminalToolData));
+			this._runInTerminalToolRegistration.value = store;
+		});
 	}
 }
 registerWorkbenchContribution2(ChatAgentToolsContribution.ID, ChatAgentToolsContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -214,6 +214,41 @@ suite('RunInTerminalTool', () => {
 			ok(toolData.modelDescription?.includes('The /tmp directory is not guaranteed to be accessible or writable and must be avoided'), 'Expected sandboxed tool description to discourage /tmp usage');
 		});
 
+		test('should include requestUnsandboxedExecution in schema when sandbox is enabled', async () => {
+			sandboxEnabled = true;
+
+			const toolData = await instantiationService.invokeFunction(createRunInTerminalToolData);
+			const properties = toolData.inputSchema?.properties as Record<string, object> | undefined;
+
+			ok(properties?.['requestUnsandboxedExecution'], 'Expected requestUnsandboxedExecution in schema when sandbox is enabled');
+			ok(properties?.['requestUnsandboxedExecutionReason'], 'Expected requestUnsandboxedExecutionReason in schema when sandbox is enabled');
+		});
+
+		test('should not include requestUnsandboxedExecution in schema when sandbox is disabled', async () => {
+			sandboxEnabled = false;
+
+			const toolData = await instantiationService.invokeFunction(createRunInTerminalToolData);
+			const properties = toolData.inputSchema?.properties as Record<string, object> | undefined;
+
+			ok(!properties?.['requestUnsandboxedExecution'], 'Expected no requestUnsandboxedExecution in schema when sandbox is disabled');
+			ok(!properties?.['requestUnsandboxedExecutionReason'], 'Expected no requestUnsandboxedExecutionReason in schema when sandbox is disabled');
+		});
+
+		test('should reflect sandbox setting changes in tool data', async () => {
+			sandboxEnabled = false;
+
+			const toolDataBefore = await instantiationService.invokeFunction(createRunInTerminalToolData);
+			const propertiesBefore = toolDataBefore.inputSchema?.properties as Record<string, object> | undefined;
+			ok(!propertiesBefore?.['requestUnsandboxedExecution'], 'Expected no requestUnsandboxedExecution before enabling sandbox');
+
+			sandboxEnabled = true;
+
+			const toolDataAfter = await instantiationService.invokeFunction(createRunInTerminalToolData);
+			const propertiesAfter = toolDataAfter.inputSchema?.properties as Record<string, object> | undefined;
+			ok(propertiesAfter?.['requestUnsandboxedExecution'], 'Expected requestUnsandboxedExecution after enabling sandbox');
+			ok(toolDataAfter.modelDescription?.includes('Sandboxing:'), 'Expected sandbox instructions in description after enabling sandbox');
+		});
+
 		test('should include allowed and denied network domains in model description', async () => {
 			sandboxEnabled = true;
 			terminalSandboxService.getResolvedNetworkDomains = () => ({

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -6,7 +6,7 @@
 import { ok, strictEqual } from 'assert';
 import { Separator } from '../../../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
-import { Emitter } from '../../../../../../base/common/event.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { isLinux, isWindows, OperatingSystem } from '../../../../../../base/common/platform.js';
 import { count } from '../../../../../../base/common/strings.js';
@@ -33,7 +33,7 @@ import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/wi
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService/chatService.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
-import { ILanguageModelToolsService, IPreparedToolInvocation, IToolInvocationPreparationContext, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
+import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocationPreparationContext, ToolDataSource, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
 import { ITerminalChatService, ITerminalService, type ITerminalInstance } from '../../../../terminal/browser/terminal.js';
 import { ITerminalProfileResolverService } from '../../../../terminal/common/terminal.js';
 import { createRunInTerminalToolData, RunInTerminalTool, type IRunInTerminalInputParams } from '../../browser/tools/runInTerminalTool.js';
@@ -43,6 +43,12 @@ import { TerminalChatService } from '../../../chat/browser/terminalChatService.j
 import type { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IAgentSessionsService } from '../../../../chat/browser/agentSessions/agentSessionsService.js';
 import { IAgentSession } from '../../../../chat/browser/agentSessions/agentSessionsModel.js';
+import { isDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { ITrustedDomainService } from '../../../../url/common/trustedDomainService.js';
+import { ChatAgentToolsContribution } from '../../browser/terminal.chatAgentTools.contribution.js';
+import { TerminalToolId } from '../../browser/tools/toolIds.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 
 class TestRunInTerminalTool extends RunInTerminalTool {
 	protected override _osBackend: Promise<OperatingSystem> = Promise.resolve(OperatingSystem.Windows);
@@ -1749,5 +1755,198 @@ suite('RunInTerminalTool', () => {
 				ok(!disclaimerValue.includes('denied'), 'Should not mention denial for non-denied commands');
 			}
 		});
+	});
+});
+
+suite('ChatAgentToolsContribution - tool registration refresh', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let configurationService: TestConfigurationService;
+	let registeredToolData: Map<string, IToolData>;
+	let trustedDomainsEmitter: Emitter<void>;
+	let sandboxEnabled: boolean;
+
+	setup(() => {
+		configurationService = new TestConfigurationService();
+		registeredToolData = new Map();
+		trustedDomainsEmitter = store.add(new Emitter<void>());
+		sandboxEnabled = false;
+
+		const logService = new NullLogService();
+		const fileService = store.add(new FileService(logService));
+		const fileSystemProvider = new TestIPCFileSystemProvider();
+		store.add(fileService.registerProvider(Schemas.file, fileSystemProvider));
+
+		const terminalServiceDisposeEmitter = store.add(new Emitter<ITerminalInstance>());
+		const chatServiceDisposeEmitter = store.add(new Emitter<{ sessionResource: URI[]; reason: 'cleared' }>());
+		const chatSessionArchivedEmitter = store.add(new Emitter<IAgentSession>());
+
+		instantiationService = workbenchInstantiationService({
+			configurationService: () => configurationService,
+			fileService: () => fileService,
+		}, store);
+
+		instantiationService.stub(IChatService, {
+			onDidDisposeSession: chatServiceDisposeEmitter.event,
+			getSession: () => undefined,
+		});
+		instantiationService.stub(IAgentSessionsService, {
+			onDidChangeSessionArchivedState: chatSessionArchivedEmitter.event,
+			model: {
+				onDidChangeSessionArchivedState: chatSessionArchivedEmitter.event,
+			} as IAgentSessionsService['model']
+		});
+		instantiationService.stub(ITerminalChatService, store.add(instantiationService.createInstance(TerminalChatService)));
+		instantiationService.stub(IHistoryService, {
+			getLastActiveWorkspaceRoot: () => undefined
+		});
+
+		const terminalSandboxService: ITerminalSandboxService = {
+			_serviceBrand: undefined,
+			isEnabled: async () => sandboxEnabled,
+			wrapCommand: (command: string) => `sandbox:${command}`,
+			getSandboxConfigPath: async () => sandboxEnabled ? '/tmp/sandbox.json' : undefined,
+			getTempDir: () => undefined,
+			setNeedsForceUpdateConfigFile: () => { },
+			getOS: async () => OperatingSystem.Linux,
+			getResolvedNetworkDomains: () => ({ allowedDomains: [], deniedDomains: [] }),
+		};
+		instantiationService.stub(ITerminalSandboxService, terminalSandboxService);
+
+		const treeSitterLibraryService = store.add(instantiationService.createInstance(TreeSitterLibraryService));
+		treeSitterLibraryService.isTest = true;
+		instantiationService.stub(ITreeSitterLibraryService, treeSitterLibraryService);
+
+		instantiationService.stub(ITerminalService, {
+			onDidDisposeInstance: terminalServiceDisposeEmitter.event,
+			setNextCommandId: async () => { }
+		});
+		instantiationService.stub(ITerminalProfileResolverService, {
+			getDefaultProfile: async () => ({ path: 'bash' } as ITerminalProfile)
+		});
+
+		instantiationService.stub(ITrustedDomainService, {
+			_serviceBrand: undefined,
+			onDidChangeTrustedDomains: trustedDomainsEmitter.event,
+			isValid: () => true,
+			trustedDomains: [],
+		});
+
+		const contextKeyService = instantiationService.get(IContextKeyService);
+		const registeredToolImpls = new Map<string, IToolImpl>();
+		const mockToolsService: Partial<ILanguageModelToolsService> = {
+			_serviceBrand: undefined,
+			onDidChangeTools: Event.None,
+			registerToolData(toolData: IToolData) {
+				registeredToolData.set(toolData.id, toolData);
+				return toDisposable(() => registeredToolData.delete(toolData.id));
+			},
+			registerToolImplementation(id: string, tool: IToolImpl) {
+				registeredToolImpls.set(id, tool);
+				return toDisposable(() => registeredToolImpls.delete(id));
+			},
+			registerTool(toolData: IToolData, tool: IToolImpl) {
+				registeredToolData.set(toolData.id, toolData);
+				registeredToolImpls.set(toolData.id, tool);
+				return toDisposable(() => {
+					registeredToolData.delete(toolData.id);
+					registeredToolImpls.delete(toolData.id);
+					if (isDisposable(tool)) {
+						tool.dispose();
+					}
+				});
+			},
+			getTools() {
+				return registeredToolData.values();
+			},
+			executeToolSet: new ToolSet('execute', 'execute', Codicon.play, ToolDataSource.Internal, undefined, undefined, contextKeyService),
+			readToolSet: new ToolSet('read', 'read', Codicon.book, ToolDataSource.Internal, undefined, undefined, contextKeyService),
+		};
+		instantiationService.stub(ILanguageModelToolsService, mockToolsService as ILanguageModelToolsService);
+	});
+
+	async function flushAsync(): Promise<void> {
+		// Multiple microtask cycles to let async _registerRunInTerminalTool complete
+		for (let i = 0; i < 10; i++) {
+			await new Promise<void>(resolve => setTimeout(resolve, 0));
+		}
+	}
+
+	async function createContribution(): Promise<ChatAgentToolsContribution> {
+		const contribution = store.add(instantiationService.createInstance(ChatAgentToolsContribution));
+		await flushAsync();
+		return contribution;
+	}
+
+	test('should register run_in_terminal tool on construction', async () => {
+		await createContribution();
+		ok(registeredToolData.has(TerminalToolId.RunInTerminal), 'Expected run_in_terminal tool to be registered');
+	});
+
+	test('should refresh run_in_terminal tool data when sandbox setting changes', async () => {
+		await createContribution();
+
+		const toolDataBefore = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataBefore, 'Expected run_in_terminal tool to be registered');
+		const propertiesBefore = toolDataBefore.inputSchema?.properties as Record<string, object> | undefined;
+		ok(!propertiesBefore?.['requestUnsandboxedExecution'], 'Expected no requestUnsandboxedExecution before enabling sandbox');
+
+		// Enable sandbox and fire config change
+		sandboxEnabled = true;
+		configurationService.setUserConfiguration(TerminalChatAgentToolsSettingId.TerminalSandboxEnabled, true);
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === TerminalChatAgentToolsSettingId.TerminalSandboxEnabled,
+			affectedKeys: new Set([TerminalChatAgentToolsSettingId.TerminalSandboxEnabled]),
+			source: ConfigurationTarget.USER,
+			change: null!,
+		});
+
+		// Wait for async registration
+		await flushAsync();
+
+		const toolDataAfter = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataAfter, 'Expected run_in_terminal tool to still be registered');
+		const propertiesAfter = toolDataAfter.inputSchema?.properties as Record<string, object> | undefined;
+		ok(propertiesAfter?.['requestUnsandboxedExecution'], 'Expected requestUnsandboxedExecution after enabling sandbox');
+	});
+
+	test('should refresh run_in_terminal tool data when trusted domains change', async () => {
+		await createContribution();
+
+		const toolDataBefore = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataBefore, 'Expected run_in_terminal tool to be registered');
+
+		// Fire trusted domains change
+		trustedDomainsEmitter.fire();
+
+		// Wait for async registration
+		await flushAsync();
+
+		// Tool should still be registered (re-registered with fresh data)
+		const toolDataAfter = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataAfter, 'Expected run_in_terminal tool to still be registered after trusted domains change');
+	});
+
+	test('should refresh run_in_terminal tool data when sandbox network setting changes', async () => {
+		sandboxEnabled = true;
+		await createContribution();
+
+		const toolDataBefore = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataBefore, 'Expected run_in_terminal tool to be registered');
+
+		// Fire network config change
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === TerminalChatAgentToolsSettingId.TerminalSandboxNetwork,
+			affectedKeys: new Set([TerminalChatAgentToolsSettingId.TerminalSandboxNetwork]),
+			source: ConfigurationTarget.USER,
+			change: null!,
+		});
+
+		// Wait for async registration
+		await flushAsync();
+
+		const toolDataAfter = registeredToolData.get(TerminalToolId.RunInTerminal);
+		ok(toolDataAfter, 'Expected run_in_terminal tool to still be registered after network setting change');
 	});
 });


### PR DESCRIPTION
When the terminal sandbox setting is toggled at runtime, the run_in_terminal tool's schema and description were not updated because the tool data was only computed once at startup. This meant the model never learned about `requestUnsandboxedExecution` when sandbox was enabled after startup.

Fix by using a `MutableDisposable` to manage the tool registration and re-registering whenever sandbox-related settings, network domains, or trusted domains change.

Fixes #303714

cc @Tyriar @meganrogge 