### PR TITLE
sessions - restore file icons in modal editor titles

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -112,11 +112,6 @@
 	background: rgba(0, 0, 0, 0.5);
 }
 
-/* Hide the file icon in modal editor titles */
-.agent-sessions-workbench .modal-editor-title .monaco-icon-label::before,
-.agent-sessions-workbench .modal-editor-title .monaco-icon-label > .monaco-icon-label-iconpath {
-	display: none;
-}
 
 /* ---- Customization Empty State ---- */
 


### PR DESCRIPTION
CSS rules were added that explicitly hide file icons in modal editor titles for the sessions app via `display: none`. This removes those rules to restore the icons.

The icon rendering code in `modalEditorPart.ts` already correctly passes `icon: activeEditor.getIcon()` — the CSS was overriding it.