### PR TITLE
Fix wrapped title spacing on the agent sessions welcome page

### DIFF
--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
@@ -40,7 +40,7 @@
 .agentSessionsWelcome-header h1.product-name {
 	font-size: 32px;
 	font-weight: 400;
-	line-height: 1.25;
+	line-height: 1;
 	margin: 0 0 12px 0;
 	color: var(--vscode-foreground);
 }

--- a/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
+++ b/src/vs/workbench/contrib/welcomeAgentSessions/browser/media/agentSessionsWelcome.css
@@ -40,6 +40,7 @@
 .agentSessionsWelcome-header h1.product-name {
 	font-size: 32px;
 	font-weight: 400;
+	line-height: 1.25;
 	margin: 0 0 12px 0;
 	color: var(--vscode-foreground);
 }


### PR DESCRIPTION
## Summary
- add an explicit line-height to the welcome page product title
- prevent wrapped titles from overlapping when the page is narrow

Fixes #297827.

Before:
<img width="278" height="144" alt="image" src="https://github.com/user-attachments/assets/d2402536-5324-4dae-b0e3-fdcab380640a" />

After:
<img width="283" height="151" alt="image" src="https://github.com/user-attachments/assets/de4f0a37-19e9-41d4-83d1-18176bf0a465" />

## Testing
- Not run (CSS-only change; no focused automated test covers this welcome page header)