### PR TITLE
Fix inlay hints duplicating after model.setValue()

### DIFF
--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -707,7 +707,13 @@ export class InlayHintsController implements IEditorContribution {
 		const decorationIdsToReplace: string[] = [];
 		for (const [id, metadata] of this._decorationsMetadata) {
 			const range = this._editor.getModel()?.getDecorationRange(id);
-			if (range && ranges.some(r => r.containsRange(range))) {
+			if (!range) {
+				// Decoration was destroyed (e.g. by model.setValue) — clean up stale entry
+				metadata.classNameRef.dispose();
+				this._decorationsMetadata.delete(id);
+				continue;
+			}
+			if (ranges.some(r => r.containsRange(range))) {
 				decorationIdsToReplace.push(id);
 				metadata.classNameRef.dispose();
 				this._decorationsMetadata.delete(id);


### PR DESCRIPTION
## Summary

`model.setValue()` destroys all decorations by resetting the internal decorations map in `_setValueFromTextBuffer`. However, the inlay hints controller's `_decorationsMetadata` retains references to the old decoration IDs. Since `_updateHintsDecorators` only cleans up entries where `getDecorationRange()` returns a valid range, entries with null ranges (destroyed decorations) silently accumulate.

This causes inlay hints to multiply when reusing a single editor model across multiple files via `setValue()`: on hover, `_getInlineHintsForRange` iterates `_decorationsMetadata` and checks `item.anchor.range` (the original anchor position) rather than the model's decoration range, so stale items whose anchor positions overlap the current line are included alongside current items.

## Repro

1. Create a Monaco editor with a single model and an inlay hints provider
2. Call `editor.getModel().setValue(file1Content)` — hints render correctly
3. Call `editor.getModel().setValue(file2Content)` — hints still look correct
4. Hover over any inlay hint — the hint now appears twice
5. Each additional `setValue()` call adds another duplicate on hover

## Fix

Added a null-range check in `_updateHintsDecorators` to evict stale `_decorationsMetadata` entries whose decorations were destroyed, preventing accumulation across `setValue()` calls.