### PR TITLE
fix: show warning when publishing a repository with no commits

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4350,6 +4350,11 @@ export class CommandCenter {
 		const branchName = repository.HEAD && repository.HEAD.name || '';
 		const remotes = repository.remotes;
 
+		if (!repository.HEAD?.commit) {
+			window.showWarningMessage(l10n.t('The repository has no commits yet. Please make an initial commit before publishing.'));
+			return;
+		}
+
 		if (remotes.length === 0) {
 			const publishers = this.model.getRemoteSourcePublishers();
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user initializes a new git repository, adds files (but makes no commits), and then tries to use "Git: Publish Branch", the operation fails with a cryptic error message: `Can't push refs to remote. Try running 'Pull' first to integrate your changes.`

This happens because git's branch reference doesn't actually exist until the first commit is created - `git push` fails since there's no ref to push.

Closes #246562

## What is the new behavior?

The publish command now detects when the repository has no commits (HEAD has no commit hash) and shows a clear, actionable warning message: **"The repository has no commits yet. Please make an initial commit before publishing."**

This helps users understand exactly what they need to do - make their first commit - instead of seeing a confusing git push error.

## Additional context

As noted by the maintainer in the issue, the branch reference in git does not exist until the first commit is created. Even though `git init` creates a default branch name, the ref is not materialized until a commit is made. This is standard git behavior, but the error message from VS Code was misleading.