### PR TITLE
chore: fix spelling typo "occured" in parcelWatcher.ts comments

### DIFF
--- a/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
+++ b/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts
@@ -170,7 +170,7 @@ export class ParcelWatcher extends BaseWatcher implements IRecursiveWatcherWithS
 	// to schedule sufficiently after Parcel.
 	//
 	// Note: since Parcel 2.0.7, the very first event is
-	// emitted without delay if no events occured over a
+	// emitted without delay if no events occurred over a
 	// duration of 500ms. But we always want to aggregate
 	// events to apply our coleasing logic.
 	//


### PR DESCRIPTION
Hello! 👋 

This is a small chore PR. I was reading through the new file watcher logic and noticed a minor typographical error in the inline comments where "occured" was used instead of "occurred". 

**Changes:**
- Fixed spelling of `occured` -> `occurred` inside [src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts](cci:7://file:///Users/pushkargupta/Desktop/PR/VS%20/vscode/src/vs/platform/files/node/watcher/parcel/parcelWatcher.ts:0:0-0:0).

It's a very tiny change, but I hope it helps keep the codebase clean!

Thank you for reviewing!
