### PR TITLE
Keyboard layout - replace all dashes/dots in macOS layout labels

### DIFF
--- a/src/vs/platform/keyboardLayout/common/keyboardLayout.ts
+++ b/src/vs/platform/keyboardLayout/common/keyboardLayout.ts
@@ -132,13 +132,13 @@ export function parseKeyboardLayoutDescription(layout: IKeyboardLayoutInfo | nul
 
 		if (/^com\.apple\.keylayout\./.test(macLayout.id)) {
 			return {
-				label: macLayout.id.replace(/^com\.apple\.keylayout\./, '').replace(/-/, ' '),
+				label: macLayout.id.replace(/^com\.apple\.keylayout\./, '').replace(/-/g, ' '),
 				description: ''
 			};
 		}
 		if (/^.*inputmethod\./.test(macLayout.id)) {
 			return {
-				label: macLayout.id.replace(/^.*inputmethod\./, '').replace(/[-\.]/, ' '),
+				label: macLayout.id.replace(/^.*inputmethod\./, '').replace(/[-\.]/g, ' '),
 				description: `Input Method (${macLayout.lang})`
 			};
 		}


### PR DESCRIPTION
Add the missing global flag to two regex replacements in macOS keyboard layout label generation.

Without `/g`, `String.prototype.replace` only replaces the first match:

- `"US-International-PC"` displayed as `"US International-PC"` instead of `"US International PC"`
- `"Kotoeri.Roman-English"` displayed as `"Kotoeri Roman-English"` instead of `"Kotoeri Roman English"`

Same class of bug as #303603 which fixed a similar missing `/g` in `settingsTreeModels.ts`.