### PR TITLE
Fix get_task_output empty results for background tasks while preserving single-run reused terminal behavior

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { IMarker as IXtermMarker } from '@xterm/xterm';
 import type { CancellationToken } from '../../../../../../../base/common/cancellation.js';
 import { MarkdownString } from '../../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore } from '../../../../../../../base/common/lifecycle.js';
@@ -96,7 +97,7 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 			return { content: [{ kind: 'text', value: `Terminal not found for task ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('copilotChat.terminalNotFound', 'Terminal not found for task \`{0}\`', taskLabel)) };
 		}
 		const startMarkersByTerminalInstanceId = task.configurationProperties.isBackground
-			? new Map<number, ReturnType<typeof terminals[number]['registerMarker']>>()
+			? new Map<number, IXtermMarker | undefined>()
 			: undefined;
 		if (startMarkersByTerminalInstanceId) {
 			// Background/watch tasks should read their current buffer when queried after start.
@@ -105,43 +106,46 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 			}
 		}
 		const store = new DisposableStore();
-		const terminalResults = await collectTerminalResults(
-			terminals,
-			task,
-			this._instantiationService,
-			invocation.context!,
-			_progress,
-			token,
-			store,
-			(terminalTask) => this._isTaskActive(terminalTask),
-			dependencyTasks,
-			this._tasksService,
-			startMarkersByTerminalInstanceId
-		);
-		store.dispose();
-		for (const r of terminalResults) {
-			this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.getTaskOutputTool.get', {
-				taskId: args.id,
-				bufferLength: r.output.length ?? 0,
-				pollDurationMs: r.pollDurationMs ?? 0,
-				inputToolManualAcceptCount: r.inputToolManualAcceptCount ?? 0,
-				inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
-				inputToolManualChars: r.inputToolManualChars ?? 0,
-				inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
-				inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0,
-				inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0
-			});
-		}
-		const details = terminalResults.map(r => `Terminal: ${r.name}\nOutput:\n${r.output}`);
-		const uniqueDetails = Array.from(new Set(details)).join('\n\n');
-		const toolResultDetails = toolResultDetailsFromResponse(terminalResults);
-		const toolResultMessage = toolResultMessageFromResponse(undefined, taskLabel, toolResultDetails, terminalResults, true, task.configurationProperties.isBackground);
+		try {
+			const terminalResults = await collectTerminalResults(
+				terminals,
+				task,
+				this._instantiationService,
+				invocation.context!,
+				_progress,
+				token,
+				store,
+				(terminalTask) => this._isTaskActive(terminalTask),
+				dependencyTasks,
+				this._tasksService,
+				startMarkersByTerminalInstanceId
+			);
+			for (const r of terminalResults) {
+				this._telemetryService.publicLog2?.<TaskToolEvent, TaskToolClassification>('copilotChat.getTaskOutputTool.get', {
+					taskId: args.id,
+					bufferLength: r.output.length ?? 0,
+					pollDurationMs: r.pollDurationMs ?? 0,
+					inputToolManualAcceptCount: r.inputToolManualAcceptCount ?? 0,
+					inputToolManualRejectCount: r.inputToolManualRejectCount ?? 0,
+					inputToolManualChars: r.inputToolManualChars ?? 0,
+					inputToolManualShownCount: r.inputToolManualShownCount ?? 0,
+					inputToolFreeFormInputCount: r.inputToolFreeFormInputCount ?? 0,
+					inputToolFreeFormInputShownCount: r.inputToolFreeFormInputShownCount ?? 0
+				});
+			}
+			const details = terminalResults.map(r => `Terminal: ${r.name}\nOutput:\n${r.output}`);
+			const uniqueDetails = Array.from(new Set(details)).join('\n\n');
+			const toolResultDetails = toolResultDetailsFromResponse(terminalResults);
+			const toolResultMessage = toolResultMessageFromResponse(undefined, taskLabel, toolResultDetails, terminalResults, true, task.configurationProperties.isBackground);
 
-		return {
-			content: [{ kind: 'text', value: uniqueDetails }],
-			toolResultMessage,
-			toolResultDetails
-		};
+			return {
+				content: [{ kind: 'text', value: uniqueDetails }],
+				toolResultMessage,
+				toolResultDetails
+			};
+		} finally {
+			store.dispose();
+		}
 	}
 	private async _isTaskActive(task: Task): Promise<boolean> {
 		const busyTasks = await this._tasksService.getBusyTasks();

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/task/getTaskOutputTool.ts
@@ -95,6 +95,15 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 		if (!terminals || terminals.length === 0) {
 			return { content: [{ kind: 'text', value: `Terminal not found for task ${taskLabel}` }], toolResultMessage: new MarkdownString(localize('copilotChat.terminalNotFound', 'Terminal not found for task \`{0}\`', taskLabel)) };
 		}
+		const startMarkersByTerminalInstanceId = task.configurationProperties.isBackground
+			? new Map<number, ReturnType<typeof terminals[number]['registerMarker']>>()
+			: undefined;
+		if (startMarkersByTerminalInstanceId) {
+			// Background/watch tasks should read their current buffer when queried after start.
+			for (const terminal of terminals) {
+				startMarkersByTerminalInstanceId.set(terminal.instanceId, undefined);
+			}
+		}
 		const store = new DisposableStore();
 		const terminalResults = await collectTerminalResults(
 			terminals,
@@ -106,7 +115,8 @@ export class GetTaskOutputTool extends Disposable implements IToolImpl {
 			store,
 			(terminalTask) => this._isTaskActive(terminalTask),
 			dependencyTasks,
-			this._tasksService
+			this._tasksService,
+			startMarkersByTerminalInstanceId
 		);
 		store.dispose();
 		for (const r of terminalResults) {


### PR DESCRIPTION
Fixes #304057.

`get_task_output` could return empty output even when the task terminal had content because output collection could start from a fresh marker created at read time, which for completed/background tasks can point to the end of the buffer.

Now, in `getTaskOutputTool`, pass a start-marker map only for background tasks. For those background/watch tasks, set each terminal entry to undefined so collection reads the current terminal buffer instead of from a newly created marker.

Keep existing behavior for single-run tasks, so reused-terminal protection remains and old buffer content is not pulled in.
