### PR TITLE
Fix typos in comments, docs, and test strings

### DIFF
--- a/src/vs/editor/standalone/common/monarch/monarchCompile.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchCompile.ts
@@ -88,7 +88,7 @@ function createKeywordMatcher(arr: string[], caseInsensitive: boolean = false): 
  */
 function compileRegExp<S extends true | false>(lexer: monarchCommon.ILexerMin, str: string, handleSn: S): S extends true ? RegExp | DynamicRegExp : RegExp;
 function compileRegExp(lexer: monarchCommon.ILexerMin, str: string, handleSn: true | false): RegExp | DynamicRegExp {
-	// @@ must be interpreted as a literal @, so we replace all occurences of @@ with a placeholder character
+	// @@ must be interpreted as a literal @, so we replace all occurrences of @@ with a placeholder character
 	str = str.replace(/@@/g, `\x01`);
 
 	let n = 0;

--- a/src/vs/editor/test/common/model/tokensStore.test.ts
+++ b/src/vs/editor/test/common/model/tokensStore.test.ts
@@ -449,7 +449,7 @@ suite('TokensStore', () => {
 	});
 
 
-	test('issue #95949: Identifiers are colored in bold when targetting keywords', () => {
+	test('issue #95949: Identifiers are colored in bold when targeting keywords', () => {
 
 		function createTMMetadata(foreground: number, fontStyle: number, languageId: number): number {
 			return (

--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,9 +170,9 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
-	// events to apply our coleasing logic.
+	// events to apply our coalescing logic.
 	//
 	private static readonly FILE_CHANGES_HANDLER_DELAY = 75;
 

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -405,7 +405,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 	 *
 	 * @param handle used to get notebook serializer
 	 * @param textQuery the text query to search using
-	 * @param viewTypeFileTargets the globs (and associated ranks) that are targetting for opening this type of notebook
+	 * @param viewTypeFileTargets the globs (and associated ranks) that are targeting for opening this type of notebook
 	 * @param otherViewTypeFileTargets ranked globs for other editors that we should consider when deciding whether it will open as this notebook
 	 * @param token cancellation token
 	 * @returns `IRawClosedNotebookFileMatch` for every file. Files without matches will just have a `IRawClosedNotebookFileMatch`

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3122,7 +3122,7 @@ export class ChatResponseMarkdownPart {
 
 /**
  * TODO if 'vulnerabilities' is finalized, this should be merged with the base ChatResponseMarkdownPart. I just don't see how to do that while keeping
- * vulnerabilities in a seperate API proposal in a clean way.
+ * vulnerabilities in a separate API proposal in a clean way.
  */
 export class ChatResponseMarkdownWithVulnerabilitiesPart {
 	value: vscode.MarkdownString;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1050,7 +1050,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentLanguageModel.set(model, undefined);
 
 		if (this.cachedWidth) {
-			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
+			// For quick chat and editor chat, relayout because the input may need to shrink to accommodate the model name
 			this.layout(this.cachedWidth);
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/utils/mock.test.ts
@@ -35,33 +35,33 @@ suite('mockService', () => {
 			assert.strictEqual(
 				mock.bar,
 				'oh hi!',
-				'bar should be overriden',
+				'bar should be overridden',
 			);
 
 			assert.strictEqual(
 				mock.baz,
 				42,
-				'baz should be overriden',
+				'baz should be overridden',
 			);
 
 			assert(
 				!(mock.anotherMethod(490274)),
-				'Must execute overriden method correctly 1.',
+				'Must execute overridden method correctly 1.',
 			);
 
 			assert(
 				mock.anotherMethod(NaN),
-				'Must execute overriden method correctly 2.',
+				'Must execute overridden method correctly 2.',
 			);
 
 			assert.throws(() => {
-				// property is not overriden so must throw
+				// property is not overridden so must throw
 				// eslint-disable-next-line local/code-no-unused-expressions
 				mock.foo;
 			});
 
 			assert.throws(() => {
-				// function is not overriden so must throw
+				// function is not overridden so must throw
 				mock.someMethod(randomBoolean());
 			});
 		});

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -726,7 +726,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(listenerDisposables);
 
 		const sessionRunningScheduler = listenerDisposables.add(new RunOnceScheduler(() => {
-			// Do not immediatly defocus the stack frame if the session is running
+			// Do not immediately defocus the stack frame if the session is running
 			if (session.state === State.Running && this.viewModel.focusedSession === session) {
 				this.viewModel.setFocus(undefined, this.viewModel.focusedThread, session, false);
 			}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1490,7 +1490,7 @@ export class DebugSession implements IDebugSession {
 	private shutdown(): void {
 		this.rawListeners.clear();
 		if (this.raw) {
-			// Send out disconnect and immediatly dispose (do not wait for response) #127418
+			// Send out disconnect and immediately dispose (do not wait for response) #127418
 			this.raw.disconnect({});
 			this.raw.dispose();
 			this.raw = undefined;

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -198,7 +198,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 							const config = this.configurationService.getValue<IFilesConfiguration>();
 							if (config.workbench?.editor?.enablePreview) {
 								// delay open editors view when preview is enabled
-								// to accomodate for the user doing a double click
+								// to accommodate for the user doing a double click
 								// to pin the editor.
 								// without this delay a double click would be not
 								// possible because the next element would move

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -174,7 +174,7 @@ export class NotebookEditor extends EditorPane implements INotebookEditorPane, I
 		if (!visible) {
 			this._saveEditorViewState(this.input);
 			if (this.input && this._widget.value) {
-				// the widget is not transfered to other editor inputs
+				// the widget is not transferred to other editor inputs
 				this._widget.value.onWillHide();
 			}
 		}

--- a/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/test/common/history.test.ts
@@ -511,7 +511,7 @@ suite('Terminal history', () => {
 				});
 			});
 
-			suite('local (overriden path)', () => {
+			suite('local (overridden path)', () => {
 				let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 				setup(() => {
 					originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };
@@ -569,7 +569,7 @@ suite('Terminal history', () => {
 			});
 		});
 
-		suite('remote (overriden path)', () => {
+		suite('remote (overridden path)', () => {
 			let originalEnvValues: { XDG_DATA_HOME: string | undefined };
 			setup(() => {
 				originalEnvValues = { XDG_DATA_HOME: env['XDG_DATA_HOME'] };

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/lspTerminalModelContentProvider.ts
@@ -52,7 +52,7 @@ export class LspTerminalModelContentProvider extends Disposable implements ILspT
 
 	/**
 	 * Sets or updates content for a terminal virtual document.
-	 * This is when user has executed succesful command in terminal.
+	 * This is when user has executed successful command in terminal.
 	 * Transfer the content to virtual document, and relocate delimiter to get terminal prompt ready for next prompt.
 	 */
 	setContent(content: string): void {

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -2482,7 +2482,7 @@ suite('EditorService', () => {
 		const untypedInput1 = input1.toUntyped();
 		assert.ok(untypedInput1);
 
-		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overriden
+		// Open editor input 1 and it shouldn't trigger because typed inputs aren't overridden
 		await service.openEditor(input1);
 		assert.strictEqual(editorCount, 0);
 

--- a/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
+++ b/src/vs/workbench/services/extensions/common/extensionRunningLocationTracker.ts
@@ -163,7 +163,7 @@ export class ExtensionRunningLocationTracker {
 		// When doing extension host debugging, we will ignore the configured affinity
 		// because we can currently debug a single extension host
 		if (!this._environmentService.isExtensionDevelopment) {
-			// Go through each configured affinity and try to accomodate it
+			// Go through each configured affinity and try to accommodate it
 			const configuredAffinities = this._configurationService.getValue<{ [extensionId: string]: number } | undefined>('extensions.experimental.affinity') || {};
 			const configuredExtensionIds = Object.keys(configuredAffinities);
 			const configuredAffinityToResultingAffinity = new Map<number, number>();

--- a/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/rpcProtocol.test.ts
@@ -227,7 +227,7 @@ suite('RPCProtocol', () => {
 		});
 	});
 
-	test('SerializableObjectWithBuffers is correctly transfered', function (done) {
+	test('SerializableObjectWithBuffers is correctly transferred', function (done) {
 		delegate = (a1: SerializableObjectWithBuffers<{ string: string; buff: VSBuffer }>, a2: number) => {
 			return new SerializableObjectWithBuffers({ string: a1.value.string + ' world', buff: a1.value.buff });
 		};


### PR DESCRIPTION
## Summary
- Fix misspellings in code comments: `occured`, `coleasing`, `accomodate`, `transfered`, `immediatly`, `seperate`, `occurences`
- Fix misspellings in JSDoc comments: `succesful`, `targetting`
- Fix misspellings in test strings and suite names: `overriden`, `transfered`, `targetting`

No functional changes. All fixes are in human-readable text (comments, documentation strings, and test assertion messages).

16 files changed, 23 typos fixed.