### PR TITLE
fix: show helpful error message when pushing files exceeding size limit

### DIFF
--- a/extensions/git/src/api/git.constants.ts
+++ b/extensions/git/src/api/git.constants.ts
@@ -95,4 +95,5 @@ export const GitErrorCodes = Object.freeze({
 	WorktreeContainsChanges: 'WorktreeContainsChanges',
 	WorktreeAlreadyExists: 'WorktreeAlreadyExists',
 	WorktreeBranchAlreadyUsed: 'WorktreeBranchAlreadyUsed',
+	FileSizeLimitExceeded: 'FileSizeLimitExceeded',
 }) satisfies Record<keyof typeof git.GitErrorCodes, string>;

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -508,5 +508,6 @@ export const enum GitErrorCodes {
 	CherryPickConflict = 'CherryPickConflict',
 	WorktreeContainsChanges = 'WorktreeContainsChanges',
 	WorktreeAlreadyExists = 'WorktreeAlreadyExists',
-	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed'
+	WorktreeBranchAlreadyUsed = 'WorktreeBranchAlreadyUsed',
+	FileSizeLimitExceeded = 'FileSizeLimitExceeded'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -5593,6 +5593,9 @@ export class CommandCenter {
 					case GitErrorCodes.PushRejected:
 						message = l10n.t('Can\'t push refs to remote. Try running "Pull" first to integrate your changes.');
 						break;
+					case GitErrorCodes.FileSizeLimitExceeded:
+						message = l10n.t('Can\'t push refs to remote because a file exceeds the remote\'s file size limit. Consider using Git LFS to track large files.');
+						break;
 					case GitErrorCodes.ForcePushWithLeaseRejected:
 					case GitErrorCodes.ForcePushWithLeaseIfIncludesRejected:
 						message = l10n.t('Can\'t force push refs to remote. The tip of the remote-tracking branch has been updated since the last checkout. Try running "Pull" first to pull the latest changes from the remote branch first.');

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2531,7 +2531,9 @@ export class Repository {
 			await this.exec(args, { env: { 'GIT_HTTP_USER_AGENT': this.git.userAgent } });
 		} catch (err) {
 			if (/^error: failed to push some refs to\b/m.test(err.stderr || '')) {
-				if (forcePushMode === ForcePushMode.ForceWithLease && /! \[rejected\].*\(stale info\)/m.test(err.stderr || '')) {
+				if (/exceeds.*file size limit|large files detected|this exceeds/im.test(err.stderr || '')) {
+					err.gitErrorCode = GitErrorCodes.FileSizeLimitExceeded;
+				} else if (forcePushMode === ForcePushMode.ForceWithLease && /! \[rejected\].*\(stale info\)/m.test(err.stderr || '')) {
 					err.gitErrorCode = GitErrorCodes.ForcePushWithLeaseRejected;
 				} else if (forcePushMode === ForcePushMode.ForceWithLeaseIfIncludes && /! \[rejected\].*\(remote ref updated since checkout\)/m.test(err.stderr || '')) {
 					err.gitErrorCode = GitErrorCodes.ForcePushWithLeaseIfIncludesRejected;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / UX improvement

## What is the current behavior?

When pushing a file that exceeds the remote's file size limit (e.g., GitHub's 100MB limit), VS Code shows the generic error message: **"Can't push refs to remote. Try running 'Pull' first to integrate your changes."**

This message is misleading because the actual problem is a large file, not a missing pull. Users have to dig into the git output to find the real error.

Closes #226011

## What is the new behavior?

The push error handler now detects when the failure is caused by a file exceeding the remote's size limit (by matching patterns like "exceeds file size limit", "large files detected", or "this exceeds" in stderr) and shows a clear, actionable error message:

**"Can't push refs to remote because a file exceeds the remote's file size limit. Consider using Git LFS to track large files."**

## Changes

1. **`extensions/git/src/api/git.d.ts`** and **`extensions/git/src/api/git.constants.ts`**: Added new `FileSizeLimitExceeded` error code
2. **`extensions/git/src/git.ts`**: Added detection of large file errors in the push method's error handler, before the generic `PushRejected` fallback
3. **`extensions/git/src/commands.ts`**: Added user-friendly error message for the new error code

## Additional context

The regex pattern matches several common remote error formats:
- GitHub: `remote: error: File X is Y MB; this exceeds GitHub's file size limit of 100.00 MB`
- GitHub: `remote: error: GH001: Large files detected`
- GitLab and other remotes that use similar "exceeds" or "file size limit" wording