### PR TITLE
fix: handle dirty worktree error on checkout with treeish argument

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2851,8 +2851,34 @@ export class CommandCenter {
 
 	private async _checkout(repository: Repository, opts?: { detached?: boolean; treeish?: string }): Promise<boolean> {
 		if (typeof opts?.treeish === 'string') {
-			await repository.checkout(opts?.treeish, opts);
-			return true;
+			try {
+				await repository.checkout(opts?.treeish, opts);
+				return true;
+			} catch (err) {
+				if (err.gitErrorCode !== GitErrorCodes.DirtyWorkTree) {
+					throw err;
+				}
+
+				const stash = l10n.t('Stash & Checkout');
+				const migrate = l10n.t('Migrate Changes');
+				const force = l10n.t('Force Checkout');
+				const choice = await window.showWarningMessage(l10n.t('Your local changes would be overwritten by checkout.'), { modal: true }, stash, migrate, force);
+
+				if (choice === force) {
+					await this.cleanAll(repository);
+					await repository.checkout(opts.treeish, opts);
+				} else if (choice === stash || choice === migrate) {
+					if (await this._stash(repository, true)) {
+						await repository.checkout(opts.treeish, opts);
+
+						if (choice === migrate) {
+							await this.stashPopLatest(repository);
+						}
+					}
+				}
+
+				return true;
+			}
 		}
 
 		const createBranch = new CreateBranchItem();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When checking out a branch/commit via code paths that pass a `treeish` string directly to `_checkout()` — such as `checkoutDetached`, `git.graph.checkout`, `git.graph.checkoutRef`, or the Source Control Graph context menu — and the working tree has uncommitted changes, the checkout fails with an unhelpful error message. The user is not offered the "Stash & Checkout / Migrate Changes / Force Checkout" dialog that the QuickPick-based checkout flow provides.

This happens because the early-return path in `_checkout()` (when `opts.treeish` is a string) calls `repository.checkout()` without any try/catch for `DirtyWorkTree` errors.

Closes #283516

## What is the new behavior?

The `treeish` early-return path now catches `DirtyWorkTree` errors and shows the same modal dialog as the QuickPick flow:

- **Stash & Checkout** — stashes changes, checks out, leaves stash
- **Migrate Changes** — stashes changes, checks out, pops stash
- **Force Checkout** — discards changes and checks out

All other errors are re-thrown unchanged.

## Additional context

The fix mirrors the existing error handling from lines ~2930-2977 (the QuickPick checkout flow) but calls `repository.checkout()` directly instead of `item.run()`, since the treeish string is already known.

Only `extensions/git/src/commands.ts` is changed. TypeScript compilation passes cleanly.