### PR TITLE
fix: resolve shared refs from commonPath in linked worktrees

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3332,7 +3332,19 @@ export class Repository {
 			const result = await fs.readFile(path.join(this.dotGit.path, ref), 'utf8');
 			return result.trim();
 		} catch (err) {
-			this.logger.warn(`[Git][revParse] Unable to read file: ${err.message}`);
+			// For linked worktrees, shared refs (refs/heads/*, refs/remotes/*,
+			// refs/tags/*) live in the common gitdir, not the worktree-specific
+			// gitdir. Try the common path before falling back to git rev-parse.
+			if (/ENOENT/.test(err.message) && this.dotGit.commonPath) {
+				try {
+					const result = await fs.readFile(path.join(this.dotGit.commonPath, ref), 'utf8');
+					return result.trim();
+				} catch (commonErr) {
+					this.logger.warn(`[Git][revParse] Unable to read file: ${commonErr.message}`);
+				}
+			} else {
+				this.logger.warn(`[Git][revParse] Unable to read file: ${err.message}`);
+			}
 		}
 
 		try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In linked worktrees, `revParse()` only reads ref files from the worktree-specific gitdir (`this.dotGit.path`). However, shared refs like `refs/heads/*`, `refs/remotes/*`, and `refs/tags/*` are stored in the common gitdir (`this.dotGit.commonPath`), not in the per-worktree gitdir.

This causes the fast-path file read to always fail with ENOENT for shared refs in linked worktrees, logging a warning and falling back to spawning `git rev-parse` via the CLI. While the fallback produces correct results, it is slower and generates unnecessary warning logs.

Closes #297786

## What is the new behavior?

When the initial file read from the worktree gitdir fails with ENOENT and `this.dotGit.commonPath` is available, `revParse()` now tries reading the ref from the common gitdir before falling back to the `git rev-parse` CLI.

This matches git's own ref resolution order:
1. Per-worktree refs (e.g., `HEAD`, `MERGE_HEAD`) from `$GIT_DIR`
2. Shared refs (e.g., `refs/heads/*`, `refs/remotes/*`) from `$GIT_COMMON_DIR`

For non-worktree repositories, `commonPath` is `undefined`, so behavior is unchanged.

## Additional context

This is consistent with how `commonPath` is already used elsewhere in the same file:
- `getWorktreesFS()` (line 3004): `this.dotGit.commonPath ?? this.dotGit.path`
- `getRemotesFS()` (line 3096): `this.dotGit.commonPath ?? this.dotGit.path`