### PR TITLE
Refactor chat command handling to utilize context key expressions for improved command visibility and execution conditions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommands.ts
@@ -27,8 +27,8 @@ import { CONFIGURE_PROMPTS_ACTION_ID } from './promptSyntax/runPromptAction.js';
 import { CONFIGURE_SKILLS_ACTION_ID } from './promptSyntax/skillActions.js';
 import { IChatWidgetService } from './chat.js';
 import { agentSlashCommandToMarkdown, agentToMarkdown } from './widget/chatContentParts/chatMarkdownDecorationsRenderer.js';
-import { Target } from '../common/promptSyntax/promptTypes.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { AgentSessionProviders } from './agentSessions/agentSessions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 
 export class ChatSlashCommandsContribution extends Disposable {
@@ -53,6 +53,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			detail: nls.localize('clear', "Start a new chat and archive the current one"),
 			sortText: 'z2_clear',
 			executeImmediately: true,
+			silent: true,
 			locations: [ChatAgentLocation.Chat]
 		}, async (_prompt, _progress, _history, _location, sessionResource) => {
 			agentSessionsService.getSession(sessionResource)?.setArchived(true);
@@ -65,7 +66,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await instantiationService.invokeFunction(showConfigureHooksQuickPick);
 		}));
@@ -75,7 +76,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			sortText: 'z3_models',
 			executeImmediately: true,
 			silent: true,
-			locations: [ChatAgentLocation.Chat],
+			locations: [ChatAgentLocation.Chat]
 		}, async () => {
 			await commandService.executeCommand(OpenModelPickerAction.ID);
 		}));
@@ -86,7 +87,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(ConfigureToolsAction.ID);
 		}));
@@ -97,7 +98,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(ManagePluginsAction.ID);
 		}));
@@ -120,7 +121,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(OpenModePickerAction.ID);
 		}));
@@ -131,7 +132,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(CONFIGURE_SKILLS_ACTION_ID);
 		}));
@@ -142,7 +143,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(CONFIGURE_INSTRUCTIONS_ACTION_ID);
 		}));
@@ -153,7 +154,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async () => {
 			await commandService.executeCommand(CONFIGURE_PROMPTS_ACTION_ID);
 		}));
@@ -178,7 +179,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: false,
 			silent: true,
 			locations: [ChatAgentLocation.Chat],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async (prompt, _progress, _history, _location, sessionResource) => {
 			const title = prompt.trim();
 			if (title) {
@@ -200,7 +201,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				targets: [Target.VSCode, Target.GitHubCopilot]
+				when: ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+				),
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -211,7 +215,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				targets: [Target.VSCode, Target.GitHubCopilot]
+				when: ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+				),
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -222,7 +229,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				targets: [Target.VSCode, Target.GitHubCopilot]
+				when: ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+				),
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.AutoApprove);
 			}));
@@ -233,7 +243,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 				executeImmediately: true,
 				silent: true,
 				locations: [ChatAgentLocation.Chat],
-				targets: [Target.VSCode, Target.GitHubCopilot]
+				when: ContextKeyExpr.or(
+					ChatContextKeys.lockedToCodingAgent.negate(),
+					ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+				),
 			}, async (_prompt, _progress, _history, _location, sessionResource) => {
 				setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 			}));
@@ -245,7 +258,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 					executeImmediately: true,
 					silent: true,
 					locations: [ChatAgentLocation.Chat],
-					targets: [Target.VSCode, Target.GitHubCopilot]
+					when: ContextKeyExpr.or(
+						ChatContextKeys.lockedToCodingAgent.negate(),
+						ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+					),
 				}, async (_prompt, _progress, _history, _location, sessionResource) => {
 					setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Autopilot);
 				}));
@@ -256,7 +272,10 @@ export class ChatSlashCommandsContribution extends Disposable {
 					executeImmediately: true,
 					silent: true,
 					locations: [ChatAgentLocation.Chat],
-					targets: [Target.VSCode, Target.GitHubCopilot]
+					when: ContextKeyExpr.or(
+						ChatContextKeys.lockedToCodingAgent.negate(),
+						ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background),
+					),
 				}, async (_prompt, _progress, _history, _location, sessionResource) => {
 					setPermissionLevelForSession(sessionResource, ChatPermissionLevel.Default);
 				}));
@@ -269,7 +288,7 @@ export class ChatSlashCommandsContribution extends Disposable {
 			executeImmediately: true,
 			locations: [ChatAgentLocation.Chat],
 			modes: [ChatModeKind.Ask],
-			targets: [Target.VSCode]
+			when: ChatContextKeys.lockedToCodingAgent.negate(),
 		}, async (prompt, progress, _history, _location, sessionResource) => {
 			const defaultAgent = chatAgentService.getDefaultAgent(ChatAgentLocation.Chat);
 			const agents = chatAgentService.getAgents();

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -356,7 +356,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 					selectedAgent: this._lastSelectedAgent,
 					mode: this.input.currentModeKind,
 					attachmentCapabilities: this.attachmentCapabilities,
-					forcedAgent: this._lockedAgent?.id ? this.chatAgentService.getAgent(this._lockedAgent.id) : undefined
+					forcedAgent: this._lockedAgent?.id ? this.chatAgentService.getAgent(this._lockedAgent.id) : undefined,
+					contextMatchesRules: when => this.contextKeyService.contextMatchesRules(when),
 				});
 			this._onDidChangeParsedInput.fire();
 		}
@@ -882,7 +883,17 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 
 		const previous = this.parsedChatRequest;
-		this.parsedChatRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequestWithReferences(getDynamicVariablesForWidget(this), getSelectedToolAndToolSetsForWidget(this), this.getInput(), this.location, { selectedAgent: this._lastSelectedAgent, mode: this.input.currentModeKind, attachmentCapabilities: this.attachmentCapabilities });
+		this.parsedChatRequest = this.instantiationService.createInstance(ChatRequestParser).parseChatRequestWithReferences(
+			getDynamicVariablesForWidget(this),
+			getSelectedToolAndToolSetsForWidget(this),
+			this.getInput(),
+			this.location,
+			{
+				selectedAgent: this._lastSelectedAgent,
+				mode: this.input.currentModeKind,
+				attachmentCapabilities: this.attachmentCapabilities,
+				contextMatchesRules: when => this.contextKeyService.contextMatchesRules(when)
+			});
 		if (!previous || !IParsedChatRequest.equals(previous, this.parsedChatRequest)) {
 			this._onDidChangeParsedInput.fire();
 		}
@@ -2424,7 +2435,12 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			userSelectedModelId: this.input.currentLanguageModel,
 			location: this.location,
 			locationData: this._location.resolveData?.(),
-			parserContext: { selectedAgent: this._lastSelectedAgent, mode: this.input.currentModeKind, attachmentCapabilities: this._lastSelectedAgent?.capabilities ?? this.attachmentCapabilities },
+			parserContext: {
+				selectedAgent: this._lastSelectedAgent,
+				mode: this.input.currentModeKind,
+				attachmentCapabilities: this._lastSelectedAgent?.capabilities ?? this.attachmentCapabilities,
+				contextMatchesRules: when => this.contextKeyService.contextMatchesRules(when)
+			},
 			attachedContext: requestInputs.attachedContext.asArray(),
 			resolvedVariables: resolvedImageVariables,
 			noCommandDetection: options?.noCommandDetection,

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions.ts
@@ -55,10 +55,7 @@ import { ChatAgentLocation, ChatModeKind, isSupportedChatFileScheme } from '../.
 import { isToolSet } from '../../../../common/tools/languageModelToolsService.js';
 import { IChatSessionsService } from '../../../../common/chatSessionsService.js';
 import { IPromptsService } from '../../../../common/promptSyntax/service/promptsService.js';
-import {
-	PromptsType,
-	Target
-} from '../../../../common/promptSyntax/promptTypes.js';
+import { PromptsType } from '../../../../common/promptSyntax/promptTypes.js';
 import { ChatSubmitAction, IChatExecuteActionContext } from '../../../actions/chatExecuteActions.js';
 import { IChatWidget, IChatWidgetService } from '../../../chat.js';
 import { resizeImage } from '../../../chatImageUtils.js';
@@ -67,7 +64,6 @@ import { IChatService } from '../../../../common/chatService/chatService.js';
 import { IChatDebugService } from '../../../../common/chatDebugService.js';
 import { createDebugEventsAttachment } from '../../../chatDebug/chatDebugAttachment.js';
 import { getPromptFileType } from '../../../../common/promptSyntax/config/promptFileLocations.js';
-import { getChatSessionType } from '../../../../common/model/chatUri.js';
 
 /**
  * Regex matching a slash command word (e.g. `/foo`). Uses `\p{L}` for Unicode
@@ -99,14 +95,6 @@ class SlashCommandCompletions extends Disposable {
 				const widget = this.chatWidgetService.getWidgetByInputUri(model.uri);
 				if (!widget || !widget.viewModel) {
 					return null;
-				}
-
-
-				let customAgentTarget: Target | undefined = undefined;
-				if (widget.lockedAgentId) {
-					const sessionResource = widget.viewModel.model.sessionResource;
-					const ctx = sessionResource && chatService.getChatSessionFromInternalUri(sessionResource);
-					customAgentTarget = (ctx ? chatSessionsService.getCustomAgentTargetForSessionType(getChatSessionType(sessionResource)) : undefined) ?? Target.Undefined;
 				}
 
 				const range = computeCompletionRanges(model, position, SlashCommandWord);
@@ -147,9 +135,6 @@ class SlashCommandCompletions extends Disposable {
 								return true;
 							}
 							if (c.modes && c.modes.length && !c.modes.includes(ChatModeKind.Agent)) {
-								return false;
-							}
-							if (c.targets && customAgentTarget && !c.targets.includes(customAgentTarget)) {
 								return false;
 							}
 							return true;

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorContrib.ts
@@ -474,7 +474,17 @@ class ChatTokenDeleter extends Disposable {
 			// If this was a simple delete, try to find out whether it was inside a token
 			if (!change.text && this.widget.viewModel) {
 				const attachmentCapabilities = previousSelectedAgent?.capabilities ?? this.widget.attachmentCapabilities;
-				const previousParsedValue = parser.parseChatRequestWithReferences(getDynamicVariablesForWidget(this.widget), getSelectedToolAndToolSetsForWidget(this.widget), previousInputValue, this.widget.location, { selectedAgent: previousSelectedAgent, mode: this.widget.input.currentModeKind, attachmentCapabilities });
+				const previousParsedValue = parser.parseChatRequestWithReferences(
+					getDynamicVariablesForWidget(this.widget),
+					getSelectedToolAndToolSetsForWidget(this.widget),
+					previousInputValue,
+					this.widget.location,
+					{
+						selectedAgent: previousSelectedAgent,
+						mode: this.widget.input.currentModeKind,
+						attachmentCapabilities,
+						contextMatchesRules: when => this.widget.scopedContextKeyService.contextMatchesRules(when)
+					});
 
 				// For dynamic variables, this has to happen in ChatDynamicVariableModel with the other bookkeeping
 				const deletableTokens = previousParsedValue.parts.filter(p => p instanceof ChatRequestAgentPart || p instanceof ChatRequestAgentSubcommandPart || p instanceof ChatRequestSlashCommandPart || p instanceof ChatRequestSlashPromptPart || p instanceof ChatRequestToolPart);

--- a/src/vs/workbench/contrib/chat/common/participants/chatSlashCommands.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatSlashCommands.ts
@@ -14,7 +14,6 @@ import { IChatFollowup, IChatProgress, IChatResponseProgressFileTreeData, IChatS
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { Target } from '../promptSyntax/promptTypes.js';
 
 //#region slash service, commands etc
 
@@ -39,7 +38,6 @@ export interface IChatSlashData {
 
 	locations: ChatAgentLocation[];
 	modes?: ChatModeKind[];
-	targets?: Target[];
 
 	/**
 	 * Optional context key expression that controls visibility of this command.

--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../../base/common/uri.js';
+import { ContextKeyExpression } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IPosition, Position } from '../../../../../editor/common/core/position.js';
 import { Range } from '../../../../../editor/common/core/range.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
@@ -26,6 +27,8 @@ export interface IChatParserContext {
 	/** Parse as this agent, even when it does not appear in the query text */
 	forcedAgent?: IChatAgentData;
 	attachmentCapabilities?: IChatAgentAttachmentCapabilities;
+	/** Evaluates a context key expression against the current widget context. */
+	contextMatchesRules?: (when: ContextKeyExpression) => boolean;
 }
 
 export class ChatRequestParser {
@@ -225,7 +228,7 @@ export class ChatRequestParser {
 
 		const capabilities = context?.attachmentCapabilities ?? usedAgent?.capabilities;
 		const slashCommands = this.slashCommandService.getCommands(location, context?.mode ?? ChatModeKind.Ask);
-		const slashCommand = slashCommands.find(c => c.command === command);
+		const slashCommand = slashCommands.find(c => c.command === command && (!c.when || context?.contextMatchesRules?.(c.when) !== false));
 		// If there is no agent, we allow any slash command.
 		// If there is an agent, we let
 		// * silent ones go through since they are only UI-facing and don't influence chat history


### PR DESCRIPTION
I wanted to get rid of the target usage here because ideally we replace the:
* `ChatContextKeys.lockedToCodingAgent.negate()`
* `ChatContextKeys.lockedCodingAgentId.isEqualTo(AgentSessionProviders.Background)`

with when clauses backed by real features that either:
* work for all agents (like `/hooks`, `/agents`, `/skills` etc)
* work for agents that support whatever feature it provides (mode providing (autopilot, etc)

Let me know what you think of this. I think really, if these slash commands just turn around and call VS Code commands, then why don't these commands have a menu they can contribute... but that's a larger architectural change.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
