### PR TITLE
Fix terminal sandbox tmp dir scoping

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService.ts
@@ -142,9 +142,9 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 		// Use ELECTRON_RUN_AS_NODE=1 to make Electron executable behave as Node.js
 		// TMPDIR must be set as environment variable before the command
 		// Quote shell arguments so the wrapped command cannot break out of the outer shell.
-		const wrappedCommand = `PATH="$PATH:${dirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" CLAUDE_TMPDIR="${this._tempDir.path}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c ${this._quoteShellArgument(command)}`;
+		const wrappedCommand = `PATH="$PATH:${dirname(this._rgPath)}" TMPDIR="${this._tempDir.path}" CLAUDE_TMPDIR="${this._tempDir.path}" "${this._execPath}" "${this._srtPath}" --settings "${this._sandboxConfigPath}" -c ${this._quoteShellArgument(command)}`;
 		if (this._remoteEnvDetails) {
-			return `"${this._execPath}" ${wrappedCommand}`;
+			return `${wrappedCommand}`;
 		}
 		return `ELECTRON_RUN_AS_NODE=1 ${wrappedCommand}`;
 	}
@@ -258,16 +258,25 @@ export class TerminalSandboxService extends Disposable implements ITerminalSandb
 	}
 
 	private _getSandboxTempDirPath(remoteEnv: IRemoteAgentEnvironment | null): URI | undefined {
+		const sandboxTempDirName = this._getSandboxWindowTempDirName();
 		if (remoteEnv?.userHome) {
-			return URI.joinPath(remoteEnv.userHome, this._productService.serverDataFolderName ?? this._productService.dataFolderName, TerminalSandboxService._sandboxTempDirName);
+			const sandboxRoot = URI.joinPath(remoteEnv.userHome, this._productService.serverDataFolderName ?? this._productService.dataFolderName, TerminalSandboxService._sandboxTempDirName);
+			return sandboxTempDirName ? URI.joinPath(sandboxRoot, sandboxTempDirName) : sandboxRoot;
 		}
 
 		const nativeEnv = this._environmentService as IEnvironmentService & { userHome?: URI };
 		if (nativeEnv.userHome) {
-			return URI.joinPath(nativeEnv.userHome, this._productService.dataFolderName, TerminalSandboxService._sandboxTempDirName);
+			const sandboxRoot = URI.joinPath(nativeEnv.userHome, this._productService.dataFolderName, TerminalSandboxService._sandboxTempDirName);
+			return sandboxTempDirName ? URI.joinPath(sandboxRoot, sandboxTempDirName) : sandboxRoot;
 		}
 
 		return undefined;
+	}
+
+	private _getSandboxWindowTempDirName(): string | undefined {
+		const workbenchEnv = this._environmentService as IEnvironmentService & { window?: { id?: number } };
+		const windowId = workbenchEnv.window?.id;
+		return typeof windowId === 'number' ? `tmp_vscode_${windowId}` : undefined;
 	}
 
 	public getResolvedNetworkDomains(): ITerminalSandboxResolvedNetworkDomains {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts
@@ -40,6 +40,7 @@ suite('TerminalSandboxService - allowTrustedDomains', () => {
 	let createdFiles: Map<string, string>;
 	let createdFolders: string[];
 	let deletedFolders: string[];
+	const windowId = 7;
 
 	class MockTrustedDomainService implements ITrustedDomainService {
 		_serviceBrand: undefined;
@@ -173,10 +174,11 @@ suite('TerminalSandboxService - allowTrustedDomains', () => {
 
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IFileService, fileService);
-		instantiationService.stub(IEnvironmentService, <IEnvironmentService & { tmpDir?: URI; execPath?: string }>{
+		instantiationService.stub(IEnvironmentService, <IEnvironmentService & { tmpDir?: URI; execPath?: string; window?: { id: number } }>{
 			_serviceBrand: undefined,
 			tmpDir: URI.file('/tmp'),
-			execPath: '/usr/bin/node'
+			execPath: '/usr/bin/node',
+			window: { id: windowId }
 		});
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IProductService, productService);
@@ -370,7 +372,7 @@ suite('TerminalSandboxService - allowTrustedDomains', () => {
 	test('should create sandbox temp dir under the server data folder', async () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 		const configPath = await sandboxService.getSandboxConfigPath();
-		const expectedTempDir = URI.joinPath(URI.file('/home/user'), productService.serverDataFolderName ?? productService.dataFolderName, 'tmp');
+		const expectedTempDir = URI.joinPath(URI.file('/home/user'), productService.serverDataFolderName ?? productService.dataFolderName, 'tmp', `tmp_vscode_${windowId}`);
 
 		strictEqual(sandboxService.getTempDir()?.path, expectedTempDir.path, 'Sandbox temp dir should live under the server data folder');
 		strictEqual(createdFolders[0], expectedTempDir.path, 'Sandbox temp dir should be created before writing the config');
@@ -380,7 +382,7 @@ suite('TerminalSandboxService - allowTrustedDomains', () => {
 	test('should delete sandbox temp dir on shutdown', async () => {
 		const sandboxService = store.add(instantiationService.createInstance(TerminalSandboxService));
 		await sandboxService.getSandboxConfigPath();
-		const expectedTempDir = URI.joinPath(URI.file('/home/user'), productService.serverDataFolderName ?? productService.dataFolderName, 'tmp');
+		const expectedTempDir = URI.joinPath(URI.file('/home/user'), productService.serverDataFolderName ?? productService.dataFolderName, 'tmp', `tmp_vscode_${windowId}`);
 
 		lifecycleService.fireShutdown();
 		await Promise.all(lifecycleService.shutdownJoiners);


### PR DESCRIPTION
## Summary

This change scopes terminal sandbox temporary data to a per-window subdirectory so shutdown cleanup only removes the sandbox files created by the current VS Code window.

## What Changed

- derive a per-window sandbox temp folder name from `environmentService.window?.id`
- create sandbox temp paths under the existing `tmp` root using `tmp_vscode_<windowId>`
- keep cleanup targeted to `this._tempDir`, which now resolves to a window-specific directory
- preserve the existing shared root location under the product data folder for both remote and native environments
- update `TerminalSandboxService` tests to inject a window id and assert the scoped temp directory path
- keep the sandbox command wrapper using `this._execPath` directly when launching the sandbox runtime, and return the wrapped command as-is for remote environments

## Why

Previously, sandbox temp data was stored in a shared `tmp` directory. Because shutdown deletes the resolved sandbox temp directory recursively, closing one window could remove sandbox files that belonged to another open VS Code window. Scoping the temp directory by window id avoids that cross-window cleanup behavior.

## Testing

- `npm run compile-check-ts-native`
- `node ./test/unit/browser/index.js --run src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts --browser chromium`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/terminalSandboxService.test.ts`

Fixes #299224