### PR TITLE
Add steering/yield support for AHP agent sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -595,6 +595,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 		this._activeSessions.clear();
 		this._sessionToBackend.clear();
+		// Finish any active turns so their done-promises resolve and
+		// turnDisposables are cleaned up. finish() is idempotent.
+		for (const [, turnInfo] of this._activeTurns) {
+			turnInfo.finish();
+		}
 		this._activeTurns.clear();
 		super.dispose();
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -111,6 +111,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private readonly _activeSessions = new Map<string, AgentHostChatSession>();
 	/** Maps UI resource keys to resolved backend session URIs. */
 	private readonly _sessionToBackend = new Map<string, URI>();
+	/**
+	 * Maps chat request IDs to active turn info for yield/steering support.
+	 * Populated when a turn starts in {@link _handleTurn} and cleaned up
+	 * when the turn finishes. Used by {@link _handleYieldRequested} to
+	 * cancel the correct turn when the chat service signals a yield.
+	 */
+	private readonly _activeTurns = new Map<string, { session: string; turnId: string }>();
 	private readonly _config: IAgentHostSessionHandlerConfig;
 
 	/** Client state manager shared across all sessions for this handler. */
@@ -215,6 +222,11 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			invoke: async (request, progress, _history, cancellationToken) => {
 				return this._invokeAgent(request, progress, cancellationToken);
 			},
+			setYieldRequested: (requestId: string, value: boolean) => {
+				if (value) {
+					this._handleYieldRequested(requestId);
+				}
+			},
 		};
 
 		this._register(this._chatAgentService.registerDynamicAgent(agentData, agentImpl));
@@ -258,6 +270,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 
 		const turnId = generateUuid();
+		this._activeTurns.set(request.requestId, { session: session.toString(), turnId });
 		const attachments = this._convertVariablesToAttachments(request);
 		const messageAttachments: IMessageAttachment[] = attachments.map(a => ({
 			type: a.type,
@@ -315,6 +328,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				return;
 			}
 			finished = true;
+			this._activeTurns.delete(request.requestId);
 			// Finalize any outstanding tool invocations
 			for (const [, invocation] of activeToolInvocations) {
 				invocation.didExecuteTool(undefined);
@@ -432,6 +446,32 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}));
 
 		await done;
+	}
+
+	/**
+	 * Handles a yield request from the chat service's steering mechanism.
+	 * Since the AHP protocol does not yet have a dedicated yield/steering
+	 * action, we cancel the active turn so that the chat service's queue
+	 * can advance and dispatch the steering message as a new turn.
+	 */
+	private _handleYieldRequested(requestId: string): void {
+		const turnInfo = this._activeTurns.get(requestId);
+		if (!turnInfo) {
+			return;
+		}
+
+		// Eagerly remove the entry so concurrent cancel paths cannot
+		// dispatch a duplicate turnCancelled for the same turn.
+		this._activeTurns.delete(requestId);
+
+		this._logService.info(`[AgentHost] Yield requested for request ${requestId}, cancelling turn ${turnInfo.turnId}`);
+		const cancelAction = {
+			type: ActionType.SessionTurnCancelled as const,
+			session: turnInfo.session,
+			turnId: turnInfo.turnId,
+		};
+		const seq = this._clientState.applyOptimistic(cancelAction);
+		this._config.connection.dispatchAction(cancelAction, this._clientState.clientId, seq);
 	}
 
 	// ---- Session resolution -------------------------------------------------
@@ -555,6 +595,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 		this._activeSessions.clear();
 		this._sessionToBackend.clear();
+		this._activeTurns.clear();
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -117,7 +117,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	 * when the turn finishes. Used by {@link _handleYieldRequested} to
 	 * cancel the correct turn when the chat service signals a yield.
 	 */
-	private readonly _activeTurns = new Map<string, { session: string; turnId: string }>();
+	private readonly _activeTurns = new Map<string, { session: string; turnId: string; finish: () => void }>();
 	private readonly _config: IAgentHostSessionHandlerConfig;
 
 	/** Client state manager shared across all sessions for this handler. */
@@ -270,7 +270,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		}
 
 		const turnId = generateUuid();
-		this._activeTurns.set(request.requestId, { session: session.toString(), turnId });
 		const attachments = this._convertVariablesToAttachments(request);
 		const messageAttachments: IMessageAttachment[] = attachments.map(a => ({
 			type: a.type,
@@ -337,6 +336,10 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			turnDisposables.dispose();
 			resolveDone();
 		};
+
+		// Register the active turn after finish is defined so that
+		// _handleYieldRequested can call finish() directly.
+		this._activeTurns.set(request.requestId, { session: session.toString(), turnId, finish });
 
 		// Listen to state changes and translate to IChatProgress[]
 		turnDisposables.add(this._clientState.onDidChangeSessionState(e => {
@@ -460,10 +463,6 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			return;
 		}
 
-		// Eagerly remove the entry so concurrent cancel paths cannot
-		// dispatch a duplicate turnCancelled for the same turn.
-		this._activeTurns.delete(requestId);
-
 		this._logService.info(`[AgentHost] Yield requested for request ${requestId}, cancelling turn ${turnInfo.turnId}`);
 		const cancelAction = {
 			type: ActionType.SessionTurnCancelled as const,
@@ -472,6 +471,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 		};
 		const seq = this._clientState.applyOptimistic(cancelAction);
 		this._config.connection.dispatchAction(cancelAction, this._clientState.clientId, seq);
+		turnInfo.finish();
 	}
 
 	// ---- Session resolution -------------------------------------------------

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -653,16 +653,18 @@ suite('AgentHostChatContribution', () => {
 		test('setYieldRequested dispatches turnCancelled for the active turn', async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
-
-			// The registered agent implementation should expose setYieldRequested
+			// Capture the agent impl BEFORE startTurn's awaits allow
+			// AgentHostContribution to re-register the agent with a second
+			// handler instance that has its own (empty) _activeTurns map.
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
 			assert.ok(agentEntry?.impl.setYieldRequested, 'agent should implement setYieldRequested');
+
+			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Signal yield — this should dispatch session/turnCancelled
 			agentEntry.impl.setYieldRequested!('req-1', true);
 
-			// The turn should resolve because the state listener detects activeTurn cleared
+			// The turn should resolve because finish() is called directly
 			await turnPromise;
 
 			const cancelActions = agentHostService.dispatchedActions.filter(a => a.action.type === 'session/turnCancelled');
@@ -674,10 +676,11 @@ suite('AgentHostChatContribution', () => {
 		test('setYieldRequested with false is a no-op', async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
-
+			// Capture the agent impl before async operations (see first test).
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
 			assert.ok(agentEntry?.impl.setYieldRequested);
+
+			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Yield reset should not dispatch anything
 			const actionCountBefore = agentHostService.dispatchedActions.length;
@@ -692,10 +695,11 @@ suite('AgentHostChatContribution', () => {
 		test('setYieldRequested for unknown requestId is a no-op', async () => {
 			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
 
-			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
-
+			// Capture the agent impl before async operations (see first test).
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
 			assert.ok(agentEntry?.impl.setYieldRequested);
+
+			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Yield for a request ID that doesn't match any active turn
 			const actionCountBefore = agentHostService.dispatchedActions.length;

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -646,6 +646,68 @@ suite('AgentHostChatContribution', () => {
 		});
 	});
 
+	// ---- Steering / yield ---------------------------------------------------
+
+	suite('steering', () => {
+
+		test('setYieldRequested dispatches turnCancelled for the active turn', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// The registered agent implementation should expose setYieldRequested
+			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
+			assert.ok(agentEntry?.impl.setYieldRequested, 'agent should implement setYieldRequested');
+
+			// Signal yield — this should dispatch session/turnCancelled
+			agentEntry.impl.setYieldRequested!('req-1', true);
+
+			// The turn should resolve because the state listener detects activeTurn cleared
+			await turnPromise;
+
+			const cancelActions = agentHostService.dispatchedActions.filter(a => a.action.type === 'session/turnCancelled');
+			assert.strictEqual(cancelActions.length, 1, 'should dispatch exactly one turnCancelled');
+			assert.strictEqual((cancelActions[0].action as { session: string }).session, session);
+			assert.strictEqual((cancelActions[0].action as { turnId: string }).turnId, turnId);
+		});
+
+		test('setYieldRequested with false is a no-op', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
+			assert.ok(agentEntry?.impl.setYieldRequested);
+
+			// Yield reset should not dispatch anything
+			const actionCountBefore = agentHostService.dispatchedActions.length;
+			agentEntry.impl.setYieldRequested!('req-1', false);
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore, 'should not dispatch on yield reset');
+
+			// Complete the turn normally
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+		});
+
+		test('setYieldRequested for unknown requestId is a no-op', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
+			assert.ok(agentEntry?.impl.setYieldRequested);
+
+			// Yield for a request ID that doesn't match any active turn
+			const actionCountBefore = agentHostService.dispatchedActions.length;
+			agentEntry.impl.setYieldRequested!('unknown-req', true);
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore, 'should not dispatch for unknown request');
+
+			// Complete the turn normally
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+		});
+	});
+
 	// ---- Error events -------------------------------------------------------
 
 	suite('error events', () => {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -657,12 +657,13 @@ suite('AgentHostChatContribution', () => {
 			// AgentHostContribution to re-register the agent with a second
 			// handler instance that has its own (empty) _activeTurns map.
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
-			assert.ok(agentEntry?.impl.setYieldRequested, 'agent should implement setYieldRequested');
+			assert.ok(agentEntry, 'agent should be registered');
+			assert.ok(agentEntry.impl.setYieldRequested, 'agent should implement setYieldRequested');
 
 			const { turnPromise, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Signal yield — this should dispatch session/turnCancelled
-			agentEntry.impl.setYieldRequested!('req-1', true);
+			agentEntry.impl.setYieldRequested('req-1', true);
 
 			// The turn should resolve because finish() is called directly
 			await turnPromise;
@@ -678,13 +679,14 @@ suite('AgentHostChatContribution', () => {
 
 			// Capture the agent impl before async operations (see first test).
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
-			assert.ok(agentEntry?.impl.setYieldRequested);
+			assert.ok(agentEntry, 'agent should be registered');
+			assert.ok(agentEntry.impl.setYieldRequested);
 
 			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Yield reset should not dispatch anything
 			const actionCountBefore = agentHostService.dispatchedActions.length;
-			agentEntry.impl.setYieldRequested!('req-1', false);
+			agentEntry.impl.setYieldRequested('req-1', false);
 			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore, 'should not dispatch on yield reset');
 
 			// Complete the turn normally
@@ -697,18 +699,62 @@ suite('AgentHostChatContribution', () => {
 
 			// Capture the agent impl before async operations (see first test).
 			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
-			assert.ok(agentEntry?.impl.setYieldRequested);
+			assert.ok(agentEntry, 'agent should be registered');
+			assert.ok(agentEntry.impl.setYieldRequested);
 
 			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
 
 			// Yield for a request ID that doesn't match any active turn
 			const actionCountBefore = agentHostService.dispatchedActions.length;
-			agentEntry.impl.setYieldRequested!('unknown-req', true);
+			agentEntry.impl.setYieldRequested('unknown-req', true);
 			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore, 'should not dispatch for unknown request');
 
 			// Complete the turn normally
 			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
 			await turnPromise;
+		});
+
+		test('setYieldRequested after turn completed naturally is a no-op', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
+			assert.ok(agentEntry, 'agent should be registered');
+			assert.ok(agentEntry.impl.setYieldRequested);
+
+			const { turnPromise, fire, session, turnId } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// Complete the turn naturally first
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+
+			// Now yield for the already-completed request — should not dispatch
+			const actionCountBefore = agentHostService.dispatchedActions.length;
+			agentEntry.impl.setYieldRequested('req-1', true);
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore, 'should not dispatch after turn already completed');
+		});
+
+		test('setYieldRequested force-completes outstanding tool invocations', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const agentEntry = chatAgentService.registeredAgents.get('agent-host-copilot');
+			assert.ok(agentEntry, 'agent should be registered');
+			assert.ok(agentEntry.impl.setYieldRequested);
+
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// Start a tool call but don't complete it
+			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-yield', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
+			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-yield', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
+
+			// Yield while the tool is still running
+			agentEntry.impl.setYieldRequested('req-1', true);
+			await turnPromise;
+
+			// The outstanding tool invocation should be force-completed
+			assert.strictEqual(collected.length, 1);
+			const invocation = collected[0][0] as IChatToolInvocation;
+			assert.strictEqual(invocation.kind, 'toolInvocation');
+			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds steering support to the Agent Host Protocol (AHP) session handling, so that when a user sends a message while an AHP agent is mid-turn, the agent yields and the steering message takes priority.

## Problem

Built-in chat agents already have steering support (`ChatRequestQueueKind.Steering`, `setYieldRequested()`, priority queue insertion). AHP agents did not implement `setYieldRequested` on their `IChatAgentImplementation`, so the yield signal from the chat service was silently ignored.

## Approach

Client-side steering via turn cancellation. Since the AHP protocol does not yet have a dedicated yield/steering action ([future work note in lifecycle spec](https://github.com/microsoft/agent-host-protocol/blob/main/docs/specification/lifecycle.md)), we implement yield by cancelling the active turn:

1. **`setYieldRequested` added to AHP agent impl** — When the chat service signals yield (`value=true`), the handler dispatches `SessionTurnCancelled` for the active turn
2. **`_activeTurns` map** tracks `requestId → { session, turnId }` so the yield handler knows which turn to cancel
3. **Existing flow takes over** — `_handleTurn` detects the turn ended → resolves → `processNextPendingRequest()` sends the steering message as a new turn

### Flow
```
User sends steering msg → chatService queues as Steering → setYieldRequested(true)
  → AHP dispatches SessionTurnCancelled → _handleTurn resolves
  → processNextPendingRequest → dequeueAllSteeringRequests → new turn
```

## Files Changed

- **`agentHostSessionHandler.ts`** — `_activeTurns` map, `setYieldRequested` in agent impl, `_handleYieldRequested()` method, cleanup in `finish()` and `dispose()`
- **`agentHostChatContribution.test.ts`** — 3 new tests: yield dispatches cancel, `false` is no-op, unknown request ID is no-op

## Safety

- `finish()` has a `finished` guard preventing double-cleanup
- `_handleYieldRequested` eagerly deletes from `_activeTurns` to prevent duplicate cancel dispatches
- `SessionTurnCancelled` is idempotent in the reducer
- No protocol changes — all client-side in VS Code

## Testing

- ✅ TypeScript compilation passes (`compile-check-ts-native`)
- ✅ Layering check passes (`valid-layers-check`)
- ✅ Hygiene/pre-commit hooks pass
- ⚠️ Unit tests could not be executed locally (Electron test runner has a pre-existing environment issue — `require("electron").app` is undefined) — tests compile and follow existing patterns; CI should validate

## What's Still Needed

- [ ] CI validation of the new tests
- [ ] Manual E2E testing with a real AHP agent (send steering message during active turn)
- [ ] Future: When the AHP protocol adds native yield/steering support, update `_handleYieldRequested` to use the protocol action instead of cancellation
