### PR TITLE
Revert "Session grouping api"

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -15,7 +15,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { ISessionOpenOptions, openSession as openSessionDefault } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsOpener.js';
 import { ChatViewPaneTarget, IChatWidget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { IChatSessionProviderOptionItem, IChatSessionsService } from '../../../../workbench/contrib/chat/common/chatSessionsService.js';
-import { IChatService, IChatSendRequestOptions, IChatSessionGrouping } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
+import { IChatService, IChatSendRequestOptions } from '../../../../workbench/contrib/chat/common/chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../../../../workbench/contrib/chat/common/constants.js';
 import { IAgentSession, isAgentSession } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { IAgentSessionsService } from '../../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
@@ -29,7 +29,6 @@ import { ILanguageModelToolsService } from '../../../../workbench/contrib/chat/c
 import { GITHUB_REMOTE_FILE_SCHEME } from '../common/sessionWorkspace.js';
 import { IGitHubSessionContext } from '../../github/common/types.js';
 import { ResourceSet } from '../../../../base/common/map.js';
-import { generateUuid } from '../../../../base/common/uuid.js';
 
 export const IsNewChatSessionContext = new RawContextKey<boolean>('isNewChatSession', true);
 
@@ -99,7 +98,7 @@ export interface ISessionsManagementService {
 	 * Open a new session, apply options, and send the initial request.
 	 * Looks up the session by resource URI and builds send options from it.
 	 */
-	sendRequestForNewSession(sessionResource: URI, options?: { permissionLevel?: ChatPermissionLevel; sessionGrouping?: IChatSessionGrouping }): Promise<void>;
+	sendRequestForNewSession(sessionResource: URI, options?: { permissionLevel?: ChatPermissionLevel }): Promise<void>;
 
 	/**
 	 * Commit files in a worktree and refresh the agent sessions model
@@ -284,7 +283,7 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		return newSession;
 	}
 
-	async sendRequestForNewSession(sessionResource: URI, options?: { permissionLevel?: ChatPermissionLevel; sessionGrouping?: IChatSessionGrouping }): Promise<void> {
+	async sendRequestForNewSession(sessionResource: URI, options?: { permissionLevel?: ChatPermissionLevel }): Promise<void> {
 		const session = this._newSession.value;
 		if (!session) {
 			this.logService.error(`[SessionsManagementService] No new session found for resource: ${sessionResource.toString()}`);
@@ -330,7 +329,6 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 			},
 			agentIdSilent: contribution?.type,
 			attachedContext: session.attachedContext,
-			sessionGrouping: options?.sessionGrouping ?? { id: generateUuid(), order: 0 },
 		};
 
 		await this.chatSessionsService.getOrCreateChatSession(session.resource, CancellationToken.None);

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -3447,7 +3447,6 @@ export namespace ChatAgentRequest {
 			subAgentInvocationId: request.subAgentInvocationId,
 			subAgentName: request.subAgentName,
 			parentRequestId: request.parentRequestId,
-			sessionGrouping: request.sessionGrouping,
 			hasHooksEnabled: request.hasHooksEnabled ?? false,
 			hooks: request.hooks ? ChatRequestHooksConverter.to(request.hooks) : undefined,
 		};
@@ -3475,8 +3474,6 @@ export namespace ChatAgentRequest {
 			delete (requestWithAllProps as any).subAgentName;
 			// eslint-disable-next-line local/code-no-any-casts
 			delete (requestWithAllProps as any).parentRequestId;
-			// eslint-disable-next-line local/code-no-any-casts
-			delete (requestWithAllProps as any).sessionGrouping;
 			// eslint-disable-next-line local/code-no-any-casts
 			delete (requestWithAllProps as any).hasHooksEnabled;
 			// eslint-disable-next-line local/code-no-any-casts

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1368,12 +1368,6 @@ export const enum ChatRequestQueueKind {
 	Steering = 'steering'
 }
 
-export interface IChatSessionGrouping {
-	readonly id: string;
-	readonly order: number;
-	readonly kind?: string;
-}
-
 export interface IChatSendRequestOptions {
 	modeInfo?: IChatRequestModeInfo;
 	userSelectedModelId?: string;
@@ -1398,7 +1392,7 @@ export interface IChatSendRequestOptions {
 
 	/**
 	 * The label of the confirmation action that was selected.
-	*/
+	 */
 	confirmation?: string;
 
 	/**
@@ -1410,11 +1404,9 @@ export interface IChatSendRequestOptions {
 	/**
 	 * When true, the queued request will not be processed immediately even if no request is active.
 	 * The request stays in the queue until `processPendingRequests` is called explicitly.
-	*/
+	 */
 	pauseQueue?: boolean;
 
-	/** Optional metadata for grouping related requests together in the UI, e.g. for sub-agent interactions */
-	sessionGrouping?: IChatSessionGrouping;
 }
 
 export type IChatModelReference = IReference<IChatModel>;

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1170,7 +1170,6 @@ export class ChatService extends Disposable implements IChatService {
 							modeInstructions: options?.modeInfo?.modeInstructions,
 							permissionLevel: options?.modeInfo?.permissionLevel,
 							editedFileEvents: request.editedFileEvents,
-							sessionGrouping: options?.sessionGrouping,
 							hooks: collectedHooks,
 							hasHooksEnabled: !!collectedHooks && Object.values(collectedHooks).some(arr => arr.length > 0),
 						};

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -29,7 +29,7 @@ import { ILogService } from '../../../../../platform/log/common/log.js';
 import { CellUri, ICellEditOperation } from '../../../notebook/common/notebookCommon.js';
 import { ChatRequestToolReferenceEntry, IChatRequestVariableEntry, isImplicitVariableEntry, isStringImplicitContextValue, isStringVariableEntry } from '../attachments/chatVariableEntries.js';
 import { migrateLegacyTerminalToolSpecificData } from '../chat.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionGrouping, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, isIUsedContext } from '../chatService/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, ChatRequestQueueKind, ChatResponseClearToPreviousToolInvocationReason, ElicitationState, IChatAgentMarkdownContentWithVulnerability, IChatClearToPreviousToolInvocation, IChatCodeCitation, IChatCommandButton, IChatConfirmation, IChatContentInlineReference, IChatContentReference, IChatDisabledClaudeHooksPart, IChatEditingSessionAction, IChatElicitationRequest, IChatElicitationRequestSerialized, IChatExternalToolInvocationUpdate, IChatExtensionsContent, IChatFollowup, IChatHookPart, IChatLocationData, IChatMarkdownContent, IChatMcpServersStarting, IChatMcpServersStartingSerialized, IChatModelReference, IChatMultiDiffData, IChatMultiDiffDataSerialized, IChatNotebookEdit, IChatProgress, IChatProgressMessage, IChatPullRequestContent, IChatQuestionCarousel, IChatResponseCodeblockUriPart, IChatResponseProgressFileTreeData, IChatSendRequestOptions, IChatService, IChatSessionContext, IChatSessionTiming, IChatTask, IChatTaskSerialized, IChatTextEdit, IChatThinkingPart, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData, IChatUndoStop, IChatUsage, IChatUsedContext, IChatWarningMessage, IChatWorkspaceEdit, ResponseModelState, isIUsedContext } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ChatToolInvocation } from './chatProgressTypes/chatToolInvocation.js';
 import { ToolDataSource, IToolData } from '../tools/languageModelToolsService.js';
@@ -71,7 +71,6 @@ export interface ISerializableSendOptions {
 	agentIdSilent?: string;
 	slashCommand?: string;
 	confirmation?: string;
-	sessionGrouping?: IChatSessionGrouping;
 }
 
 /**
@@ -2778,7 +2777,6 @@ export function serializeSendOptions(options: IChatSendRequestOptions): ISeriali
 		agentIdSilent: options.agentIdSilent,
 		slashCommand: options.slashCommand,
 		confirmation: options.confirmation,
-		sessionGrouping: options.sessionGrouping,
 	};
 }
 

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -24,7 +24,7 @@ import { ChatContextKeys } from '../actions/chatContextKeys.js';
 import { IChatAgentEditedFileEvent, IChatProgressHistoryResponseContent, IChatRequestModeInstructions, IChatRequestVariableData, ISerializableChatAgentData } from '../model/chatModel.js';
 import { ChatRequestHooks } from '../promptSyntax/hookSchema.js';
 import { IRawChatCommandContribution } from './chatParticipantContribTypes.js';
-import { IChatFollowup, IChatLocationData, IChatProgress, IChatResponseErrorDetails, IChatSessionGrouping, IChatTaskDto } from '../chatService/chatService.js';
+import { IChatFollowup, IChatLocationData, IChatProgress, IChatResponseErrorDetails, IChatTaskDto } from '../chatService/chatService.js';
 import { ChatAgentLocation, ChatConfiguration, ChatModeKind, ChatPermissionLevel } from '../constants.js';
 import { ILanguageModelsService } from '../languageModels.js';
 
@@ -178,10 +178,6 @@ export interface IChatAgentRequest {
 	 * The request ID of the parent request that invoked this subagent.
 	 */
 	parentRequestId?: string;
-	/**
-	 * Optional metadata used to group related requests together in the UI.
-	 */
-	sessionGrouping?: IChatSessionGrouping;
 
 }
 

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -292,32 +292,6 @@ suite('ChatService', () => {
 		await assertSnapshot(toSnapshotExportData(model));
 	});
 
-	test('sendRequest forwards sessionGrouping to the agent request', async () => {
-		const receivedSessionGroupings: Array<{ readonly id: string; readonly order: number; readonly kind?: string } | undefined> = [];
-		const groupAwareAgent: IChatAgentImplementation = {
-			async invoke(request) {
-				receivedSessionGroupings.push(request.sessionGrouping);
-				return {};
-			},
-		};
-
-		testDisposables.add(chatAgentService.registerAgent('groupAwareAgent', { ...getAgentData('groupAwareAgent'), isDefault: true }));
-		testDisposables.add(chatAgentService.registerAgentImplementation('groupAwareAgent', groupAwareAgent));
-
-		const testService = createChatService();
-		const modelRef = testDisposables.add(startSessionModel(testService));
-		const model = modelRef.object;
-
-		const response = await testService.sendRequest(model.sessionResource, 'test request', {
-			agentId: 'groupAwareAgent',
-			sessionGrouping: { id: 'group-123', order: 2, kind: 'subagent' }
-		});
-		ChatSendResult.assertSent(response);
-		await response.data.responseCompletePromise;
-
-		assert.deepStrictEqual(receivedSessionGroupings, [{ id: 'group-123', order: 2, kind: 'subagent' }]);
-	});
-
 	test('history', async () => {
 		const historyLengthAgent: IChatAgentImplementation = {
 			async invoke(request, progress, history, token) {

--- a/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatModel.test.ts
@@ -1099,13 +1099,12 @@ suite('ChatModel - Pending Requests', () => {
 	test('pending requests preserve send options', () => {
 		const model = createModel();
 		const request = addRequestToModel(model, 'test');
-		const sendOptions = { agentId: 'test-agent', attempt: 3, sessionGrouping: { id: 'group-123', order: 1, kind: 'subagent' } };
+		const sendOptions = { agentId: 'test-agent', attempt: 3 };
 
 		const pending = model.addPendingRequest(request, ChatRequestQueueKind.Queued, sendOptions);
 
 		assert.strictEqual(pending.sendOptions.agentId, 'test-agent');
 		assert.strictEqual(pending.sendOptions.attempt, 3);
-		assert.deepStrictEqual(pending.sendOptions.sessionGrouping, { id: 'group-123', order: 1, kind: 'subagent' });
 	});
 });
 

--- a/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantPrivate.d.ts
@@ -50,12 +50,6 @@ declare module 'vscode' {
 		constructor(cell: TextDocument);
 	}
 
-	export interface ChatRequestSessionGrouping {
-		readonly id: string;
-		readonly order: number;
-		readonly kind?: string;
-	}
-
 	export interface ChatRequest {
 		/**
 		 * The id of the chat request. Used to identity an interaction with any of the chat surfaces.
@@ -121,11 +115,6 @@ declare module 'vscode' {
 		 * The request ID of the parent request that invoked this subagent.
 		 */
 		readonly parentRequestId?: string;
-
-		/**
-		 * Optional metadata used to group related requests together in the UI.
-		 */
-		readonly sessionGrouping?: ChatRequestSessionGrouping;
 
 		/**
 		 * The permission level for tool auto-approval in this request.


### PR DESCRIPTION
```Copilot Generated Description:``` Revert the implementation of the session grouping API, removing related interfaces and properties from the codebase. This includes the removal of session grouping from request options and related tests.

