### PR TITLE
Add steering/yield support for AHP agent sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler.ts
@@ -111,6 +111,8 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	private readonly _activeSessions = new Map<string, AgentHostChatSession>();
 	/** Maps UI resource keys to resolved backend session URIs. */
 	private readonly _sessionToBackend = new Map<string, URI>();
+	/** Maps chat request IDs to active turn info for steering/yield support. */
+	private readonly _activeTurnsByRequestId = new Map<string, { session: string; turnId: string; finish: () => void }>();
 	private readonly _config: IAgentHostSessionHandlerConfig;
 
 	/** Client state manager shared across all sessions for this handler. */
@@ -215,9 +217,42 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			invoke: async (request, progress, _history, cancellationToken) => {
 				return this._invokeAgent(request, progress, cancellationToken);
 			},
+			setYieldRequested: (requestId: string, value: boolean) => {
+				this._handleYieldRequested(requestId, value);
+			},
 		};
 
 		this._register(this._chatAgentService.registerDynamicAgent(agentData, agentImpl));
+	}
+
+	/**
+	 * Handles the yield signal from the chat framework. When a steering
+	 * message arrives while an AHP turn is active, the framework calls
+	 * this to ask the agent to yield. Since the AHP protocol doesn't
+	 * support native steering yet, we cancel the active turn so the
+	 * steering message can be processed as the next turn.
+	 */
+	private _handleYieldRequested(requestId: string, value: boolean): void {
+		if (!value) {
+			return;
+		}
+
+		const activeTurn = this._activeTurnsByRequestId.get(requestId);
+		if (!activeTurn) {
+			return;
+		}
+
+		this._logService.info(`[AgentHost] Yield requested for requestId=${requestId}, dispatching turnCancelled for turnId=${activeTurn.turnId}`);
+
+		const cancelAction = {
+			type: ActionType.SessionTurnCancelled as const,
+			session: activeTurn.session,
+			turnId: activeTurn.turnId,
+		};
+		const seq = this._clientState.applyOptimistic(cancelAction);
+		this._config.connection.dispatchAction(cancelAction, this._clientState.clientId, seq);
+
+		activeTurn.finish();
 	}
 
 	private async _invokeAgent(
@@ -315,6 +350,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 				return;
 			}
 			finished = true;
+			this._activeTurnsByRequestId.delete(request.requestId);
 			// Finalize any outstanding tool invocations
 			for (const [, invocation] of activeToolInvocations) {
 				invocation.didExecuteTool(undefined);
@@ -323,6 +359,13 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 			turnDisposables.dispose();
 			resolveDone();
 		};
+
+		// Register this turn for yield/steering support
+		this._activeTurnsByRequestId.set(request.requestId, {
+			session: session.toString(),
+			turnId,
+			finish,
+		});
 
 		// Listen to state changes and translate to IChatProgress[]
 		turnDisposables.add(this._clientState.onDidChangeSessionState(e => {
@@ -550,6 +593,7 @@ export class AgentHostSessionHandler extends Disposable implements IChatSessionC
 	// ---- Lifecycle ----------------------------------------------------------
 
 	override dispose(): void {
+		this._activeTurnsByRequestId.clear();
 		for (const [, session] of this._activeSessions) {
 			session.dispose();
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -646,6 +646,106 @@ suite('AgentHostChatContribution', () => {
 		});
 	});
 
+	// ---- Steering / yield ---------------------------------------------------
+
+	suite('steering', () => {
+
+		test('yield dispatches turnCancelled and resolves the turn', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// Stream some partial content before yielding
+			fire({ type: 'session/delta', session, turnId, content: 'partial ' } as ISessionAction);
+
+			// Trigger yield via the agent implementation
+			const agentImpl = chatAgentService.registeredAgents.get('agent-host-copilot')!.impl;
+			agentImpl.setYieldRequested!('req-1', true);
+
+			await turnPromise;
+
+			// Should have dispatched turnCancelled
+			assert.ok(
+				agentHostService.dispatchedActions.some(a => a.action.type === 'session/turnCancelled'),
+				'Expected session/turnCancelled to be dispatched',
+			);
+
+			// Partial content streamed before yield should be preserved
+			assert.ok(collected.length >= 1);
+			assert.strictEqual((collected[0][0] as IChatMarkdownContent).content.value, 'partial ');
+		});
+
+		test('yield when no active turn is a no-op', async () => {
+			const { chatAgentService, agentHostService } = createContribution(disposables);
+
+			const agentImpl = chatAgentService.registeredAgents.get('agent-host-copilot')!.impl;
+			const actionCountBefore = agentHostService.dispatchedActions.length;
+
+			// Call yield with a non-existent request — should be a no-op
+			agentImpl.setYieldRequested!('non-existent-request', true);
+
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountBefore);
+		});
+
+		test('yield with value=false is a no-op', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+			const actionCountAfterStart = agentHostService.dispatchedActions.length;
+
+			// Call yield with value=false — should not cancel
+			const agentImpl = chatAgentService.registeredAgents.get('agent-host-copilot')!.impl;
+			agentImpl.setYieldRequested!('req-1', false);
+
+			// No new actions should have been dispatched
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountAfterStart);
+
+			// Complete the turn normally
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+		});
+
+		test('yield after natural completion is a no-op', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// Complete turn naturally
+			fire({ type: 'session/turnComplete', session, turnId } as ISessionAction);
+			await turnPromise;
+
+			const actionCountAfterComplete = agentHostService.dispatchedActions.length;
+
+			// Yield after completion — should be a no-op
+			const agentImpl = chatAgentService.registeredAgents.get('agent-host-copilot')!.impl;
+			agentImpl.setYieldRequested!('req-1', true);
+
+			assert.strictEqual(agentHostService.dispatchedActions.length, actionCountAfterComplete);
+		});
+
+		test('yield force-completes outstanding tool invocations', async () => {
+			const { sessionHandler, agentHostService, chatAgentService } = createContribution(disposables);
+
+			const { turnPromise, collected, session, turnId, fire } = await startTurn(sessionHandler, agentHostService, disposables);
+
+			// Start a tool invocation without completing it
+			fire({ type: 'session/toolCallStart', session, turnId, toolCallId: 'tc-yield', toolName: 'bash', displayName: 'Bash' } as ISessionAction);
+			fire({ type: 'session/toolCallReady', session, turnId, toolCallId: 'tc-yield', invocationMessage: 'Running Bash command', confirmed: 'not-needed' } as ISessionAction);
+
+			// Yield while tool is in progress
+			const agentImpl = chatAgentService.registeredAgents.get('agent-host-copilot')!.impl;
+			agentImpl.setYieldRequested!('req-1', true);
+
+			await turnPromise;
+
+			// The orphaned tool invocation should be force-completed
+			assert.strictEqual(collected.length, 1);
+			const invocation = collected[0][0] as IChatToolInvocation;
+			assert.strictEqual(invocation.kind, 'toolInvocation');
+			assert.strictEqual(IChatToolInvocation.isComplete(invocation), true);
+		});
+	});
+
 	// ---- Error events -------------------------------------------------------
 
 	suite('error events', () => {


### PR DESCRIPTION
## Summary

Adds `setYieldRequested` support to the AHP agent session handler, enabling steering messages to interrupt active AHP turns.

## Problem

When a user sends a message while an AHP agent is mid-turn, VS Code's chat framework calls `setYieldRequested(requestId, true)` on the agent implementation. The AHP session handler did not implement this callback, so steering messages were queued but never processed until the current turn completed naturally.

## Approach

Since the AHP protocol does not have native steering support yet (marked as "FUTURE WORK" in the lifecycle spec), we implement yield as **cancel + finish**:

1. When `setYieldRequested(requestId, true)` is called, we look up the active turn for that request ID
2. Dispatch `SessionTurnCancelled` to tell the AHP server to stop the current turn
3. Call `finish()` to resolve the turn promise and trigger cleanup

This causes the chat service's `processNextPendingRequest()` to fire, which dequeues and processes the steering message as the next turn.

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| **Yield = cancel** | AHP protocol has no yield/pause mechanism; cancellation is the cleanest way to end a turn |
| **Partial response preserved** | Chat service keeps accumulated progress from the cancelled turn |
| **Idempotent finish()** | The existing `finished` guard prevents double-cleanup if yield races with natural completion |
| **Map-based tracking** | `_activeTurnsByRequestId` maps chat request IDs to active turn info (session, turnId, finish callback) |

### Consistency with built-in agents

Built-in agents use `setYieldRequested` as an advisory signal — they check an observable and decide to stop. For AHP agents, the agent runs remotely, so we can't just set an observable. Instead, we take the decisive action of cancelling the turn, which achieves the same end result: the current turn ends, and the steering message processes next.

## What changes when AHP gets native steering

When the AHP protocol adds native steering support, this implementation should be updated to:
1. Dispatch a new `session/steeringRequested` action instead of `session/turnCancelled`
2. Let the server handle the transition (pause/resume instead of cancel)
3. Remove the client-side `finish()` call since the server will manage turn lifecycle

## Tests

Added 5 tests in `agentHostChatContribution.test.ts`:
- Yield dispatches `turnCancelled` and resolves the turn (with partial content preserved)
- Yield when no active turn is a no-op
- Yield with `value=false` is a no-op
- Yield after natural completion is a no-op
- Yield force-completes outstanding tool invocations

## Validation
- `npm run compile-check-ts-native` passes
- All 18,433 tests pass