### PR TITLE
Skip confirmation dialog when unarchiving a single session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -168,23 +168,23 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 	}
 	async run(accessor: ServicesAccessor) {
 		const agentSessionsService = accessor.get(IAgentSessionsService);
-		const dialogService = accessor.get(IDialogService);
 
 		const sessionsToArchive = agentSessionsService.model.sessions.filter(session => !session.isArchived());
 		if (sessionsToArchive.length === 0) {
 			return;
 		}
 
-		const confirmed = await dialogService.confirm({
-			message: sessionsToArchive.length === 1
-				? localize('archiveAllSessions.confirmSingle', "Are you sure you want to archive 1 agent session?")
-				: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
-			detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Chat view."),
-			primaryButton: localize('archiveAllSessions.archive', "Archive")
-		});
+		if (sessionsToArchive.length > 1) {
+			const dialogService = accessor.get(IDialogService);
+			const confirmed = await dialogService.confirm({
+				message: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
+				detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Chat view."),
+				primaryButton: localize('archiveAllSessions.archive', "Archive")
+			});
 
-		if (!confirmed.confirmed) {
-			return;
+			if (!confirmed.confirmed) {
+				return;
+			}
 		}
 
 		for (const session of sessionsToArchive) {
@@ -252,28 +252,27 @@ export class ArchiveAgentSessionSectionAction extends Action2 {
 			return;
 		}
 
-		const dialogService = accessor.get(IDialogService);
-		const storageService = accessor.get(IStorageService);
+		if (context.sessions.length > 1) {
+			const storageService = accessor.get(IStorageService);
+			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
+			if (!skipConfirmation) {
+				const dialogService = accessor.get(IDialogService);
+				const confirmed = await dialogService.confirm({
+					message: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} agent sessions from '{1}'?", context.sessions.length, context.label),
+					detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
+					primaryButton: localize('archiveSectionSessions.archive', "Archive All"),
+					checkbox: {
+						label: localize('doNotAskAgain', "Do not ask me again")
+					}
+				});
 
-		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
-		if (!skipConfirmation) {
-			const confirmed = await dialogService.confirm({
-				message: context.sessions.length === 1
-					? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to archive 1 agent session from '{0}'?", context.label)
-					: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} agent sessions from '{1}'?", context.sessions.length, context.label),
-				detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
-				primaryButton: localize('archiveSectionSessions.archive', "Archive All"),
-				checkbox: {
-					label: localize('doNotAskAgain', "Do not ask me again")
+				if (!confirmed.confirmed) {
+					return;
 				}
-			});
 
-			if (!confirmed.confirmed) {
-				return;
-			}
-
-			if (confirmed.checkboxChecked) {
-				storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				if (confirmed.checkboxChecked) {
+					storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				}
 			}
 		}
 
@@ -309,27 +308,26 @@ export class UnarchiveAgentSessionSectionAction extends Action2 {
 			return;
 		}
 
-		const dialogService = accessor.get(IDialogService);
-		const storageService = accessor.get(IStorageService);
+		if (context.sessions.length > 1) {
+			const storageService = accessor.get(IStorageService);
+			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
+			if (!skipConfirmation) {
+				const dialogService = accessor.get(IDialogService);
+				const confirmed = await dialogService.confirm({
+					message: localize('unarchiveSectionSessions.confirm', "Are you sure you want to unarchive {0} agent sessions?", context.sessions.length),
+					primaryButton: localize('unarchiveSectionSessions.unarchive', "Unarchive All"),
+					checkbox: {
+						label: localize('doNotAskAgain', "Do not ask me again")
+					}
+				});
 
-		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
-		if (!skipConfirmation) {
-			const confirmed = await dialogService.confirm({
-				message: context.sessions.length === 1
-					? localize('unarchiveSectionSessions.confirmSingle', "Are you sure you want to unarchive 1 agent session?")
-					: localize('unarchiveSectionSessions.confirm', "Are you sure you want to unarchive {0} agent sessions?", context.sessions.length),
-				primaryButton: localize('unarchiveSectionSessions.unarchive', "Unarchive All"),
-				checkbox: {
-					label: localize('doNotAskAgain', "Do not ask me again")
+				if (!confirmed.confirmed) {
+					return;
 				}
-			});
 
-			if (!confirmed.confirmed) {
-				return;
-			}
-
-			if (confirmed.checkboxChecked) {
-				storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				if (confirmed.checkboxChecked) {
+					storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -175,16 +175,16 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 			return;
 		}
 
-		if (sessionsToArchive.length > 1) {
-			const confirmed = await dialogService.confirm({
-				message: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
-				detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Sessions view."),
-				primaryButton: localize('archiveAllSessions.archive', "Archive")
-			});
+		const confirmed = await dialogService.confirm({
+			message: sessionsToArchive.length === 1
+				? localize('archiveAllSessions.confirmSingle', "Are you sure you want to archive 1 agent session?")
+				: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
+			detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Sessions view."),
+			primaryButton: localize('archiveAllSessions.archive', "Archive")
+		});
 
-			if (!confirmed.confirmed) {
-				return;
-			}
+		if (!confirmed.confirmed) {
+			return;
 		}
 
 		for (const session of sessionsToArchive) {
@@ -255,25 +255,25 @@ export class ArchiveAgentSessionSectionAction extends Action2 {
 		const dialogService = accessor.get(IDialogService);
 		const storageService = accessor.get(IStorageService);
 
-		if (context.sessions.length > 1) {
-			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
-			if (!skipConfirmation) {
-				const confirmed = await dialogService.confirm({
-					message: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} agent sessions from '{1}'?", context.sessions.length, context.label),
-					detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
-					primaryButton: localize('archiveSectionSessions.archive', "Archive All"),
-					checkbox: {
-						label: localize('doNotAskAgain', "Do not ask me again")
-					}
-				});
-
-				if (!confirmed.confirmed) {
-					return;
+		const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
+		if (!skipConfirmation) {
+			const confirmed = await dialogService.confirm({
+				message: context.sessions.length === 1
+					? localize('archiveSectionSessions.confirmSingle', "Are you sure you want to archive 1 agent session from '{0}'?", context.label)
+					: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} agent sessions from '{1}'?", context.sessions.length, context.label),
+				detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
+				primaryButton: localize('archiveSectionSessions.archive', "Archive All"),
+				checkbox: {
+					label: localize('doNotAskAgain', "Do not ask me again")
 				}
+			});
 
-				if (confirmed.checkboxChecked) {
-					storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
-				}
+			if (!confirmed.confirmed) {
+				return;
+			}
+
+			if (confirmed.checkboxChecked) {
+				storageService.store(ConfirmArchiveStorageKey, true, StorageScope.PROFILE, StorageTarget.USER);
 			}
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -178,7 +178,7 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 		if (sessionsToArchive.length > 1) {
 			const confirmed = await dialogService.confirm({
 				message: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
-				detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Chat view."),
+				detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Sessions view."),
 				primaryButton: localize('archiveAllSessions.archive', "Archive")
 			});
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -179,7 +179,7 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 			message: sessionsToArchive.length === 1
 				? localize('archiveAllSessions.confirmSingle', "Are you sure you want to archive 1 agent session?")
 				: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
-			detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Sessions view."),
+			detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
 			primaryButton: localize('archiveAllSessions.archive', "Archive")
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions.ts
@@ -168,6 +168,7 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 	}
 	async run(accessor: ServicesAccessor) {
 		const agentSessionsService = accessor.get(IAgentSessionsService);
+		const dialogService = accessor.get(IDialogService);
 
 		const sessionsToArchive = agentSessionsService.model.sessions.filter(session => !session.isArchived());
 		if (sessionsToArchive.length === 0) {
@@ -175,7 +176,6 @@ export class ArchiveAllAgentSessionsAction extends Action2 {
 		}
 
 		if (sessionsToArchive.length > 1) {
-			const dialogService = accessor.get(IDialogService);
 			const confirmed = await dialogService.confirm({
 				message: localize('archiveAllSessions.confirm', "Are you sure you want to archive {0} agent sessions?", sessionsToArchive.length),
 				detail: localize('archiveAllSessions.detail', "You can unarchive sessions later if needed from the Chat view."),
@@ -252,11 +252,12 @@ export class ArchiveAgentSessionSectionAction extends Action2 {
 			return;
 		}
 
+		const dialogService = accessor.get(IDialogService);
+		const storageService = accessor.get(IStorageService);
+
 		if (context.sessions.length > 1) {
-			const storageService = accessor.get(IStorageService);
 			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 			if (!skipConfirmation) {
-				const dialogService = accessor.get(IDialogService);
 				const confirmed = await dialogService.confirm({
 					message: localize('archiveSectionSessions.confirm', "Are you sure you want to archive {0} agent sessions from '{1}'?", context.sessions.length, context.label),
 					detail: localize('archiveSectionSessions.detail', "You can unarchive sessions later if needed from the sessions view."),
@@ -308,11 +309,12 @@ export class UnarchiveAgentSessionSectionAction extends Action2 {
 			return;
 		}
 
+		const dialogService = accessor.get(IDialogService);
+		const storageService = accessor.get(IStorageService);
+
 		if (context.sessions.length > 1) {
-			const storageService = accessor.get(IStorageService);
 			const skipConfirmation = storageService.getBoolean(ConfirmArchiveStorageKey, StorageScope.PROFILE, false);
 			if (!skipConfirmation) {
-				const dialogService = accessor.get(IDialogService);
 				const confirmed = await dialogService.confirm({
 					message: localize('unarchiveSectionSessions.confirm', "Are you sure you want to unarchive {0} agent sessions?", context.sessions.length),
 					primaryButton: localize('unarchiveSectionSessions.unarchive', "Unarchive All"),


### PR DESCRIPTION
Skip the confirmation dialog when unarchiving only 1 session — the dialog should only appear when multiple sessions are affected.

Also updates the archive detail message to say "Sessions view" instead of "Chat view".