### PR TITLE
Show static pinned icon on sessions list items that hides on hover

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -62,6 +62,7 @@ interface IAgentSessionItemTemplate {
 
 	// Column 2 Row 1
 	readonly title: IconLabel;
+	readonly pinnedIndicator: HTMLElement;
 	readonly statusContainer: HTMLElement;
 	readonly statusTime: HTMLElement;
 	readonly titleToolbar: MenuWorkbenchToolBar;
@@ -139,6 +140,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 				h('div.agent-session-main-col', [
 					h('div.agent-session-title-row', [
 						h('div.agent-session-title@title'),
+						h('div.agent-session-pinned-indicator@pinnedIndicator'),
 						h('div.agent-session-title-toolbar@titleToolbar'),
 					]),
 					h('div.agent-session-details-row', [
@@ -174,6 +176,7 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			element: elements.item,
 			icon: elements.icon,
 			title: disposables.add(new IconLabel(elements.title, { supportHighlights: true, supportIcons: true })),
+			pinnedIndicator: elements.pinnedIndicator,
 			titleToolbar,
 			badge: elements.badge,
 			separator: elements.separator,
@@ -217,6 +220,11 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		ChatContextKeys.isReadAgentSession.bindTo(template.contextKeyService).set(session.element.isRead());
 		ChatContextKeys.agentSessionType.bindTo(template.contextKeyService).set(session.element.providerType);
 		template.titleToolbar.context = session.element;
+
+		// Pinned indicator
+		const isPinned = session.element.isPinned();
+		template.pinnedIndicator.className = 'agent-session-pinned-indicator ' + (ThemeIcon.asClassName(Codicon.pinned));
+		template.pinnedIndicator.classList.toggle('visible', isPinned);
 
 		// Badge
 		const hasBadge = this.renderBadge(session, template);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -48,6 +48,19 @@
 		color: var(--vscode-descriptionForeground);
 	}
 
+	.monaco-list-row .agent-session-pinned-indicator {
+		display: none;
+		height: 16px;
+		align-items: center;
+		color: var(--vscode-descriptionForeground);
+		font-size: 12px;
+		pointer-events: none;
+
+		&.visible {
+			display: flex;
+		}
+	}
+
 	.monaco-list-row .agent-session-title-toolbar {
 		/* for the absolute positioning of the toolbar below */
 		position: relative;
@@ -62,9 +75,13 @@
 		}
 	}
 
-	/* On hover or keyboard focus: show toolbar */
+	/* On hover or keyboard focus: show toolbar, hide pinned indicator */
 	.monaco-list-row:hover,
 	.monaco-list-row.focused:not(.selected) {
+
+		.agent-session-pinned-indicator {
+			display: none;
+		}
 
 		.agent-session-title-toolbar {
 			display: block;


### PR DESCRIPTION
When a session is pinned, renders a non-clickable pinned icon (`Codicon.pinned`) in the title row where the action bar lives. The icon:

- Is visible by default when a session is pinned
- Hides on hover/focus when the action bar appears (avoiding visual overlap)
- Is not interactive (`pointer-events: none`)

### Changes

- **`agentSessionsViewer.ts`** — Added `pinnedIndicator` element to the template DOM and interface. In `renderElement`, applies the `Codicon.pinned` icon class and toggles visibility based on pinned state.
- **`agentsessionsviewer.css`** — Styles for the pinned indicator: hidden by default, shown when `.visible`, hidden again on hover/focus when the toolbar appears.


closes https://github.com/microsoft/vscode/issues/304046