### PR TITLE
Fix Claude agent title bar after first session creation

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditor.ts
@@ -8,6 +8,7 @@ import { renderIcon } from '../../../../../../base/browser/ui/iconLabel/iconLabe
 import { raceCancellationError } from '../../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
+import { isEqual } from '../../../../../../base/common/resources.js';
 import { ThemeIcon } from '../../../../../../base/common/themables.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import * as nls from '../../../../../../nls.js';
@@ -129,6 +130,14 @@ export class ChatEditor extends AbstractEditorWithViewState<IChatEditorViewState
 				}));
 		this._register(this.widget.onDidSubmitAgent(() => {
 			this.group.pinEditor(this.input);
+		}));
+		this._register(this.widget.onDidChangeViewModel(({ currentSessionResource }) => {
+			const input = this.input;
+			if (!(input instanceof ChatEditorInput) || !currentSessionResource || isEqual(input.sessionResource, currentSessionResource)) {
+				return;
+			}
+
+			void input.updateSessionResource(currentSessionResource);
 		}));
 		this.widget.render(parent);
 		this.widget.setVisible(true);

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/editor/chatEditorInput.ts
@@ -5,7 +5,7 @@
 
 import { CancellationToken } from '../../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { Disposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
+import { Disposable, IDisposable, MutableDisposable } from '../../../../../../base/common/lifecycle.js';
 import { revive } from '../../../../../../base/common/marshalling.js';
 import { Schemas } from '../../../../../../base/common/network.js';
 import { isEqual } from '../../../../../../base/common/resources.js';
@@ -46,6 +46,7 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 	private cachedIcon: ThemeIcon | URI | undefined;
 
 	private readonly modelRef = this._register(new MutableDisposable<IChatModelReference>());
+	private readonly modelDisposables = this._register(new MutableDisposable<IDisposable>());
 
 	private get model(): IChatModel | undefined {
 		return this.modelRef.value?.object;
@@ -211,19 +212,22 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 		const searchParams = new URLSearchParams(this.resource.query);
 		const chatSessionType = searchParams.get('chatSessionType');
 		const inputType = chatSessionType ?? this.resource.authority;
+		let modelRef: IChatModelReference | undefined;
 
 		if (this._sessionResource) {
-			this.modelRef.value = await this.chatService.acquireOrLoadSession(this._sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+			modelRef = await this.chatService.acquireOrLoadSession(this._sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
 
 			// For local session only, if we find no existing session, create a new one
-			if (!this.model && LocalChatSessionUri.parseLocalSessionId(this._sessionResource)) {
-				this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: true });
+			if (!modelRef && LocalChatSessionUri.parseLocalSessionId(this._sessionResource)) {
+				modelRef = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: true });
 			}
 		} else if (!this.options.target) {
-			this.modelRef.value = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType });
+			modelRef = this.chatService.startNewLocalSession(ChatAgentLocation.Chat, { canUseTools: !inputType });
 		} else if (this.options.target.data) {
-			this.modelRef.value = this.chatService.loadSessionFromData(this.options.target.data);
+			modelRef = this.chatService.loadSessionFromData(this.options.target.data);
 		}
+
+		this.bindModelRef(modelRef);
 
 		if (!this.model || this.isDisposed()) {
 			return null;
@@ -231,19 +235,11 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 
 		this._sessionResource = this.model.sessionResource;
 
-		this._register(this.model.onDidChange((e) => {
-			// Invalidate icon cache when label changes
-			this.cachedIcon = undefined;
-			this._onDidChangeLabel.fire();
-		}));
-
 		// Check if icon has changed after model resolution
 		const newIcon = this.resolveIcon();
 		if (newIcon && (!this.cachedIcon || !this.iconsEqual(this.cachedIcon, newIcon))) {
 			this.cachedIcon = newIcon;
 		}
-
-		this._onDidChangeLabel.fire();
 
 		return this._register(new ChatEditorModel(this.model));
 	}
@@ -256,6 +252,37 @@ export class ChatEditorInput extends EditorInput implements IEditorCloseHandler 
 			return a.toString() === b.toString();
 		}
 		return false;
+	}
+
+	private bindModelRef(modelRef: IChatModelReference | undefined): void {
+		this.modelRef.value = modelRef;
+		this.modelDisposables.clear();
+
+		if (modelRef) {
+			this._sessionResource = modelRef.object.sessionResource;
+			this.modelDisposables.value = modelRef.object.onDidChange(() => {
+				this.cachedIcon = undefined;
+				this._onDidChangeLabel.fire();
+			});
+		}
+
+		this.cachedIcon = undefined;
+		this._onDidChangeLabel.fire();
+	}
+
+	async updateSessionResource(sessionResource: URI): Promise<void> {
+		if (this.isDisposed() || isEqual(this._sessionResource, sessionResource)) {
+			return;
+		}
+
+		const modelRef = this.chatService.acquireExistingSession(sessionResource)
+			?? await this.chatService.acquireOrLoadSession(sessionResource, ChatAgentLocation.Chat, CancellationToken.None);
+
+		if (!modelRef || this.isDisposed()) {
+			return;
+		}
+
+		this.bindModelRef(modelRef);
 	}
 
 }


### PR DESCRIPTION
## Summary
- keep the chat editor input in sync when a contributed session swaps from an untitled bootstrap URI to its real session URI
- update the chat editor title state as soon as the widget switches models so title-bar dependent UI does not wait for a reopen
- reuse the existing session model when possible instead of leaving the editor bound to the bootstrap session

Fixes #304274.

## Testing
- Not run (repo not bootstrapped in this workspace)