### PR TITLE
Include metadata in agent sessions trace logging

### DIFF
--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -100,12 +100,6 @@
 	box-sizing: border-box;
 }
 
-/* ---- Session List ---- */
-
-.agent-sessions-workbench .agent-session-title {
-	color: var(--vscode-list-activeSelectionForeground);
-}
-
 /* ---- Modal Editor Block ---- */
 
 .agent-sessions-workbench .monaco-modal-editor-block {

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -375,7 +375,8 @@ class AgentSessionsLogger extends Disposable {
 			if (session.metadata && Object.keys(session.metadata).length > 0) {
 				lines.push(`  Metadata:`);
 				for (const [key, value] of Object.entries(session.metadata)) {
-					lines.push(`    ${key}: ${JSON.stringify(value)}`);
+					const renderedValue = typeof value === 'string' ? value : safeStringify(value);
+					lines.push(`    ${key}: ${renderedValue}`);
 				}
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsModel.ts
@@ -371,6 +371,14 @@ class AgentSessionsLogger extends Disposable {
 				}
 			}
 
+			// Metadata
+			if (session.metadata && Object.keys(session.metadata).length > 0) {
+				lines.push(`  Metadata:`);
+				for (const [key, value] of Object.entries(session.metadata)) {
+					lines.push(`    ${key}: ${JSON.stringify(value)}`);
+				}
+			}
+
 			// Our state (read/unread, archived)
 			lines.push(`  State:`);
 			lines.push(`    Archived (provider): ${session.archived ?? 'N/A'}`);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/media/agentsessionsviewer.css
@@ -44,11 +44,12 @@
 		.agent-session-diff-container {
 			.agent-session-diff-added,
 			.agent-session-diff-removed {
-					color: unset;
+				color: unset;
 			}
 		}
 	}
 
+	.monaco-list-row.selected .agent-session-item,
 	.monaco-list-row.selected .agent-session-title {
 		color: unset;
 	}


### PR DESCRIPTION
When tracing agent sessions information via the output channel, the session metadata was not included. This adds a `Metadata:` section to the trace output that logs each key/value pair, consistent with how other optional fields like Description, Badge, and Tooltip are handled. Empty or absent metadata is skipped.