### PR TITLE
Make "attach" only a QuickAccess thing, not a QuickPick thing

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
@@ -165,14 +165,6 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 			}
 		}));
 
-		// Attach the active symbol as context
-		disposables.add(picker.onDidAttach(() => {
-			const [item] = picker.activeItems;
-			if (typeof item?.attach === 'function') {
-				item.attach();
-			}
-		}));
-
 		// Resolve symbols from document once and reuse this
 		// request for all filtering and typing then on
 		const symbolsPromise = this.getDocumentSymbols(model, token);

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -64,8 +64,9 @@ export interface IPickerQuickAccessItem extends IQuickPickItem {
 	 * open and allow multiple picks.
 	 *
 	 * @param keyMods the state of modifier keys when the item was accepted.
+	 * @param event the underlying event that caused this to trigger.
 	 */
-	attach?(keyMods: IKeyMods): void;
+	attach?(keyMods: IKeyMods, event: IQuickPickDidAcceptEvent): void;
 }
 
 export interface IPickerQuickAccessSeparator extends IQuickPickSeparator {
@@ -348,7 +349,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 			if (typeof item?.accept === 'function') {
 				const isAttachAction = isKeyModified(picker.keyMods) && !!item.attach;
 				if (isAttachAction) {
-					item.attach!(picker.keyMods);
+					item.attach!(picker.keyMods, event);
 					return;
 				}
 				if (!event.inBackground) {

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -6,7 +6,7 @@
 import { timeout } from '../../../base/common/async.js';
 import { CancellationToken, CancellationTokenSource } from '../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from '../../../base/common/lifecycle.js';
-import { IKeyMods, IQuickPickDidAcceptEvent, IQuickPickSeparator, IQuickPick, IQuickPickItem, IQuickInputButton } from '../common/quickInput.js';
+import { IKeyMods, IQuickPickDidAcceptEvent, IQuickPickSeparator, IQuickPick, IQuickPickItem, IQuickInputButton, isKeyModified } from '../common/quickInput.js';
 import { IQuickAccessProvider, IQuickAccessProviderRunOptions } from '../common/quickAccess.js';
 import { isFunction } from '../../../base/common/types.js';
 
@@ -51,7 +51,7 @@ export interface IPickerQuickAccessItem extends IQuickPickItem {
 	 * @param buttonIndex index of the button of the item that
 	 * was clicked.
 	 *
-	 * @param the state of modifier keys when the button was triggered.
+	 * @param keyMods the state of modifier keys when the button was triggered.
 	 *
 	 * @returns a value that indicates what should happen after the trigger
 	 * which can be a `Promise` for long running operations.
@@ -59,10 +59,13 @@ export interface IPickerQuickAccessItem extends IQuickPickItem {
 	trigger?(buttonIndex: number, keyMods: IKeyMods): TriggerAction | Promise<TriggerAction>;
 
 	/**
-	 * A method that will be executed when the pick item should be attached
-	 * as context, e.g. to a chat conversation.
+	 * When set, this will be invoked instead of `accept` if modifier keys are held down.
+	 * This is useful for actions like "attach to context" where you want to keep the picker
+	 * open and allow multiple picks.
+	 *
+	 * @param keyMods the state of modifier keys when the item was accepted.
 	 */
-	attach?(): void;
+	attach?(keyMods: IKeyMods): void;
 }
 
 export interface IPickerQuickAccessSeparator extends IQuickPickSeparator {
@@ -73,7 +76,7 @@ export interface IPickerQuickAccessSeparator extends IQuickPickSeparator {
 	 * @param buttonIndex index of the button of the item that
 	 * was clicked.
 	 *
-	 * @param the state of modifier keys when the button was triggered.
+	 * @param keyMods the state of modifier keys when the button was triggered.
 	 *
 	 * @returns a value that indicates what should happen after the trigger
 	 * which can be a `Promise` for long running operations.
@@ -343,19 +346,16 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 
 			const [item] = picker.selectedItems;
 			if (typeof item?.accept === 'function') {
+				const isAttachAction = isKeyModified(picker.keyMods) && !!item.attach;
+				if (isAttachAction) {
+					item.attach!(picker.keyMods);
+					return;
+				}
 				if (!event.inBackground) {
 					picker.hide(); // hide picker unless we accept in background
 				}
 
 				item.accept(picker.keyMods, event);
-			}
-		}));
-
-		// Attach the active pick item as context
-		disposables.add(picker.onDidAttach(() => {
-			const [item] = picker.activeItems;
-			if (typeof item?.attach === 'function') {
-				item.attach();
 			}
 		}));
 

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -532,7 +532,6 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 	private readonly onWillAcceptEmitter = this._register(new Emitter<IQuickPickWillAcceptEvent>());
 	private readonly onDidAcceptEmitter = this._register(new Emitter<IQuickPickDidAcceptEvent>());
 	private readonly onDidCustomEmitter = this._register(new Emitter<void>());
-	private readonly onDidAttachEmitter = this._register(new Emitter<void>());
 	private _items: O extends { useSeparators: true } ? Array<T | IQuickPickSeparator> : Array<T> = [];
 	private itemsUpdated = false;
 	private _canSelectMany = false;
@@ -643,8 +642,6 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 	onDidAccept = this.onDidAcceptEmitter.event;
 
 	onDidCustom = this.onDidCustomEmitter.event;
-
-	onDidAttach = this.onDidAttachEmitter.event;
 
 	get items() {
 		return this._items;
@@ -1179,10 +1176,6 @@ export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: bool
 			this.onDidChangeSelectionEmitter.fire(this.selectedItems);
 		}
 		this.handleAccept(inBackground ?? false);
-	}
-
-	attach(): void {
-		this.onDidAttachEmitter.fire();
 	}
 }
 

--- a/src/vs/platform/quickinput/browser/quickInputActions.ts
+++ b/src/vs/platform/quickinput/browser/quickInputActions.ts
@@ -44,7 +44,7 @@ function registerQuickPickCommandAndKeybindingRule(rule: PartialExcept<ICommandA
 const ctrlKeyMod = isMacintosh ? KeyMod.WinCtrl : KeyMod.CtrlCmd;
 
 // This function will generate all the combinations of keybindings for the given primary keybinding
-function getSecondary(primary: number, secondary: number[], options: { withAltMod?: boolean; withCtrlMod?: boolean; withCmdMod?: boolean } = {}): number[] {
+function getSecondary(primary: number, secondary: number[], options: { withAltMod?: boolean; withCtrlMod?: boolean; withCmdMod?: boolean; withShiftMod?: boolean } = {}): number[] {
 	if (options.withAltMod) {
 		secondary.push(KeyMod.Alt + primary);
 	}
@@ -52,6 +52,18 @@ function getSecondary(primary: number, secondary: number[], options: { withAltMo
 		secondary.push(ctrlKeyMod + primary);
 		if (options.withAltMod) {
 			secondary.push(KeyMod.Alt + ctrlKeyMod + primary);
+		}
+	}
+	if (options.withShiftMod) {
+		secondary.push(KeyMod.Shift + primary);
+		if (options.withAltMod) {
+			secondary.push(KeyMod.Alt + KeyMod.Shift + primary);
+		}
+		if (options.withCtrlMod) {
+			secondary.push(ctrlKeyMod + KeyMod.Shift + primary);
+			if (options.withAltMod) {
+				secondary.push(KeyMod.Alt + ctrlKeyMod + KeyMod.Shift + primary);
+			}
 		}
 	}
 
@@ -213,7 +225,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const currentQuickPick = accessor.get(IQuickInputService).currentQuickInput as IQuickPick<any> | IQuickTree<any> | IInputBox;
 		currentQuickPick?.accept();
 	},
-	secondary: getSecondary(KeyCode.Enter, [], { withAltMod: true, withCtrlMod: true, withCmdMod: true })
+	secondary: getSecondary(KeyCode.Enter, [], { withAltMod: true, withCtrlMod: true, withCmdMod: true, withShiftMod: true })
 });
 
 registerQuickPickCommandAndKeybindingRule(

--- a/src/vs/platform/quickinput/browser/quickInputActions.ts
+++ b/src/vs/platform/quickinput/browser/quickInputActions.ts
@@ -239,26 +239,6 @@ registerQuickPickCommandAndKeybindingRule(
 
 //#endregion
 
-//#region Attach
-
-registerQuickPickCommandAndKeybindingRule(
-	{
-		id: 'quickInput.attach',
-		when: ContextKeyExpr.and(
-			inQuickInputContext,
-			ContextKeyExpr.equals(quickInputTypeContextKeyValue, QuickInputType.QuickPick),
-		),
-		primary: KeyMod.Shift | KeyCode.Enter,
-		weight: KeybindingWeight.WorkbenchContrib + 100,
-		handler: (accessor) => {
-			const currentQuickPick = accessor.get(IQuickInputService).currentQuickInput as IQuickPick<any>;
-			currentQuickPick?.attach();
-		},
-	},
-);
-
-//#endregion
-
 //#region Hide
 
 registerQuickInputCommandAndKeybindingRule(

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -60,7 +60,7 @@ export class QuickInputController extends Disposable {
 	private readonly onDidAcceptEmitter = this._register(new Emitter<void>());
 	private readonly onDidCustomEmitter = this._register(new Emitter<void>());
 	private readonly onDidTriggerButtonEmitter = this._register(new Emitter<IQuickInputButton>());
-	private keyMods: Writeable<IKeyMods> = { ctrlCmd: false, alt: false };
+	private keyMods: Writeable<IKeyMods> = { ctrlCmd: false, alt: false, shift: false };
 
 	private controller: IQuickInput | null = null;
 	get currentQuickInput() { return this.controller ?? undefined; }
@@ -120,6 +120,7 @@ export class QuickInputController extends Disposable {
 		const listener = (e: KeyboardEvent | MouseEvent) => {
 			this.keyMods.ctrlCmd = e.ctrlKey || e.metaKey;
 			this.keyMods.alt = e.altKey;
+			this.keyMods.shift = e.shiftKey;
 		};
 
 		for (const event of [dom.EventType.KEY_DOWN, dom.EventType.KEY_UP, dom.EventType.MOUSE_DOWN]) {
@@ -837,13 +838,14 @@ export class QuickInputController extends Disposable {
 		}
 	}
 
-	async accept(keyMods: IKeyMods = { alt: false, ctrlCmd: false }) {
+	async accept(keyMods: IKeyMods = { alt: false, ctrlCmd: false, shift: false }) {
 		// When accepting the item programmatically, it is important that
 		// we update `keyMods` either from the provided set or unset it
 		// because the accept did not happen from mouse or keyboard
 		// interaction on the list itself
 		this.keyMods.alt = keyMods.alt;
 		this.keyMods.ctrlCmd = keyMods.ctrlCmd;
+		this.keyMods.shift = keyMods.shift;
 
 		this.onDidAcceptEmitter.fire();
 	}

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -115,13 +115,14 @@ export interface IQuickPickSeparator {
 export interface IKeyMods {
 	readonly ctrlCmd: boolean;
 	readonly alt: boolean;
+	readonly shift: boolean;
 }
 
 export function isKeyModified(keyMods: IKeyMods): boolean {
-	return keyMods.ctrlCmd || keyMods.alt;
+	return keyMods.ctrlCmd || keyMods.alt || keyMods.shift;
 }
 
-export const NO_KEY_MODS: IKeyMods = { ctrlCmd: false, alt: false };
+export const NO_KEY_MODS: IKeyMods = { ctrlCmd: false, alt: false, shift: false };
 
 export interface IQuickNavigateConfiguration {
 	keybindings: readonly ResolvedKeybinding[];

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -117,6 +117,10 @@ export interface IKeyMods {
 	readonly alt: boolean;
 }
 
+export function isKeyModified(keyMods: IKeyMods): boolean {
+	return keyMods.ctrlCmd || keyMods.alt;
+}
+
 export const NO_KEY_MODS: IKeyMods = { ctrlCmd: false, alt: false };
 
 export interface IQuickNavigateConfiguration {
@@ -713,16 +717,6 @@ export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators:
 	 * @param inBackground Whether you are accepting an item in the background and keeping the picker open.
 	 */
 	accept(inBackground?: boolean): void;
-
-	/**
-	 * An event that is fired when an item should be attached as context.
-	 */
-	readonly onDidAttach: Event<void>;
-
-	/**
-	 * Programmatically triggers the attach action for the active item.
-	 */
-	attach(): void;
 }
 
 /**

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -19,7 +19,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/c
 import { toDisposable } from '../../../../base/common/lifecycle.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { QuickPick } from '../../browser/quickInput.js';
-import { IQuickPickItem, ItemActivation } from '../../common/quickInput.js';
+import { IQuickPickItem, ItemActivation, isKeyModified, NO_KEY_MODS } from '../../common/quickInput.js';
 import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
 import { IThemeService } from '../../../theme/common/themeService.js';
 import { IConfigurationService } from '../../../configuration/common/configuration.js';
@@ -277,5 +277,17 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 
 		assert.strictEqual(activeItemsFromEvent.length, 0);
 		assert.strictEqual(quickpick.activeItems.length, 0);
+	});
+
+	test('isKeyModified - returns false when no modifiers are pressed', () => {
+		assert.strictEqual(isKeyModified(NO_KEY_MODS), false);
+		assert.strictEqual(isKeyModified({ ctrlCmd: false, alt: false, shift: false }), false);
+	});
+
+	test('isKeyModified - returns true when any modifier is pressed', () => {
+		assert.strictEqual(isKeyModified({ ctrlCmd: true, alt: false, shift: false }), true);
+		assert.strictEqual(isKeyModified({ ctrlCmd: false, alt: true, shift: false }), true);
+		assert.strictEqual(isKeyModified({ ctrlCmd: false, alt: false, shift: true }), true);
+		assert.strictEqual(isKeyModified({ ctrlCmd: true, alt: true, shift: true }), true);
 	});
 });

--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -56,7 +56,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: 0,
 	handler: accessor => {
 		const quickInputService = accessor.get(IQuickInputService);
-		return quickInputService.accept({ ctrlCmd: true, alt: false });
+		return quickInputService.accept({ ctrlCmd: true, alt: false, shift: false });
 	}
 });
 

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -1087,8 +1087,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			},
 			accept: (keyMods, event) => this.openAnything(resourceOrEditor, { keyMods, range: this.pickState.lastRange, preserveFocus: event.inBackground, forcePinned: event.inBackground }),
 			attach: (keyMods, event) => {
-				// Only support adding context to chat when ctrl/cmd is pressed
-				if (keyMods.ctrlCmd) {
+				// Only support adding context to chat when shift is pressed
+				if (keyMods.shift) {
 					const widget = this.chatWidgetService.lastFocusedWidget;
 					if (widget && resource) {
 						widget.attachmentModel.addContext(widget.attachmentModel.asFileVariableEntry(resource));

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -1086,11 +1086,18 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 				return TriggerAction.NO_ACTION;
 			},
 			accept: (keyMods, event) => this.openAnything(resourceOrEditor, { keyMods, range: this.pickState.lastRange, preserveFocus: event.inBackground, forcePinned: event.inBackground }),
-			attach: () => {
-				const widget = this.chatWidgetService.lastFocusedWidget;
-				if (widget && resource) {
-					widget.attachmentModel.addContext(widget.attachmentModel.asFileVariableEntry(resource));
+			attach: (keyMods, event) => {
+				// Only support adding context to chat when ctrl/cmd is pressed
+				if (keyMods.ctrlCmd) {
+					const widget = this.chatWidgetService.lastFocusedWidget;
+					if (widget && resource) {
+						widget.attachmentModel.addContext(widget.attachmentModel.asFileVariableEntry(resource));
+					}
+					return;
 				}
+
+				// Fallback to accept behavior.
+				this.openAnything(resourceOrEditor, { keyMods, range: this.pickState.lastRange, preserveFocus: event.inBackground, forcePinned: event.inBackground });
 			}
 		};
 	}

--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -214,18 +214,25 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 					return TriggerAction.CLOSE_PICKER;
 				},
 				accept: async (keyMods, event) => this.openSymbol(provider, symbol, token, { keyMods, preserveFocus: event.inBackground, forcePinned: event.inBackground }),
-				attach: () => {
-					const widget = this.chatWidgetService.lastFocusedWidget;
-					if (widget) {
-						const entry: ISymbolVariableEntry = {
-							kind: 'symbol',
-							id: JSON.stringify({ uri: symbolUri.toString(), range: symbol.location.range }),
-							name: symbol.name,
-							value: symbol.location,
-							symbolKind: symbol.kind,
-						};
-						widget.attachmentModel.addContext(entry);
+				attach: (keyMods, event) => {
+					// Only support adding context to chat when cmd/ctrl is pressed
+					if (keyMods.ctrlCmd) {
+						const widget = this.chatWidgetService.lastFocusedWidget;
+						if (widget) {
+							const entry: ISymbolVariableEntry = {
+								kind: 'symbol',
+								id: JSON.stringify({ uri: symbolUri.toString(), range: symbol.location.range }),
+								name: symbol.name,
+								value: symbol.location,
+								symbolKind: symbol.kind,
+							};
+							widget.attachmentModel.addContext(entry);
+						}
+						return;
 					}
+
+					// Fallback to accept behavior.
+					this.openSymbol(provider, symbol, token, { keyMods, preserveFocus: event.inBackground, forcePinned: event.inBackground });
 				},
 			});
 

--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -215,8 +215,8 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 				},
 				accept: async (keyMods, event) => this.openSymbol(provider, symbol, token, { keyMods, preserveFocus: event.inBackground, forcePinned: event.inBackground }),
 				attach: (keyMods, event) => {
-					// Only support adding context to chat when cmd/ctrl is pressed
-					if (keyMods.ctrlCmd) {
+					// Only support adding context to chat when shift is pressed
+					if (keyMods.shift) {
 						const widget = this.chatWidgetService.lastFocusedWidget;
 						if (widget) {
 							const entry: ISymbolVariableEntry = {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
@@ -363,14 +363,14 @@ suite('TerminalProfileService', () => {
 
 		test('createInstance', async () => {
 			mockTerminalProfileService.setDefaultProfileName(powershellProfile.profileName);
-			const pick = { ...powershellPick, keyMods: { alt: true, ctrlCmd: false } };
+			const pick = { ...powershellPick, keyMods: { alt: true, ctrlCmd: false, shift: false } };
 			quickInputService.setPick(pick);
 			const result = await terminalProfileQuickpick.showAndGetResult('createInstance');
-			deepStrictEqual(result, { config: powershellProfile, keyMods: { alt: true, ctrlCmd: false } });
+			deepStrictEqual(result, { config: powershellProfile, keyMods: { alt: true, ctrlCmd: false, shift: false } });
 		});
 
 		test('createInstance with contributed', async () => {
-			const pick = { ...jsdebugPick, keyMods: { alt: true, ctrlCmd: false } };
+			const pick = { ...jsdebugPick, keyMods: { alt: true, ctrlCmd: false, shift: true } };
 			quickInputService.setPick(pick);
 			const result = await terminalProfileQuickpick.showAndGetResult('createInstance');
 			const expected = {
@@ -380,7 +380,7 @@ suite('TerminalProfileService', () => {
 					options: { color: undefined, icon: 'debug' },
 					title: jsdebugProfile.title,
 				},
-				keyMods: { alt: true, ctrlCmd: false }
+				keyMods: { alt: true, ctrlCmd: false, shift: true }
 			};
 			deepStrictEqual(result, expected);
 		});

--- a/src/vs/workbench/test/browser/quickAccess.test.ts
+++ b/src/vs/workbench/test/browser/quickAccess.test.ts
@@ -6,12 +6,12 @@
 import assert from 'assert';
 import { Registry } from '../../../platform/registry/common/platform.js';
 import { IQuickAccessRegistry, Extensions, IQuickAccessProvider, QuickAccessRegistry } from '../../../platform/quickinput/common/quickAccess.js';
-import { IQuickPick, IQuickPickItem, IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
+import { IQuickPick, IQuickPickItem, IQuickInputService, IKeyMods, IQuickPickDidAcceptEvent } from '../../../platform/quickinput/common/quickInput.js';
 import { CancellationToken } from '../../../base/common/cancellation.js';
 import { TestServiceAccessor, workbenchInstantiationService, createEditorPart } from './workbenchTestServices.js';
 import { DisposableStore, toDisposable, IDisposable } from '../../../base/common/lifecycle.js';
 import { timeout } from '../../../base/common/async.js';
-import { PickerQuickAccessProvider, FastAndSlowPicks } from '../../../platform/quickinput/browser/pickerQuickAccess.js';
+import { PickerQuickAccessProvider, FastAndSlowPicks, IPickerQuickAccessItem } from '../../../platform/quickinput/browser/pickerQuickAccess.js';
 import { URI } from '../../../base/common/uri.js';
 import { IEditorGroupsService } from '../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../services/editor/common/editorService.js';
@@ -450,4 +450,135 @@ suite('QuickAccess', () => {
 		}
 		await part.activeGroup.closeAllEditors();
 	});
+
+	//#region attach dispatch tests
+
+	interface ITestAttachPickItem extends IPickerQuickAccessItem {
+		label: string;
+		accept?(keyMods: IKeyMods, event: IQuickPickDidAcceptEvent): void;
+		attach?(keyMods: IKeyMods, event: IQuickPickDidAcceptEvent): void;
+	}
+
+	let attachTestAcceptCalled = false;
+	let attachTestAttachCalled = false;
+	let attachTestAttachKeyMods: IKeyMods | undefined;
+
+	class AttachTestQuickPickProvider extends PickerQuickAccessProvider<ITestAttachPickItem> {
+		constructor() {
+			super('attach');
+		}
+
+		protected _getPicks(): ITestAttachPickItem[] {
+			return [{
+				label: 'Test Item',
+				accept: () => {
+					attachTestAcceptCalled = true;
+				},
+				attach: (keyMods) => {
+					attachTestAttachCalled = true;
+					attachTestAttachKeyMods = keyMods;
+				}
+			}];
+		}
+	}
+
+	class AttachTestNoAttachProvider extends PickerQuickAccessProvider<ITestAttachPickItem> {
+		constructor() {
+			super('noattach');
+		}
+
+		protected _getPicks(): ITestAttachPickItem[] {
+			return [{
+				label: 'No Attach Item',
+				accept: () => {
+					attachTestAcceptCalled = true;
+				}
+			}];
+		}
+	}
+
+	const attachProviderDescriptor = { ctor: AttachTestQuickPickProvider, prefix: 'attach', helpEntries: [] };
+	const noAttachProviderDescriptor = { ctor: AttachTestNoAttachProvider, prefix: 'noattach', helpEntries: [] };
+
+	function resetAttachState() {
+		attachTestAcceptCalled = false;
+		attachTestAttachCalled = false;
+		attachTestAttachKeyMods = undefined;
+	}
+
+	test('quick pick access - accept without modifier keys calls accept, not attach', async () => {
+		const registry = (Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess));
+		const restore = (registry as QuickAccessRegistry).clear();
+		const disposables = new DisposableStore();
+
+		disposables.add(registry.registerQuickAccessProvider(attachProviderDescriptor));
+		resetAttachState();
+
+		accessor.quickInputService.quickAccess.show('attach');
+		await accessor.quickInputService.accept();
+
+		assert.strictEqual(attachTestAcceptCalled, true);
+		assert.strictEqual(attachTestAttachCalled, false);
+
+		disposables.dispose();
+		restore();
+	});
+
+	test('quick pick access - accept with ctrlCmd calls attach instead of accept', async () => {
+		const registry = (Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess));
+		const restore = (registry as QuickAccessRegistry).clear();
+		const disposables = new DisposableStore();
+
+		disposables.add(registry.registerQuickAccessProvider(attachProviderDescriptor));
+		resetAttachState();
+
+		accessor.quickInputService.quickAccess.show('attach');
+		await accessor.quickInputService.accept({ ctrlCmd: true, alt: false, shift: false });
+
+		assert.strictEqual(attachTestAcceptCalled, false);
+		assert.strictEqual(attachTestAttachCalled, true);
+		assert.deepStrictEqual(attachTestAttachKeyMods, { ctrlCmd: true, alt: false, shift: false });
+
+		disposables.dispose();
+		restore();
+	});
+
+	test('quick pick access - accept with alt calls attach instead of accept', async () => {
+		const registry = (Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess));
+		const restore = (registry as QuickAccessRegistry).clear();
+		const disposables = new DisposableStore();
+
+		disposables.add(registry.registerQuickAccessProvider(attachProviderDescriptor));
+		resetAttachState();
+
+		accessor.quickInputService.quickAccess.show('attach');
+		await accessor.quickInputService.accept({ ctrlCmd: false, alt: true, shift: false });
+
+		assert.strictEqual(attachTestAcceptCalled, false);
+		assert.strictEqual(attachTestAttachCalled, true);
+		assert.deepStrictEqual(attachTestAttachKeyMods, { ctrlCmd: false, alt: true, shift: false });
+
+		disposables.dispose();
+		restore();
+	});
+
+	test('quick pick access - accept with modifier keys but no attach method calls accept', async () => {
+		const registry = (Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess));
+		const restore = (registry as QuickAccessRegistry).clear();
+		const disposables = new DisposableStore();
+
+		disposables.add(registry.registerQuickAccessProvider(noAttachProviderDescriptor));
+		resetAttachState();
+
+		accessor.quickInputService.quickAccess.show('noattach');
+		await accessor.quickInputService.accept({ ctrlCmd: true, alt: false, shift: false });
+
+		assert.strictEqual(attachTestAcceptCalled, true);
+		assert.strictEqual(attachTestAttachCalled, false);
+
+		disposables.dispose();
+		restore();
+	});
+
+	//#endregion
 });


### PR DESCRIPTION
Follow up from https://github.com/microsoft/vscode/pull/303513 to scope this feature down to just Quick Access and not all of Quick Pick.

I think there's room for improvement here - like, I think I would prefer for `attach` to be folded in to `accept`.

So this behavior of:
> The picker will close automatically before running this.

for accept, feels wrong and should be re-evaluated.

But I don't want to start promoting multiple ways to handle accept in Quick Pick land... so this PR is fine for now.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
