### PR TITLE
Sessions: fix stale CI checks when switching active session

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -863,6 +863,23 @@ export class ChangesViewPane extends ViewPane {
 		// Bind CI status widget to active session's PR CI model
 		if (this.ciStatusWidget) {
 			const activeSessionResourceObs = derived(this, reader => this.sessionManagementService.activeSession.read(reader)?.resource);
+
+			// Immediately refresh PR data when the active session changes so
+			// that CI checks and PR state are up-to-date without waiting for
+			// the next polling cycle.
+			this.renderDisposables.add(autorun(reader => {
+				const session = this.sessionManagementService.activeSession.read(reader);
+				if (!session) {
+					return;
+				}
+				const context = this.sessionManagementService.getGitHubContextForSession(session.resource);
+				if (!context || context.prNumber === undefined) {
+					return;
+				}
+				const prModel = this.gitHubService.getPullRequest(context.owner, context.repo, context.prNumber);
+				prModel.refresh();
+			}));
+
 			const ciModelObs = derived(this, reader => {
 				const session = this.sessionManagementService.activeSession.read(reader);
 				if (!session) {
@@ -872,16 +889,18 @@ export class ChangesViewPane extends ViewPane {
 				if (!context || context.prNumber === undefined) {
 					return undefined;
 				}
-				// Use the PR's headRef from the PR model to get CI checks
 				const prModel = this.gitHubService.getPullRequest(context.owner, context.repo, context.prNumber);
 				const pr = prModel.pullRequest.read(reader);
 				if (!pr) {
-					// Trigger a refresh if PR data isn't loaded yet
-					prModel.refresh();
 					return undefined;
 				}
-				const ciModel = this.gitHubService.getPullRequestCI(context.owner, context.repo, pr.headRef);
+				// Use the PR's headSha (commit SHA) rather than the branch
+				// name so CI checks can still be fetched after branch deletion
+				// (e.g. after the PR is merged).
+				const ciModel = this.gitHubService.getPullRequestCI(context.owner, context.repo, pr.headSha);
 				ciModel.refresh();
+				ciModel.startPolling();
+				reader.store.add({ dispose: () => ciModel.stopPolling() });
 				return ciModel;
 			});
 			this.renderDisposables.add(this.ciStatusWidget.bind(ciModelObs, activeSessionResourceObs));

--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -864,22 +864,6 @@ export class ChangesViewPane extends ViewPane {
 		if (this.ciStatusWidget) {
 			const activeSessionResourceObs = derived(this, reader => this.sessionManagementService.activeSession.read(reader)?.resource);
 
-			// Immediately refresh PR data when the active session changes so
-			// that CI checks and PR state are up-to-date without waiting for
-			// the next polling cycle.
-			this.renderDisposables.add(autorun(reader => {
-				const session = this.sessionManagementService.activeSession.read(reader);
-				if (!session) {
-					return;
-				}
-				const context = this.sessionManagementService.getGitHubContextForSession(session.resource);
-				if (!context || context.prNumber === undefined) {
-					return;
-				}
-				const prModel = this.gitHubService.getPullRequest(context.owner, context.repo, context.prNumber);
-				prModel.refresh();
-			}));
-
 			const ciModelObs = derived(this, reader => {
 				const session = this.sessionManagementService.activeSession.read(reader);
 				if (!session) {

--- a/src/vs/sessions/contrib/github/browser/fetchers/githubPRFetcher.ts
+++ b/src/vs/sessions/contrib/github/browser/fetchers/githubPRFetcher.ts
@@ -24,7 +24,7 @@ interface IGitHubPRResponse {
 	readonly state: 'open' | 'closed';
 	readonly draft: boolean;
 	readonly user: { readonly login: string; readonly avatar_url: string };
-	readonly head: { readonly ref: string };
+	readonly head: { readonly ref: string; readonly sha: string };
 	readonly base: { readonly ref: string };
 	readonly created_at: string;
 	readonly updated_at: string;
@@ -312,6 +312,7 @@ function mapPullRequest(data: IGitHubPRResponse): IGitHubPullRequest {
 		state,
 		author: mapUser(data.user),
 		headRef: data.head.ref,
+		headSha: data.head.sha,
 		baseRef: data.base.ref,
 		isDraft: data.draft,
 		createdAt: data.created_at,

--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -5,6 +5,7 @@
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
+import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
@@ -19,6 +20,8 @@ class GitHubActiveSessionRefreshContribution extends Disposable implements IWork
 
 	static readonly ID = 'sessions.contrib.githubActiveSessionRefresh';
 
+	private _lastSessionResource: URI | undefined;
+
 	constructor(
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@IGitHubService private readonly _gitHubService: IGitHubService,
@@ -28,8 +31,13 @@ class GitHubActiveSessionRefreshContribution extends Disposable implements IWork
 		this._register(autorun(reader => {
 			const session = this._sessionsManagementService.activeSession.read(reader);
 			if (!session) {
+				this._lastSessionResource = undefined;
 				return;
 			}
+			if (this._lastSessionResource?.toString() === session.resource.toString()) {
+				return;
+			}
+			this._lastSessionResource = session.resource;
 			const context = this._sessionsManagementService.getGitHubContextForSession(session.resource);
 			if (!context || context.prNumber === undefined) {
 				return;

--- a/src/vs/sessions/contrib/github/browser/github.contribution.ts
+++ b/src/vs/sessions/contrib/github/browser/github.contribution.ts
@@ -3,7 +3,42 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../base/common/observable.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { GitHubService, IGitHubService } from './githubService.js';
 
+/**
+ * Immediately refreshes PR data when the active session changes so that
+ * CI checks and PR state are up-to-date without waiting for the next
+ * polling cycle.
+ */
+class GitHubActiveSessionRefreshContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'sessions.contrib.githubActiveSessionRefresh';
+
+	constructor(
+		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@IGitHubService private readonly _gitHubService: IGitHubService,
+	) {
+		super();
+
+		this._register(autorun(reader => {
+			const session = this._sessionsManagementService.activeSession.read(reader);
+			if (!session) {
+				return;
+			}
+			const context = this._sessionsManagementService.getGitHubContextForSession(session.resource);
+			if (!context || context.prNumber === undefined) {
+				return;
+			}
+			const prModel = this._gitHubService.getPullRequest(context.owner, context.repo, context.prNumber);
+			prModel.refresh();
+		}));
+	}
+}
+
 registerSingleton(IGitHubService, GitHubService, InstantiationType.Delayed);
+registerWorkbenchContribution2(GitHubActiveSessionRefreshContribution.ID, GitHubActiveSessionRefreshContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/github/common/types.ts
+++ b/src/vs/sessions/contrib/github/common/types.ts
@@ -50,6 +50,7 @@ export interface IGitHubPullRequest {
 	readonly state: GitHubPullRequestState;
 	readonly author: IGitHubUser;
 	readonly headRef: string;
+	readonly headSha: string;
 	readonly baseRef: string;
 	readonly isDraft: boolean;
 	readonly createdAt: string;

--- a/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
+++ b/src/vs/sessions/contrib/github/test/browser/githubModels.test.ts
@@ -242,6 +242,7 @@ function makePR(): IGitHubPullRequest {
 		state: GitHubPullRequestState.Open,
 		author: { login: 'author', avatarUrl: '' },
 		headRef: 'feature',
+		headSha: 'abc123',
 		baseRef: 'main',
 		isDraft: false,
 		createdAt: '2024-01-01T00:00:00Z',


### PR DESCRIPTION
## Problem

When switching between sessions, CI checks could display stale "running" status even though the PR had already been merged. Two root causes:

1. **No immediate PR refresh on session switch** — PR data was only updated on the next polling cycle (up to 30s for PR, 60s for CI), so switching sessions showed stale data.
2. **CI lookups used branch name (`headRef`)** — After a PR is merged and the head branch is deleted, GitHub's API returns 404 for the branch-based CI check lookup, leaving stale data in the observables.

## Fix

### Use commit SHA for CI lookups
- Added `headSha` field to `IGitHubPullRequest` (mapped from `data.head.sha` in the API response)
- Changed CI check lookup from `pr.headRef` (branch name) to `pr.headSha` (commit SHA), which remains valid even after branch deletion

### Immediate refresh on session change
- Added `GitHubActiveSessionRefreshContribution` workbench contribution in the GitHub sessions contribution that watches the active session and immediately calls `prModel.refresh()` when the session changes
- Tracks `_lastSessionResource` to only refresh when the session actually changes

### CI polling lifecycle
- Added `ciModel.startPolling()` / `stopPolling()` lifecycle management via `reader.store` in the CI model derived, ensuring polling is properly started for the active session and stopped when switching away

## Files changed
- `src/vs/sessions/contrib/github/common/types.ts` — Added `headSha` to `IGitHubPullRequest`
- `src/vs/sessions/contrib/github/browser/fetchers/githubPRFetcher.ts` — Map `head.sha` from API response
- `src/vs/sessions/contrib/github/browser/github.contribution.ts` — New `GitHubActiveSessionRefreshContribution`
- `src/vs/sessions/contrib/changes/browser/changesView.ts` — Use `headSha` for CI lookups, manage CI polling lifecycle
- `src/vs/sessions/contrib/github/test/browser/githubModels.test.ts` — Updated test helper