### PR TITLE
Refactor session pickers to individual toolbar action items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -667,43 +667,6 @@ export class OpenWorkspacePickerAction extends Action2 {
 	}
 }
 
-export class ChatSessionPrimaryPickerAction extends Action2 {
-	static readonly ID = 'workbench.action.chat.chatSessionPrimaryPicker';
-	constructor() {
-		super({
-			id: ChatSessionPrimaryPickerAction.ID,
-			title: localize2('interactive.openChatSessionPrimaryPicker.label', "Open Primary Session Picker"),
-			category: CHAT_CATEGORY,
-			f1: false,
-			precondition: ChatContextKeys.enabled,
-			menu: {
-				id: MenuId.ChatInput,
-				order: 4,
-				group: 'navigation',
-				when:
-					ContextKeyExpr.and(
-						ChatContextKeys.chatSessionHasModels,
-						ContextKeyExpr.or(
-							ChatContextKeys.lockedToCodingAgent,
-							ContextKeyExpr.and(
-								ChatContextKeys.inAgentSessionsWelcome,
-								ChatContextKeys.chatSessionType.notEqualsTo('local')
-							)
-						)
-					)
-			}
-		});
-	}
-
-	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
-		const widgetService = accessor.get(IChatWidgetService);
-		const widget = widgetService.lastFocusedWidget;
-		if (widget) {
-			widget.input.openChatSessionPicker();
-		}
-	}
-}
-
 export const ChangeChatModelActionId = 'workbench.action.chat.changeModel';
 class ChangeChatModelAction extends Action2 {
 	static readonly ID = ChangeChatModelActionId;
@@ -1195,7 +1158,6 @@ export function registerChatExecuteActions() {
 	registerAction2(OpenSessionTargetPickerAction);
 	registerAction2(OpenDelegationPickerAction);
 	registerAction2(OpenWorkspacePickerAction);
-	registerAction2(ChatSessionPrimaryPickerAction);
 	registerAction2(ChangeChatModelAction);
 	registerAction2(CancelEdit);
 	registerAction2(GetHandoffsAction);

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessionPickerActionItem.ts
@@ -205,7 +205,7 @@ export class ChatSessionPickerActionItem extends ActionWidgetDropdownActionViewI
 	 * Returns the CSS class to add to the container. Can be overridden by subclasses.
 	 */
 	protected getContainerClass(): string {
-		return 'chat-sessionPicker-item';
+		return 'chat-input-picker-item';
 	}
 
 	protected override updateEnabled(): void {

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/chatSessions.contribution.ts
@@ -17,6 +17,7 @@ import { URI, UriComponents } from '../../../../../base/common/uri.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, IMenuService, MenuId, MenuItemAction, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ContextKeyExpr, IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IRelaxedExtensionDescription } from '../../../../../platform/extensions/common/extensions.js';
 import { InstantiationType, registerSingleton } from '../../../../../platform/instantiation/common/extensions.js';
@@ -46,13 +47,18 @@ import { BugIndicatingError, isCancellationError } from '../../../../../base/com
 import { IEditorGroupsService } from '../../../../services/editor/common/editorGroupsService.js';
 import { isUntitledChatSession, LocalChatSessionUri } from '../../common/model/chatUri.js';
 import { assertNever } from '../../../../../base/common/assert.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { Target } from '../../common/promptSyntax/promptTypes.js';
 import { slashReg } from '../../common/requestParser/chatRequestParser.js';
 import { IPromptsService } from '../../common/promptSyntax/service/promptsService.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { ILanguageModelToolsService } from '../../common/tools/languageModelToolsService.js';
 import { IChatModel } from '../../common/model/chatModel.js';
+
+/**
+ * Prefix for dynamically registered session picker action IDs.
+ * Format: `${CHAT_SESSION_PICKER_ACTION_PREFIX}${sessionType}/${groupId}`
+ */
+export const CHAT_SESSION_PICKER_ACTION_PREFIX = 'workbench.action.chat.chatSessionPicker.';
 
 const extensionPoint = ExtensionsRegistry.registerExtensionPoint<IChatSessionsExtensionPoint[]>({
 	extensionPoint: 'chatSessions',
@@ -307,6 +313,7 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 
 	private readonly inProgressMap = new Map</* chatSessionType */ string, number>();
 	private readonly _sessionTypeOptions = new Map<string, IChatSessionProviderOptionGroup[]>();
+	private readonly _sessionPickerMenuRegistrations = this._register(new DisposableMap</* sessionType */ string>());
 
 	private readonly _sessions = new ResourceMap<ContributedChatSessionData>();
 	private readonly _resourceAliases = new ResourceMap<URI>(); // real resource -> untitled resource
@@ -1159,6 +1166,49 @@ export class ChatSessionsService extends Disposable implements IChatSessionsServ
 		} else {
 			this._sessionTypeOptions.delete(chatSessionType);
 		}
+
+		// Register/unregister individual menu items for each option group
+		this._sessionPickerMenuRegistrations.deleteAndDispose(chatSessionType);
+		if (optionGroups && optionGroups.length > 0) {
+			const disposables = new DisposableStore();
+
+			const baseWhen = ContextKeyExpr.and(
+				ChatContextKeys.chatSessionHasModels,
+				ChatContextKeys.agentSessionType.isEqualTo(chatSessionType),
+				ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent,
+					ContextKeyExpr.and(
+						ChatContextKeys.inAgentSessionsWelcome,
+						ChatContextKeys.chatSessionType.notEqualsTo('local')
+					)
+				)
+			);
+
+			for (let i = 0; i < optionGroups.length; i++) {
+				const group = optionGroups[i];
+				const actionId = `${CHAT_SESSION_PICKER_ACTION_PREFIX}${chatSessionType}/${group.id}`;
+
+				// Combine base when clause with per-group visibility context key
+				const groupWhen = ContextKeyExpr.and(
+					baseWhen,
+					ContextKeyExpr.has(`chatSessionPickerGroup.${group.id}`)
+				);
+
+				disposables.add(CommandsRegistry.registerCommand(actionId, () => { /* Picker is opened via the action view item */ }));
+				disposables.add(MenuRegistry.appendMenuItem(MenuId.ChatInput, {
+					command: {
+						id: actionId,
+						title: group.name,
+					},
+					group: 'navigation',
+					order: 4 + i * 0.01,
+					when: groupWhen
+				}));
+			}
+
+			this._sessionPickerMenuRegistrations.set(chatSessionType, disposables);
+		}
+
 		this._onDidChangeOptionGroups.fire(chatSessionType);
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
+++ b/src/vs/workbench/contrib/chat/browser/chatSessions/media/chatSessionPickerActionItem.css
@@ -14,11 +14,7 @@
 
 .chat-session-option-picker */
 
-.monaco-action-bar .action-item.chat-sessionPicker-item {
-	overflow: hidden;
-}
-
-.monaco-action-bar .action-item .chat-session-option-picker {
+.monaco-action-bar .action-item.chat-input-picker-item .chat-session-option-picker {
 	align-items: center;
 	overflow: hidden;
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -8,7 +8,7 @@ import { addDisposableListener } from '../../../../../../base/browser/dom.js';
 import { DEFAULT_FONT_FAMILY } from '../../../../../../base/browser/fonts.js';
 import { IHistoryNavigationWidget } from '../../../../../../base/browser/history.js';
 import { hasModifierKeys, StandardKeyboardEvent } from '../../../../../../base/browser/keyboardEvent.js';
-import { ActionViewItem, BaseActionViewItem, IActionViewItemOptions } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { BaseActionViewItem } from '../../../../../../base/browser/ui/actionbar/actionViewItems.js';
 import * as aria from '../../../../../../base/browser/ui/aria/aria.js';
 import { ButtonWithIcon } from '../../../../../../base/browser/ui/button/button.js';
 import { createInstantHoverDelegate } from '../../../../../../base/browser/ui/hover/hoverDelegateFactory.js';
@@ -96,7 +96,8 @@ import { IChatResponseViewModel, isResponseVM } from '../../../common/model/chat
 import { IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ILanguageModelToolsService } from '../../../common/tools/languageModelToolsService.js';
 import { ChatHistoryNavigator } from '../../../common/widget/chatWidgetHistoryService.js';
-import { ChatSessionPrimaryPickerAction, ChatSubmitAction, IChatExecuteActionContext, OpenDelegationPickerAction, OpenModelPickerAction, OpenModePickerAction, OpenPermissionPickerAction, OpenSessionTargetPickerAction, OpenWorkspacePickerAction } from '../../actions/chatExecuteActions.js';
+import { ChatSubmitAction, IChatExecuteActionContext, OpenDelegationPickerAction, OpenModelPickerAction, OpenModePickerAction, OpenPermissionPickerAction, OpenSessionTargetPickerAction, OpenWorkspacePickerAction } from '../../actions/chatExecuteActions.js';
+import { CHAT_SESSION_PICKER_ACTION_PREFIX } from '../../chatSessions/chatSessions.contribution.js';
 import { AgentSessionProviders, getAgentSessionProvider } from '../../agentSessions/agentSessions.js';
 import { IAgentSessionsService } from '../../agentSessions/agentSessionsService.js';
 import { ChatAttachmentModel } from '../../attachments/chatAttachmentModel.js';
@@ -387,10 +388,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private permissionWidget: PermissionPickerActionItem | undefined;
 	private sessionTargetWidget: SessionTypePickerActionItem | undefined;
 	private delegationWidget: DelegationSessionPickerActionItem | undefined;
-	private readonly chatSessionPickerWidgets = this._register(new DisposableMap<string, ChatSessionPickerActionItem | SearchableOptionPickerActionItem>());
-	private chatSessionPickerContainer: HTMLElement | undefined;
-	private _lastSessionPickerAction: MenuItemAction | undefined;
-	private _lastSessionPickerOptions: IChatInputPickerOptions | undefined;
+	private chatSessionPickerWidgets: Map<string, ChatSessionPickerActionItem | SearchableOptionPickerActionItem> = new Map();
+	private readonly _groupVisibilityContextKeys: Map<string, IContextKey<boolean>> = new Map();
 	private readonly _waitForPersistedLanguageModel: MutableDisposable<IDisposable> = this._register(new MutableDisposable<IDisposable>());
 	private readonly _chatSessionOptionEmitters = this._register(new DisposableMap<string, Emitter<IChatSessionProviderOptionItem>>());
 
@@ -850,63 +849,54 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
-	 * Create picker widgets for all option groups available for the current session type.
+	 * Create a single picker widget for a specific option group.
 	 */
-	private createChatSessionPickerWidgets(action: MenuItemAction, pickerOptions?: IChatInputPickerOptions): (ChatSessionPickerActionItem | SearchableOptionPickerActionItem)[] {
-		this._lastSessionPickerAction = action;
-		this._lastSessionPickerOptions = pickerOptions;
-
-		const result = this.computeVisibleOptionGroups();
-		if (!result) {
-			return [];
+	private createSingleSessionPickerWidget(
+		action: MenuItemAction,
+		optionGroup: IChatSessionProviderOptionGroup,
+		effectiveSessionType: string,
+		pickerOptions?: IChatInputPickerOptions
+	): ChatSessionPickerActionItem | SearchableOptionPickerActionItem {
+		// Dispose existing widget for this group if any
+		const existingWidget = this.chatSessionPickerWidgets.get(optionGroup.id);
+		if (existingWidget) {
+			existingWidget.dispose();
+			this.chatSessionPickerWidgets.delete(optionGroup.id);
 		}
 
-		const { visibleGroupIds, optionGroups, effectiveSessionType } = result;
-		this.chatSessionPickerWidgets.clearAndDisposeAll();
+		const initialItem = this.getCurrentOptionForGroup(optionGroup.id);
+		const initialState = { group: optionGroup, item: initialItem };
 
-		const widgets: (ChatSessionPickerActionItem | SearchableOptionPickerActionItem)[] = [];
-		for (const optionGroup of optionGroups) {
-			if (!visibleGroupIds.has(optionGroup.id)) {
-				continue;
-			}
+		const itemDelegate: IChatSessionPickerDelegate = {
+			getCurrentOption: () => this.getCurrentOptionForGroup(optionGroup.id),
+			onDidChangeOption: this.getOrCreateOptionEmitter(optionGroup.id).event,
+			setOption: (option: IChatSessionProviderOptionItem) => {
+				this.updateOptionContextKey(optionGroup.id, option.id);
+				this.getOrCreateOptionEmitter(optionGroup.id).fire(option);
 
-			const initialItem = this.getCurrentOptionForGroup(optionGroup.id);
-			const initialState = { group: optionGroup, item: initialItem };
-
-			// Create delegate for this option group
-			const itemDelegate: IChatSessionPickerDelegate = {
-				getCurrentOption: () => this.getCurrentOptionForGroup(optionGroup.id),
-				onDidChangeOption: this.getOrCreateOptionEmitter(optionGroup.id).event,
-				setOption: (option: IChatSessionProviderOptionItem) => {
-					// Update context key for this option group
-					this.updateOptionContextKey(optionGroup.id, option.id);
-					this.getOrCreateOptionEmitter(optionGroup.id).fire(option);
-
-					// Notify session if we have one (not in welcome view before session creation)
-					const sessionResource = this._widget?.viewModel?.model.sessionResource;
-					const currentCtx = sessionResource ? this.chatService.getChatSessionFromInternalUri(sessionResource) : undefined;
-					if (currentCtx) {
-						this.chatSessionsService.setSessionOption(currentCtx.chatSessionResource, optionGroup.id, option);
-					}
-
-					// Refresh pickers to re-evaluate visibility of other option groups
-					this.refreshChatSessionPickers();
-				},
-				getOptionGroup: () => {
-					const groups = this.chatSessionsService.getOptionGroupsForSessionType(effectiveSessionType);
-					return groups?.find(g => g.id === optionGroup.id);
-				},
-				getSessionResource: () => {
-					return this._widget?.viewModel?.model.sessionResource;
+				const sessionResource = this._widget?.viewModel?.model.sessionResource;
+				const currentCtx = sessionResource ? this.chatService.getChatSessionFromInternalUri(sessionResource) : undefined;
+				if (currentCtx) {
+					this.chatSessionsService.setSessionOption(currentCtx.chatSessionResource, optionGroup.id, option);
 				}
-			};
 
-			const widget = this.instantiationService.createInstance(optionGroup.searchable ? SearchableOptionPickerActionItem : ChatSessionPickerActionItem, action, initialState, itemDelegate, pickerOptions);
-			this.chatSessionPickerWidgets.set(optionGroup.id, widget);
-			widgets.push(widget);
-		}
+				this.refreshChatSessionPickers();
+			},
+			getOptionGroup: () => {
+				const groups = this.chatSessionsService.getOptionGroupsForSessionType(effectiveSessionType);
+				return groups?.find(g => g.id === optionGroup.id);
+			},
+			getSessionResource: () => {
+				return this._widget?.viewModel?.model.sessionResource;
+			}
+		};
 
-		return widgets;
+		const widget = this.instantiationService.createInstance(
+			optionGroup.searchable ? SearchableOptionPickerActionItem : ChatSessionPickerActionItem,
+			action, initialState, itemDelegate, pickerOptions
+		);
+		this.chatSessionPickerWidgets.set(optionGroup.id, widget);
+		return widget;
 	}
 
 	/**
@@ -1594,6 +1584,59 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	/**
+	 * Get or create a boolean context key for an option group's visibility.
+	 * Used by dynamic menu items to control individual picker visibility.
+	 */
+	private getOrCreateGroupVisibilityKey(groupId: string): IContextKey<boolean> | undefined {
+		if (!this._scopedContextKeyService) {
+			return undefined;
+		}
+		let key = this._groupVisibilityContextKeys.get(groupId);
+		if (!key) {
+			const rawKey = new RawContextKey<boolean>(`chatSessionPickerGroup.${groupId}`, false);
+			key = rawKey.bindTo(this._scopedContextKeyService);
+			this._groupVisibilityContextKeys.set(groupId, key);
+		}
+		return key;
+	}
+
+	/**
+	 * Update per-group visibility context keys.
+	 * Also cleans up stale widget references for groups that no longer exist.
+	 */
+	private updateGroupVisibilityKeys(optionGroups: IChatSessionProviderOptionGroup[], visibleGroupIds: Set<string>): void {
+		// Set visible groups to true
+		for (const group of optionGroups) {
+			this.getOrCreateGroupVisibilityKey(group.id)?.set(visibleGroupIds.has(group.id));
+		}
+		// Clear any previously visible groups that are no longer in the option groups list,
+		// and dispose their stale widget references
+		for (const [groupId, key] of this._groupVisibilityContextKeys) {
+			if (!optionGroups.some(g => g.id === groupId)) {
+				key.set(false);
+				const widget = this.chatSessionPickerWidgets.get(groupId);
+				if (widget) {
+					widget.dispose();
+					this.chatSessionPickerWidgets.delete(groupId);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Clear all group visibility context keys and dispose stale widgets.
+	 */
+	private clearAllGroupVisibilityKeys(): void {
+		for (const key of this._groupVisibilityContextKeys.values()) {
+			key.set(false);
+		}
+		for (const widget of this.chatSessionPickerWidgets.values()) {
+			widget.dispose();
+		}
+		this.chatSessionPickerWidgets.clear();
+	}
+
+	/**
 	 * Computes which option groups should be visible for the current session.
 	 *
 	 * A picker should show if and only if:
@@ -1616,6 +1659,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const setNoOptions = () => {
 			this.chatSessionHasOptions.set(false);
 			this.chatSessionOptionsValid.set(true);
+			this.clearAllGroupVisibilityKeys();
 		};
 
 		const sessionResource = this._widget?.viewModel?.model.sessionResource;
@@ -1717,44 +1761,27 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.chatSessionHasOptions.set(true);
 		this.chatSessionOptionsValid.set(allOptionsValid);
 
+		// Update per-group visibility context keys for dynamic menu item when clauses
+		this.updateGroupVisibilityKeys(optionGroups, visibleGroupIds);
+
 		return { visibleGroupIds, optionGroups, ctx, effectiveSessionType };
 	}
 
 	/**
 	 * Refresh all registered option groups for the current chat session.
 	 * Fires events for each option group with their current selection.
+	 * Context keys are updated by computeVisibleOptionGroups(), which triggers
+	 * the toolbar to re-evaluate menu items and show/hide individual pickers.
 	 */
 	private refreshChatSessionPickers(): void {
-		// Use the shared helper to compute visibility and update context keys
+		// Compute visibility and update context keys (triggers toolbar rebuild via when clause changes)
 		const result = this.computeVisibleOptionGroups();
 
 		if (!result) {
-			// No visible options - helper already updated context keys
-			this.hideAllSessionPickerWidgets();
 			return;
 		}
 
-		const { visibleGroupIds, optionGroups, ctx } = result;
-
-		// Check if widgets need recreation (different set of visible groups)
-		const currentWidgetGroupIds = new Set(this.chatSessionPickerWidgets.keys());
-		const needsRecreation =
-			currentWidgetGroupIds.size !== visibleGroupIds.size ||
-			!Array.from(visibleGroupIds).every(id => currentWidgetGroupIds.has(id));
-
-		if (needsRecreation && this._lastSessionPickerAction && this.chatSessionPickerContainer) {
-			const widgets = this.createChatSessionPickerWidgets(this._lastSessionPickerAction, this._lastSessionPickerOptions);
-			dom.clearNode(this.chatSessionPickerContainer);
-			for (const widget of widgets) {
-				const container = dom.$('.action-item.chat-sessionPicker-item');
-				widget.render(container);
-				this.chatSessionPickerContainer.appendChild(container);
-			}
-		}
-
-		if (this.chatSessionPickerContainer) {
-			this.chatSessionPickerContainer.style.display = '';
-		}
+		const { optionGroups, ctx } = result;
 
 		// Fire option change events for existing widgets to sync their state
 		// (only if we have a session context - in welcome view, options aren't persisted yet)
@@ -1766,25 +1793,17 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					if (optionGroup) {
 						const currentOptionId = typeof currentOption === 'string' ? currentOption : currentOption.id;
 						const item = optionGroup.items.find((m: IChatSessionProviderOptionItem) => m.id === currentOptionId);
-						// If currentOption is an object (not a string ID), it represents a complete option item and should be used directly.
-						// Otherwise, if it's a string ID, look up the corresponding item and use that.
 						if (item && typeof currentOption === 'string') {
 							this.getOrCreateOptionEmitter(optionGroupId).fire(item);
 						} else if (typeof currentOption !== 'string') {
 							this.getOrCreateOptionEmitter(optionGroupId).fire(currentOption);
 						}
-
 					}
 				}
 			}
 		}
 	}
 
-	private hideAllSessionPickerWidgets(): void {
-		if (this.chatSessionPickerContainer) {
-			this.chatSessionPickerContainer.style.display = 'none';
-		}
-	}
 
 	/**
 	 * Get the current option for a specific option group.
@@ -2305,14 +2324,23 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 					} else {
 						return new HiddenActionViewItem(action);
 					}
-				} else if (action.id === ChatSessionPrimaryPickerAction.ID && action instanceof MenuItemAction) {
-					// Create all pickers and return a container action view item
-					const widgets = this.createChatSessionPickerWidgets(action, pickerOptions);
-					if (widgets.length === 0) {
+				} else if (action.id.startsWith(CHAT_SESSION_PICKER_ACTION_PREFIX) && action instanceof MenuItemAction) {
+					// Dynamic session picker - one action per option group
+					const suffix = action.id.substring(CHAT_SESSION_PICKER_ACTION_PREFIX.length);
+					const slashIdx = suffix.indexOf('/');
+					if (slashIdx === -1) {
 						return new HiddenActionViewItem(action);
 					}
-					// Create a container to hold all picker widgets
-					return this.instantiationService.createInstance(ChatSessionPickersContainerActionItem, action, widgets);
+					const sessionType = suffix.substring(0, slashIdx);
+					const groupId = suffix.substring(slashIdx + 1);
+
+					const optionGroups = this.chatSessionsService.getOptionGroupsForSessionType(sessionType);
+					const group = optionGroups?.find(g => g.id === groupId);
+					if (!group) {
+						return new HiddenActionViewItem(action);
+					}
+
+					return this.createSingleSessionPickerWidget(action, group, sessionType, pickerOptions);
 				}
 				return undefined;
 			}
@@ -2320,11 +2348,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.inputActionsToolbar.getElement().classList.add('chat-input-toolbar');
 		this.inputActionsToolbar.context = { widget } satisfies IChatExecuteActionContext;
 		this._register(this.inputActionsToolbar.onDidChangeMenuItems(() => {
-			// Update container reference for the pickers
-			const toolbarElement = this.inputActionsToolbar.getElement();
-			// eslint-disable-next-line no-restricted-syntax
-			const container = toolbarElement.querySelector('.chat-sessionPicker-container');
-			this.chatSessionPickerContainer = container as HTMLElement | undefined;
 			if (this.cachedWidth && typeof this.cachedInputToolbarWidth === 'number' && this.cachedInputToolbarWidth !== this.inputActionsToolbar.getItemsWidth()) {
 				this._toolbarRelayoutScheduler.schedule();
 			}
@@ -3359,34 +3382,6 @@ function getLastPosition(model: ITextModel): IPosition {
 
 const chatInputEditorContainerSelector = '.interactive-input-editor';
 setupSimpleEditorSelectionStyling(chatInputEditorContainerSelector);
-
-type ChatSessionPickerWidget = ChatSessionPickerActionItem | SearchableOptionPickerActionItem;
-
-class ChatSessionPickersContainerActionItem extends ActionViewItem {
-	constructor(
-		action: IAction,
-		private readonly widgets: ChatSessionPickerWidget[],
-		options?: IActionViewItemOptions
-	) {
-		super(null, action, options ?? {});
-	}
-
-	override render(container: HTMLElement): void {
-		container.classList.add('chat-sessionPicker-container');
-		for (const widget of this.widgets) {
-			const itemContainer = dom.$('.action-item.chat-sessionPicker-item');
-			widget.render(itemContainer);
-			container.appendChild(itemContainer);
-		}
-	}
-
-	override dispose(): void {
-		for (const widget of this.widgets) {
-			widget.dispose();
-		}
-		super.dispose();
-	}
-}
 
 class HiddenActionViewItem extends BaseActionViewItem {
 	constructor(action: IAction) {

--- a/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/chat.css
@@ -1519,8 +1519,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	}
 }
 
-.interactive-session .chat-input-toolbar .chat-input-picker-item .action-label,
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label {
+.interactive-session .chat-input-toolbar .chat-input-picker-item .action-label {
 	height: 16px;
 	padding: 3px 1px 3px 7px;
 	display: flex;
@@ -1536,8 +1535,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 /* When chevrons are hidden and only showing an icon (no label), size to 22x22 with centered icon */
 .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label.hide-chevrons:not(:has(.chat-input-picker-label)),
-.interactive-session .chat-input-toolbar .chat-input-picker-item.hide-chevrons .action-label:not(:has(.chat-input-picker-label)),
-.interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label.hide-chevrons:not(:has(.chat-input-picker-label)) {
+.interactive-session .chat-input-toolbar .chat-input-picker-item.hide-chevrons .action-label:not(:has(.chat-input-picker-label)) {
 	width: 22px;
 	min-width: 22px;
 	height: 22px;
@@ -1564,8 +1562,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	font-size: 14px;
 }
 
-.monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down,
-.monaco-workbench .interactive-session .chat-input-toolbar .chat-sessionPicker-item .action-label .codicon-chevron-down {
+.monaco-workbench .interactive-session .chat-input-toolbar .chat-input-picker-item .action-label .codicon-chevron-down {
 	font-size: 10px;
 	margin-left: 4px;
 	opacity: 0.75;
@@ -1577,10 +1574,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	gap: 4px;
 }
 
-.interactive-session .chat-input-toolbars .chat-sessionPicker-container {
-	display: flex;
-	max-width: 100%;
-}
+
 
 .monaco-workbench .interactive-session .chat-input-toolbars .monaco-action-bar .action-item .codicon,
 .monaco-workbench .interactive-session .chat-input-toolbars .action-label .codicon {


### PR DESCRIPTION
Fixes #299564

## Summary
- Replace the single session-picker container action item with individual action items (one per picker)
- Register session picker actions dynamically per option group in the chat input menu
- Use the same picker container CSS class as built-in pickers (`chat-input-picker-item`)
- Remove the old `ChatSessionPrimaryPickerAction` and container rendering path

## Why
Claude session pickers were previously bundled into one toolbar action item, which caused responsive/overflow behavior issues:
- all pickers shrank together
- overflow treated them as one item
- labeling/behavior differed from built-in pickers

This change aligns contributed session pickers with built-in picker behavior so each picker is independently sized and overflowed by the toolbar.

## Validation
- Type check: `node_modules/.bin/tsc --project ./src/tsconfig.json --noEmit --skipLibCheck` (with `NODE_OPTIONS=--max-old-space-size=8192`)
- `npm run valid-layers-check`

(Full unit test run wasn’t possible in this environment due to Electron test runtime constraints.)