### PR TITLE
sessions: polish New Session button shortcut chip and layout

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -473,8 +473,9 @@ The Changes view is registered in `contrib/changesView/browser/changesView.contr
 The Sessions view is registered in `contrib/sessions/browser/sessions.contribution.ts`:
 
 - **Container**: Sessions container in `ViewContainerLocation.Sidebar` (default)
-- **View**: `SessionsViewId` with `AgenticSessionsViewPane`
+- **View**: `SessionsViewId` with `SessionsView` (`contrib/sessions/browser/views/sessionsView.ts`)
 - **Window visibility**: `WindowVisibility.Sessions`
+- **Primary action**: The sidebar content starts with a left-aligned secondary "New Session" button rendered as `$(plus) Session`, with an inline shortcut hint that reflects the active `workbench.action.sessions.newChat` keybinding when one is available
 
 ---
 
@@ -643,6 +644,7 @@ interface IPartVisibilityState {
 | Date | Change |
 |------|--------|
 | 2026-03-26 | Updated the sessions sidebar appear animation so only the body content (`.part.sidebar > .content`) slides/fades in during reveal while the sidebar title/header and footer remain fixed |
+| 2026-03-25 | Updated Sessions view documentation to reflect the refactored `SessionsView` implementation in `contrib/sessions/browser/views/sessionsView.ts` and documented the left-aligned "+ Session" sidebar action with its inline keybinding hint |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |
 | 2026-02-17 | Added `-webkit-app-region: drag` to sidebar title area so it can be used to drag the window; interactive children (actions, composite bar, labels) marked `no-drag`; CSS rules scoped to `.agent-sessions-workbench` in `parts/media/sidebarPart.css` |

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css
@@ -74,21 +74,66 @@
 	}
 
 	.agent-sessions-new-button-container {
-		padding: 8px 12px;
+		padding: 6px 12px 8px 12px;
 	}
 
 	.agent-sessions-new-button-container .monaco-button {
-		position: relative;
 		display: flex;
 		align-items: center;
-		justify-content: center;
+		justify-content: space-between;
+		column-gap: 12px;
+		padding-right: 5px;
+		text-align: left;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-button-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		flex: 1;
+		min-width: 0;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-button-label > .codicon {
+		margin: 0;
+		font-size: 14px;
+		line-height: 14px;
+		transform: translateY(1px);
 	}
 
 	.agent-sessions-new-button-container .monaco-button .new-session-keybinding-hint {
-		position: absolute;
-		right: 10px;
+		display: inline-block;
+		flex-shrink: 0;
+		font-family: var(--monaco-monospace-font);
 		font-size: 11px;
-		opacity: 0.5;
+		line-height: 1;
+		padding: 2px 4px;
+		border: 1px solid transparent;
+		border-radius: 2px;
+		background-color: var(--vscode-keybindingLabel-background);
+		color: var(--vscode-keybindingLabel-foreground);
+		box-shadow: none;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-keybinding-hint .monaco-keybinding {
+		line-height: 1;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-keybinding-hint .monaco-keybinding > .monaco-keybinding-key {
+		margin: 0 1px;
+		padding: 0;
+		min-width: auto;
+		border: 0;
+		background-color: transparent;
+		box-shadow: none;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-keybinding-hint .monaco-keybinding > .monaco-keybinding-key:first-child {
+		margin-left: 0;
+	}
+
+	.agent-sessions-new-button-container .monaco-button .new-session-keybinding-hint .monaco-keybinding > .monaco-keybinding-key:last-child {
+		margin-right: 0;
 	}
 
 	.agent-sessions-control-container {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -5,7 +5,11 @@
 
 import '../media/sessionsViewPane.css';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { KeybindingLabel } from '../../../../../base/browser/ui/keybindingLabel/keybindingLabel.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { Event } from '../../../../../base/common/event.js';
 import { autorun } from '../../../../../base/common/observable.js';
+import { OS } from '../../../../../base/common/platform.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
@@ -119,16 +123,59 @@ export class SessionsView extends ViewPane {
 
 		// New Session Button
 		const newSessionButtonContainer = DOM.append(sessionsContent, $('.agent-sessions-new-button-container'));
-		const newSessionButton = this._register(new Button(newSessionButtonContainer, { ...defaultButtonStyles, secondary: true }));
-		newSessionButton.label = localize('newSession', "New Session");
+		const newSessionButton = this._register(new Button(newSessionButtonContainer, {
+			...defaultButtonStyles,
+			secondary: true,
+			supportIcons: true,
+		}));
+		newSessionButton.label = `$(${Codicon.plus.id}) ${localize('sessionLabel', "Session")}`;
 		this._register(newSessionButton.onDidClick(() => this.sessionsManagementService.openNewSessionView()));
 
-		// Keybinding hint inside the button
-		const keybinding = this.keybindingService.lookupKeybinding(ACTION_ID_NEW_SESSION);
-		if (keybinding) {
-			const keybindingHint = DOM.append(newSessionButton.element, $('span.new-session-keybinding-hint'));
-			keybindingHint.textContent = keybinding.getLabel() ?? '';
-		}
+		const buttonLabel = $('.new-session-button-label');
+		const keybindingHint = $('span.new-session-keybinding-hint');
+		const keybindingHintLabel = this._register(new KeybindingLabel(keybindingHint, OS, {
+			disableTitle: true,
+			keybindingLabelBackground: 'transparent',
+			keybindingLabelForeground: 'inherit',
+			keybindingLabelBorder: 'transparent',
+			keybindingLabelBottomBorder: undefined,
+			keybindingLabelShadow: undefined,
+		}));
+		DOM.append(buttonLabel, ...Array.from(newSessionButton.element.childNodes));
+		DOM.reset(newSessionButton.element, buttonLabel);
+
+		const getNewSessionKeybinding = () => {
+			const primaryKeybinding = this.keybindingService.lookupKeybinding(ACTION_ID_NEW_SESSION);
+			const resolvedKeybindings = this.keybindingService.lookupKeybindings(ACTION_ID_NEW_SESSION);
+			return primaryKeybinding ?? resolvedKeybindings[0];
+		};
+
+		let lastRenderedKeybindingLabel: string | undefined;
+		let lastRenderedKeybindingAriaLabel: string | undefined;
+		const updateNewSessionButtonKeybinding = () => {
+			const keybinding = getNewSessionKeybinding();
+			const keybindingLabel = keybinding?.getLabel() ?? undefined;
+			const keybindingAriaLabel = keybinding?.getAriaLabel() ?? undefined;
+			if (lastRenderedKeybindingLabel === keybindingLabel && lastRenderedKeybindingAriaLabel === keybindingAriaLabel) {
+				return;
+			}
+
+			lastRenderedKeybindingLabel = keybindingLabel;
+			lastRenderedKeybindingAriaLabel = keybindingAriaLabel;
+			newSessionButton.element.title = keybindingLabel
+				? localize('newSessionButtonTitle', "New Session ({0})", keybindingLabel)
+				: localize('newSessionButtonTitleWithoutKeybinding', "New Session");
+			newSessionButton.element.setAttribute('aria-label', keybindingAriaLabel
+				? localize('newSessionButtonAriaLabel', "New Session ({0})", keybindingAriaLabel)
+				: localize('newSessionButtonAriaLabelWithoutKeybinding', "New Session"));
+
+			DOM.reset(newSessionButton.element, buttonLabel);
+			keybindingHintLabel.set(keybinding);
+			if (keybinding) {
+				DOM.append(newSessionButton.element, keybindingHint);
+			}
+		};
+		this._register(Event.runAndSubscribe(this.keybindingService.onDidUpdateKeybindings, updateNewSessionButtonKeybinding));
 
 		// Sessions List Control
 		this.sessionsControlContainer = DOM.append(sessionsContent, $('.agent-sessions-control-container'));

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsView.ts
@@ -34,7 +34,7 @@ import { IHostService } from '../../../../../workbench/services/host/browser/hos
 
 const $ = DOM.$;
 export const SessionsViewId = 'sessions.workbench.view.sessionsView';
-const ACTION_ID_NEW_SESSION = 'workbench.action.chat.newChat';
+const ACTION_ID_NEW_SESSION = 'workbench.action.sessions.newChat';
 const GROUPING_STORAGE_KEY = 'sessionsViewPane.grouping';
 const SORTING_STORAGE_KEY = 'sessionsViewPane.sorting';
 


### PR DESCRIPTION
## Summary
- update the Sessions view **New Session** button to show a codicon-plus label (`+ Session`) with left-aligned content
- render a right-side shortcut hint chip using platform-specific notation (`⌘ N` on macOS, `Ctrl N` otherwise)
- if sessions new chat keybinding is changed the chip will be updated to reflect the new customized keybinding
- refine shortcut chip styling: monospace text, flat appearance, 2px radius, transparent border, and improved spacing/alignment
- improve icon optics by reducing plus size and adjusting vertical alignment
- move button alignment to flex-based layout (no absolute positioning / margin-auto hack)

## Files
- `src/vs/sessions/contrib/sessions/browser/sessionsViewPane.ts`
- `src/vs/sessions/contrib/sessions/browser/media/sessionsViewPane.css`

## Validation
- `npm run compile-check-ts-native` (pass)
- `npm run hygiene` in the original workspace reports an existing unrelated issue in `extensions/mermaid-chat-features/chat-webview-out/codicon.css` (missing/bad copyright header)
- pre-commit hygiene on the PR branch passed for these changes

## Screenshot

<img width="344" height="99" alt="Screenshot 2026-03-24 at 3 53 30 PM" src="https://github.com/user-attachments/assets/642e84cd-039f-4f68-a2b4-c31026ab5dff" />

Customized keybindings:

<img width="343" height="104" alt="Screenshot 2026-03-24 at 3 38 34 PM" src="https://github.com/user-attachments/assets/ef42efaa-0b48-4ba2-b387-06bd4067cca0" />

<img width="346" height="103" alt="Screenshot 2026-03-24 at 3 37 43 PM" src="https://github.com/user-attachments/assets/29591e59-36bf-4f18-85d4-233aab207a18" />