### PR TITLE
sessions: collapse customizations section by default in sidebar

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -52,7 +52,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
 		// Get initial collapsed state
-		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, false);
+		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
 		if (isCollapsed) {


### PR DESCRIPTION
The AI Customizations section in the sessions sidebar was expanded by default, taking up space before users need it.

This changes the default collapsed state from `false` to `true` so the section starts hidden. Users who expand it will have their preference persisted in profile storage as before.