### PR TITLE
fix: allow context menu when actions are empty but contextMenu option is set

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -265,7 +265,7 @@ export class WorkbenchToolBar extends ToolBar {
 					}));
 				}
 
-				if (actions.length === 0) {
+				if (actions.length === 0 && !this._options?.contextMenu) {
 					return;
 				}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/304132

On Windows, right-clicking the command center toolbar shows the native OS context menu instead of the VS Code context menu (which contains the Quick Agent Input toggle). This happens because the early return on `actions.length === 0` prevents `showContextMenu` from being called even when `this._options?.contextMenu` is configured.

Changed the guard to `actions.length === 0 && !this._options?.contextMenu` so the context menu still shows when a `contextMenu` menuId is set.