### PR TITLE
fix: improve HTML sample snippet with lang attribute and modern defaults

### DIFF
--- a/extensions/html-language-features/client/src/htmlClient.ts
+++ b/extensions/html-language-features/client/src/htmlClient.ts
@@ -317,14 +317,13 @@ async function startClientWithParticipants(languageParticipants: LanguagePartici
 				const snippetProposal = new CompletionItem('HTML sample', CompletionItemKind.Snippet);
 				snippetProposal.range = range;
 				const content = ['<!DOCTYPE html>',
-					'<html>',
+					'<html lang="${1:en}">',
 					'<head>',
 					'\t<meta charset=\'utf-8\'>',
-					'\t<meta http-equiv=\'X-UA-Compatible\' content=\'IE=edge\'>',
-					'\t<title>${1:Page Title}</title>',
 					'\t<meta name=\'viewport\' content=\'width=device-width, initial-scale=1\'>',
-					'\t<link rel=\'stylesheet\' type=\'text/css\' media=\'screen\' href=\'${2:main.css}\'>',
-					'\t<script src=\'${3:main.js}\'></script>',
+					'\t<title>${2:Page Title}</title>',
+					'\t<link rel=\'stylesheet\' type=\'text/css\' media=\'screen\' href=\'${3:main.css}\'>',
+					'\t<script src=\'${4:main.js}\'></script>',
 					'</head>',
 					'<body>',
 					'\t$0',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / UX improvement

## What is the current behavior?

The `HTML sample` completion snippet has several issues:
1. Missing `lang` attribute on the `<html>` tag (accessibility and i18n concern)
2. Includes obsolete `<meta http-equiv='X-UA-Compatible' content='IE=edge'>` tag, which is only relevant for legacy IE browsers
3. Tab stops prompt for viewport values, which are universally standardized

Closes #272331

## What is the new behavior?

The updated snippet:
- Adds `lang` attribute with `${1:en}` tab stop to the `<html>` tag for accessibility
- Removes the obsolete `X-UA-Compatible` meta tag
- Places viewport meta before `<title>` (standard ordering)
- Tab stop flow: `lang` → `title` → `stylesheet href` → `script src` → `body content`

**Before:**
```html
<!DOCTYPE html>
<html>
<head>
    <meta charset='utf-8'>
    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
    <title>Page Title</title>
    <meta name='viewport' content='width=device-width, initial-scale=1'>
    <link rel='stylesheet' type='text/css' media='screen' href='main.css'>
    <script src='main.js'></script>
</head>
<body>
    
</body>
</html>
```

**After:**
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset='utf-8'>
    <meta name='viewport' content='width=device-width, initial-scale=1'>
    <title>Page Title</title>
    <link rel='stylesheet' type='text/css' media='screen' href='main.css'>
    <script src='main.js'></script>
</head>
<body>
    
</body>
</html>
```

## Additional context

- The `lang` attribute is recommended by WCAG accessibility guidelines and is included in modern HTML boilerplates
- The `X-UA-Compatible` meta tag was only needed for Internet Explorer and is no longer relevant
- Viewport meta is placed before `<title>` to follow the convention of meta declarations first
- The viewport values (`width=device-width, initial-scale=1`) are universally standard and don't need tab stops