### PR TITLE
Editor - fix paste preference filter matching all providers

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -657,7 +657,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		if ('only' in preference) {
 			return provider.providedPasteEditKinds.some(providedKind => preference.only.contains(providedKind));
 		} else if ('preferences' in preference) {
-			return preference.preferences.some(providedKind => preference.preferences.some(preferredKind => preferredKind.contains(providedKind)));
+			return provider.providedPasteEditKinds.some(providedKind => preference.preferences.some(preferredKind => preferredKind.contains(providedKind)));
 		} else {
 			return provider.id === preference.providerId;
 		}


### PR DESCRIPTION
Fix paste preference provider filter that always matches every provider.

### Problem

In `providerMatchesPreference()`, the `'preferences'` branch iterates `preference.preferences` in both its outer and inner `.some()` loops. Since `HierarchicalKind.contains()` is reflexive, this always returns true when preferences is non-empty -- every provider passes the filter regardless of what kinds it provides.

The `'only'` branch correctly iterates `provider.providedPasteEditKinds` in the outer loop.

### Fix

Change the outer `.some()` to iterate `provider.providedPasteEditKinds`, matching the `'only'` branch pattern.