### PR TITLE
Settings editor - avoid repeated extension list refresh

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1396,7 +1396,10 @@ export class SettingsEditor2 extends EditorPane {
 		const additionalGroups: ISettingsGroup[] = [];
 		let setAdditionalGroups = false;
 		const toggleData = await getExperimentalExtensionToggleData(this.chatEntitlementService, this.extensionGalleryService, this.productService);
-		if (toggleData && groups.filter(g => g.extensionInfo).length) {
+		if (toggleData && groups.filter(g => g.extensionInfo).length && Object.keys(toggleData.settingsEditorRecommendedExtensions).length) {
+			// Refresh installed extensions once per onConfigUpdate invocation for performance,
+			// instead of per extension. The installed list may still change while iterating.
+			await this.refreshInstalledExtensionsList();
 			for (const key in toggleData.settingsEditorRecommendedExtensions) {
 				const extension: IGalleryExtension = toggleData.recommendedExtensionsGalleryInfo[key];
 				if (!extension) {
@@ -1404,8 +1407,6 @@ export class SettingsEditor2 extends EditorPane {
 				}
 
 				const extensionId = extension.identifier.id;
-				// prevent race between extension update handler and this (onConfigUpdate) handler
-				await this.refreshInstalledExtensionsList();
 				const extensionInstalled = this.installedExtensionIds.includes(extensionId);
 
 				// Drill down to see whether the group and setting already exist


### PR DESCRIPTION
Move `refreshInstalledExtensionsList()` from inside the recommended-extensions loop to before it.

### Problem

In `onConfigUpdate()`, the loop over `toggleData.settingsEditorRecommendedExtensions` calls `await this.refreshInstalledExtensionsList()` on every iteration. This method calls `extensionManagementService.getInstalled()` (full IPC roundtrip) to fetch all installed extensions.

The installed extension list does not change between loop iterations, so N recommended extensions produce N identical IPC calls.

### Fix

Call `refreshInstalledExtensionsList()` once before the loop. This still prevents the race between concurrent `onConfigUpdate` calls (the original comment's concern) while avoiding redundant IPC.