### PR TITLE
Fix remote agent host file picker for new URI scheme

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
+++ b/src/vs/platform/agentHost/common/agentHostFileSystemProvider.ts
@@ -75,8 +75,13 @@ export class AgentHostFileSystemProvider extends Disposable implements IFileSyst
 	async stat(resource: URI): Promise<IStat> {
 		const path = resource.path;
 
-		// Root directory
+		// Root directory - either the bare scheme root or the root of the
+		// decoded remote filesystem (e.g. `/file/-/` decodes to `file:///`).
 		if (path === '/' || path === '') {
+			return { type: FileType.Directory, mtime: 0, ctime: 0, size: 0, permissions: FilePermission.Readonly };
+		}
+		const decodedPath = fromAgentHostUri(resource).path;
+		if (decodedPath === '/' || decodedPath === '') {
 			return { type: FileType.Directory, mtime: 0, ctime: 0, size: 0, permissions: FilePermission.Readonly };
 		}
 

--- a/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
+++ b/src/vs/platform/agentHost/test/common/agentHostFileSystemProvider.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { URI } from '../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { agentHostRemotePath, agentHostUri } from '../../common/agentHostFileSystemProvider.js';
-import { AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../common/agentHostUri.js';
+import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority, fromAgentHostUri, toAgentHostUri } from '../../common/agentHostUri.js';
 
 suite('AgentHostFileSystemProvider - URI helpers', () => {
 
@@ -121,10 +121,58 @@ suite('toAgentHostUri / fromAgentHostUri', () => {
 		assert.strictEqual(result.toString(), original.toString());
 	});
 
+	test('agentHostUri for root path produces valid encoded URI', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const uri = agentHostUri(authority, '/');
+		assert.strictEqual(uri.scheme, AGENT_HOST_SCHEME);
+		assert.strictEqual(uri.authority, authority);
+		// The decoded path should be root
+		assert.strictEqual(fromAgentHostUri(uri).path, '/');
+	});
+
 	test('fromAgentHostUri handles malformed path gracefully', () => {
 		const uri = URI.from({ scheme: AGENT_HOST_SCHEME, authority: 'host', path: '/file' });
 		const result = fromAgentHostUri(uri);
-		// Should not throw — falls back to extracting scheme only
+		// Should not throw - falls back to extracting scheme only
 		assert.strictEqual(result.scheme, 'file');
+	});
+});
+
+suite('AGENT_HOST_LABEL_FORMATTER', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Replicates the stripPathSegments logic from the label service to
+	 * verify that the formatter's configuration is consistent with the
+	 * URI encoding.
+	 */
+	function stripPath(path: string, segments: number): string {
+		let pos = 0;
+		for (let i = 0; i < segments; i++) {
+			const next = path.indexOf('/', pos + 1);
+			if (next === -1) {
+				break;
+			}
+			pos = next;
+		}
+		return path.substring(pos);
+	}
+
+	test('stripPathSegments matches URI encoding for file URIs', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const originalPath = '/Users/roblou/code/vscode';
+		const encodedUri = agentHostUri(authority, originalPath);
+
+		const stripped = stripPath(encodedUri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
+		assert.strictEqual(stripped, originalPath);
+	});
+
+	test('stripPathSegments matches URI encoding with authority', () => {
+		const originalUri = URI.from({ scheme: 'agenthost-content', authority: 'myhost', path: '/snap/before' });
+		const encodedUri = toAgentHostUri(originalUri, 'remote-host');
+
+		const stripped = stripPath(encodedUri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
+		assert.strictEqual(stripped, '/snap/before');
 	});
 });

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -262,12 +262,19 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			if (cached) {
 				return cached;
 			}
-			const activeSessionItem = this._sessionsManagementService.getActiveSession();
-			if (activeSessionItem?.repository) {
-				// Decode the agent host URI to get the actual remote filesystem path
-				const dir = agentHostRemotePath(activeSessionItem.repository);
-				sessionWorkingDirs.set(resourceKey, dir);
-				return dir;
+			const repository = this._sessionsManagementService.getActiveSession()?.repository;
+			if (repository) {
+				let dir: string | undefined;
+				if (repository.scheme === AGENT_HOST_SCHEME) {
+					// Decode the agent host URI to get the actual remote filesystem path
+					dir = agentHostRemotePath(repository);
+				} else if (repository.scheme === 'file') {
+					dir = repository.fsPath || repository.path;
+				}
+				if (dir) {
+					sessionWorkingDirs.set(resourceKey, dir);
+					return dir;
+				}
 			}
 			return undefined;
 		};

--- a/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
+++ b/src/vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableMap, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import * as nls from '../../../../nls.js';
-import { AgentHostFileSystemProvider } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
+import { AgentHostFileSystemProvider, agentHostRemotePath } from '../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
 import { AGENT_HOST_LABEL_FORMATTER, AGENT_HOST_SCHEME, agentHostAuthority } from '../../../../platform/agentHost/common/agentHostUri.js';
 import { type AgentProvider, type IAgentConnection } from '../../../../platform/agentHost/common/agentService.js';
 import { IRemoteAgentHostConnectionInfo, IRemoteAgentHostService, RemoteAgentHostsEnabledSettingId, RemoteAgentHostsSettingId } from '../../../../platform/agentHost/common/remoteAgentHostService.js';
@@ -264,9 +264,8 @@ export class RemoteAgentHostContribution extends Disposable implements IWorkbenc
 			}
 			const activeSessionItem = this._sessionsManagementService.getActiveSession();
 			if (activeSessionItem?.repository) {
-				// The repository URI's path is the remote filesystem path
-				// (set via agentHostRemotePath in the folder picker callback)
-				const dir = activeSessionItem.repository.path;
+				// Decode the agent host URI to get the actual remote filesystem path
+				const dir = agentHostRemotePath(activeSessionItem.repository);
 				sessionWorkingDirs.set(resourceKey, dir);
 				return dir;
 			}

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -138,6 +138,15 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 	 * {@link remoteAuthority}).
 	 */
 	private scopedAuthority: string | undefined;
+	/**
+	 * Path prefix that the label formatter strips from URIs in the
+	 * scoped scheme (e.g. `/file/-` for agent host URIs that encode
+	 * the original scheme and authority as leading path segments).
+	 *
+	 * Stripped by {@link pathFromUri} and re-applied by
+	 * {@link remoteUriFrom} so the user sees clean paths.
+	 */
+	private scopedPathPrefix: string = '';
 	private readonly onBusyChangeEmitter = this._register(new Emitter<boolean>());
 	private updatingPromise: CancelablePromise<boolean> | undefined;
 
@@ -200,6 +209,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 	public async showOpenDialog(options: IOpenDialogOptions = {}): Promise<URI[] | undefined> {
 		this.scheme = this.getScheme(options.availableFileSystems, options.defaultUri);
 		this.scopedAuthority = this.getScopedAuthority(options.defaultUri);
+		this.scopedPathPrefix = options.defaultUri && this.scopedAuthority ? this.computeScopedPathPrefix(options.defaultUri) : '';
 		this.userHome = await this.getUserHome();
 		this.trueHome = await this.getUserHome(true);
 		const newOptions = this.getOptions(options);
@@ -217,6 +227,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 	public async showSaveDialog(options: ISaveDialogOptions): Promise<URI | undefined> {
 		this.scheme = this.getScheme(options.availableFileSystems, options.defaultUri);
 		this.scopedAuthority = this.getScopedAuthority(options.defaultUri);
+		this.scopedPathPrefix = options.defaultUri && this.scopedAuthority ? this.computeScopedPathPrefix(options.defaultUri) : '';
 		this.userHome = await this.getUserHome();
 		this.trueHome = await this.getUserHome(true);
 		this.requiresTrailing = true;
@@ -264,8 +275,9 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		// When scoped to a specific authority (e.g. agenthost://host/...),
 		// construct the URI directly with the authority to avoid
 		// toLocalResource stripping or replacing it.
+		// Re-add the scopedPathPrefix that was stripped in pathFromUri.
 		if (this.scopedAuthority) {
-			return URI.from({ scheme: this.scheme, authority: this.scopedAuthority, path, query: hintUri?.query, fragment: hintUri?.fragment });
+			return URI.from({ scheme: this.scheme, authority: this.scopedAuthority, path: this.scopedPathPrefix + path, query: hintUri?.query, fragment: hintUri?.fragment });
 		}
 		const uri: URI = this.scheme === Schemas.file ? URI.file(path) : URI.from({ scheme: this.scheme, path, query: hintUri?.query, fragment: hintUri?.fragment });
 		// If the default scheme is file, then we don't care about the remote authority or the hint authority
@@ -306,6 +318,23 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		return undefined;
 	}
 
+	/**
+	 * Computes the path prefix that the label formatter strips for the
+	 * scoped scheme, by comparing the raw URI path with the label
+	 * service's formatted output.
+	 *
+	 * For example, an agent host URI with path `/file/-/Users/roblou`
+	 * formats as `/Users/roblou`, so the prefix is `/file/-`.
+	 */
+	private computeScopedPathPrefix(uri: URI): string {
+		const fullPath = uri.path;
+		const displayPath = this.labelService.getUriLabel(uri);
+		if (displayPath && fullPath.endsWith(displayPath)) {
+			return fullPath.substring(0, fullPath.length - displayPath.length);
+		}
+		return '';
+	}
+
 	private async getRemoteAgentEnvironment(): Promise<IRemoteAgentEnvironment | null> {
 		if (this.remoteAgentEnvironment === undefined) {
 			this.remoteAgentEnvironment = await this.remoteAgentService.getEnvironment();
@@ -317,8 +346,9 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		// When scoped to a custom authority, the platform userHome is not
 		// meaningful (it would return a local file:// path). Use the root
 		// of the scoped filesystem as the home directory instead.
+		// Include the scopedPathPrefix so the URI resolves correctly.
 		if (this.scopedAuthority) {
-			return Promise.resolve(URI.from({ scheme: this.scheme, authority: this.scopedAuthority, path: '/' }));
+			return Promise.resolve(URI.from({ scheme: this.scheme, authority: this.scopedAuthority, path: this.scopedPathPrefix + '/' }));
 		}
 		return trueHome
 			? this.pathService.userHome({ preferLocal: this.scheme === Schemas.file })
@@ -1025,9 +1055,15 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 	private pathFromUri(uri: URI, endWithSeparator: boolean = false): string {
 		// For authority-scoped schemes, use the raw path component instead
 		// of fsPath, which would prepend the authority as a UNC prefix.
+		// Strip the scopedPathPrefix so the user sees clean paths
+		// (e.g. `/Users/roblou/code` instead of `/file/-/Users/roblou/code`).
 		let result: string;
 		if (this.scopedAuthority) {
-			result = uri.path.replace(/\n/g, '');
+			let path = uri.path;
+			if (this.scopedPathPrefix && path.startsWith(this.scopedPathPrefix)) {
+				path = path.substring(this.scopedPathPrefix.length);
+			}
+			result = path.replace(/\n/g, '');
 		} else {
 			result = normalizeDriveLetter(uri.fsPath, this.isWindows).replace(/\n/g, '');
 		}
@@ -1071,6 +1107,14 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 	}
 
 	private async createBackItem(currFolder: URI): Promise<FileQuickPickItem | undefined> {
+		// For authority-scoped URIs with a path prefix, treat the prefix
+		// root as the filesystem root so the user cannot navigate above it.
+		if (this.scopedPathPrefix) {
+			const pathAfterPrefix = currFolder.path.substring(this.scopedPathPrefix.length);
+			if (pathAfterPrefix === '/' || pathAfterPrefix === '') {
+				return undefined;
+			}
+		}
 		// For authority-scoped URIs, compare within the original scheme so
 		// that the authority is preserved and the root is detected correctly.
 		const compareScheme = this.scopedAuthority ? this.scheme : Schemas.file;

--- a/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
+++ b/src/vs/workbench/services/dialogs/test/browser/simpleFileDialog.test.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { AGENT_HOST_SCHEME, AGENT_HOST_LABEL_FORMATTER, agentHostAuthority } from '../../../../../platform/agentHost/common/agentHostUri.js';
+import { agentHostUri } from '../../../../../platform/agentHost/common/agentHostFileSystemProvider.js';
+
+/**
+ * Tests for the scoped path prefix logic used by SimpleFileDialog.
+ *
+ * SimpleFileDialog is tightly coupled to many services and difficult to
+ * instantiate in isolation. Instead of mocking the full dialog, we test
+ * the underlying data transformations that drive the fix:
+ *
+ * 1. computeScopedPathPrefix - derived from comparing the raw URI path
+ *    with the label-service-formatted output.
+ * 2. pathFromUri - stripping the prefix from the raw path.
+ * 3. remoteUriFrom - re-adding the prefix to user input.
+ */
+suite('SimpleFileDialog - scoped path prefix', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Replicates the stripPathSegments logic from the label service to
+	 * produce the display path that the label formatter would return.
+	 */
+	function labelFormatterDisplay(path: string, stripSegments: number): string {
+		let pos = 0;
+		for (let i = 0; i < stripSegments; i++) {
+			const next = path.indexOf('/', pos + 1);
+			if (next === -1) {
+				break;
+			}
+			pos = next;
+		}
+		return path.substring(pos);
+	}
+
+	/**
+	 * Replicates SimpleFileDialog.computeScopedPathPrefix:
+	 * compares raw URI path with formatted display path to find the prefix.
+	 */
+	function computeScopedPathPrefix(uri: URI, displayPath: string): string {
+		const fullPath = uri.path;
+		if (displayPath && fullPath.endsWith(displayPath)) {
+			return fullPath.substring(0, fullPath.length - displayPath.length);
+		}
+		return '';
+	}
+
+	/**
+	 * Replicates the scoped branch of SimpleFileDialog.pathFromUri:
+	 * strips the prefix from the raw URI path.
+	 */
+	function pathFromUri(uri: URI, prefix: string, endWithSeparator: boolean = false): string {
+		let path = uri.path;
+		if (prefix && path.startsWith(prefix)) {
+			path = path.substring(prefix.length);
+		}
+		let result = path.replace(/\n/g, '');
+		result = result.replace(/\\/g, '/');
+		if (endWithSeparator && !result.endsWith('/')) {
+			result = result + '/';
+		}
+		return result;
+	}
+
+	/**
+	 * Replicates the scoped branch of SimpleFileDialog.remoteUriFrom:
+	 * re-adds the prefix to construct a proper URI.
+	 */
+	function remoteUriFrom(path: string, scheme: string, authority: string, prefix: string): URI {
+		return URI.from({ scheme, authority, path: prefix + path });
+	}
+
+	test('computeScopedPathPrefix extracts prefix for agent host URI', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const uri = agentHostUri(authority, '/Users/roblou/code');
+
+		const displayPath = labelFormatterDisplay(uri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
+		const prefix = computeScopedPathPrefix(uri, displayPath);
+
+		assert.strictEqual(prefix, '/file/-');
+		assert.strictEqual(displayPath, '/Users/roblou/code');
+	});
+
+	test('computeScopedPathPrefix works for URI with original authority', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const originalUri = URI.from({ scheme: 'agenthost-content', authority: 'session1', path: '/snap/before' });
+		const uri = URI.from({
+			scheme: AGENT_HOST_SCHEME,
+			authority,
+			path: `/${originalUri.scheme}/${originalUri.authority}${originalUri.path}`,
+		});
+
+		const displayPath = labelFormatterDisplay(uri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
+		const prefix = computeScopedPathPrefix(uri, displayPath);
+
+		assert.strictEqual(prefix, '/agenthost-content/session1');
+		assert.strictEqual(displayPath, '/snap/before');
+	});
+
+	test('computeScopedPathPrefix returns empty for scheme without stripping', () => {
+		const uri = URI.from({ scheme: 'file', path: '/Users/roblou/code' });
+		// If display matches the full path, prefix is empty
+		const prefix = computeScopedPathPrefix(uri, '/Users/roblou/code');
+		assert.strictEqual(prefix, '');
+	});
+
+	test('pathFromUri strips prefix to show clean path', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const uri = agentHostUri(authority, '/Users/roblou/code');
+		const prefix = '/file/-';
+
+		assert.strictEqual(pathFromUri(uri, prefix), '/Users/roblou/code');
+	});
+
+	test('pathFromUri with trailing separator', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const uri = agentHostUri(authority, '/Users/roblou/code');
+		const prefix = '/file/-';
+
+		assert.strictEqual(pathFromUri(uri, prefix, true), '/Users/roblou/code/');
+	});
+
+	test('pathFromUri without prefix returns raw path', () => {
+		const uri = URI.from({ scheme: 'file', path: '/Users/roblou/code' });
+		assert.strictEqual(pathFromUri(uri, ''), '/Users/roblou/code');
+	});
+
+	test('remoteUriFrom re-adds prefix to reconstruct encoded URI', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const prefix = '/file/-';
+		const cleanPath = '/Users/roblou/code';
+
+		const result = remoteUriFrom(cleanPath, AGENT_HOST_SCHEME, authority, prefix);
+
+		assert.strictEqual(result.scheme, AGENT_HOST_SCHEME);
+		assert.strictEqual(result.authority, authority);
+		assert.strictEqual(result.path, '/file/-/Users/roblou/code');
+	});
+
+	test('full round-trip: URI -> pathFromUri -> remoteUriFrom -> same URI', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const originalPath = '/Users/roblou/code/vscode';
+		const uri = agentHostUri(authority, originalPath);
+
+		// Compute prefix
+		const displayPath = labelFormatterDisplay(uri.path, AGENT_HOST_LABEL_FORMATTER.formatting.stripPathSegments!);
+		const prefix = computeScopedPathPrefix(uri, displayPath);
+
+		// pathFromUri extracts clean path
+		const cleanPath = pathFromUri(uri, prefix);
+		assert.strictEqual(cleanPath, originalPath);
+
+		// remoteUriFrom reconstructs the original URI
+		const reconstructed = remoteUriFrom(cleanPath, AGENT_HOST_SCHEME, authority, prefix);
+		assert.strictEqual(reconstructed.path, uri.path);
+		assert.strictEqual(reconstructed.scheme, uri.scheme);
+		assert.strictEqual(reconstructed.authority, uri.authority);
+	});
+
+	test('createBackItem root detection with prefix', () => {
+		const authority = agentHostAuthority('localhost:8089');
+		const prefix = '/file/-';
+
+		// Simulate root folder: path = prefix + '/'
+		const rootUri = URI.from({ scheme: AGENT_HOST_SCHEME, authority, path: prefix + '/' });
+		const pathAfterPrefix = rootUri.path.substring(prefix.length);
+		assert.strictEqual(pathAfterPrefix === '/' || pathAfterPrefix === '', true, 'root should be detected');
+
+		// Simulate non-root folder
+		const subUri = URI.from({ scheme: AGENT_HOST_SCHEME, authority, path: prefix + '/Users/roblou' });
+		const subPathAfterPrefix = subUri.path.substring(prefix.length);
+		assert.notStrictEqual(subPathAfterPrefix, '/');
+		assert.notStrictEqual(subPathAfterPrefix, '');
+	});
+});


### PR DESCRIPTION
Update the remote agent host file picker to support a new URI scheme, ensuring proper decoding of paths for remote files. 