### PR TITLE
fix: re-layout list when toggling browse mode in MCP/plugin widgets

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget.ts
@@ -382,6 +382,8 @@ export class McpListWidget extends Disposable {
 	private galleryServers: IWorkbenchMcpServer[] = [];
 	private searchQuery: string = '';
 	private browseMode: boolean = false;
+	private lastHeight: number = 0;
+	private lastWidth: number = 0;
 	private readonly collapsedGroups = new Set<string>();
 	private galleryCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
@@ -607,6 +609,11 @@ export class McpListWidget extends Disposable {
 			this.galleryCts?.dispose(true);
 			this.galleryServers = [];
 			this.filterServers();
+		}
+
+		// Re-layout to account for the back link height change
+		if (this.lastHeight > 0) {
+			this.layout(this.lastHeight, this.lastWidth);
 		}
 	}
 
@@ -882,6 +889,8 @@ export class McpListWidget extends Disposable {
 	 * Layouts the widget.
 	 */
 	layout(height: number, width: number): void {
+		this.lastHeight = height;
+		this.lastWidth = width;
 		const sectionFooterHeight = this.sectionHeader.offsetHeight || 0;
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight || 52;
 		const backLinkHeight = this.browseMode ? (this.backLink.offsetHeight || 28) : 0;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget.ts
@@ -298,6 +298,8 @@ export class PluginListWidget extends Disposable {
 	private marketplaceItems: IMarketplacePluginItem[] = [];
 	private searchQuery: string = '';
 	private browseMode: boolean = false;
+	private lastHeight: number = 0;
+	private lastWidth: number = 0;
 	private readonly collapsedGroups = new Set<string>();
 	private marketplaceCts: CancellationTokenSource | undefined;
 	private readonly delayedFilter = new Delayer<void>(200);
@@ -519,6 +521,11 @@ export class PluginListWidget extends Disposable {
 			this.marketplaceItems = [];
 			this.filterPlugins();
 		}
+
+		// Re-layout to account for the back link height change
+		if (this.lastHeight > 0) {
+			this.layout(this.lastHeight, this.lastWidth);
+		}
 	}
 
 	private async queryMarketplace(): Promise<void> {
@@ -692,6 +699,8 @@ export class PluginListWidget extends Disposable {
 	}
 
 	layout(height: number, width: number): void {
+		this.lastHeight = height;
+		this.lastWidth = width;
 		const sectionFooterHeight = this.sectionHeader.offsetHeight || 0;
 		const searchBarHeight = this.searchAndButtonContainer.offsetHeight || 52;
 		const backLinkHeight = this.browseMode ? (this.backLink.offsetHeight || 28) : 0;


### PR DESCRIPTION
When toggling browse mode, the back link appears/disappears but layout() was never re-called, causing the list height to not account for the changed chrome. This clipped the last entry.

Cache the last layout dimensions and re-call layout() after toggling browse mode.

Fixes https://github.com/microsoft/vscode/issues/304139

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
