### PR TITLE
Enable terminal commands to run freely in `Autopilot` and `Bypass Approvals` modes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -164,7 +164,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
+											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -115,7 +115,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 										icon: Codicon.warning,
 										markdownDetails: [{
 											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail',
-												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete.")),
+												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.")),
 										}],
 									},
 								});
@@ -166,7 +166,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 										icon: Codicon.rocket,
 										markdownDetails: [{
 											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail',
-												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will continue making decisions on your behalf between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
+												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will make decisions on your behalf.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -100,7 +100,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
-									message: localize('permissions.autoApprove.warning.title', "Enable Bypass Approvals?"),
+									message: localize(
+										'permissions.autoApprove.warning.title',
+										"Enable Bypass Approvals and Run Terminal Commands?"
+									),
 									buttons: [
 										{
 											label: localize('permissions.autoApprove.warning.confirm', "Enable"),
@@ -114,7 +117,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.warning,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail', "Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete.")),
+											markdown: new MarkdownString(localize(
+												'permissions.autoApprove.warning.detail',
+												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete."
+											)),
 										}],
 									},
 								});
@@ -150,7 +156,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
-									message: localize('permissions.autopilot.warning.title', "Enable Autopilot?"),
+									message: localize(
+										'permissions.autopilot.warning.title',
+										"Enable Autopilot and Run Terminal Commands?"
+									),
 									buttons: [
 										{
 											label: localize('permissions.autopilot.warning.confirm', "Enable"),
@@ -164,7 +173,10 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. The agent will make decisions on your behalf without asking for confirmation between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
+											markdown: new MarkdownString(localize(
+												'permissions.autopilot.warning.detail',
+												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will continue making decisions on your behalf between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only."
+											)),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -85,7 +85,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						...action,
 						id: 'chat.permissions.autoApprove',
 						label: localize('permissions.autoApprove', "Bypass Approvals"),
-						description: localize('permissions.autoApprove.subtext', "Auto-approve tool calls, but still pause between turns"),
+						description: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
 						icon: ThemeIcon.fromId(Codicon.warning.id),
 						checked: currentLevel === ChatPermissionLevel.AutoApprove,
 						enabled: !policyRestricted,
@@ -93,17 +93,14 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						hover: {
 							content: policyRestricted
 								? localize('permissions.autoApprove.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors. Unlike Autopilot, this mode still pauses between turns."),
+								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors"),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
 							if (!hasShownElevatedWarning(ChatPermissionLevel.AutoApprove)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
-									message: localize(
-										'permissions.autoApprove.warning.title',
-										"Enable Bypass Approvals and Run Terminal Commands?"
-									),
+									message: localize('permissions.autoApprove.warning.title', "Enable Bypass Approvals?"),
 									buttons: [
 										{
 											label: localize('permissions.autoApprove.warning.confirm', "Enable"),
@@ -117,10 +114,8 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.warning,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize(
-												'permissions.autoApprove.warning.detail',
-												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete."
-											)),
+											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail',
+												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete.")),
 										}],
 									},
 								});
@@ -141,7 +136,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						...action,
 						id: 'chat.permissions.autopilot',
 						label: localize('permissions.autopilot', "Autopilot (Preview)"),
-						description: localize('permissions.autopilot.subtext', "Bypass approvals and continue until the task is complete"),
+						description: localize('permissions.autopilot.subtext', "Autonomously iterates from start to finish"),
 						icon: ThemeIcon.fromId(Codicon.rocket.id),
 						checked: currentLevel === ChatPermissionLevel.Autopilot,
 						enabled: !policyRestricted,
@@ -149,17 +144,14 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						hover: {
 							content: policyRestricted
 								? localize('permissions.autopilot.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue autonomously until the task is done. This includes everything in Bypass Approvals."),
+								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done"),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
 							if (!hasShownElevatedWarning(ChatPermissionLevel.Autopilot)) {
 								const result = await this.dialogService.prompt({
 									type: Severity.Warning,
-									message: localize(
-										'permissions.autopilot.warning.title',
-										"Enable Autopilot and Run Terminal Commands?"
-									),
+									message: localize('permissions.autopilot.warning.title', "Enable Autopilot?"),
 									buttons: [
 										{
 											label: localize('permissions.autopilot.warning.confirm', "Enable"),
@@ -173,10 +165,8 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize(
-												'permissions.autopilot.warning.detail',
-												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will continue making decisions on your behalf between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only."
-											)),
+											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail',
+												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will continue making decisions on your behalf between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -85,7 +85,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						...action,
 						id: 'chat.permissions.autoApprove',
 						label: localize('permissions.autoApprove', "Bypass Approvals"),
-						description: localize('permissions.autoApprove.subtext', "All tool calls are auto-approved"),
+						description: localize('permissions.autoApprove.subtext', "Auto-approve tool calls, but still pause between turns"),
 						icon: ThemeIcon.fromId(Codicon.warning.id),
 						checked: currentLevel === ChatPermissionLevel.AutoApprove,
 						enabled: !policyRestricted,
@@ -93,7 +93,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						hover: {
 							content: policyRestricted
 								? localize('permissions.autoApprove.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors"),
+								: localize('permissions.autoApprove.description', "Auto-approve all tool calls and retry on errors. Unlike Autopilot, this mode still pauses between turns."),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
@@ -114,7 +114,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.warning,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail', "Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.")),
+											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail', "Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.\n\nThis mode still pauses between turns. Use **Autopilot** if you want the agent to continue until the task is complete.")),
 										}],
 									},
 								});
@@ -135,7 +135,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						...action,
 						id: 'chat.permissions.autopilot',
 						label: localize('permissions.autopilot', "Autopilot (Preview)"),
-						description: localize('permissions.autopilot.subtext', "Autonomously iterates from start to finish"),
+						description: localize('permissions.autopilot.subtext', "Bypass approvals and continue until the task is complete"),
 						icon: ThemeIcon.fromId(Codicon.rocket.id),
 						checked: currentLevel === ChatPermissionLevel.Autopilot,
 						enabled: !policyRestricted,
@@ -143,7 +143,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 						hover: {
 							content: policyRestricted
 								? localize('permissions.autopilot.policyDescription', "Disabled by enterprise policy")
-								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue until the task is done"),
+								: localize('permissions.autopilot.description', "Auto-approve all tool calls and continue autonomously until the task is done. This includes everything in Bypass Approvals."),
 							position: pickerOptions.hoverPosition
 						},
 						run: async () => {
@@ -164,7 +164,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
+											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. The agent will make decisions on your behalf without asking for confirmation between turns.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem.ts
@@ -114,8 +114,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.warning,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail',
-												"Bypass Approvals will auto-approve all tool calls without asking for confirmation. Terminal commands will run immediately without a confirmation prompt. This includes file edits and external tool calls.")),
+											markdown: new MarkdownString(localize('permissions.autoApprove.warning.detail', "Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.")),
 										}],
 									},
 								});
@@ -165,8 +164,7 @@ export class PermissionPickerActionItem extends ChatInputPickerActionViewItem {
 									custom: {
 										icon: Codicon.rocket,
 										markdownDetails: [{
-											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail',
-												"Autopilot includes Bypass Approvals behavior and also keeps going until the task is complete. Terminal commands will run without confirmation prompts, and the agent will make decisions on your behalf.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
+											markdown: new MarkdownString(localize('permissions.autopilot.warning.detail', "Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.")),
 										}],
 									},
 								});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/runInTerminalToolTelemetry.ts
@@ -19,7 +19,7 @@ export class RunInTerminalToolTelemetry {
 		subCommands: string[];
 		autoApproveAllowed: 'allowed' | 'needsOptIn' | 'off';
 		autoApproveResult: 'approved' | 'denied' | 'manual';
-		autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined;
+		autoApproveReason: 'subCommand' | 'commandLine' | undefined;
 		autoApproveDefault: boolean | undefined;
 	}) {
 		const subCommandsSanitized = state.subCommands.map(e => {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAnalyzer.ts
@@ -66,13 +66,4 @@ export interface ICommandLineAnalyzerResult {
 	readonly customActions?: ToolConfirmationAction[];
 	// Indicates that auto approval should be forced (e.g. sandboxed commands).
 	readonly forceAutoApproval?: boolean;
-	/**
-	 * Optional denial details when this analyzer explicitly denied auto-execution.
-	 */
-	readonly denialDetails?: {
-		readonly scope: 'subCommand' | 'commandLine';
-		readonly deniedCommand: string;
-		readonly reason: string;
-		readonly ruleSourceText?: string;
-	};
 }

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -83,7 +83,8 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		let autoApproveInfo: IMarkdownString | undefined;
 		let customActions: ToolConfirmationAction[] | undefined;
 
-		if (!subCommands) {
+		if (!subCommands?.length) {
+			this._log('No sub-commands were parsed, auto approval is not allowed');
 			return {
 				isAutoApproveAllowed: false,
 				disclaimers: [],

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -51,7 +51,8 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 	}
 
 	async analyze(options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
-		if (options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource)) {
+		const isAutoApproveEnabledInSettings = this._configurationService.getValue<boolean>(TerminalChatAgentToolsSettingId.EnableAutoApprove) === true;
+		if (isAutoApproveEnabledInSettings && options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource)) {
 			this._log('Session has auto approval enabled, auto approving command');
 			const disableUri = createCommandUri(TerminalChatCommandId.DisableSessionAutoApproval, options.chatSessionResource);
 			const mdTrustSettings = {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -51,9 +51,20 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 	}
 
 	async analyze(options: ICommandLineAnalyzerOptions): Promise<ICommandLineAnalyzerResult> {
-		const hasSessionAutoApproval = options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource);
-		if (hasSessionAutoApproval) {
-			this._log('Session has auto approval enabled');
+		if (options.chatSessionResource && this._terminalChatService.hasChatSessionAutoApproval(options.chatSessionResource)) {
+			this._log('Session has auto approval enabled, auto approving command');
+			const disableUri = createCommandUri(TerminalChatCommandId.DisableSessionAutoApproval, options.chatSessionResource);
+			const mdTrustSettings = {
+				isTrusted: {
+					enabledCommands: [TerminalChatCommandId.DisableSessionAutoApproval]
+				}
+			};
+			return {
+				isAutoApproved: true,
+				isAutoApproveAllowed: true,
+				disclaimers: [],
+				autoApproveInfo: new MarkdownString(`${localize('autoApprove.session', 'Auto approved for this session')} ([${localize('autoApprove.session.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings),
+			};
 		}
 
 		const trimmedCommandLine = options.commandLine.trimStart();
@@ -86,44 +97,26 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		];
 
 		let isDenied = false;
-		let autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined;
+		let autoApproveReason: 'subCommand' | 'commandLine' | undefined;
 		let autoApproveDefault: boolean | undefined;
-		let denialDetails: ICommandLineAnalyzerResult['denialDetails'];
 
-		const deniedSubCommandResultIndex = subCommandResults.findIndex(e => e.result === 'denied');
-		const deniedSubCommandResult = deniedSubCommandResultIndex !== -1 ? subCommandResults[deniedSubCommandResultIndex] : undefined;
+		const deniedSubCommandResult = subCommandResults.find(e => e.result === 'denied');
 		if (deniedSubCommandResult) {
 			this._log('Sub-command DENIED auto approval');
 			isDenied = true;
 			autoApproveDefault = isAutoApproveRule(deniedSubCommandResult.rule) ? deniedSubCommandResult.rule.isDefaultRule : undefined;
 			autoApproveReason = 'subCommand';
-			denialDetails = {
-				scope: 'subCommand',
-				deniedCommand: subCommands[deniedSubCommandResultIndex] ?? trimmedCommandLine,
-				reason: deniedSubCommandResult.reason,
-				ruleSourceText: isAutoApproveRule(deniedSubCommandResult.rule) ? deniedSubCommandResult.rule.sourceText : undefined,
-			};
 		} else if (commandLineResult.result === 'denied') {
 			this._log('Command line DENIED auto approval');
 			isDenied = true;
 			autoApproveDefault = isAutoApproveRule(commandLineResult.rule) ? commandLineResult.rule.isDefaultRule : undefined;
 			autoApproveReason = 'commandLine';
-			denialDetails = {
-				scope: 'commandLine',
-				deniedCommand: trimmedCommandLine,
-				reason: commandLineResult.reason,
-				ruleSourceText: isAutoApproveRule(commandLineResult.rule) ? commandLineResult.rule.sourceText : undefined,
-			};
 		} else {
 			if (subCommandResults.every(e => e.result === 'approved')) {
 				this._log('All sub-commands auto-approved');
 				isAutoApproved = true;
 				autoApproveReason = 'subCommand';
 				autoApproveDefault = subCommandResults.every(e => isAutoApproveRule(e.rule) && e.rule.isDefaultRule);
-			} else if (hasSessionAutoApproval) {
-				this._log('Session auto approval - approving non-denied command');
-				isAutoApproved = true;
-				autoApproveReason = 'session';
 			} else {
 				this._log('All sub-commands NOT auto-approved');
 				if (commandLineResult.result === 'approved') {
@@ -145,15 +138,7 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		// Apply auto approval or force it off depending on enablement/opt-in state
 		const isAutoApproveEnabled = this._configurationService.getValue(TerminalChatAgentToolsSettingId.EnableAutoApprove) === true;
 		const isAutoApproveWarningAccepted = this._storageService.getBoolean(TerminalToolConfirmationStorageKeys.TerminalAutoApproveWarningAccepted, StorageScope.APPLICATION, false);
-		if (hasSessionAutoApproval && isAutoApproved) {
-			const disableUri = createCommandUri(TerminalChatCommandId.DisableSessionAutoApproval, options.chatSessionResource!);
-			const mdTrustSettings = {
-				isTrusted: {
-					enabledCommands: [TerminalChatCommandId.DisableSessionAutoApproval]
-				}
-			};
-			autoApproveInfo = new MarkdownString(`${localize('autoApprove.session', 'Auto approved for this session')} ([${localize('autoApprove.session.disable', 'Disable')}](${disableUri.toString()}))`, mdTrustSettings);
-		} else if (isAutoApproveEnabled && isAutoApproved) {
+		if (isAutoApproveEnabled && isAutoApproved) {
 			autoApproveInfo = this._createAutoApproveInfo(
 				isAutoApproved,
 				isDenied,
@@ -210,14 +195,13 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 			disclaimers,
 			autoApproveInfo,
 			customActions,
-			denialDetails,
 		};
 	}
 
 	private _createAutoApproveInfo(
 		isAutoApproved: boolean,
 		isDenied: boolean,
-		autoApproveReason: 'subCommand' | 'commandLine' | 'session' | undefined,
+		autoApproveReason: 'subCommand' | 'commandLine' | undefined,
 		subCommandResults: ICommandApprovalResultWithReason[],
 		commandLineResult: ICommandApprovalResultWithReason,
 	): IMarkdownString | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.ts
@@ -84,6 +84,15 @@ export class CommandLineAutoApproveAnalyzer extends Disposable implements IComma
 		let customActions: ToolConfirmationAction[] | undefined;
 
 		if (!subCommands?.length) {
+			if (trimmedCommandLine.length === 0) {
+				this._log('Command line is empty, auto approving');
+				return {
+					isAutoApproved: true,
+					isAutoApproveAllowed: true,
+					disclaimers: [],
+				};
+			}
+
 			this._log('No sub-commands were parsed, auto approval is not allowed');
 			return {
 				isAutoApproveAllowed: false,

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -9,7 +9,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
@@ -47,7 +47,7 @@ import { SandboxedCommandLinePresenter } from './commandLinePresenter/sandboxedC
 import { RunInTerminalToolTelemetry } from '../runInTerminalToolTelemetry.js';
 import { ShellIntegrationQuality, ToolTerminalCreator, type IToolTerminal } from '../toolTerminalCreator.js';
 import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../treeSitterCommandParser.js';
-import { type ICommandLineAnalyzer, type ICommandLineAnalyzerOptions, type ICommandLineAnalyzerResult } from './commandLineAnalyzer/commandLineAnalyzer.js';
+import { type ICommandLineAnalyzer, type ICommandLineAnalyzerOptions } from './commandLineAnalyzer/commandLineAnalyzer.js';
 import { CommandLineAutoApproveAnalyzer } from './commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
 import { CommandLineFileWriteAnalyzer } from './commandLineAnalyzer/commandLineFileWriteAnalyzer.js';
 import { CommandLineSandboxAnalyzer } from './commandLineAnalyzer/commandLineSandboxAnalyzer.js';
@@ -375,8 +375,6 @@ const telemetryIgnoredSequences = [
 ];
 
 const altBufferMessage = '\n' + localize('runInTerminalTool.altBufferMessage', "The command opened the alternate buffer.");
-const deniedCommandCircuitBreakerThreshold = 3;
-type DenialDetails = NonNullable<ICommandLineAnalyzerResult['denialDetails']>;
 
 
 export class RunInTerminalTool extends Disposable implements IToolImpl {
@@ -395,7 +393,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 	protected readonly _sessionTerminalAssociations = new ResourceMap<IToolTerminal>();
 	protected readonly _sessionTerminalInstances = new ResourceMap<Set<ITerminalInstance>>();
-	private readonly _sessionDeniedCommandCounts = new ResourceMap<Map<string, number>>();
 	private readonly _terminalsBeingDisposedBySessionCleanup = new Set<ITerminalInstance>();
 
 	// Immutable window state
@@ -767,28 +764,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		// Check if the session's permission level (Autopilot/Bypass Approvals) auto-approves all tools.
 		// When active, skip terminal confirmation entirely since the user has opted into full auto-approval.
 		const isSessionAutoApproved = chatSessionResource && this._isSessionAutoApproveLevel(chatSessionResource);
-		const deniedAnalyzerResult = commandLineAnalyzerResults.find(e => e.isAutoApproved === false && e.denialDetails);
-
-		// In auto-approval session mode, fail closed for policy-denied commands instead of showing
-		// a confirmation that may block unattended runs.
-		if (isSessionAutoApproved && deniedAnalyzerResult?.denialDetails && context.forceConfirmationReason === undefined) {
-			const denial = deniedAnalyzerResult.denialDetails;
-			const deniedRule = denial.ruleSourceText
-				? ` Rule: \`${escapeMarkdownSyntaxTokens(denial.ruleSourceText)}\`.`
-				: '';
-			const deniedAttempts = this._recordDeniedCommandAttempt(chatSessionResource!, denial);
-			const shouldCircuitBreak = deniedAttempts >= deniedCommandCircuitBreakerThreshold;
-			toolSpecificData.alternativeRecommendation = shouldCircuitBreak
-				? `POLICY_DENIED_CIRCUIT_BREAKER: Command was blocked ${deniedAttempts} times in this session and will not be retried. Scope: ${denial.scope}. Command: \`${escapeMarkdownSyntaxTokens(denial.deniedCommand)}\`. Reason: ${denial.reason}.${deniedRule}`
-				: `POLICY_DENIED: Command was not executed in auto-approval session mode. Scope: ${denial.scope}. Command: \`${escapeMarkdownSyntaxTokens(denial.deniedCommand)}\`. Reason: ${denial.reason}.${deniedRule}`;
-			return {
-				confirmationMessages: undefined,
-				toolSpecificData,
-			};
-		}
-		if (isSessionAutoApproved && chatSessionResource) {
-			this._sessionDeniedCommandCounts.delete(chatSessionResource);
-		}
 
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
 		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;
@@ -839,10 +814,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		const inspected = this._configurationService.inspect<boolean>(ChatConfiguration.GlobalAutoApprove);
 		if (inspected.policyValue === false) {
 			return false;
-		}
-		// Check the terminal chat service's session auto-approval state
-		if (this._terminalChatService.hasChatSessionAutoApproval(chatSessionResource)) {
-			return true;
 		}
 		// Check the live widget picker level (handles mid-session switches).
 		// Fall back to lastFocusedWidget if the session-specific widget isn't found
@@ -1525,7 +1496,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		this._sessionTerminalAssociations.delete(chatSessionResource);
 		this._sessionTerminalInstances.delete(chatSessionResource);
-		this._sessionDeniedCommandCounts.delete(chatSessionResource);
 
 		for (const terminal of terminalsToDispose) {
 			// Skip redundant map walks in onDidDispose since this session has already been removed.
@@ -1544,18 +1514,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 		for (const termId of terminalToRemove) {
 			RunInTerminalTool._activeExecutions.delete(termId);
 		}
-	}
-
-	private _recordDeniedCommandAttempt(chatSessionResource: URI, denial: DenialDetails): number {
-		let sessionCounts = this._sessionDeniedCommandCounts.get(chatSessionResource);
-		if (!sessionCounts) {
-			sessionCounts = new Map<string, number>();
-			this._sessionDeniedCommandCounts.set(chatSessionResource, sessionCounts);
-		}
-		const signature = JSON.stringify([denial.scope, denial.deniedCommand, denial.ruleSourceText ?? denial.reason]);
-		const attempts = (sessionCounts.get(signature) ?? 0) + 1;
-		sessionCounts.set(signature, attempts);
-		return attempts;
 	}
 
 	private _addSessionTerminalAssociation(chatSessionResource: URI, toolTerminal: IToolTerminal): void {

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -9,7 +9,7 @@ import { CancellationToken, CancellationTokenSource } from '../../../../../../ba
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { CancellationError } from '../../../../../../base/common/errors.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
+import { escapeMarkdownSyntaxTokens, MarkdownString, type IMarkdownString } from '../../../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../../../base/common/map.js';
 import { getMediaMime } from '../../../../../../base/common/mime.js';
@@ -647,7 +647,14 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 			chatSessionResource,
 			requiresUnsandboxConfirmation,
 		};
-		const commandLineAnalyzerResults = await Promise.all(this._commandLineAnalyzers.map(e => e.analyze(commandLineAnalyzerOptions)));
+
+		// In Autopilot/Bypass Approvals modes, do not interact with terminal auto-approve rules.
+		// Commands should flow through directly based on the chat permission level.
+		const isSessionAutoApproved = chatSessionResource && this._isSessionAutoApproveLevel(chatSessionResource);
+		const commandLineAnalyzers = isSessionAutoApproved
+			? this._commandLineAnalyzers.filter(e => !(e instanceof CommandLineAutoApproveAnalyzer))
+			: this._commandLineAnalyzers;
+		const commandLineAnalyzerResults = await Promise.all(commandLineAnalyzers.map(e => e.analyze(commandLineAnalyzerOptions)));
 
 		const disclaimersRaw = commandLineAnalyzerResults.map(e => e.disclaimers).filter(e => !!e).flatMap(e => e);
 		let disclaimer: IMarkdownString | undefined;
@@ -760,10 +767,6 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 				? localize('runInTerminal.unsandboxed.background', "Run `{0}` command outside the sandbox in background?", shellType)
 				: localize('runInTerminal.unsandboxed', "Run `{0}` command outside the sandbox?", shellType);
 		}
-
-		// Check if the session's permission level (Autopilot/Bypass Approvals) auto-approves all tools.
-		// When active, skip terminal confirmation entirely since the user has opted into full auto-approval.
-		const isSessionAutoApproved = chatSessionResource && this._isSessionAutoApproveLevel(chatSessionResource);
 
 		// If forceConfirmationReason is set, always show confirmation regardless of auto-approval
 		const shouldShowConfirmation = (!isFinalAutoApproved && !isSessionAutoApproved) || context.forceConfirmationReason !== undefined;

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
@@ -57,4 +57,21 @@ suite('CommandLineAutoApproveAnalyzer', () => {
 		strictEqual(result.isAutoApproved, undefined);
 		strictEqual(result.disclaimers?.length ?? 0, 0);
 	});
+
+	test('should auto approve empty command strings when sub-command parsing returns an empty list', async () => {
+		const options: ICommandLineAnalyzerOptions = {
+			commandLine: '   ',
+			cwd: undefined,
+			shell: 'pwsh',
+			os: OperatingSystem.Windows,
+			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+			terminalToolSessionId: 'test',
+			chatSessionResource: undefined,
+		};
+
+		const result = await analyzer.analyze(options);
+		strictEqual(result.isAutoApproveAllowed, true);
+		strictEqual(result.isAutoApproved, true);
+		strictEqual(result.disclaimers?.length ?? 0, 0);
+	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/browser/commandLineAutoApproveAnalyzer.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strictEqual } from 'assert';
+import { OperatingSystem } from '../../../../../../base/common/platform.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import type { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
+import type { ICommandLineAnalyzerOptions } from '../../browser/tools/commandLineAnalyzer/commandLineAnalyzer.js';
+import { CommandLineAutoApproveAnalyzer } from '../../browser/tools/commandLineAnalyzer/commandLineAutoApproveAnalyzer.js';
+import { RunInTerminalToolTelemetry } from '../../browser/runInTerminalToolTelemetry.js';
+import { TreeSitterCommandParser, TreeSitterCommandParserLanguage } from '../../browser/treeSitterCommandParser.js';
+
+suite('CommandLineAutoApproveAnalyzer', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: IInstantiationService;
+	let analyzer: CommandLineAutoApproveAnalyzer;
+
+	setup(() => {
+		const configurationService = new TestConfigurationService();
+		instantiationService = workbenchInstantiationService({
+			configurationService: () => configurationService
+		}, store);
+
+		const parser = {
+			extractSubCommands: async () => [],
+		} as unknown as TreeSitterCommandParser;
+		const telemetry = {
+			logPrepare: () => { },
+		} as unknown as RunInTerminalToolTelemetry;
+
+		analyzer = store.add(instantiationService.createInstance(
+			CommandLineAutoApproveAnalyzer,
+			parser,
+			telemetry,
+			() => { }
+		));
+	});
+
+	test('should not allow auto approve when sub-command parsing returns an empty list', async () => {
+		const options: ICommandLineAnalyzerOptions = {
+			commandLine: 'rm -- file.txt',
+			cwd: undefined,
+			shell: 'pwsh',
+			os: OperatingSystem.Windows,
+			treeSitterLanguage: TreeSitterCommandParserLanguage.PowerShell,
+			terminalToolSessionId: 'test',
+			chatSessionResource: undefined,
+		};
+
+		const result = await analyzer.analyze(options);
+		strictEqual(result.isAutoApproveAllowed, false);
+		strictEqual(result.isAutoApproved, undefined);
+		strictEqual(result.disclaimers?.length ?? 0, 0);
+	});
+});

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1588,7 +1588,7 @@ suite('RunInTerminalTool', () => {
 
 			const sessionResource = LocalChatSessionUri.forSession('autopilot-session');
 			instantiationService.stub(IChatWidgetService, {
-				getWidgetBySessionResource: () => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.Autopilot } } }),
+				getWidgetBySessionResource: (() => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.Autopilot } } })) as unknown as IChatWidgetService['getWidgetBySessionResource'],
 				lastFocusedWidget: undefined,
 			});
 
@@ -1615,7 +1615,7 @@ suite('RunInTerminalTool', () => {
 
 			const sessionResource = LocalChatSessionUri.forSession('bypass-session');
 			instantiationService.stub(IChatWidgetService, {
-				getWidgetBySessionResource: () => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.AutoApprove } } }),
+				getWidgetBySessionResource: (() => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.AutoApprove } } })) as unknown as IChatWidgetService['getWidgetBySessionResource'],
 				lastFocusedWidget: undefined,
 			});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -31,6 +31,8 @@ import { TestContextService } from '../../../../../test/common/workbenchTestServ
 import { TestIPCFileSystemProvider } from '../../../../../test/electron-browser/workbenchTestServices.js';
 import { TerminalToolConfirmationStorageKeys } from '../../../../chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart.js';
 import { IChatService, type IChatTerminalToolInvocationData } from '../../../../chat/common/chatService/chatService.js';
+import { IChatWidgetService } from '../../../../chat/browser/chat.js';
+import { ChatPermissionLevel } from '../../../../chat/common/constants.js';
 import { LocalChatSessionUri } from '../../../../chat/common/model/chatUri.js';
 import { ITerminalSandboxService } from '../../common/terminalSandboxService.js';
 import { ILanguageModelToolsService, IPreparedToolInvocation, IToolData, IToolImpl, IToolInvocationPreparationContext, ToolDataSource, ToolSet, type ToolConfirmationAction } from '../../../../chat/common/tools/languageModelToolsService.js';
@@ -1577,6 +1579,60 @@ suite('RunInTerminalTool', () => {
 			const terminalData = result!.toolSpecificData as IChatTerminalToolInvocationData;
 			ok(terminalData.autoApproveInfo, 'Expected autoApproveInfo to be defined');
 			ok(terminalData.autoApproveInfo.value.includes('Auto approved for this session'), 'Expected session approval message');
+		});
+
+		test('should bypass terminal auto-approve feature in Autopilot mode', async () => {
+			setAutoApprove({
+				curl: false
+			});
+
+			const sessionResource = LocalChatSessionUri.forSession('autopilot-session');
+			instantiationService.stub(IChatWidgetService, {
+				getWidgetBySessionResource: () => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.Autopilot } } }),
+				lastFocusedWidget: undefined,
+			});
+
+			const autopilotRunInTerminalTool = store.add(instantiationService.createInstance(TestRunInTerminalTool));
+			const result = await autopilotRunInTerminalTool.prepareToolInvocation({
+				parameters: {
+					command: 'curl https://example.com',
+					explanation: 'Fetch a URL',
+					goal: 'Download content',
+					isBackground: false,
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource,
+			} as IToolInvocationPreparationContext, CancellationToken.None);
+
+			assertAutoApproved(result);
+			const terminalData = result!.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.autoApproveInfo, undefined, 'Expected no terminal auto-approve info in Autopilot mode');
+		});
+
+		test('should bypass terminal auto-approve feature in Bypass Approvals mode', async () => {
+			setAutoApprove({
+				curl: false
+			});
+
+			const sessionResource = LocalChatSessionUri.forSession('bypass-session');
+			instantiationService.stub(IChatWidgetService, {
+				getWidgetBySessionResource: () => ({ input: { currentModeInfo: { permissionLevel: ChatPermissionLevel.AutoApprove } } }),
+				lastFocusedWidget: undefined,
+			});
+
+			const bypassRunInTerminalTool = store.add(instantiationService.createInstance(TestRunInTerminalTool));
+			const result = await bypassRunInTerminalTool.prepareToolInvocation({
+				parameters: {
+					command: 'curl https://example.com',
+					explanation: 'Fetch a URL',
+					goal: 'Download content',
+					isBackground: false,
+				} as IRunInTerminalInputParams,
+				chatSessionResource: sessionResource,
+			} as IToolInvocationPreparationContext, CancellationToken.None);
+
+			assertAutoApproved(result);
+			const terminalData = result!.toolSpecificData as IChatTerminalToolInvocationData;
+			strictEqual(terminalData.autoApproveInfo, undefined, 'Expected no terminal auto-approve info in Bypass Approvals mode');
 		});
 	});
 

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -1551,11 +1551,7 @@ suite('RunInTerminalTool', () => {
 	});
 
 	suite('session auto approval', () => {
-		setup(() => {
-			setAutoApprove({ rm: false });
-		});
-
-		test('should return policy denial details for denied commands when session has auto approval enabled', async () => {
+		test('should auto approve all commands when session has auto approval enabled', async () => {
 			const sessionId = 'test-session-123';
 			const sessionResource = LocalChatSessionUri.forSession(sessionId);
 			const terminalChatService = instantiationService.get(ITerminalChatService);
@@ -1579,61 +1575,8 @@ suite('RunInTerminalTool', () => {
 			assertAutoApproved(result);
 
 			const terminalData = result!.toolSpecificData as IChatTerminalToolInvocationData;
-			ok(terminalData.alternativeRecommendation, 'Expected policy denial alternative recommendation');
-			ok(terminalData.alternativeRecommendation.includes('POLICY_DENIED'), 'Expected policy denial marker');
-			ok(terminalData.alternativeRecommendation.includes('rm dangerous-file.txt'), 'Expected denied command details');
-		});
-
-		test('should still show confirmation when forceConfirmationReason is provided', async () => {
-			const sessionId = 'test-session-123-force';
-			const sessionResource = LocalChatSessionUri.forSession(sessionId);
-			const terminalChatService = instantiationService.get(ITerminalChatService);
-
-			terminalChatService.setChatSessionAutoApproval(sessionResource, true);
-
-			const context: IToolInvocationPreparationContext = {
-				parameters: {
-					command: 'rm dangerous-file.txt',
-					explanation: 'Remove a file',
-					goal: 'Remove a file',
-					isBackground: false
-				} as IRunInTerminalInputParams,
-				chatSessionResource: sessionResource,
-				forceConfirmationReason: 'test'
-			} as IToolInvocationPreparationContext;
-
-			const result = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
-			assertConfirmationRequired(result);
-		});
-
-		test('should circuit break repeated denied command attempts in auto approval sessions', async () => {
-			const sessionId = 'test-session-123-circuit-break';
-			const sessionResource = LocalChatSessionUri.forSession(sessionId);
-			const terminalChatService = instantiationService.get(ITerminalChatService);
-
-			terminalChatService.setChatSessionAutoApproval(sessionResource, true);
-
-			const context: IToolInvocationPreparationContext = {
-				parameters: {
-					command: 'rm dangerous-file.txt',
-					explanation: 'Remove a file',
-					goal: 'Remove a file',
-					isBackground: false
-				} as IRunInTerminalInputParams,
-				chatSessionResource: sessionResource
-			} as IToolInvocationPreparationContext;
-
-			const first = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
-			const second = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
-			const third = await runInTerminalTool.prepareToolInvocation(context, CancellationToken.None);
-
-			const firstData = first!.toolSpecificData as IChatTerminalToolInvocationData;
-			const secondData = second!.toolSpecificData as IChatTerminalToolInvocationData;
-			const thirdData = third!.toolSpecificData as IChatTerminalToolInvocationData;
-
-			ok(firstData.alternativeRecommendation?.includes('POLICY_DENIED'), 'Expected initial policy denial message');
-			ok(secondData.alternativeRecommendation?.includes('POLICY_DENIED'), 'Expected second policy denial message');
-			ok(thirdData.alternativeRecommendation?.includes('POLICY_DENIED_CIRCUIT_BREAKER'), 'Expected circuit breaker policy denial message');
+			ok(terminalData.autoApproveInfo, 'Expected autoApproveInfo to be defined');
+			ok(terminalData.autoApproveInfo.value.includes('Auto approved for this session'), 'Expected session approval message');
 		});
 	});
 


### PR DESCRIPTION
Reverts https://github.com/microsoft/vscode/pull/300824 which fixed eval issues by returning early from the tool if a denied command was attempted. This caused issues like https://github.com/microsoft/vscode/issues/303174, where commands were disallowed vs prompted for.

Now, we will skip the `auto approval` feature/system when a user is in `Autopilot` or `Bypass Approvals` mode so terminal commands run freely.

Also specifies "terminal commands" in `Autopilot` dialog (`Bypass Approvals` already had this).

Address #303174 in main. This will be a candidate.
