### PR TITLE
Use terminal-secure icon for sandboxed commands

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -2277,7 +2277,7 @@ written authorization of the copyright holder.
 
 ---------------------------------------------------------
 
-vscode-codicons 0.0.41 - MIT and Creative Commons Attribution 4.0
+vscode-codicons 0.0.46-0 - MIT and Creative Commons Attribution 4.0
 https://github.com/microsoft/vscode-codicons
 
 Attribution 4.0 International

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -606,7 +606,7 @@
 				}
 			},
 			"license": "MIT and Creative Commons Attribution 4.0",
-			"version": "0.0.41"
+			"version": "0.0.46-0"
 		},
 		{
 			"component": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.45-14",
+        "@vscode/codicons": "^0.0.46-0",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -4315,9 +4315,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-14",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-14.tgz",
-      "integrity": "sha512-EdrK2NnxNGluUm9ZlU1C5VTLfG1cpO4C0CCXloS+8bDuTbidE1qtwaF5lHPcoDE102WBqBzWA09nVKFoN8RSOA==",
+      "version": "0.0.46-0",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-0.tgz",
+      "integrity": "sha512-6/ddrtzpxvUK4JSVHI0SCNXw1tI4S7KnIb28X+HWexJIv9oNQK6Mhe2qydnoGlCYt+RzqaQ0pjRS8U3smE9rrA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.45-14",
+    "@vscode/codicons": "^0.0.46-0",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.45-14",
+        "@vscode/codicons": "^0.0.46-0",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.45-14",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45-14.tgz",
-      "integrity": "sha512-EdrK2NnxNGluUm9ZlU1C5VTLfG1cpO4C0CCXloS+8bDuTbidE1qtwaF5lHPcoDE102WBqBzWA09nVKFoN8RSOA==",
+      "version": "0.0.46-0",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-0.tgz",
+      "integrity": "sha512-6/ddrtzpxvUK4JSVHI0SCNXw1tI4S7KnIb28X+HWexJIv9oNQK6Mhe2qydnoGlCYt+RzqaQ0pjRS8U3smE9rrA==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.45-14",
+    "@vscode/codicons": "^0.0.46-0",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.23",

--- a/src/vs/base/common/codiconsLibrary.ts
+++ b/src/vs/base/common/codiconsLibrary.ts
@@ -656,4 +656,5 @@ export const codiconsLibrary = {
 	claude: register('claude', 0xec82),
 	openInWindow: register('open-in-window', 0xec83),
 	newSession: register('new-session', 0xec84),
+	terminalSecure: register('terminal-secure', 0xec85),
 } as const;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart.ts
@@ -803,7 +803,7 @@ export class ChatSubagentContentPart extends ChatCollapsibleContentPart implemen
 
 		// Wrap with icon like thinking parts do
 		const itemWrapper = $('.chat-thinking-tool-wrapper');
-		const icon = getToolInvocationIcon(toolInvocation.toolId);
+		const icon = getToolInvocationIcon(toolInvocation.toolId, toolInvocation.icon);
 		const iconElement = createThinkingIcon(icon);
 		itemWrapper.appendChild(content);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -69,7 +69,11 @@ function isGenericEditToolId(toolId: string): boolean {
 		lowerToolId.includes('editfile');
 }
 
-export function getToolInvocationIcon(toolId: string): ThemeIcon {
+export function getToolInvocationIcon(toolId: string, registeredIcon?: ThemeIcon): ThemeIcon {
+	if (registeredIcon) {
+		return registeredIcon;
+	}
+
 	const lowerToolId = toolId.toLowerCase();
 
 	if (
@@ -1593,6 +1597,7 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		const itemWrapper = $('.chat-thinking-tool-wrapper');
 		const isMarkdownEdit = toolInvocationOrMarkdown?.kind === 'markdownContent';
 		const isTerminalTool = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized') && toolInvocationOrMarkdown.toolSpecificData?.kind === 'terminal';
+		const toolInvocationIcon = toolInvocationOrMarkdown && (toolInvocationOrMarkdown.kind === 'toolInvocation' || toolInvocationOrMarkdown.kind === 'toolInvocationSerialized') ? toolInvocationOrMarkdown.icon : undefined;
 
 		let icon: ThemeIcon;
 		if (isMarkdownEdit) {
@@ -1600,13 +1605,13 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		} else if (isTerminalTool) {
 			const terminalData = (toolInvocationOrMarkdown as IChatToolInvocation | IChatToolInvocationSerialized).toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number } };
 			const exitCode = terminalData?.terminalCommandState?.exitCode;
-			icon = exitCode !== undefined && exitCode !== 0 ? Codicon.error : Codicon.terminal;
+			icon = exitCode !== undefined && exitCode !== 0 ? Codicon.error : (toolInvocationIcon ?? Codicon.terminal);
 		} else if (content.classList.contains('chat-hook-outcome-blocked')) {
 			icon = Codicon.error;
 		} else if (content.classList.contains('chat-hook-outcome-warning')) {
 			icon = Codicon.warning;
 		} else {
-			icon = toolInvocationId ? getToolInvocationIcon(toolInvocationId) : Codicon.tools;
+			icon = toolInvocationId ? getToolInvocationIcon(toolInvocationId, toolInvocationIcon) : Codicon.tools;
 		}
 
 		const iconElement = createThinkingIcon(icon);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart.ts
@@ -1603,9 +1603,16 @@ ${this.hookCount > 0 ? `EXAMPLES WITH BLOCKED CONTENT (from hooks):
 		if (isMarkdownEdit) {
 			icon = Codicon.pencil;
 		} else if (isTerminalTool) {
-			const terminalData = (toolInvocationOrMarkdown as IChatToolInvocation | IChatToolInvocationSerialized).toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number } };
+			const terminalData = (toolInvocationOrMarkdown as IChatToolInvocation | IChatToolInvocationSerialized).toolSpecificData as { kind: 'terminal'; terminalCommandState?: { exitCode?: number }; commandLine?: { isSandboxWrapped?: boolean } };
 			const exitCode = terminalData?.terminalCommandState?.exitCode;
-			icon = exitCode !== undefined && exitCode !== 0 ? Codicon.error : (toolInvocationIcon ?? Codicon.terminal);
+			const isSandboxWrapped = terminalData?.commandLine?.isSandboxWrapped;
+			if (exitCode !== undefined && exitCode !== 0) {
+				icon = Codicon.error;
+			} else if (isSandboxWrapped) {
+				icon = Codicon.terminalSecure;
+			} else {
+				icon = toolInvocationIcon ?? Codicon.terminal;
+			}
 		} else if (content.classList.contains('chat-hook-outcome-blocked')) {
 			icon = Codicon.error;
 		} else if (content.classList.contains('chat-hook-outcome-warning')) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart.ts
@@ -1665,8 +1665,8 @@ class ChatTerminalThinkingCollapsibleWrapper extends ChatCollapsibleContentPart 
 
 		if (this._isSandboxWrapped) {
 			this._collapseButton.label = new MarkdownString(this._isComplete
-				? '$(lock) ' + localize('chat.terminal.ranInSandbox', "Ran `{0}` in sandbox", this._commandText)
-				: '$(lock) ' + localize('chat.terminal.runningInSandbox', "Running `{0}` in sandbox", this._commandText), { supportThemeIcons: true });
+				? localize('chat.terminal.ranInSandbox', "Ran `{0}` in sandbox", this._commandText)
+				: localize('chat.terminal.runningInSandbox', "Running `{0}` in sandbox", this._commandText));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -610,6 +610,7 @@ export interface IChatToolInvocation {
 	readonly toolId: string;
 	readonly toolCallId: string;
 	readonly subAgentInvocationId?: string;
+	readonly icon?: ThemeIcon;
 	readonly state: IObservable<IChatToolInvocation.State>;
 	generatedTitle?: string;
 	isAttachedToThinking: boolean;
@@ -873,6 +874,7 @@ export interface IChatToolInvocationSerialized {
 	isComplete: boolean;
 	toolCallId: string;
 	toolId: string;
+	readonly icon?: undefined;
 	source: ToolDataSource | undefined; // undefined on pre-1.104 versions
 	readonly subAgentInvocationId?: string;
 	generatedTitle?: string;

--- a/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation.ts
@@ -6,6 +6,7 @@
 import { encodeBase64 } from '../../../../../../base/common/buffer.js';
 import { IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { IObservable, ISettableObservable, observableValue } from '../../../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { localize } from '../../../../../../nls.js';
 import { ConfirmedReason, IChatExtensionsContent, IChatModifiedFilesConfirmationData, IChatSimpleToolInvocationData, IChatSubagentToolInvocationData, IChatTodoListContent, IChatToolInputInvocationData, IChatToolInvocation, IChatToolInvocationSerialized, ToolConfirmKind, type IChatTerminalToolInvocationData } from '../../chatService/chatService.js';
 import { IPreparedToolInvocation, isToolResultOutputDetails, IToolConfirmationMessages, IToolData, IToolProgressStep, IToolResult, ToolDataSource } from '../../tools/languageModelToolsService.js';
@@ -27,6 +28,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 	public confirmationMessages: IToolConfirmationMessages | undefined;
 	public presentation: IPreparedToolInvocation['presentation'];
 	public readonly toolId: string;
+	public readonly icon?: ThemeIcon;
 	public source: ToolDataSource;
 	public readonly subAgentInvocationId: string | undefined;
 	public parameters: unknown;
@@ -86,6 +88,7 @@ export class ChatToolInvocation implements IChatToolInvocation {
 		this.presentation = preparedInvocation?.presentation;
 		this.toolSpecificData = preparedInvocation?.toolSpecificData;
 		this.toolId = toolData.id;
+		this.icon = preparedInvocation?.icon ?? (toolData.icon && ThemeIcon.isThemeIcon(toolData.icon) ? toolData.icon : undefined);
 		this.source = toolData.source;
 		this.subAgentInvocationId = subAgentInvocationId;
 		this.parameters = parameters;

--- a/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/tools/languageModelToolsService.ts
@@ -372,6 +372,7 @@ export interface IPreparedToolInvocation {
 	originMessage?: string | IMarkdownString;
 	confirmationMessages?: IToolConfirmationMessages;
 	presentation?: ToolInvocationPresentation;
+	icon?: ThemeIcon;
 	toolSpecificData?: IChatTerminalToolInvocationData | IChatToolInputInvocationData | IChatExtensionsContent | IChatTodoListContent | IChatSubagentToolInvocationData | IChatSimpleToolInvocationData | IChatModifiedFilesConfirmationData;
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -274,7 +274,7 @@ export async function createRunInTerminalToolData(
 		modelDescription,
 		userDescription: localize('runInTerminalTool.userDescription', 'Run commands in the terminal'),
 		source: ToolDataSource.Internal,
-		icon: Codicon.terminal,
+		icon: isSandboxEnabled ? Codicon.terminalSecure : Codicon.terminal,
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -810,14 +810,15 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const escapedDisplayCommand = escapeMarkdownSyntaxTokens(displayCommand);
 		const invocationMessage = toolSpecificData.commandLine.isSandboxWrapped
 			? args.isBackground
-				? new MarkdownString('$(lock) ' + localize('runInTerminal.invocation.sandbox.background', "Running `{0}` in sandbox in background", escapedDisplayCommand), { supportThemeIcons: true })
-				: new MarkdownString('$(lock) ' + localize('runInTerminal.invocation.sandbox', "Running `{0}` in sandbox", escapedDisplayCommand), { supportThemeIcons: true })
+				? new MarkdownString(localize('runInTerminal.invocation.sandbox.background', "Running `{0}` in sandbox in background", escapedDisplayCommand))
+				: new MarkdownString(localize('runInTerminal.invocation.sandbox', "Running `{0}` in sandbox", escapedDisplayCommand))
 			: args.isBackground
 				? new MarkdownString(localize('runInTerminal.invocation.background', "Running `{0}` in background", escapedDisplayCommand))
 				: new MarkdownString(localize('runInTerminal.invocation', "Running `{0}`", escapedDisplayCommand));
 
 		return {
 			invocationMessage,
+			icon: toolSpecificData.commandLine.isSandboxWrapped ? Codicon.terminalSecure : Codicon.terminal,
 			confirmationMessages,
 			toolSpecificData,
 		};

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -289,7 +289,7 @@ suite('RunInTerminalTool', () => {
 			const preparedInvocation = await executeToolTest({ command: 'echo hello' });
 
 			ok(preparedInvocation, 'Expected prepared invocation to be defined');
-			strictEqual((preparedInvocation.invocationMessage as IMarkdownString).value, '$(lock) Running `echo hello` in sandbox');
+			strictEqual((preparedInvocation.invocationMessage as IMarkdownString).value, 'Running `echo hello` in sandbox');
 
 			const terminalData = preparedInvocation.toolSpecificData as IChatTerminalToolInvocationData;
 			strictEqual(terminalData.commandLine.isSandboxWrapped, true);


### PR DESCRIPTION
Fixes #303422

## Changes

### Adopt `@vscode/codicons` 0.0.46-0
- Update `@vscode/codicons` from `0.0.45-14` to `0.0.46-0` in root and `remote/web`
- Copy updated `codiconsLibrary.ts` (adds `terminal-secure` icon)
- Update `cgmanifest.json` and `ThirdPartyNotices.txt`

### Use `terminal-secure` codicon for sandboxed terminal commands
- Add optional `icon` field to `IPreparedToolInvocation` and `IChatToolInvocation`, allowing tools to set a per-invocation icon
- The terminal tool sets the icon to `terminal-secure` when sandbox is active, or `terminal` otherwise
- `getToolInvocationIcon()` now accepts an optional registered icon, using it when provided instead of the ID-based heuristic
- Remove $(lock) theme icon prefix from sandbox invocation messages — the icon on the tool invocation itself now communicates the sandbox state

cc @Tyriar @meganrogge @roblourens @justschen
