### PR TITLE
Sessions: Use ITaskService to run tasks instead of terminal commands

### DIFF
--- a/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionsConfigurationService.ts
@@ -7,17 +7,17 @@ import { Disposable, DisposableStore, MutableDisposable } from '../../../../base
 import { autorun, IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { joinPath, dirname, isEqual } from '../../../../base/common/resources.js';
 import { parse } from '../../../../base/common/jsonc.js';
-import { isMacintosh, isWindows } from '../../../../base/common/platform.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { TerminalLocation } from '../../../../platform/terminal/common/terminal.js';
+import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IActiveSessionItem, ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { IJSONEditingService } from '../../../../workbench/services/configuration/common/jsonEditing.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IPreferencesService } from '../../../../workbench/services/preferences/common/preferences.js';
-import { ITerminalInstance, ITerminalService } from '../../../../workbench/contrib/terminal/browser/terminal.js';
 import { CommandString } from '../../../../workbench/contrib/tasks/common/taskConfiguration.js';
+import { TaskRunSource } from '../../../../workbench/contrib/tasks/common/tasks.js';
+import { ITaskService } from '../../../../workbench/contrib/tasks/common/taskService.js';
 
 export type TaskStorageTarget = 'user' | 'workspace';
 type TaskRunOnOption = 'default' | 'folderOpen' | 'worktreeCreated';
@@ -102,8 +102,8 @@ export interface ISessionsConfigurationService {
 	removeTask(taskLabel: string, session: IActiveSessionItem, target: TaskStorageTarget): Promise<void>;
 
 	/**
-	 * Runs a task entry in a terminal, resolving the correct platform
-	 * command and using the session worktree as cwd.
+	 * Runs a task via the task service, looking it up by label in the
+	 * workspace folder corresponding to the session worktree.
 	 */
 	runTask(task: ITaskEntry, session: IActiveSessionItem): Promise<void>;
 
@@ -125,12 +125,8 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	declare readonly _serviceBrand: undefined;
 
 	private static readonly _PINNED_TASK_LABELS_KEY = 'agentSessions.pinnedTaskLabels';
-	private static readonly _SUPPORTED_TASK_TYPES = new Set(['shell', 'npm']);
-
 	private readonly _sessionTasks = observableValue<readonly ISessionTaskWithTarget[]>(this, []);
 	private readonly _fileWatcher = this._register(new MutableDisposable());
-	/** Maps `cwd.toString() + command` to the terminal `instanceId`. */
-	private readonly _taskTerminals = new Map<string, number>();
 	private readonly _knownSessionWorktrees = new Map<string, string | undefined>();
 	private readonly _pinnedTaskLabels: Map<string, string>;
 	private readonly _pinnedTaskObservables = new Map<string, ReturnType<typeof observableValue<string | undefined>>>();
@@ -142,7 +138,8 @@ export class SessionsConfigurationService extends Disposable implements ISession
 		@IFileService private readonly _fileService: IFileService,
 		@IJSONEditingService private readonly _jsonEditingService: IJSONEditingService,
 		@IPreferencesService private readonly _preferencesService: IPreferencesService,
-		@ITerminalService private readonly _terminalService: ITerminalService,
+		@ITaskService private readonly _taskService: ITaskService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
 		@IStorageService private readonly _storageService: IStorageService,
 	) {
@@ -328,29 +325,22 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	}
 
 	async runTask(task: ITaskEntry, session: IActiveSessionItem): Promise<void> {
-		const command = this._resolveCommand(task);
-		if (!command) {
-			return;
-		}
-
 		const cwd = session.worktree ?? session.repository;
 		if (!cwd) {
 			return;
 		}
 
-		const terminalKey = `${cwd.toString()}${command}`;
-		let terminal = this._getExistingTerminalInstance(terminalKey);
-		if (!terminal) {
-			terminal = await this._terminalService.createTerminal({
-				location: TerminalLocation.Panel,
-				config: { name: task.label },
-				cwd
-			});
-			this._taskTerminals.set(terminalKey, terminal.instanceId);
+		const workspaceFolder = this._workspaceContextService.getWorkspaceFolder(cwd);
+		if (!workspaceFolder) {
+			return;
 		}
-		await terminal.sendText(command, true);
-		this._terminalService.setActiveInstance(terminal);
-		await this._terminalService.revealActiveTerminal();
+
+		const resolvedTask = await this._taskService.getTask(workspaceFolder, task.label);
+		if (!resolvedTask) {
+			return;
+		}
+
+		await this._taskService.run(resolvedTask, undefined, TaskRunSource.User);
 	}
 
 	getPinnedTaskLabel(repository: URI | undefined): IObservable<string | undefined> {
@@ -376,19 +366,6 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	}
 
 	// --- private helpers ---
-
-	private _getExistingTerminalInstance(terminalKey: string): ITerminalInstance | undefined {
-		const instanceId = this._taskTerminals.get(terminalKey);
-		if (instanceId === undefined) {
-			return undefined;
-		}
-		const instance = this._terminalService.instances.find(i => i.instanceId === instanceId);
-		if (!instance || instance.hasChildProcesses) {
-			this._taskTerminals.delete(terminalKey);
-			return undefined;
-		}
-		return instance;
-	}
 
 	private _getTasksJsonUri(session: IActiveSessionItem, target: TaskStorageTarget): URI | undefined {
 		if (target === 'workspace') {
@@ -432,50 +409,7 @@ export class SessionsConfigurationService extends Disposable implements ISession
 	}
 
 	private _isSupportedTask(task: ITaskEntry): boolean {
-		return !!task.type && SessionsConfigurationService._SUPPORTED_TASK_TYPES.has(task.type);
-	}
-
-	private _resolveCommand(task: ITaskEntry): string | undefined {
-		if (task.type === 'npm') {
-			if (!task.script) {
-				return undefined;
-			}
-			const base = task.path
-				? `npm --prefix ${task.path} run ${task.script}`
-				: `npm run ${task.script}`;
-			return this._appendArgs(base, task.args);
-		}
-
-		let command: string | undefined;
-		let platformArgs: CommandString[] | undefined;
-
-		if (isWindows && task.windows?.command) {
-			command = task.windows.command;
-			platformArgs = task.windows.args;
-		} else if (isMacintosh && task.osx?.command) {
-			command = task.osx.command;
-			platformArgs = task.osx.args;
-		} else if (!isWindows && !isMacintosh && task.linux?.command) {
-			command = task.linux.command;
-			platformArgs = task.linux.args;
-		} else {
-			command = task.command;
-		}
-
-		// Platform-specific args override task-level args
-		const args = platformArgs ?? task.args;
-		return this._appendArgs(command, args);
-	}
-
-	private _appendArgs(command: string | undefined, args: CommandString[] | undefined): string | undefined {
-		if (!command) {
-			return undefined;
-		}
-		if (!args || args.length === 0) {
-			return command;
-		}
-		const resolvedArgs = args.map(a => CommandString.value(a)).join(' ');
-		return `${command} ${resolvedArgs}`;
+		return !!task.label;
 	}
 
 	private _handleActiveSessionChange(session: IActiveSessionItem | undefined): void {

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -13,11 +13,13 @@ import { IFileContent, IFileService } from '../../../../../platform/files/common
 import { InMemoryStorageService, IStorageService } from '../../../../../platform/storage/common/storage.js';
 import { IJSONEditingService, IJSONValue } from '../../../../../workbench/services/configuration/common/jsonEditing.js';
 import { IPreferencesService } from '../../../../../workbench/services/preferences/common/preferences.js';
-import { ITerminalInstance, ITerminalService } from '../../../../../workbench/contrib/terminal/browser/terminal.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IActiveSessionItem, ISessionsManagementService } from '../../../sessions/browser/sessionsManagementService.js';
 import { INonSessionTaskEntry, ISessionsConfigurationService, SessionsConfigurationService, ITaskEntry } from '../../browser/sessionsConfigurationService.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { observableValue } from '../../../../../base/common/observable.js';
+import { Task } from '../../../../../workbench/contrib/tasks/common/tasks.js';
+import { ITaskService } from '../../../../../workbench/contrib/tasks/common/taskService.js';
 
 function makeSession(opts: { repository?: URI; worktree?: URI } = {}): IActiveSessionItem {
 	return {
@@ -53,12 +55,13 @@ suite('SessionsConfigurationService', () => {
 	let service: ISessionsConfigurationService;
 	let fileContents: Map<string, string>;
 	let jsonEdits: { uri: URI; values: IJSONValue[] }[];
-	let createdTerminals: { name: string | undefined; cwd: URI | string | undefined }[];
-	let sentCommands: { command: string }[];
+	let ranTasks: { label: string }[];
 	let committedFiles: { session: IActiveSessionItem; fileUris: URI[] }[];
 	let storageService: InMemoryStorageService;
 	let readFileCalls: URI[];
 	let activeSessionObs: ReturnType<typeof observableValue<IActiveSessionItem | undefined>>;
+	let tasksByLabel: Map<string, Task>;
+	let workspaceFoldersByUri: Map<string, IWorkspaceFolder>;
 
 	const userSettingsUri = URI.parse('file:///user/settings.json');
 	const repoUri = URI.parse('file:///repo');
@@ -67,10 +70,11 @@ suite('SessionsConfigurationService', () => {
 	setup(() => {
 		fileContents = new Map();
 		jsonEdits = [];
-		createdTerminals = [];
-		sentCommands = [];
+		ranTasks = [];
 		committedFiles = [];
 		readFileCalls = [];
+		tasksByLabel = new Map();
+		workspaceFoldersByUri = new Map();
 
 		const instantiationService = store.add(new TestInstantiationService());
 		activeSessionObs = observableValue('activeSession', undefined);
@@ -98,28 +102,24 @@ suite('SessionsConfigurationService', () => {
 			override userSettingsResource = userSettingsUri;
 		});
 
-		let nextInstanceId = 1;
-		const terminalInstances: (Partial<ITerminalInstance> & { instanceId: number })[] = [];
-
-		const terminalServiceMock = new class extends mock<ITerminalService>() {
-			override get instances(): readonly ITerminalInstance[] { return terminalInstances as ITerminalInstance[]; }
-			override async createTerminal(opts?: { config?: { name?: string }; cwd?: URI }) {
-				const instance: Partial<ITerminalInstance> & { instanceId: number } = {
-					instanceId: nextInstanceId++,
-					initialCwd: opts?.cwd?.fsPath,
-					cwd: opts?.cwd?.fsPath,
-					hasChildProcesses: false,
-					sendText: async (text: string) => { sentCommands.push({ command: text }); },
-				};
-				createdTerminals.push({ name: opts?.config?.name, cwd: opts?.cwd });
-				terminalInstances.push(instance);
-				return instance as ITerminalInstance;
+		instantiationService.stub(ITaskService, new class extends mock<ITaskService>() {
+			override async getTask(_workspaceFolder: any, alias: string | any) {
+				const label = typeof alias === 'string' ? alias : '';
+				return tasksByLabel.get(label);
 			}
-			override setActiveInstance() { }
-			override async revealActiveTerminal() { }
-		};
+			override async run(task: Task | undefined) {
+				if (task) {
+					ranTasks.push({ label: task._label });
+				}
+				return undefined;
+			}
+		});
 
-		instantiationService.stub(ITerminalService, terminalServiceMock);
+		instantiationService.stub(IWorkspaceContextService, new class extends mock<IWorkspaceContextService>() {
+			override getWorkspaceFolder(resource: URI): IWorkspaceFolder | null {
+				return workspaceFoldersByUri.get(resource.toString()) ?? null;
+			}
+		});
 
 		instantiationService.stub(ISessionsManagementService, new class extends mock<ISessionsManagementService>() {
 			override activeSession = activeSessionObs;
@@ -160,7 +160,7 @@ suite('SessionsConfigurationService', () => {
 		await new Promise(r => setTimeout(r, 10));
 		const tasks = obs.get();
 
-		assert.deepStrictEqual(tasks.map(t => t.task.label), ['build', 'test', 'watch']);
+		assert.deepStrictEqual(tasks.map(t => t.task.label), ['build', 'test', 'watch', 'gulp-task']);
 	});
 
 	test('getSessionTasks returns empty array when no worktree', async () => {
@@ -211,7 +211,7 @@ suite('SessionsConfigurationService', () => {
 
 	// --- getNonSessionTasks ---
 
-	test('getNonSessionTasks returns only tasks without inSessions and with supported types', async () => {
+	test('getNonSessionTasks returns only tasks without inSessions', async () => {
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		fileContents.set(worktreeTasksUri.toString(), tasksJsonContent([
 			makeTask('build', 'npm run build', true),
@@ -226,7 +226,7 @@ suite('SessionsConfigurationService', () => {
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
 		const nonSessionTasks = await service.getNonSessionTasks(session);
 
-		assert.deepStrictEqual(nonSessionTasks.map(t => t.task.label), ['lint', 'test', 'watch']);
+		assert.deepStrictEqual(nonSessionTasks.map(t => t.task.label), ['lint', 'test', 'watch', 'gulp-task']);
 	});
 
 	test('getNonSessionTasks reads from repository when no worktree', async () => {
@@ -567,133 +567,57 @@ suite('SessionsConfigurationService', () => {
 
 	// --- runTask ---
 
-	test('runTask creates terminal and sends command', async () => {
+	function registerMockTask(label: string, folder: URI): void {
+		tasksByLabel.set(label, { _label: label } as unknown as Task);
+		workspaceFoldersByUri.set(folder.toString(), { uri: folder, name: 'folder', index: 0, toResource: () => folder } as IWorkspaceFolder);
+	}
+
+	test('runTask looks up task by label and runs it via the task service', async () => {
+		registerMockTask('build', worktreeUri);
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task = makeTask('build', 'npm run build');
 
-		await service.runTask(task, session);
+		await service.runTask(makeTask('build', 'npm run build'), session);
 
-		assert.strictEqual(createdTerminals.length, 1);
-		assert.strictEqual(createdTerminals[0].name, 'build');
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'npm run build');
-	});
-
-	test('runTask resolves npm task to npm run <script>', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task = makeNpmTask('watch', 'watch');
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(createdTerminals.length, 1);
-		assert.strictEqual(createdTerminals[0].name, 'watch');
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'npm run watch');
-	});
-
-	test('runTask does nothing for npm task without script', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task: ITaskEntry = { label: 'broken', type: 'npm', inSessions: true };
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(createdTerminals.length, 0);
-		assert.strictEqual(sentCommands.length, 0);
+		assert.strictEqual(ranTasks.length, 1);
+		assert.strictEqual(ranTasks[0].label, 'build');
 	});
 
 	test('runTask does nothing when no cwd available', async () => {
 		const session = makeSession({ repository: undefined, worktree: undefined });
 		await service.runTask(makeTask('build', 'npm run build'), session);
 
-		assert.strictEqual(createdTerminals.length, 0);
-		assert.strictEqual(sentCommands.length, 0);
+		assert.strictEqual(ranTasks.length, 0);
 	});
 
-	test('runTask reuses the same terminal for the same command and worktree', async () => {
+	test('runTask does nothing when workspace folder not found', async () => {
+		// No workspace folder registered for worktreeUri
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task = makeTask('build', 'npm run build');
+		await service.runTask(makeTask('build', 'npm run build'), session);
 
-		await service.runTask(task, session);
-		await service.runTask(task, session);
-
-		assert.strictEqual(createdTerminals.length, 1, 'should create only one terminal');
-		assert.strictEqual(sentCommands.length, 2, 'should send command twice');
-		assert.strictEqual(sentCommands[0].command, 'npm run build');
-		assert.strictEqual(sentCommands[1].command, 'npm run build');
+		assert.strictEqual(ranTasks.length, 0);
 	});
 
-	test('runTask creates different terminals for different commands', async () => {
+	test('runTask does nothing when task not found by label', async () => {
+		workspaceFoldersByUri.set(worktreeUri.toString(), { uri: worktreeUri, name: 'folder', index: 0, toResource: () => worktreeUri } as IWorkspaceFolder);
+		// No task registered for 'nonexistent'
 		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
+		await service.runTask(makeTask('nonexistent', 'echo hi'), session);
+
+		assert.strictEqual(ranTasks.length, 0);
+	});
+
+	test('runTask uses repository as cwd when worktree is not available', async () => {
+		registerMockTask('build', repoUri);
+		const session = makeSession({ repository: repoUri });
 
 		await service.runTask(makeTask('build', 'npm run build'), session);
-		await service.runTask(makeTask('test', 'npm test'), session);
 
-		assert.strictEqual(createdTerminals.length, 2, 'should create two terminals');
-		assert.strictEqual(createdTerminals[0].name, 'build');
-		assert.strictEqual(createdTerminals[1].name, 'test');
-	});
-
-	test('runTask appends args to shell command', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task: ITaskEntry = { label: 'build', type: 'shell', command: 'dotnet', args: ['build', '--configuration', 'Release'], inSessions: true };
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'dotnet build --configuration Release');
-	});
-
-	test('runTask appends args to npm task', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task: ITaskEntry = { label: 'test', type: 'npm', script: 'test', args: ['--', '--coverage'], inSessions: true };
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'npm run test -- --coverage');
-	});
-
-	test('runTask resolves CommandString objects in args', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task: ITaskEntry = {
-			label: 'build', type: 'shell', command: 'gcc',
-			args: [
-				{ value: '-o', quoting: 'escape' as const },
-				'output.exe',
-				'main.c',
-			],
-			inSessions: true
-		};
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'gcc -o output.exe main.c');
-	});
-
-	test('runTask sends only command when args is empty', async () => {
-		const session = makeSession({ worktree: worktreeUri, repository: repoUri });
-		const task: ITaskEntry = { label: 'build', type: 'shell', command: 'make', args: [], inSessions: true };
-
-		await service.runTask(task, session);
-
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'make');
-	});
-
-	test('runTask creates different terminals for same command in different worktrees', async () => {
-		const wt1 = URI.parse('file:///worktree1');
-		const wt2 = URI.parse('file:///worktree2');
-		const session1 = makeSession({ worktree: wt1, repository: repoUri });
-		const session2 = makeSession({ worktree: wt2, repository: repoUri });
-
-		await service.runTask(makeTask('build', 'npm run build'), session1);
-		await service.runTask(makeTask('build', 'npm run build'), session2);
-
-		assert.strictEqual(createdTerminals.length, 2, 'should create two terminals for different worktrees');
+		assert.strictEqual(ranTasks.length, 1);
+		assert.strictEqual(ranTasks[0].label, 'build');
 	});
 
 	test('runs worktreeCreated session tasks when a session gains a worktree', async () => {
+		registerMockTask('build', worktreeUri);
 		const sessionResource = URI.parse('file:///session-worktree-created');
 		const worktreeTasksUri = URI.parse('file:///worktree/.vscode/tasks.json');
 		const userTasksUri = URI.from({ scheme: userSettingsUri.scheme, path: '/user/tasks.json' });
@@ -709,8 +633,8 @@ suite('SessionsConfigurationService', () => {
 		activeSessionObs.set({ ...makeSession({ repository: repoUri, worktree: worktreeUri }), resource: sessionResource }, undefined);
 		await new Promise(r => setTimeout(r, 10));
 
-		assert.strictEqual(sentCommands.length, 1);
-		assert.strictEqual(sentCommands[0].command, 'npm run build');
+		assert.strictEqual(ranTasks.length, 1);
+		assert.strictEqual(ranTasks[0].label, 'build');
 	});
 
 });


### PR DESCRIPTION
## Summary

Replace the hacky terminal-based task execution in the sessions window with proper `ITaskService.run()` delegation. Previously, running a task from the dropdown menu created a terminal instance and sent a command string directly, which meant only `shell` and `npm` task types were supported.

## Changes

**`sessionsConfigurationService.ts`:**
- `runTask()` now resolves the session's workspace folder via `IWorkspaceContextService`, looks up the task by label via `ITaskService.getTask()`, and runs it with `ITaskService.run()` — delegating all platform-specific execution to the task system
- Removed `ITerminalService` dependency, `_resolveCommand`, `_appendArgs`, `_getExistingTerminalInstance`, `_taskTerminals` cache, and `_SUPPORTED_TASK_TYPES` filter
- All task types are now supported (not just `shell` and `npm`)

**`sessionsConfigurationService.test.ts`:**
- Replaced terminal mocks with `ITaskService` and `IWorkspaceContextService` mocks
- Updated `runTask` tests to verify task service interaction instead of terminal creation/command sending
- Updated filter tests to reflect that all task types are now accepted