### PR TITLE
sessions: move layout controller out of changes contrib and track panel visibility per session

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.contribution.ts
@@ -13,7 +13,6 @@ import { IViewContainersRegistry, ViewContainerLocation, IViewsRegistry, Extensi
 import { CHANGES_VIEW_CONTAINER_ID, CHANGES_VIEW_ID, ChangesViewPane, ChangesViewPaneContainer } from './changesView.js';
 import './changesViewActions.js';
 import './fixCIChecksAction.js';
-import { ChangesViewController } from './changesViewController.js';
 import { ChangesTitleBarContribution } from './changesTitleBarWidget.js';
 
 const changesViewIcon = registerIcon('changes-view-icon', Codicon.gitCompare, localize2('changesViewIcon', 'View icon for the Changes view.').value);
@@ -44,5 +43,4 @@ viewsRegistry.registerViews([{
 	windowVisibility: WindowVisibility.Sessions
 }], changesViewContainer);
 
-registerWorkbenchContribution2(ChangesViewController.ID, ChangesViewController, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ChangesTitleBarContribution.ID, ChangesTitleBarContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/layout/browser/layout.contribution.ts
+++ b/src/vs/sessions/contrib/layout/browser/layout.contribution.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../../workbench/common/contributions.js';
+import { SessionLayoutController } from './sessionLayoutController.js';
+
+registerWorkbenchContribution2(SessionLayoutController.ID, SessionLayoutController, WorkbenchPhase.BlockRestore);

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -13,18 +13,19 @@ import { IChatService } from '../../../../workbench/contrib/chat/common/chatServ
 import { IWorkbenchLayoutService, Parts } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { IViewsService } from '../../../../workbench/services/views/common/viewsService.js';
-import { CHANGES_VIEW_ID } from './changesView.js';
+import { CHANGES_VIEW_ID } from '../../changes/browser/changesView.js';
 
 interface IPendingTurnState {
 	readonly hadChangesBeforeSend: boolean;
 	readonly submittedAt: number;
 }
 
-export class ChangesViewController extends Disposable {
+export class SessionLayoutController extends Disposable {
 
-	static readonly ID = 'workbench.contrib.changesViewController';
+	static readonly ID = 'workbench.contrib.sessionLayoutController';
 
 	private readonly pendingTurnStateByResource = new ResourceMap<IPendingTurnState>();
+	private readonly panelVisibilityByResource = new ResourceMap<boolean>();
 
 	constructor(
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
@@ -55,7 +56,7 @@ export class ChangesViewController extends Disposable {
 			return changes.length > 0;
 		});
 
-		// Switch between sessions
+		// Switch between sessions: sync auxiliary bar visibility
 		this._register(autorun(reader => {
 			const activeSessionHasChanges = activeSessionHasChangesObs.read(reader);
 			this.syncAuxiliaryBarVisibility(activeSessionHasChanges);
@@ -94,6 +95,29 @@ export class ChangesViewController extends Disposable {
 				hadChangesBeforeSend: activeSessionHasChangesObs.get(),
 				submittedAt: Date.now(),
 			});
+		}));
+
+		// Track user-initiated panel visibility changes for the active session
+		this._register(this.layoutService.onDidChangePartVisibility(e => {
+			if (e.partId !== Parts.PANEL_PART) {
+				return;
+			}
+
+			const sessionResource = activeSessionResourceObs.get();
+			if (sessionResource) {
+				this.panelVisibilityByResource.set(sessionResource, e.visible);
+			}
+		}));
+
+		// Switch between sessions: sync panel visibility
+		this._register(autorun(reader => {
+			const sessionResource = activeSessionResourceObs.read(reader);
+			if (!sessionResource) {
+				return;
+			}
+
+			const panelVisible = this.panelVisibilityByResource.get(sessionResource) ?? false;
+			this.layoutService.setPartHidden(!panelVisible, Parts.PANEL_PART);
 		}));
 	}
 

--- a/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
+++ b/src/vs/sessions/contrib/layout/browser/sessionLayoutController.ts
@@ -26,6 +26,7 @@ export class SessionLayoutController extends Disposable {
 
 	private readonly pendingTurnStateByResource = new ResourceMap<IPendingTurnState>();
 	private readonly panelVisibilityByResource = new ResourceMap<boolean>();
+	private previousSessionResource: URI | undefined;
 
 	constructor(
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
@@ -109,15 +110,25 @@ export class SessionLayoutController extends Disposable {
 			}
 		}));
 
-		// Switch between sessions: sync panel visibility
+		// Switch between sessions: sync panel visibility.
+		// Save the outgoing session's panel state, then restore the incoming
+		// session's state only if it was previously recorded. First visits
+		// inherit the current panel visibility.
 		this._register(autorun(reader => {
 			const sessionResource = activeSessionResourceObs.read(reader);
 			if (!sessionResource) {
 				return;
 			}
 
-			const panelVisible = this.panelVisibilityByResource.get(sessionResource) ?? false;
-			this.layoutService.setPartHidden(!panelVisible, Parts.PANEL_PART);
+			if (this.previousSessionResource && !isEqual(this.previousSessionResource, sessionResource)) {
+				this.panelVisibilityByResource.set(this.previousSessionResource, this.layoutService.isVisible(Parts.PANEL_PART));
+			}
+			this.previousSessionResource = sessionResource;
+
+			const panelVisible = this.panelVisibilityByResource.get(sessionResource);
+			if (panelVisible !== undefined) {
+				this.layoutService.setPartHidden(!panelVisible, Parts.PANEL_PART);
+			}
 		}));
 	}
 

--- a/src/vs/sessions/sessions.desktop.main.ts
+++ b/src/vs/sessions/sessions.desktop.main.ts
@@ -206,6 +206,7 @@ import './contrib/chat/browser/customizationsDebugLog.contribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changes/browser/changesView.contribution.js';
+import './contrib/layout/browser/layout.contribution.js';
 import './contrib/codeReview/browser/codeReview.contributions.js';
 import './contrib/files/browser/files.contribution.js';
 import './contrib/github/browser/github.contribution.js';

--- a/src/vs/sessions/sessions.web.main.ts
+++ b/src/vs/sessions/sessions.web.main.ts
@@ -161,6 +161,7 @@ import './contrib/terminal/browser/sessionsTerminalContribution.js';
 import './contrib/sessions/browser/sessions.contribution.js';
 import './contrib/sessions/browser/customizationsToolbar.contribution.js';
 import './contrib/changes/browser/changesView.contribution.js';
+import './contrib/layout/browser/layout.contribution.js';
 import './contrib/codeReview/browser/codeReview.contributions.js';
 import './contrib/github/browser/github.contribution.js';
 import './contrib/fileTreeView/browser/fileTreeView.contribution.js';


### PR DESCRIPTION
## Summary

Moves the `ChangesViewController` out of the changes contrib folder into a new dedicated `contrib/layout` folder, renamed to `SessionLayoutController`. This better reflects its responsibility: managing **layout state** (part visibility) when switching sessions — not just the changes view.

Additionally extends the controller to **track panel part visibility per session**. When a user shows or hides the panel in a session, that visibility state is remembered. When switching back to that session, the panel is restored to its last-known state (default: hidden).

## Changes

- **New `contrib/layout/browser/`** — dedicated contrib folder for session layout concerns
  - `sessionLayoutController.ts` — renamed from `ChangesViewController`, with all original auxiliary bar logic preserved, plus new panel visibility tracking
  - `layout.contribution.ts` — registers the controller at `BlockRestore` phase
- **`changesView.contribution.ts`** — removed `ChangesViewController` import and registration (now only registers view containers and `ChangesTitleBarContribution`)
- **Entry points** — added `layout.contribution.js` import to both `sessions.web.main.ts` and `sessions.desktop.main.ts`
- **Deleted** `changesViewController.ts` (git tracks as rename due to 80% similarity)

## Panel tracking details

- Listens to `onDidChangePartVisibility` for `PANEL_PART` events
- Stores per-session panel visibility in a `ResourceMap<boolean>`
- On session switch, restores panel to last-known state (defaults to hidden if no state recorded)