### PR TITLE
Handle remote agenthost reconnection

### DIFF
--- a/src/vs/platform/agentHost/common/remoteAgentHostService.ts
+++ b/src/vs/platform/agentHost/common/remoteAgentHostService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Event } from '../../../base/common/event.js';
 import { createDecorator } from '../../instantiation/common/instantiation.js';
 import type { IAgentConnection } from './agentService.js';
@@ -19,6 +20,12 @@ export interface IRemoteAgentHostEntry {
 
 export const IRemoteAgentHostService = createDecorator<IRemoteAgentHostService>('remoteAgentHostService');
 
+/** Payload for {@link IRemoteAgentHostService.onDidChangeConnectionState}. */
+export interface IConnectionStateChange {
+	readonly address: string;
+	readonly connected: boolean;
+}
+
 /**
  * Manages connections to one or more remote agent host processes over
  * WebSocket. Each connection is identified by its address string and
@@ -28,10 +35,22 @@ export const IRemoteAgentHostService = createDecorator<IRemoteAgentHostService>(
 export interface IRemoteAgentHostService {
 	readonly _serviceBrand: undefined;
 
-	/** Fires when a remote connection is established or lost. */
+	/**
+	 * Fires when configured connections are added or removed
+	 * (e.g. the settings list changes).
+	 */
 	readonly onDidChangeConnections: Event<void>;
 
-	/** Currently connected remote addresses with metadata. */
+	/**
+	 * Fires when a specific connection transitions between
+	 * connected and disconnected states.
+	 */
+	readonly onDidChangeConnectionState: Event<IConnectionStateChange>;
+
+	/**
+	 * All configured remote addresses with metadata.
+	 * Includes both connected and disconnected entries.
+	 */
 	readonly connections: readonly IRemoteAgentHostConnectionInfo[];
 
 	/**
@@ -41,19 +60,35 @@ export interface IRemoteAgentHostService {
 	 * Returns `undefined` if no active connection exists for the address.
 	 */
 	getConnection(address: string): IAgentConnection | undefined;
+
+	/**
+	 * Ensure an active connection to the given address, reconnecting
+	 * on demand if the connection was previously lost.
+	 *
+	 * This method is silent - it does not show progress UI. Callers that
+	 * want progress indicators for user-initiated actions should wrap
+	 * this call with their own progress notifications.
+	 *
+	 * @throws if the connection cannot be established.
+	 */
+	ensureConnected(address: string, token?: CancellationToken): Promise<IAgentConnection>;
 }
 
 /** Metadata about a single remote connection. */
 export interface IRemoteAgentHostConnectionInfo {
 	readonly address: string;
 	readonly name: string;
-	readonly clientId: string;
+	/** Whether the WebSocket connection is currently active. */
+	readonly connected: boolean;
+	readonly clientId?: string;
 	readonly defaultDirectory?: string;
 }
 
 export class NullRemoteAgentHostService implements IRemoteAgentHostService {
 	declare readonly _serviceBrand: undefined;
 	readonly onDidChangeConnections = Event.None;
+	readonly onDidChangeConnectionState = Event.None;
 	readonly connections: readonly IRemoteAgentHostConnectionInfo[] = [];
 	getConnection(): IAgentConnection | undefined { return undefined; }
+	async ensureConnected(): Promise<IAgentConnection> { throw new Error('No remote agent host connections available'); }
 }

--- a/src/vs/platform/agentHost/electron-browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/electron-browser/remoteAgentHostProtocolClient.ts
@@ -8,6 +8,7 @@
 // higher-level API matching IAgentService.
 
 import { DeferredPromise } from '../../../base/common/async.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
 import { hasKey } from '../../../base/common/types.js';
@@ -16,9 +17,10 @@ import { generateUuid } from '../../../base/common/uuid.js';
 import { ILogService } from '../../log/common/log.js';
 import { AgentSession, IAgentConnection, IAgentCreateSessionConfig, IAgentDescriptor, IAgentSessionMetadata, IAuthenticateParams, IAuthenticateResult, IResourceMetadata } from '../common/agentService.js';
 import type { IClientNotificationMap, ICommandMap } from '../common/state/protocol/messages.js';
+import type { IReconnectResult } from '../common/state/protocol/commands.js';
 import type { IActionEnvelope, INotification, ISessionAction } from '../common/state/sessionActions.js';
 import { PROTOCOL_VERSION } from '../common/state/sessionCapabilities.js';
-import { isJsonRpcNotification, isJsonRpcResponse, type IJsonRpcResponse, type IProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
+import { ReconnectResultType, isJsonRpcNotification, isJsonRpcResponse, type IJsonRpcResponse, type IProtocolMessage, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import type { ISessionSummary } from '../common/state/sessionState.js';
 import { WebSocketClientTransport } from './webSocketClientTransport.js';
 
@@ -34,7 +36,7 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 
 	declare readonly _serviceBrand: undefined;
 
-	private readonly _clientId = generateUuid();
+	private readonly _clientId: string;
 	private readonly _transport: WebSocketClientTransport;
 	private _serverSeq = 0;
 	private _nextClientSeq = 1;
@@ -65,21 +67,34 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 		return this._defaultDirectory;
 	}
 
+	/** Last server sequence number received, for reconnection. */
+	get serverSeq(): number {
+		return this._serverSeq;
+	}
+
 	constructor(
 		address: string,
 		connectionToken: string | undefined,
+		clientId: string | undefined,
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+		this._clientId = clientId ?? generateUuid();
 		this._transport = this._register(new WebSocketClientTransport(address, connectionToken));
 		this._register(this._transport.onMessage(msg => this._handleMessage(msg)));
-		this._register(this._transport.onClose(() => this._onDidClose.fire()));
+		this._register(this._transport.onClose(() => {
+			this._rejectPendingRequests();
+			this._onDidClose.fire();
+		}));
 	}
 
 	/**
 	 * Connect to the remote agent host and perform the protocol handshake.
 	 */
-	async connect(): Promise<void> {
+	async connect(token?: CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new Error('Cancelled');
+		}
 		await this._transport.connect();
 
 		const result = await this._sendRequest('initialize', {
@@ -87,15 +102,67 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			clientId: this._clientId,
 		});
 		this._serverSeq = result.serverSeq;
+		this._parseDefaultDirectory(result.defaultDirectory);
+	}
+
+	/**
+	 * Reconnect to the remote agent host using a previous session's
+	 * clientId and serverSeq. The server either replays missed actions
+	 * or sends fresh snapshots.
+	 *
+	 * Replay actions are NOT automatically fired. The caller must call
+	 * {@link emitReplayActions} after consumers are wired to the new
+	 * connection, passing the returned result.
+	 */
+	async reconnect(lastSeenServerSeq: number, subscriptions: URI[], token?: CancellationToken): Promise<IReconnectResult> {
+		if (token?.isCancellationRequested) {
+			throw new Error('Cancelled');
+		}
+		await this._transport.connect();
+
+		const result = await this._sendRequest('reconnect', {
+			clientId: this._clientId,
+			lastSeenServerSeq,
+			subscriptions: subscriptions.map(u => u.toString()),
+		});
+
+		// Ensure serverSeq is at least what we sent, even if no actions
+		// were replayed (e.g. empty replay or snapshot-mode reconnect).
+		this._serverSeq = Math.max(this._serverSeq, lastSeenServerSeq);
+
+		// Advance serverSeq from replay actions but do not fire them yet -
+		// the caller must wire consumers first, then call emitReplayActions().
+		if (result.type === ReconnectResultType.Replay) {
+			for (const envelope of result.actions) {
+				this._serverSeq = Math.max(this._serverSeq, envelope.serverSeq);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Emit replayed action envelopes through {@link onDidAction} so that
+	 * listeners (e.g. SessionClientState) can consume them. Must be called
+	 * after consumers are wired to this client's events.
+	 */
+	emitReplayActions(result: IReconnectResult): void {
+		if (result.type === ReconnectResultType.Replay) {
+			for (const envelope of result.actions) {
+				this._onDidAction.fire(envelope);
+			}
+		}
+	}
+
+	private _parseDefaultDirectory(defaultDirectory: unknown): void {
 		// defaultDirectory arrives from the protocol as either a URI string
 		// (e.g. "file:///Users/roblou") or a serialized URI object
 		// ({ scheme, path, ... }). Extract just the filesystem path.
-		if (result.defaultDirectory) {
-			const dir = result.defaultDirectory;
-			if (typeof dir === 'string') {
-				this._defaultDirectory = URI.parse(dir).path;
+		if (defaultDirectory) {
+			if (typeof defaultDirectory === 'string') {
+				this._defaultDirectory = URI.parse(defaultDirectory).path;
 			} else {
-				this._defaultDirectory = URI.revive(dir).path;
+				this._defaultDirectory = URI.revive(defaultDirectory as { scheme: string; path: string }).path;
 			}
 		}
 	}
@@ -105,6 +172,11 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 */
 	async subscribe(resource: URI): Promise<IStateSnapshot> {
 		const result = await this._sendRequest('subscribe', { resource: resource.toString() });
+		// Advance serverSeq from the snapshot so subsequent reconnects
+		// don't re-request already-seen state.
+		if (result.snapshot?.fromSeq !== undefined) {
+			this._serverSeq = Math.max(this._serverSeq, result.snapshot.fromSeq);
+		}
 		return result.snapshot;
 	}
 
@@ -272,5 +344,13 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	 */
 	nextClientSeq(): number {
 		return this._nextClientSeq++;
+	}
+
+	/** Reject all pending requests with a connection-closed error. */
+	private _rejectPendingRequests(): void {
+		for (const [id, deferred] of this._pendingRequests) {
+			deferred.error(new Error('Connection closed'));
+			this._pendingRequests.delete(id);
+		}
 	}
 }

--- a/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
+++ b/src/vs/platform/agentHost/electron-browser/remoteAgentHostServiceImpl.ts
@@ -5,8 +5,11 @@
 
 // Service implementation that manages WebSocket connections to remote agent
 // host processes. Reads addresses from the `chat.remoteAgentHosts` setting
-// and maintains connections, reconnecting as the setting changes.
+// and maintains connections. When a connection drops the entry is preserved
+// in a disconnected state; callers trigger reconnection on demand via
+// `ensureConnected()`.
 
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { IConfigurationService } from '../../configuration/common/configuration.js';
@@ -14,19 +17,36 @@ import { IInstantiationService } from '../../instantiation/common/instantiation.
 import { ILogService } from '../../log/common/log.js';
 
 import type { IAgentConnection } from '../common/agentService.js';
+import type { IReconnectResult } from '../common/state/protocol/commands.js';
 import {
 	IRemoteAgentHostService,
 	RemoteAgentHostsSettingId,
+	type IConnectionStateChange,
 	type IRemoteAgentHostConnectionInfo,
 	type IRemoteAgentHostEntry,
 } from '../common/remoteAgentHostService.js';
 import { RemoteAgentHostProtocolClient } from './remoteAgentHostProtocolClient.js';
 
-/** Tracks a single remote connection through its lifecycle. */
+/**
+ * Tracks a single remote connection through its lifecycle.
+ * The entry persists across disconnect/reconnect cycles.
+ */
 interface IConnectionEntry {
-	readonly store: DisposableStore;
-	readonly client: RemoteAgentHostProtocolClient;
+	/** Disposables scoped to the current WebSocket connection. Disposed on disconnect. */
+	connectionStore: DisposableStore;
+	/** The active protocol client, or `undefined` when disconnected. */
+	client: RemoteAgentHostProtocolClient | undefined;
+	/** Whether the WebSocket is currently open. */
 	connected: boolean;
+	/** Connection token from settings for reconnection. */
+	connectionToken?: string;
+	// ---- Reconnection metadata (captured on disconnect) ----
+	/** Client ID to reuse across reconnects. */
+	savedClientId: string | undefined;
+	/** Last server sequence number for replay on reconnect. */
+	savedServerSeq: number;
+	/** Default directory from the last connection. */
+	savedDefaultDirectory: string | undefined;
 }
 
 export class RemoteAgentHostService extends Disposable implements IRemoteAgentHostService {
@@ -36,8 +56,13 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	private readonly _onDidChangeConnections = this._register(new Emitter<void>());
 	readonly onDidChangeConnections = this._onDidChangeConnections.event;
 
+	private readonly _onDidChangeConnectionState = this._register(new Emitter<IConnectionStateChange>());
+	readonly onDidChangeConnectionState = this._onDidChangeConnectionState.event;
+
 	private readonly _entries = new Map<string, IConnectionEntry>();
 	private readonly _names = new Map<string, string>();
+	/** Coalesces concurrent ensureConnected calls for the same address. */
+	private readonly _pendingReconnects = new Map<string, Promise<IAgentConnection>>();
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -60,14 +85,13 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	get connections(): readonly IRemoteAgentHostConnectionInfo[] {
 		const result: IRemoteAgentHostConnectionInfo[] = [];
 		for (const [address, entry] of this._entries) {
-			if (entry.connected) {
-				result.push({
-					address,
-					name: this._names.get(address) ?? address,
-					clientId: entry.client.clientId,
-					defaultDirectory: entry.client.defaultDirectory,
-				});
-			}
+			result.push({
+				address,
+				name: this._names.get(address) ?? address,
+				connected: entry.connected,
+				clientId: entry.client?.clientId ?? entry.savedClientId,
+				defaultDirectory: entry.client?.defaultDirectory ?? entry.savedDefaultDirectory,
+			});
 		}
 		return result;
 	}
@@ -77,20 +101,65 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 		return entry?.connected ? entry.client : undefined;
 	}
 
-	private _removeConnection(address: string): void {
+	async ensureConnected(address: string, token?: CancellationToken): Promise<IAgentConnection> {
+		const entry = this._entries.get(address);
+		if (!entry) {
+			throw new Error(`No configured connection for address: ${address}`);
+		}
+		if (entry.connected && entry.client) {
+			return entry.client;
+		}
+
+		// Coalesce concurrent reconnect attempts for the same address
+		const pending = this._pendingReconnects.get(address);
+		if (pending) {
+			return pending;
+		}
+
+		const reconnectPromise = this._reconnect(address, entry, token).finally(() => {
+			this._pendingReconnects.delete(address);
+		});
+		this._pendingReconnects.set(address, reconnectPromise);
+		return reconnectPromise;
+	}
+
+	private _removeEntry(address: string): void {
 		const entry = this._entries.get(address);
 		if (entry) {
+			entry.connectionStore.dispose();
+			entry.client = undefined;
+			entry.connected = false;
 			this._entries.delete(address);
-			entry.store.dispose();
+			this._pendingReconnects.delete(address);
 			this._onDidChangeConnections.fire();
 		}
+	}
+
+	private _disconnectEntry(address: string, entry: IConnectionEntry): void {
+		if (!entry.connected && !entry.client) {
+			return; // already disconnected
+		}
+
+		// Capture reconnection metadata before disposing the client
+		if (entry.client) {
+			entry.savedClientId = entry.client.clientId;
+			entry.savedServerSeq = entry.client.serverSeq;
+			entry.savedDefaultDirectory = entry.client.defaultDirectory;
+		}
+
+		entry.connectionStore.dispose();
+		entry.connectionStore = new DisposableStore();
+		entry.client = undefined;
+		entry.connected = false;
+
+		this._onDidChangeConnectionState.fire({ address, connected: false });
 	}
 
 	private _reconcileConnections(): void {
 		const entries: IRemoteAgentHostEntry[] = this._configurationService.getValue<IRemoteAgentHostEntry[]>(RemoteAgentHostsSettingId) ?? [];
 		const desired = new Set(entries.map(e => e.address));
 
-		this._logService.info(`[RemoteAgentHost] Reconciling: desired=[${[...desired].join(', ')}], current=[${[...this._entries.keys()].map(a => `${a}(${this._entries.get(a)!.connected ? 'connected' : 'pending'})`).join(', ')}]`);
+		this._logService.info(`[RemoteAgentHost] Reconciling: desired=[${[...desired].join(', ')}], current=[${[...this._entries.keys()].map(a => `${a}(${this._entries.get(a)!.connected ? 'connected' : 'disconnected'})`).join(', ')}]`);
 
 		// Update name map and detect name changes for existing connections
 		let namesChanged = false;
@@ -103,18 +172,22 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 			}
 		}
 
-		// Remove connections no longer in the setting
+		// Remove entries no longer in the setting
 		for (const address of [...this._entries.keys()]) {
 			if (!desired.has(address)) {
-				this._logService.info(`[RemoteAgentHost] Disconnecting from ${address}`);
-				this._removeConnection(address);
+				this._logService.info(`[RemoteAgentHost] Removing ${address}`);
+				this._removeEntry(address);
 			}
 		}
 
-		// Add new connections
+		// Add new entries and initiate connection
 		for (const entry of entries) {
-			if (!this._entries.has(entry.address)) {
+			const existing = this._entries.get(entry.address);
+			if (!existing) {
 				this._connectTo(entry.address, entry.connectionToken);
+			} else {
+				// Update stored connection token in case it changed
+				existing.connectionToken = entry.connectionToken;
 			}
 		}
 
@@ -125,41 +198,124 @@ export class RemoteAgentHostService extends Disposable implements IRemoteAgentHo
 	}
 
 	private _connectTo(address: string, connectionToken?: string): void {
-		const store = new DisposableStore();
-		const client = store.add(this._instantiationService.createInstance(RemoteAgentHostProtocolClient, address, connectionToken));
-		const entry: IConnectionEntry = { store, client, connected: false };
-		this._entries.set(address, entry);
+		const connectionStore = new DisposableStore();
+		const client = connectionStore.add(this._instantiationService.createInstance(
+			RemoteAgentHostProtocolClient, address, connectionToken, /* clientId */ undefined));
 
-		// Guard removal against stale callbacks: only remove if the
-		// current entry for this address is still the one we created.
-		const guardedRemove = () => {
-			if (this._entries.get(address) === entry) {
-				this._removeConnection(address);
+		const entry: IConnectionEntry = {
+			connectionStore,
+			client,
+			connected: false,
+			connectionToken,
+			savedClientId: undefined,
+			savedServerSeq: 0,
+			savedDefaultDirectory: undefined,
+		};
+		this._entries.set(address, entry);
+		// Notify immediately so the contribution layer can set up UI
+		// registrations even before the async connect completes.
+		this._onDidChangeConnections.fire();
+
+		// Guard against stale callbacks
+		const guardedDisconnect = () => {
+			if (this._entries.get(address) === entry && entry.client === client) {
+				this._logService.warn(`[RemoteAgentHost] Connection closed: ${address}`);
+				this._disconnectEntry(address, entry);
 			}
 		};
 
-		store.add(client.onDidClose(() => {
-			this._logService.warn(`[RemoteAgentHost] Connection closed: ${address}`);
-			guardedRemove();
-		}));
+		connectionStore.add(client.onDidClose(() => guardedDisconnect()));
 
 		this._logService.info(`[RemoteAgentHost] Connecting to ${address}`);
-		client.connect().then(() => {
-			if (store.isDisposed) {
-				return; // removed before connect resolved
+		// Register the initial connect as a pending attempt so that
+		// ensureConnected() joins it rather than spawning a second client.
+		const connectPromise = client.connect().then<IAgentConnection>(() => {
+			if (connectionStore.isDisposed || entry.client !== client) {
+				throw new Error('Connection superseded');
 			}
 			this._logService.info(`[RemoteAgentHost] Connected to ${address}`);
 			entry.connected = true;
-			this._onDidChangeConnections.fire();
+			this._onDidChangeConnectionState.fire({ address, connected: true });
+			return client;
 		}).catch(err => {
 			this._logService.error(`[RemoteAgentHost] Failed to connect to ${address}`, err);
-			guardedRemove();
+			// Only mutate the entry if this client is still the active one.
+			// A concurrent ensureConnected may have already replaced it.
+			if (this._entries.get(address) === entry && entry.client === client) {
+				connectionStore.dispose();
+				entry.client = undefined;
+				entry.connected = false;
+				this._onDidChangeConnectionState.fire({ address, connected: false });
+			}
+			throw err;
+		}).finally(() => {
+			this._pendingReconnects.delete(address);
 		});
+		// Prevent unhandled rejection when nobody joins via ensureConnected
+		connectPromise.catch(() => { });
+		this._pendingReconnects.set(address, connectPromise);
+	}
+
+	private async _reconnect(address: string, entry: IConnectionEntry, token?: CancellationToken): Promise<IAgentConnection> {
+		const connectionStore = new DisposableStore();
+		const client = connectionStore.add(this._instantiationService.createInstance(
+			RemoteAgentHostProtocolClient, address, entry.connectionToken,
+			entry.savedClientId));
+
+		// Guard against stale callbacks
+		const guardedDisconnect = () => {
+			if (this._entries.get(address) === entry && entry.client === client) {
+				this._logService.warn(`[RemoteAgentHost] Connection closed: ${address}`);
+				this._disconnectEntry(address, entry);
+			}
+		};
+
+		connectionStore.add(client.onDidClose(() => guardedDisconnect()));
+
+		let reconnectResult: IReconnectResult | undefined;
+		try {
+			if (entry.savedClientId) {
+				this._logService.info(`[RemoteAgentHost] Reconnecting to ${address} (clientId=${entry.savedClientId}, serverSeq=${entry.savedServerSeq})`);
+				reconnectResult = await client.reconnect(entry.savedServerSeq, [], token);
+			} else {
+				this._logService.info(`[RemoteAgentHost] Connecting to ${address}`);
+				await client.connect(token);
+			}
+		} catch (err) {
+			connectionStore.dispose();
+			this._logService.error(`[RemoteAgentHost] Failed to reconnect to ${address}`, err);
+			throw err;
+		}
+
+		// If the entry was removed while the reconnect was in-flight (e.g. the
+		// user removed the address from settings), discard the new connection.
+		if (this._entries.get(address) !== entry) {
+			connectionStore.dispose();
+			throw new Error(`Address ${address} was removed during reconnect`);
+		}
+
+		// Dispose the old connection store and swap in the new one
+		entry.connectionStore.dispose();
+		entry.connectionStore = connectionStore;
+		entry.client = client;
+		entry.connected = true;
+
+		this._logService.info(`[RemoteAgentHost] Reconnected to ${address}`);
+		// Fire state change synchronously so contribution wires consumers
+		// before replay actions are emitted below.
+		this._onDidChangeConnectionState.fire({ address, connected: true });
+
+		// Now that consumers are wired, emit any replayed actions
+		if (reconnectResult) {
+			client.emitReplayActions(reconnectResult);
+		}
+
+		return client;
 	}
 
 	override dispose(): void {
 		for (const entry of this._entries.values()) {
-			entry.store.dispose();
+			entry.connectionStore.dispose();
 		}
 		this._entries.clear();
 		super.dispose();

--- a/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
+++ b/src/vs/platform/agentHost/test/electron-browser/remoteAgentHostService.test.ts
@@ -19,7 +19,7 @@ import { DeferredPromise } from '../../../../base/common/async.js';
 
 class MockProtocolClient extends Disposable {
 	private static _nextId = 1;
-	readonly clientId = `mock-client-${MockProtocolClient._nextId++}`;
+	readonly clientId: string;
 
 	private readonly _onDidClose = this._register(new Emitter<void>());
 	readonly onDidClose = this._onDidClose.event;
@@ -27,13 +27,31 @@ class MockProtocolClient extends Disposable {
 	readonly onDidNotification = Event.None;
 
 	public connectDeferred = new DeferredPromise<void>();
+	public reconnectDeferred: DeferredPromise<{ type: string }> | undefined;
 
-	constructor(public readonly mockAddress: string) {
+	/** Tracks the last serverSeq seen during connect/reconnect. */
+	private _serverSeq = 0;
+	get serverSeq(): number { return this._serverSeq; }
+
+	constructor(
+		public readonly mockAddress: string,
+		public readonly connectionToken: string | undefined,
+		clientId: string | undefined,
+	) {
 		super();
+		this.clientId = clientId ?? `mock-client-${MockProtocolClient._nextId++}`;
 	}
 
 	async connect(): Promise<void> {
 		return this.connectDeferred.p;
+	}
+
+	async reconnect(lastSeenServerSeq: number): Promise<{ type: string }> {
+		this._serverSeq = lastSeenServerSeq;
+		if (!this.reconnectDeferred) {
+			this.reconnectDeferred = new DeferredPromise();
+		}
+		return this.reconnectDeferred.p;
 	}
 
 	fireClose(): void {
@@ -85,7 +103,7 @@ suite('RemoteAgentHostService', () => {
 		// Mock the instantiation service to capture created protocol clients
 		const mockInstantiationService: Partial<IInstantiationService> = {
 			createInstance: (_ctor: unknown, ...args: unknown[]) => {
-				const client = new MockProtocolClient(args[0] as string);
+				const client = new MockProtocolClient(args[0] as string, args[1] as string | undefined, args[2] as string | undefined);
 				disposables.add(client);
 				createdClients.push(client);
 				return client;
@@ -110,22 +128,28 @@ suite('RemoteAgentHostService', () => {
 	test('creates connection when setting is updated', async () => {
 		const connectionChanged = Event.toPromise(service.onDidChangeConnections);
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
-
-		// Resolve the connect promise
-		assert.strictEqual(createdClients.length, 1);
-		createdClients[0].connectDeferred.complete();
 		await connectionChanged;
 
+		// Entry exists but is not yet connected
 		assert.strictEqual(service.connections.length, 1);
 		assert.strictEqual(service.connections[0].address, 'ws://host1:8080');
 		assert.strictEqual(service.connections[0].name, 'Host 1');
+		assert.strictEqual(service.connections[0].connected, false);
+
+		// Complete the connect
+		const stateEvent = Event.toPromise(service.onDidChangeConnectionState);
+		createdClients[0].connectDeferred.complete();
+		await stateEvent;
+
+		assert.strictEqual(service.connections[0].connected, true);
 	});
 
 	test('getConnection returns client after successful connect', async () => {
-		const connectionChanged = Event.toPromise(service.onDidChangeConnections);
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+
+		const stateEvent = Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[0].connectDeferred.complete();
-		await connectionChanged;
+		await stateEvent;
 
 		const connection = service.getConnection('ws://host1:8080');
 		assert.ok(connection);
@@ -133,10 +157,11 @@ suite('RemoteAgentHostService', () => {
 	});
 
 	test('removes connection when setting entry is removed', async () => {
-		// Add a connection
+		// Add a connection and connect
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+		const stateEvent = Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await stateEvent;
 
 		// Remove it
 		const removedEvent = Event.toPromise(service.onDidChangeConnections);
@@ -147,31 +172,42 @@ suite('RemoteAgentHostService', () => {
 		assert.strictEqual(service.getConnection('ws://host1:8080'), undefined);
 	});
 
-	test('fires onDidChangeConnections when connection closes', async () => {
+	test('fires onDidChangeConnections when connection closes but retains entry', async () => {
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+		const stateEvent = Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await stateEvent;
 
 		// Simulate connection close
-		const closedEvent = Event.toPromise(service.onDidChangeConnections);
+		const closedEvent = Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[0].fireClose();
-		await closedEvent;
+		const stateChange = await closedEvent;
 
-		assert.strictEqual(service.connections.length, 0);
+		assert.strictEqual(stateChange.address, 'ws://host1:8080');
+		assert.strictEqual(stateChange.connected, false);
+
+		// Entry is retained as disconnected
+		assert.strictEqual(service.connections.length, 1);
+		assert.strictEqual(service.connections[0].connected, false);
+		// getConnection returns undefined for disconnected entries
 		assert.strictEqual(service.getConnection('ws://host1:8080'), undefined);
 	});
 
-	test('removes connection on connect failure', async () => {
+	test('retains entry in disconnected state on connect failure', async () => {
 		configService.setEntries([{ address: 'ws://bad:9999', name: 'Bad' }]);
 		assert.strictEqual(createdClients.length, 1);
 
 		// Fail the connection
+		const stateEvent = Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[0].connectDeferred.error(new Error('Connection refused'));
+		const stateChange = await stateEvent;
 
-		// Wait for async error handling
-		await new Promise(r => setTimeout(r, 10));
+		assert.strictEqual(stateChange.address, 'ws://bad:9999');
+		assert.strictEqual(stateChange.connected, false);
 
-		assert.strictEqual(service.connections.length, 0);
+		// Entry is retained as disconnected, not removed
+		assert.strictEqual(service.connections.length, 1);
+		assert.strictEqual(service.connections[0].connected, false);
 		assert.strictEqual(service.getConnection('ws://bad:9999'), undefined);
 	});
 
@@ -183,9 +219,9 @@ suite('RemoteAgentHostService', () => {
 
 		assert.strictEqual(createdClients.length, 2);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await Event.toPromise(service.onDidChangeConnectionState);
 		createdClients[1].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await Event.toPromise(service.onDidChangeConnectionState);
 
 		assert.strictEqual(service.connections.length, 2);
 
@@ -199,7 +235,7 @@ suite('RemoteAgentHostService', () => {
 	test('does not re-create existing connections on setting update', async () => {
 		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
 		createdClients[0].connectDeferred.complete();
-		await Event.toPromise(service.onDidChangeConnections);
+		await Event.toPromise(service.onDidChangeConnectionState);
 
 		const firstClientId = createdClients[0].clientId;
 
@@ -216,5 +252,73 @@ suite('RemoteAgentHostService', () => {
 
 		// But name should be updated
 		assert.strictEqual(service.connections[0].name, 'Renamed');
+	});
+
+	test('ensureConnected reconnects a disconnected entry', async () => {
+		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+		createdClients[0].connectDeferred.complete();
+		await Event.toPromise(service.onDidChangeConnectionState);
+
+		const firstClientId = createdClients[0].clientId;
+
+		// Disconnect
+		const disconnectEvent = Event.toPromise(service.onDidChangeConnectionState);
+		createdClients[0].fireClose();
+		await disconnectEvent;
+		assert.strictEqual(service.connections[0].connected, false);
+
+		// Reconnect via ensureConnected - the mock's reconnect() creates its own
+		// deferred, so we need to resolve it after the method call starts.
+		const reconnectPromise = service.ensureConnected('ws://host1:8080');
+
+		// A new client should have been created with the same clientId
+		assert.strictEqual(createdClients.length, 2);
+		assert.strictEqual(createdClients[1].clientId, firstClientId);
+
+		// Complete the reconnect deferred that the mock already created
+		createdClients[1].reconnectDeferred!.complete({ type: 'replayed' });
+
+		const conn = await reconnectPromise;
+		assert.ok(conn);
+		assert.strictEqual(service.connections[0].connected, true);
+	});
+
+	test('ensureConnected returns existing connection if already connected', async () => {
+		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+		createdClients[0].connectDeferred.complete();
+		await Event.toPromise(service.onDidChangeConnectionState);
+
+		const conn = await service.ensureConnected('ws://host1:8080');
+		assert.ok(conn);
+		// Should not have created a second client
+		assert.strictEqual(createdClients.length, 1);
+	});
+
+	test('ensureConnected throws for unknown address', async () => {
+		await assert.rejects(
+			() => service.ensureConnected('ws://unknown:9999'),
+			/No configured connection/,
+		);
+	});
+
+	test('removing address from settings clears disconnected entry', async () => {
+		configService.setEntries([{ address: 'ws://host1:8080', name: 'Host 1' }]);
+		createdClients[0].connectDeferred.complete();
+		await Event.toPromise(service.onDidChangeConnectionState);
+
+		// Disconnect
+		const disconnectEvent = Event.toPromise(service.onDidChangeConnectionState);
+		createdClients[0].fireClose();
+		await disconnectEvent;
+
+		// Entry still present (disconnected)
+		assert.strictEqual(service.connections.length, 1);
+
+		// Remove from settings
+		const removedEvent = Event.toPromise(service.onDidChangeConnections);
+		configService.setEntries([]);
+		await removedEvent;
+
+		assert.strictEqual(service.connections.length, 0);
 	});
 });

--- a/src/vs/sessions/contrib/chat/test/browser/workspacePicker.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/workspacePicker.test.ts
@@ -177,7 +177,7 @@ suite('WorkspacePicker', () => {
 		const authority = agentHostAuthority(address);
 
 		// Simulate a live connection so remoteName gets cached
-		connections = [{ address, name: 'macbook', clientId: 'test-client' }];
+		connections = [{ address, name: 'macbook', clientId: 'test-client', connected: true }];
 		const picker1 = ds.add(instantiationService.createInstance(WorkspacePicker));
 		const remoteUri = agentHostUri(authority, '/home/user/project');
 		picker1.setSelectedProject(new SessionWorkspace(remoteUri), false);

--- a/src/vs/sessions/contrib/remoteAgentHost/ARCHITECTURE_REVIEW.md
+++ b/src/vs/sessions/contrib/remoteAgentHost/ARCHITECTURE_REVIEW.md
@@ -1,0 +1,88 @@
+# Remote Agent Host - Architecture Review
+
+Review of the remote agent host connection management system across:
+- `src/vs/platform/agentHost/` - service interface and implementation
+- `src/vs/sessions/contrib/remoteAgentHost/` - sessions-layer orchestrator
+- `src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/` - shared handler/controller/provider components
+
+## Critical Findings
+
+### 1. Hanging turn on connection drop
+
+`_handleTurn()` in `AgentHostSessionHandler` captures a `connection` reference and awaits a `done` promise that only resolves when `SessionClientState.onDidChangeSessionState` fires the turn-complete signal. If the WebSocket drops mid-turn:
+
+- The connection-scoped `onDidAction` listener gets disposed (via `MutableDisposable`)
+- State updates stop flowing → `finish()` is never called → `done` hangs forever
+- The UI shows a perpetual spinner with no way to recover
+
+This is the most impactful issue since the reconnection spec explicitly says agent hosts shut down on idle. A user who leaves a session open will hit this.
+
+**Fix**: Turns must observe the connection going away. Options: use a per-turn `AbortSignal` tied to the connection's `onDidClose`, or have `updateConnection()`/disconnect call `finish()` on all active turns with an appropriate error message so the UI can unblock and the user can retry.
+
+### 2. No timeout on connect/reconnect
+
+`RemoteAgentHostProtocolClient.connect()` and `reconnect()` have no timeout. They depend on WebSocket TCP timeouts (30-120s+) and the `initialize`/`reconnect` JSON-RPC handshake has no timeout at all (the `DeferredPromise` waits forever). Many callers of `ensureConnected()` don't pass a `CancellationToken` - e.g., `resolveConnection`, `AgentHostFileSystemProvider._getConnection()`.
+
+**Fix**: Add a protocol-level timeout (e.g., 30s) to `connect()` and `reconnect()`, racing the handshake with a deadline. This is a system boundary where defensive timeout is essential.
+
+### 3. Dual connection-update path creates ambiguous ownership
+
+`AgentHostSessionHandler` receives connection updates via two independent paths:
+
+- **Push**: Contribution calls `handler.updateConnection(newConnection)` during `_wireConnection()`
+- **Pull**: Handler's `_ensureConnection()` calls `resolveConnection()`, gets a new object, and calls `updateConnection()` on itself
+
+Both paths converge on `updateConnection()` → `_wireConnectionEvents()`, and can race. If the handler's pull triggers a reconnect, the contribution's push also fires, potentially double-wiring subscriptions.
+
+**Fix**: Pick one owner. The cleanest option is **push-only**: the contribution pushes new connections, the handler treats `this._connection` as authoritative. Remove `resolveConnection` from the config and `_ensureConnection()` from the handler. If a turn needs a connection and none is available, throw - the contribution is responsible for connection state.
+
+## Improvement Findings
+
+### 4. DRY - Local and remote contributions duplicate ~70% of orchestration logic
+
+`RemoteAgentHostContribution` and `AgentHostContribution` independently implement near-identical logic for: root state subscription, `_handleRootStateChange` (agent diff), `_registerAgent` (session type + list controller + session handler + models), auth wiring, and IPC tracing. The only real difference is that the remote version handles per-address lifecycle and reconnection.
+
+**Suggestion**: Extract a shared `AgentHostRegistrar` that encapsulates "given a connection + root state, manage agent lifecycle." The local contribution becomes trivially thin. The remote contribution becomes focused on the connection lifecycle delta - settings reconciliation, WebSocket state machine, FS provider. This would also naturally resolve the dual-update-path problem since the registrar would own the pattern consistently.
+
+### 5. `IConnectionEntry` is a mutable bag of fields with no encapsulation
+
+Six mutable fields modified from four different methods (`_connectTo`, `_reconnect`, `_disconnectEntry`, `_removeEntry`). The multi-step mutation in `_disconnectEntry` (capture metadata, dispose client, null fields) is ordering-sensitive and easy to get wrong.
+
+**Suggestion**: Make this a class with `connect(client)`, `disconnect()`, `reconnect(client)` transition methods that enforce invariants.
+
+### 6. Silent error swallowing in session list `refresh()`
+
+The bare `catch {}` in `AgentHostSessionListController.refresh()` silently preserves cached items on failure. While correct for disconnects, it also swallows protocol errors and unexpected exceptions with no diagnostic.
+
+**Suggestion**: Log the error. Distinguish network errors (expected cache behavior) from unexpected errors (warn-level log).
+
+### 7. Stale connection reference in auth retry
+
+`_createAndSubscribe()` captures `connection` once, then on `AHP_AUTH_REQUIRED`, authenticates and retries `connection.createSession()` with the same (potentially dead) reference.
+
+**Suggestion**: Re-resolve the connection before retry.
+
+### 8. Setting removal during pending reconnect
+
+`_removeEntry()` disposes the entry but doesn't cancel the in-flight reconnect promise. The reconnect resolves, detects the entry is gone, disposes and throws - but the caller gets an error for an entry that no longer exists.
+
+**Suggestion**: Store a `CancellationTokenSource` alongside pending reconnects so removal can cancel them immediately.
+
+## Notes (Informational)
+
+- **Layering is clean** - platform → workbench → sessions, all dependencies point downward. The shared handler/controller/provider classes are genuinely reusable between local and remote.
+- **`_pendingReconnects` coalescing** is well-done, preventing race conditions on concurrent `ensureConnected()` calls.
+- **`_rejectPendingRequests`** on WebSocket close is good fail-fast behavior.
+- **Guard closures** (`guardedDisconnect`) in the service correctly prevent stale callbacks.
+- **Dual `SessionClientState`** (one for root state, one per session handler) is correct but not obvious - a comment would help.
+- **Config bag (`IAgentHostSessionHandlerConfig`)** mixes static identity with dynamic callbacks - minor ISP issue, low priority given only two consumers.
+
+## Suggested Priority
+
+1. **Add connection-drop handling to active turns** (Critical #1)
+2. **Add protocol-level timeouts** (Critical #2)
+3. **Eliminate dual update path** (Critical #3)
+4. **Extract shared agent registrar** (Improvement #4) - naturally simplifies #3
+5. **Encapsulate `IConnectionEntry`** (Improvement #5)
+6. **Log errors in `refresh()`** (Improvement #6)
+7. **Re-resolve connection on auth retry** (Improvement #7)

--- a/src/vs/sessions/contrib/remoteAgentHost/REMOTE_AGENT_HOST_RECONNECTION.md
+++ b/src/vs/sessions/contrib/remoteAgentHost/REMOTE_AGENT_HOST_RECONNECTION.md
@@ -1,0 +1,58 @@
+# Remote Agent Host Connection Lifecycle
+
+## Background
+
+A remote agent host process may shut down while the sessions app remains open. The CLI proxy that fronts the agent host stays alive and will restart the server on the next incoming connection. The sessions app must handle this gracefully.
+
+## Requirements
+
+### Connection State
+
+1. A configured remote agent host (from `chat.remoteAgentHosts`) must remain visible in the UI regardless of whether the WebSocket connection is currently active.
+
+2. The service must expose whether each configured connection is currently connected or disconnected.
+
+3. `getConnection()` must return `undefined` when the connection is not active. This is the existing contract and callers already handle it.
+
+### Disconnect Behavior
+
+4. When the WebSocket connection closes (agent host idle shutdown, crash, network loss), the connection entry must not be removed. It transitions to a disconnected state.
+
+5. The session list in the sidebar must not be cleared when the connection drops. The last known session items are retained and displayed.
+
+6. The protocol already delivers session changes via push notifications (`notify/sessionAdded`, `notify/sessionRemoved`, `session/turnComplete`). The imperative `listSessions()` call is only needed for initial population after a connection is established.
+
+### Reconnection
+
+7. The system must not automatically reconnect immediately after a disconnect. The agent host shut down intentionally (idle timeout) and restarting it without user intent wastes resources.
+
+8. When the user performs an action that requires an active connection, the system must establish a new connection on demand. The CLI proxy will restart the agent host. Examples of such actions:
+   - Creating a new session on the remote
+   - Sending a message to a session on the remote
+   - Browsing the remote filesystem (folder picker, file operations)
+
+9. If reconnection fails (proxy also shut down, network unreachable), the error must surface to the user. The connection stays in disconnected state.
+
+10. After a successful reconnection, the system must re-subscribe to protocol state (root state, session notifications) and refresh the session list, since push notifications were missed while disconnected.
+
+### Session List While Disconnected
+
+11. The session list controller must return cached items when the connection is unavailable, not an empty list.
+
+12. The cached session list may be stale (sessions created/removed by other clients while disconnected). This is acceptable. The list will be refreshed on the next successful connection.
+
+13. Refreshing the session list must not trigger a reconnection. It operates on cached data when disconnected.
+
+### Other Clients
+
+14. If another client connects to the same CLI proxy and starts sessions while this client is disconnected, this client will not know about those sessions until it reconnects. This is an accepted limitation.
+
+15. A future improvement could be a lightweight CLI proxy health endpoint that reports whether the agent host is currently running without starting it. This would enable non-intrusive polling. The current CLI proxy starts the agent host on every request, so no such probe is possible today.
+
+### Passive Callers
+
+16. `ensureConnected()` may be called by passive system operations (e.g. the file service resolving persisted `agenthost://` URIs on window restore). These calls must not show progress UI or notifications. The service itself is silent; callers that want progress UI must wrap the call at their level.
+
+### Progress UI
+
+17. When a user-initiated action triggers reconnection (browsing the remote filesystem, creating a session) and the connection takes more than a brief moment, the caller should show a progress notification ("Connecting to {name}...") with a cancel option. This is the responsibility of the caller, not the service, since only the caller knows whether the action was user-initiated.

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/agentHostFileSystemProvider.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/agentHostFileSystemProvider.ts
@@ -144,20 +144,23 @@ export class AgentHostFileSystemProvider extends Disposable implements IFileSyst
 
 	// ---- Internals ----------------------------------------------------------
 
-	private _getConnection(authority: string) {
+	private async _getConnection(authority: string) {
 		const address = this._authorityToAddress.get(authority);
 		if (!address) {
 			throw createFileSystemProviderError(`No connection for authority: ${authority}`, FileSystemProviderErrorCode.Unavailable);
 		}
-		const connection = this._remoteAgentHostService.getConnection(address);
-		if (!connection) {
-			throw createFileSystemProviderError(`Connection unavailable: ${address}`, FileSystemProviderErrorCode.Unavailable);
+		try {
+			return await this._remoteAgentHostService.ensureConnected(address);
+		} catch (err) {
+			throw createFileSystemProviderError(
+				err instanceof Error ? err.message : `Connection unavailable: ${address}`,
+				FileSystemProviderErrorCode.Unavailable,
+			);
 		}
-		return connection;
 	}
 
 	private async _listDirectory(authority: string, resource: URI): Promise<readonly IDirectoryEntry[]> {
-		const connection = this._getConnection(authority);
+		const connection = await this._getConnection(authority);
 		try {
 			// Convert the agenthost URI to a file URI for the remote server
 			const remoteUri = URI.from({ scheme: 'file', path: resource.path || '/' });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { ILogService, LogLevel } from '../../../../platform/log/common/log.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -70,12 +70,19 @@ export function getRemoteAgentHostSessionTarget(
 	return undefined;
 }
 
-/** Per-connection state bundle, disposed when a connection is removed. */
+/** Per-connection state bundle, disposed when the address is removed from settings. */
 class ConnectionState extends Disposable {
 	readonly store = this._register(new DisposableStore());
+	/**
+	 * Disposables scoped to the current WebSocket connection.
+	 * Disposed on disconnect; set to a new store on reconnect.
+	 */
+	readonly connectionStore = this._register(new MutableDisposable<DisposableStore>());
 	readonly clientState: SessionClientState;
 	readonly agents = this._register(new DisposableMap<AgentProvider, DisposableStore>());
 	readonly modelProviders = new Map<AgentProvider, AgentHostLanguageModelProvider>();
+	readonly listControllers = new Map<AgentProvider, AgentHostSessionListController>();
+	readonly sessionHandlers = new Map<AgentProvider, AgentHostSessionHandler>();
 
 	constructor(
 		clientId: string,
@@ -126,9 +133,18 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		this._fsProvider = this._register(this._instantiationService.createInstance(AgentHostFileSystemProvider));
 		this._register(this._fileService.registerProvider(AGENT_HOST_FS_SCHEME, this._fsProvider));
 
-		// Reconcile when connections change (added/removed/reconnected)
+		// Reconcile when the set of configured connections changes (added/removed)
 		this._register(this._remoteAgentHostService.onDidChangeConnections(() => {
 			this._reconcileConnections();
+		}));
+
+		// React to individual connection state transitions (disconnect/reconnect)
+		this._register(this._remoteAgentHostService.onDidChangeConnectionState(e => {
+			if (e.connected) {
+				this._handleReconnect(e.address);
+			} else {
+				this._handleDisconnect(e.address);
+			}
 		}));
 
 		// Push auth token whenever the default account or sessions change
@@ -142,7 +158,7 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	private _reconcileConnections(): void {
 		const currentAddresses = new Set(this._remoteAgentHostService.connections.map(c => c.address));
 
-		// Remove connections no longer present
+		// Remove connections no longer in settings
 		for (const [address] of this._connections) {
 			if (!currentAddresses.has(address)) {
 				this._logService.info(`[RemoteAgentHost] Removing contribution for ${address}`);
@@ -158,30 +174,46 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 				if (existing.name !== connectionInfo.name) {
 					this._logService.info(`[RemoteAgentHost] Name changed for ${connectionInfo.address}: ${existing.name} -> ${connectionInfo.name}`);
 					this._connections.deleteAndDispose(connectionInfo.address);
-					this._setupConnection(connectionInfo.address, connectionInfo.name);
+					this._setupConnection(connectionInfo);
 				}
 			} else {
-				this._setupConnection(connectionInfo.address, connectionInfo.name);
+				this._setupConnection(connectionInfo);
 			}
 		}
 	}
 
-	private _setupConnection(address: string, name: string | undefined): void {
+	private _setupConnection(connectionInfo: IRemoteAgentHostConnectionInfo): void {
+		const clientId = connectionInfo.clientId ?? connectionInfo.address;
+		const connState = new ConnectionState(clientId, connectionInfo.name, this._logService);
+		this._connections.set(connectionInfo.address, connState);
+
+		// Track authority -> address mapping for FS provider routing
+		const authority = agentHostAuthority(connectionInfo.address);
+		connState.store.add(this._fsProvider.registerAuthority(authority, connectionInfo.address));
+
+		// If already connected, wire up the connection events
+		if (connectionInfo.connected) {
+			this._wireConnection(connectionInfo.address, connState);
+		}
+	}
+
+	/**
+	 * Wire up event subscriptions and root state subscription for an
+	 * active connection. Called on initial connect and on reconnect.
+	 */
+	private _wireConnection(address: string, connState: ConnectionState): void {
 		const connection = this._remoteAgentHostService.getConnection(address);
 		if (!connection) {
 			return;
 		}
 
-		const connState = new ConnectionState(connection.clientId, name, this._logService);
-		this._connections.set(address, connState);
-		const store = connState.store;
-
-		// Track authority -> address mapping for FS provider routing
-		const authority = agentHostAuthority(address);
-		store.add(this._fsProvider.registerAuthority(authority, address));
+		// Create a fresh connectionStore for this WebSocket lifecycle.
+		// Setting the MutableDisposable value automatically disposes the old one.
+		const connectionStore = new DisposableStore();
+		connState.connectionStore.value = connectionStore;
 
 		// Forward non-session actions to client state
-		store.add(connection.onDidAction(envelope => {
+		connectionStore.add(connection.onDidAction(envelope => {
 			if (!isSessionAction(envelope.action)) {
 				connState.clientState.receiveEnvelope(envelope);
 			}
@@ -189,19 +221,19 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		}));
 
 		// Forward notifications to client state
-		store.add(connection.onDidNotification(n => {
+		connectionStore.add(connection.onDidNotification(n => {
 			connState.clientState.receiveNotification(n);
 			this._traceIpc(address, 'onDidNotification', n);
 		}));
 
 		// React to root state changes (agent discovery)
-		store.add(connState.clientState.onDidChangeRootState(rootState => {
+		connectionStore.add(connState.clientState.onDidChangeRootState(rootState => {
 			this._handleRootStateChange(address, connection, rootState);
 		}));
 
 		// Subscribe to root state
 		connection.subscribe(URI.parse(ROOT_STATE_URI)).then(snapshot => {
-			if (store.isDisposed) {
+			if (connectionStore.isDisposed) {
 				return;
 			}
 			connState.clientState.handleSnapshot(ROOT_STATE_URI, snapshot.state, snapshot.fromSeq);
@@ -211,6 +243,48 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 
 		// Authenticate with this new connection
 		this._authenticateWithConnection(connection);
+
+		// Update existing list controllers with the new connection
+		for (const controller of connState.listControllers.values()) {
+			controller.updateConnection(connection);
+		}
+
+		// Update existing session handlers with the new connection
+		for (const handler of connState.sessionHandlers.values()) {
+			handler.updateConnection(connection);
+		}
+	}
+
+	/**
+	 * Handle a connection transitioning to disconnected state.
+	 * Disposes connection-scoped subscriptions but retains UI registrations
+	 * and cached session list items.
+	 */
+	private _handleDisconnect(address: string): void {
+		const connState = this._connections.get(address);
+		if (!connState) {
+			return;
+		}
+		this._logService.info(`[RemoteAgentHost] Connection disconnected: ${address}`);
+		connState.connectionStore.clear();
+	}
+
+	/**
+	 * Handle a connection transitioning back to connected state.
+	 * Re-wires event subscriptions, root state, and refreshes the session list.
+	 */
+	private _handleReconnect(address: string): void {
+		const connState = this._connections.get(address);
+		if (!connState) {
+			// New connection added -- full setup
+			const connectionInfo = this._remoteAgentHostService.connections.find(c => c.address === address);
+			if (connectionInfo) {
+				this._setupConnection(connectionInfo);
+			}
+			return;
+		}
+		this._logService.info(`[RemoteAgentHost] Connection reconnected: ${address}`);
+		this._wireConnection(address, connState);
 	}
 
 	private _handleRootStateChange(address: string, connection: IAgentConnection, rootState: IRootState): void {
@@ -284,6 +358,11 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			return undefined;
 		};
 
+		// Resolve a live connection on demand, reconnecting if necessary
+		const resolveConnection = async (): Promise<IAgentConnection> => {
+			return this._remoteAgentHostService.ensureConnected(address);
+		};
+
 		// Chat session contribution
 		agentStore.add(this._chatSessionsService.registerChatSessionContribution({
 			type: sessionType,
@@ -298,6 +377,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 		// Session list controller (unified)
 		const listController = agentStore.add(this._instantiationService.createInstance(
 			AgentHostSessionListController, sessionType, agent.provider, connection, displayName));
+		connState.listControllers.set(agent.provider, listController);
+		agentStore.add(toDisposable(() => connState.listControllers.delete(agent.provider)));
 		agentStore.add(this._chatSessionsService.registerChatSessionItemController(sessionType, listController));
 
 		// Session handler (unified)
@@ -312,9 +393,12 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			extensionId: 'vscode.remote-agent-host',
 			extensionDisplayName: 'Remote Agent Host',
 			resolveWorkingDirectory,
-			resolveAuthentication: () => this._resolveAuthenticationInteractively(connection),
+			resolveConnection,
+			resolveAuthentication: () => this._resolveAuthenticationInteractively(address),
 		}));
 		agentStore.add(this._chatSessionsService.registerChatSessionContentProvider(sessionType, sessionHandler));
+		connState.sessionHandlers.set(agent.provider, sessionHandler);
+		agentStore.add(toDisposable(() => connState.sessionHandlers.delete(agent.provider)));
 
 		// Language model provider
 		const vendorDescriptor = { vendor, displayName, configuration: undefined, managementCommand: undefined, when: undefined };
@@ -386,8 +470,13 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 	 * Interactively prompt the user to authenticate when the server requires it.
 	 * Returns true if authentication succeeded.
 	 */
-	private async _resolveAuthenticationInteractively(connection: IAgentConnection): Promise<boolean> {
+	private async _resolveAuthenticationInteractively(address: string): Promise<boolean> {
 		try {
+			const connection = this._remoteAgentHostService.getConnection(address);
+			if (!connection) {
+				return false;
+			}
+
 			const metadata = await connection.getResourceMetadata();
 			for (const resource of metadata.resources) {
 				for (const server of resource.authorization_servers ?? []) {
@@ -404,7 +493,14 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 						authorizationServer: serverUri,
 					});
 
-					await connection.authenticate({
+					// Re-resolve the connection after the interactive auth
+					// prompt in case it was reconnected during sign-in.
+					const freshConnection = this._remoteAgentHostService.getConnection(address);
+					if (!freshConnection) {
+						return false;
+					}
+
+					await freshConnection.authenticate({
 						resource: resource.resource,
 						token: session.accessToken,
 					});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -6,7 +6,7 @@
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { MarkdownString } from '../../../../../../base/common/htmlContent.js';
-import { Disposable, DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { generateUuid } from '../../../../../../base/common/uuid.js';
@@ -99,6 +99,12 @@ export interface IAgentHostSessionHandlerConfig {
 	 */
 	readonly resolveWorkingDirectory?: (resourceKey: string) => string | undefined;
 	/**
+	 * Optional callback to resolve a live connection on demand, reconnecting
+	 * if necessary. When provided, the handler calls this before creating
+	 * sessions or dispatching turn actions.
+	 */
+	readonly resolveConnection?: () => Promise<IAgentConnection>;
+	/**
 	 * Optional callback invoked when the server rejects an operation because
 	 * authentication is required. Should trigger interactive authentication
 	 * and return true if the user authenticated successfully.
@@ -116,6 +122,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	/** Client state manager shared across all sessions for this handler. */
 	private readonly _clientState: SessionClientState;
 
+	/** Current live connection - swapped on reconnect. */
+	private _connection: IAgentConnection;
+	/** Disposables scoped to the current connection (re-wired on reconnect). */
+	private readonly _connectionSubscriptions = this._register(new MutableDisposable<DisposableStore>());
+
 	constructor(
 		config: IAgentHostSessionHandlerConfig,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
@@ -126,18 +137,74 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	) {
 		super();
 		this._config = config;
+		this._connection = config.connection;
 
 		// Create shared client state manager for this handler instance
 		this._clientState = this._register(new SessionClientState(config.connection.clientId, this._logService));
 
-		// Forward action envelopes from IPC to client state
-		this._register(config.connection.onDidAction(envelope => {
+		this._wireConnectionEvents();
+		this._registerAgent();
+	}
+
+	/**
+	 * Resolve and ensure a live connection, re-wiring events if the connection
+	 * object has changed (e.g. after reconnect).
+	 */
+	private async _ensureConnection(): Promise<IAgentConnection> {
+		if (!this._config.resolveConnection) {
+			return this._connection;
+		}
+		const conn = await this._config.resolveConnection();
+		if (conn !== this._connection) {
+			this.updateConnection(conn);
+		}
+		return conn;
+	}
+
+	/**
+	 * Replace the underlying connection after a reconnect.
+	 * Re-wires event subscriptions and re-subscribes to active sessions.
+	 */
+	updateConnection(connection: IAgentConnection): void {
+		this._connection = connection;
+		this._wireConnectionEvents();
+		this._resubscribeActiveSessions();
+	}
+
+	/**
+	 * Subscribe to the current connection's action events and forward
+	 * session actions to the handler's client state.
+	 */
+	private _wireConnectionEvents(): void {
+		const store = new DisposableStore();
+		this._connectionSubscriptions.value = store;
+		store.add(this._connection.onDidAction(envelope => {
 			if (isSessionAction(envelope.action)) {
 				this._clientState.receiveEnvelope(envelope);
 			}
 		}));
+	}
 
-		this._registerAgent();
+	/**
+	 * Re-subscribe to all backend sessions that were active before the
+	 * connection dropped, so the server resumes sending actions for them.
+	 */
+	private _resubscribeActiveSessions(): void {
+		const connectionAtCallTime = this._connection;
+		for (const [resourceKey, sessionUri] of this._sessionToBackend) {
+			this._connection.subscribe(sessionUri).then(snapshot => {
+				// Guard: skip if the session was closed or the connection
+				// was swapped again while the subscribe was in-flight.
+				if (this._connection !== connectionAtCallTime || !this._sessionToBackend.has(resourceKey)) {
+					return;
+				}
+				if (snapshot?.state) {
+					this._clientState.handleSnapshot(sessionUri.toString(), snapshot.state, snapshot.fromSeq);
+				}
+			}).catch(err => {
+				this._logService.error(`[AgentHost] Failed to re-subscribe to session ${sessionUri}`, err);
+			});
+		}
 	}
 
 	async provideChatSessionContent(sessionResource: URI, _token: CancellationToken): Promise<IChatSession> {
@@ -153,7 +220,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			resolvedSession = this._resolveSessionUri(sessionResource);
 			this._sessionToBackend.set(resourceKey, resolvedSession);
 			try {
-				const snapshot = await this._config.connection.subscribe(resolvedSession);
+				const connection = await this._ensureConnection();
+				const snapshot = await connection.subscribe(resolvedSession);
 				if (snapshot?.state) {
 					this._clientState.handleSnapshot(resolvedSession.toString(), snapshot.state, snapshot.fromSeq);
 					const sessionState = this._clientState.getSessionState(resolvedSession.toString());
@@ -162,7 +230,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					}
 				}
 			} catch (err) {
-				this._logService.warn(`[AgentHost] Failed to subscribe to existing session: ${resolvedSession.toString()}`, err);
+				this._logService.warn(`[AgentHost] Failed to subscribe to existing session: ${resolvedSession?.toString()}`, err);
 			}
 		}
 		const session = this._instantiationService.createInstance(
@@ -180,8 +248,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._sessionToBackend.delete(resourceKey);
 				if (resolvedSession) {
 					this._clientState.unsubscribe(resolvedSession.toString());
-					this._config.connection.unsubscribe(resolvedSession);
-					this._config.connection.disposeSession(resolvedSession);
+					this._connection.unsubscribe(resolvedSession);
+					// disposeSession is async RPC; if the connection is dead the
+					// request will never complete, so fire-and-forget with catch.
+					this._connection.disposeSession(resolvedSession).catch(() => { });
 				}
 			},
 		);
@@ -257,6 +327,9 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			return;
 		}
 
+		// Ensure we have a live connection (reconnect if needed)
+		const connection = await this._ensureConnection();
+
 		const turnId = generateUuid();
 		const attachments = this._convertVariablesToAttachments(request);
 		const messageAttachments: IMessageAttachment[] = attachments.map(a => ({
@@ -278,11 +351,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 					model: rawModelId,
 				};
 				const modelSeq = this._clientState.applyOptimistic(modelAction);
-				this._config.connection.dispatchAction(modelAction, this._clientState.clientId, modelSeq);
+				connection.dispatchAction(modelAction, this._clientState.clientId, modelSeq);
 			}
 		}
 
-		// Dispatch session/turnStarted — the server will call sendMessage on
+		// Dispatch session/turnStarted - the server will call sendMessage on
 		// the provider as a side effect.
 		const turnAction = {
 			type: ActionType.SessionTurnStarted as const,
@@ -294,7 +367,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			},
 		};
 		const clientSeq = this._clientState.applyOptimistic(turnAction);
-		this._config.connection.dispatchAction(turnAction, this._clientState.clientId, clientSeq);
+		connection.dispatchAction(turnAction, this._clientState.clientId, clientSeq);
 
 		// Track live ChatToolInvocation/permission objects for this turn
 		const activeToolInvocations = new Map<string, ChatToolInvocation>();
@@ -407,7 +480,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 						approved,
 					};
 					const seq = this._clientState.applyOptimistic(resolveAction);
-					this._config.connection.dispatchAction(resolveAction, this._clientState.clientId, seq);
+					this._connection.dispatchAction(resolveAction, this._clientState.clientId, seq);
 					if (approved) {
 						confirmInvocation.didExecuteTool(undefined);
 					} else {
@@ -427,7 +500,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				turnId,
 			};
 			const seq = this._clientState.applyOptimistic(cancelAction);
-			this._config.connection.dispatchAction(cancelAction, this._clientState.clientId, seq);
+			this._connection.dispatchAction(cancelAction, this._clientState.clientId, seq);
 			finish();
 		}));
 
@@ -451,9 +524,12 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		this._logService.trace(`[AgentHost] Creating new session, model=${rawModelId ?? '(default)'}, provider=${this._config.provider}`);
 
+		// Ensure a live connection before creating the session
+		const connection = await this._ensureConnection();
+
 		let session: URI;
 		try {
-			session = await this._config.connection.createSession({
+			session = await connection.createSession({
 				model: rawModelId,
 				provider: this._config.provider,
 				workingDirectory,
@@ -464,7 +540,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				this._logService.info('[AgentHost] Authentication required, prompting user...');
 				const authenticated = await this._config.resolveAuthentication();
 				if (authenticated) {
-					session = await this._config.connection.createSession({
+					// Re-resolve the connection - it may have reconnected
+					// during the interactive auth prompt.
+					const freshConnection = await this._ensureConnection();
+					session = await freshConnection.createSession({
 						model: rawModelId,
 						provider: this._config.provider,
 						workingDirectory,
@@ -479,9 +558,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 
 		this._logService.trace(`[AgentHost] Created session: ${session.toString()}`);
 
-		// Subscribe to the new session's state
+		// Subscribe to the new session's state - use the current connection
+		// which may have changed during auth.
 		try {
-			const snapshot = await this._config.connection.subscribe(session);
+			const snapshot = await this._connection.subscribe(session);
 			this._clientState.handleSnapshot(session.toString(), snapshot.state, snapshot.fromSeq);
 		} catch (err) {
 			this._logService.error(`[AgentHost] Failed to subscribe to new session: ${session.toString()}`, err);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionListController.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken, CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../../../base/common/event.js';
-import { Disposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { AgentSession, type IAgentConnection } from '../../../../../../platform/agentHost/common/agentService.js';
@@ -27,18 +27,37 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 	readonly onDidChangeChatSessionItems = this._onDidChangeChatSessionItems.event;
 
 	private _items: IChatSessionItem[] = [];
+	private _connection: IAgentConnection;
+	private readonly _connectionSubscriptions = this._register(new MutableDisposable<DisposableStore>());
 
 	constructor(
 		private readonly _sessionType: string,
 		private readonly _provider: string,
-		private readonly _connection: IAgentConnection,
+		connection: IAgentConnection,
 		private readonly _description: string | undefined,
 		@IProductService private readonly _productService: IProductService,
 	) {
 		super();
+		this._connection = connection;
+		this._wireConnectionEvents();
+	}
 
+	/**
+	 * Replace the underlying connection after a reconnect.
+	 * Re-wires event subscriptions and triggers a refresh.
+	 */
+	updateConnection(connection: IAgentConnection): void {
+		this._connection = connection;
+		this._wireConnectionEvents();
+		const cts = new CancellationTokenSource();
+		this.refresh(cts.token).finally(() => cts.dispose());
+	}
+
+	private _wireConnectionEvents(): void {
+		const store = new DisposableStore();
+		this._connectionSubscriptions.value = store;
 		// React to protocol notifications for session list changes
-		this._register(this._connection.onDidNotification(n => {
+		store.add(this._connection.onDidNotification(n => {
 			if (n.type === 'notify/sessionAdded' && n.summary.provider === this._provider) {
 				const rawId = AgentSession.id(n.summary.resource);
 				const workingDir = typeof n.summary.workingDirectory === 'string' ? n.summary.workingDirectory : undefined;
@@ -68,7 +87,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 		}));
 
 		// Refresh on turnComplete actions for metadata updates (title, timing)
-		this._register(this._connection.onDidAction(e => {
+		store.add(this._connection.onDidAction(e => {
 			if (e.action.type === 'session/turnComplete' && isSessionAction(e.action) && AgentSession.provider(e.action.session) === this._provider) {
 				const cts = new CancellationTokenSource();
 				this.refresh(cts.token).finally(() => cts.dispose());
@@ -99,7 +118,7 @@ export class AgentHostSessionListController extends Disposable implements IChatS
 				},
 			}));
 		} catch {
-			this._items = [];
+			// Preserve cached items on failure (e.g. during disconnect)
 		}
 		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: this._items });
 	}


### PR DESCRIPTION
When the agenthost is idle and shuts down, still show UI and reconnect when needed

Co-authored-by: Copilot <copilot@github.com>

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
