### PR TITLE
Git - optimize worktree ignored-path computation

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1935,7 +1935,7 @@ export class Repository implements Disposable {
 
 		for (const filePath of gitIgnoredFiles) {
 			let dir = path.dirname(filePath);
-			while (dir !== this.root && !gitIgnoredFiles.has(dir)) {
+			while (dir !== this.root && !gitIgnoredPaths.has(dir)) {
 				gitIgnoredPaths.add(dir);
 				dir = path.dirname(dir);
 			}


### PR DESCRIPTION
Fix inefficient parent directory traversal in `_getWorktreeIncludePaths()`.

### Problem

The loop that builds parent directory paths for git-ignored files uses `gitIgnoredFiles.has(dir)` as the early-exit condition. Since `gitIgnoredFiles` only contains **file** paths (not directory paths), this check is always false for directories, so every file traverses all the way up to the repo root -- redundantly re-adding the same intermediate directories.

**Example** with 100 ignored files under `node_modules/a/b/`:

- **Before:** each file walks `b/ -> a/ -> node_modules/ -> root`, totaling 400 iterations
- **After:** first file walks the full chain, remaining 99 files hit `b/` in the Set and stop immediately, totaling ~103 iterations

### Fix

Change `gitIgnoredFiles.has(dir)` to `gitIgnoredPaths.has(dir)`. The `gitIgnoredPaths` Set accumulates directories as they are added, so subsequent files sharing the same parent chain skip already-processed directories.

The final Set contents are identical -- `Set.add` on an existing element is a no-op.