### PR TITLE
Support color override for sessions

### DIFF
--- a/src/vs/platform/theme/common/colorUtils.ts
+++ b/src/vs/platform/theme/common/colorUtils.ts
@@ -127,6 +127,11 @@ export interface IColorRegistry {
 	getColorReferenceSchema(): IJSONSchema;
 
 	/**
+	 * Update the default color of a color identifier.
+	 */
+	updateDefaultColor(id: string, defaults: ColorDefaults | ColorValue | null): void;
+
+	/**
 	 * Notify when the color theme or settings change.
 	 */
 	notifyThemeUpdate(theme: IColorTheme): void;
@@ -185,6 +190,15 @@ class ColorRegistry extends Disposable implements IColorRegistry {
 		return id;
 	}
 
+
+	public updateDefaultColor(id: string, defaults: ColorDefaults | ColorValue | null): void {
+		const existing = this.colorsById[id];
+		console.log(`Updating default color for ${id} to ${JSON.stringify(defaults)}`);
+		if (existing) {
+			console.log(`Existing color contribution: ${JSON.stringify(existing)}`);
+			this.colorsById[id] = { ...existing, defaults };
+		}
+	}
 
 	public deregisterColor(id: string): void {
 		delete this.colorsById[id];

--- a/src/vs/platform/theme/common/colorUtils.ts
+++ b/src/vs/platform/theme/common/colorUtils.ts
@@ -193,9 +193,7 @@ class ColorRegistry extends Disposable implements IColorRegistry {
 
 	public updateDefaultColor(id: string, defaults: ColorDefaults | ColorValue | null): void {
 		const existing = this.colorsById[id];
-		console.log(`Updating default color for ${id} to ${JSON.stringify(defaults)}`);
 		if (existing) {
-			console.log(`Existing color contribution: ${JSON.stringify(existing)}`);
 			this.colorsById[id] = { ...existing, defaults };
 		}
 	}

--- a/src/vs/sessions/common/theme.ts
+++ b/src/vs/sessions/common/theme.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../nls.js';
-import { registerColor, transparent } from '../../platform/theme/common/colorUtils.js';
+import { getColorRegistry, registerColor, transparent } from '../../platform/theme/common/colorUtils.js';
 import { contrastBorder, iconForeground } from '../../platform/theme/common/colorRegistry.js';
 import { Color } from '../../base/common/color.js';
 import { buttonBackground } from '../../platform/theme/common/colors/inputColors.js';
-import { SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from '../../workbench/common/theme.js';
+import { editorBackground } from '../../platform/theme/common/colors/editorColors.js';
+import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from '../../workbench/common/theme.js';
 
 // Sessions sidebar background color
 export const sessionsSidebarBackground = registerColor(
@@ -69,3 +70,8 @@ export const sessionsUpdateButtonDownloadedBackground = registerColor(
 	transparent(buttonBackground, 0.7),
 	localize('sessionsUpdateButton.downloadedBackground', 'Background color of the update button when download is complete in the agent sessions window.')
 );
+
+const colorRegistry = getColorRegistry();
+
+// Override panel background to use editor background in sessions window
+colorRegistry.updateDefaultColor(PANEL_BACKGROUND, editorBackground);


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce a method to update the default color of a color identifier in the color registry. Override the panel background color to use the editor background in the sessions window.

