### PR TITLE
Fix keyboard events not reaching web content in BrowserView

### DIFF
--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -683,7 +683,6 @@ export class BrowserView extends Disposable implements ICDPTarget {
 
 		const isArrowKey = keyCode >= KeyCode.LeftArrow && keyCode <= KeyCode.DownArrow;
 		const isNonEditingKey =
-			keyCode === KeyCode.Enter ||
 			keyCode === KeyCode.Escape ||
 			keyCode >= KeyCode.F1 && keyCode <= KeyCode.F24 ||
 			keyCode >= KeyCode.AudioVolumeMute;

--- a/src/vs/platform/browserView/electron-main/browserView.ts
+++ b/src/vs/platform/browserView/electron-main/browserView.ts
@@ -688,9 +688,15 @@ export class BrowserView extends Disposable implements ICDPTarget {
 			keyCode >= KeyCode.F1 && keyCode <= KeyCode.F24 ||
 			keyCode >= KeyCode.AudioVolumeMute;
 
+		// Arrow keys are standard text navigation (word, line, document movement
+		// and selection) — always let them pass through to web content.
+		if (isArrowKey) {
+			return false;
+		}
+
 		// Ignore most Alt-only inputs (often used for accented characters or menu accelerators)
 		const isAltOnlyInput = input.alt && !input.control && !input.meta;
-		if (isAltOnlyInput && !isNonEditingKey && !isArrowKey) {
+		if (isAltOnlyInput && !isNonEditingKey) {
 			return false;
 		}
 


### PR DESCRIPTION
`tryHandleCommand` in BrowserView's `before-input-event` handler intercepts keyboard events too aggressively, preventing them from reaching web content in the built-in browser.

**Arrow keys with modifiers** (Cmd+Arrow, Option+Arrow, Option+Shift+Arrow, etc.) are routed to VS Code's command system instead of passing through for standard text navigation. On macOS this means Cmd+Left/Right (line start/end), Option+Left/Right (word navigation), and Option+Shift+Left/Right (word selection) are all broken in web pages loaded in the built-in browser.

**Enter** is classified as a "non-editing key", causing it to be intercepted rather than delivered to web page input handlers. This breaks typing in text inputs, forms, and editors (e.g. Monaco) within the built-in browser.

### Fix

- Let all arrow key events pass through to web content unconditionally, since they are standard text navigation keys
- Remove Enter from the `isNonEditingKey` list so it reaches web content