### PR TITLE
[skip ci] Fixes: Memory Leak

### DIFF
--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -86,7 +86,10 @@ interface ISimpleConnectionOptions<T extends RemoteConnection = RemoteConnection
 
 function createTimeoutCancellation(millis: number): CancellationToken {
 	const source = new CancellationTokenSource();
-	setTimeout(() => source.cancel(), millis);
+	setTimeout(() => {
+		source.cancel();
+		source.dispose();
+	}, millis);
 	return source.token;
 }
 
@@ -95,8 +98,8 @@ function combineTimeoutCancellation(a: CancellationToken, b: CancellationToken):
 		return CancellationToken.Cancelled;
 	}
 	const source = new CancellationTokenSource();
-	a.onCancellationRequested(() => source.cancel());
-	b.onCancellationRequested(() => source.cancel());
+	a.onCancellationRequested(() => { source.cancel(); source.dispose(); });
+	b.onCancellationRequested(() => { source.cancel(); source.dispose(); });
 	return source.token;
 }
 

--- a/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
@@ -50,7 +50,12 @@ export class RemoteAuthorityResolverService extends Disposable implements IRemot
 		}
 
 		const result = new DeferredPromise<URI>();
-		this._canonicalURIProvider?.(uri).then((uri) => result.complete(uri), (err) => result.error(err));
+		if (this._canonicalURIProvider) {
+			this._canonicalURIProvider(uri).then(
+				(uri) => { result.complete(uri); this._canonicalURIRequests.delete(key); },
+				(err) => { result.error(err); this._canonicalURIRequests.delete(key); }
+			);
+		}
 		this._canonicalURIRequests.set(key, { input: uri, result });
 		return result.p;
 	}
@@ -109,8 +114,19 @@ export class RemoteAuthorityResolverService extends Disposable implements IRemot
 
 	_setCanonicalURIProvider(provider: (uri: URI) => Promise<URI>): void {
 		this._canonicalURIProvider = provider;
-		this._canonicalURIRequests.forEach(({ result, input }) => {
-			this._canonicalURIProvider!(input).then((uri) => result.complete(uri), (err) => result.error(err));
+		this._canonicalURIRequests.forEach(({ result, input }, key) => {
+			this._canonicalURIProvider!(input).then(
+				(uri) => { result.complete(uri); this._canonicalURIRequests.delete(key); },
+				(err) => { result.error(err); this._canonicalURIRequests.delete(key); }
+			);
 		});
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._resolveAuthorityRequests.clear();
+		this._connectionTokens.clear();
+		this._canonicalURIRequests.clear();
+		this._canonicalURIProvider = null;
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
+++ b/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
@@ -13,6 +13,12 @@ import { IRemoteSocketFactoryService, ISocketFactory } from '../../../platform/r
 import { IExtHostContext, extHostNamedCustomer } from '../../services/extensions/common/extHostCustomers.js';
 import { ExtHostContext, ExtHostManagedSocketsShape, MainContext, MainThreadManagedSocketsShape } from '../common/extHost.protocol.js';
 
+function disposeSocketHalf(half: RemoteSocketHalf): void {
+	half.onData.dispose();
+	half.onClose.dispose();
+	half.onEnd.dispose();
+}
+
 @extHostNamedCustomer(MainContext.MainThreadManagedSockets)
 export class MainThreadManagedSockets extends Disposable implements MainThreadManagedSocketsShape {
 
@@ -26,6 +32,15 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostManagedSockets);
+	}
+
+	override dispose(): void {
+		// Dispose all remaining socket half emitters to prevent leaks
+		for (const half of this._remoteSockets.values()) {
+			disposeSocketHalf(half);
+		}
+		this._remoteSockets.clear();
+		super.dispose();
 	}
 
 	async $registerSocketFactory(socketFactoryId: number): Promise<void> {
@@ -55,11 +70,16 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 						MainThreadManagedSocket.connect(socketId, that._proxy, path, query, debugLabel, half)
 							.then(
 								socket => {
-									store.add(Event.once(socket.onDidDispose)(() => that._remoteSockets.delete(socketId)));
+									store.add(Event.once(socket.onDidDispose)(() => {
+										that._remoteSockets.delete(socketId);
+										// Note: the ManagedSocket base class registers and disposes half emitters,
+										// so we don't need to dispose them here on successful connection.
+									}));
 									resolve(socket);
 								},
 								err => {
 									that._remoteSockets.delete(socketId);
+									disposeSocketHalf(half);
 									reject(err);
 								});
 					}).catch(reject);
@@ -80,12 +100,15 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 	}
 
 	$onDidManagedSocketClose(socketId: number, error: string | undefined): void {
-		this._remoteSockets.get(socketId)?.onClose.fire({
-			type: SocketCloseEventType.NodeSocketCloseEvent,
-			error: error ? new Error(error) : undefined,
-			hadError: !!error
-		});
-		this._remoteSockets.delete(socketId);
+		const half = this._remoteSockets.get(socketId);
+		if (half) {
+			half.onClose.fire({
+				type: SocketCloseEventType.NodeSocketCloseEvent,
+				error: error ? new Error(error) : undefined,
+				hadError: !!error
+			});
+			this._remoteSockets.delete(socketId);
+		}
 	}
 
 	$onDidManagedSocketEnd(socketId: number): void {

--- a/src/vs/workbench/services/remote/common/tunnelModel.ts
+++ b/src/vs/workbench/services/remote/common/tunnelModel.ts
@@ -440,7 +440,7 @@ export class TunnelModel extends Disposable {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) {
 		super();
-		this.configPortsAttributes = new PortsAttributes(configurationService);
+		this.configPortsAttributes = this._register(new PortsAttributes(configurationService));
 		this.tunnelRestoreValue = this.getTunnelRestoreValue();
 		this._register(this.configPortsAttributes.onDidChangeAttributes(this.updateAttributes, this));
 		this.forwarded = new Map();
@@ -543,6 +543,7 @@ export class TunnelModel extends Disposable {
 	private async onTunnelClosed(address: { host: string; port: number }, reason: TunnelCloseReason) {
 		const key = makeAddress(address.host, address.port);
 		if (this.forwarded.delete(key)) {
+			this.remoteTunnels.delete(key);
 			await this.storeForwarded();
 			this._onClosePort.fire(address);
 		}
@@ -829,6 +830,13 @@ export class TunnelModel extends Disposable {
 		const key = makeAddress(host, port);
 		const oldTunnel = this.forwarded.get(key)!;
 		if ((reason === TunnelCloseReason.AutoForwardEnd) && oldTunnel && (oldTunnel.source.source === TunnelSource.Auto)) {
+			// Limit the cached properties to avoid unbounded memory growth
+			if (this.sessionCachedProperties.size >= 1000) {
+				const firstKey = this.sessionCachedProperties.keys().next().value;
+				if (firstKey !== undefined) {
+					this.sessionCachedProperties.delete(firstKey);
+				}
+			}
 			this.sessionCachedProperties.set(key, {
 				local: oldTunnel.localPort,
 				name: oldTunnel.name,
@@ -1038,5 +1046,16 @@ export class TunnelModel extends Disposable {
 
 	addAttributesProvider(provider: PortAttributesProvider) {
 		this.portAttributesProviders.push(provider);
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this.forwarded.clear();
+		this.detected.clear();
+		this.remoteTunnels.clear();
+		this.inProgress.clear();
+		this.sessionCachedProperties.clear();
+		this.unrestoredExtensionTunnels.clear();
+		this.portAttributesProviders.length = 0;
 	}
 }


### PR DESCRIPTION
- Registered configPortsAttributes with this._register()
- Added size cap (1000 entries) on sessionCachedProperties with LRU-style eviction
- Added remoteTunnels.delete(key) in onTunnelClosed to match forwarded.delete(key)
- Added dispose() override that clears all maps

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
