### PR TITLE
Fix: Increase line-height for Copilot welcome title to prevent overlap

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/agentSessionsWelcome.ts
@@ -243,7 +243,9 @@ export class AgentSessionsWelcomePage extends EditorPane {
 
 		// Header
 		const header = append(this.contentContainer, $('.agentSessionsWelcome-header'));
-		append(header, $('h1.product-name', {}, this.productService.nameLong));
+		const title = $('h1.product-name', {}, this.productService.nameLong);
+		title.style.lineHeight = '1.3';
+		append(header, title);
 
 		const startEntries = append(header, $('.agentSessionsWelcome-startEntries'));
 		await this.buildStartEntries(startEntries);


### PR DESCRIPTION
Fixes #297827

The title in the Copilot Welcome page had insufficient line-height,
causing overlapping text when wrapping.

This change increases line-height to 1.3 for better readability and proper spacing.