### PR TITLE
chore: fix spelling typo "retreived" in notebookEditorModel.test.ts

### DIFF
--- a/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
@@ -266,7 +266,7 @@ suite('NotebookFileWorkingCopyModel', function () {
 
 	});
 
-	test('Notebook model will not return a save delegate if the serializer has not been retreived', async function () {
+	test('Notebook model will not return a save delegate if the serializer has not been retrieved', async function () {
 		const notebook = instantiationService.createInstance(NotebookTextModel,
 			'notebook',
 			URI.file('test'),


### PR DESCRIPTION
Hello again! 👋

Another small chore PR. I noticed a minor typographical error in the test descriptions inside [src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts](cci:7://file:///Users/pushkargupta/Desktop/PR/VS%20/vscode/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts:0:0-0:0) where "retreived" was used instead of "retrieved".

**Changes:**
- Fixed spelling of `retreived` -> `retrieved`.

Thanks!
