### PR TITLE
fix: show correct version info in TypeScript version picker

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -106,9 +106,9 @@ export class TypeScriptVersionManager extends Disposable {
 	}
 
 	private getBundledPickItem(): QuickPickItem {
-		const bundledVersion = this.versionProvider.defaultVersion;
+		const bundledVersion = this.versionProvider.bundledVersion;
 		return {
-			label: (!this.useWorkspaceTsdkSetting || !vscode.workspace.isTrusted
+			label: (this.currentVersion.eq(bundledVersion)
 				? '• '
 				: '') + vscode.l10n.t("Use VS Code's Version"),
 			description: bundledVersion.displayName,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `typescript.tsdk` is configured (either as a user/global setting or workspace setting), the "TypeScript: Select TypeScript Version..." command shows incorrect information for the "Use VS Code's Version" item:

1. The **version number** and **path** displayed for the bundled version item come from `defaultVersion`, which resolves to the user-configured global TypeScript SDK path instead of the actual VS Code bundled version
2. The **active indicator** (bullet) uses a heuristic based on `useWorkspaceTsdkSetting` state rather than actually comparing the current version to the bundled version

This causes the picker to show the workspace TypeScript path under "Use VS Code's Version", which is confusing.

Closes #263226

## What is the new behavior?

- The "Use VS Code's Version" item now always shows the actual bundled TypeScript version info by using `bundledVersion` instead of `defaultVersion`
- The active indicator now correctly compares `currentVersion` against the bundled version using `.eq()`, consistent with how the workspace version item already works

## Additional context

The fix is a two-line change in `getBundledPickItem()`:
1. `this.versionProvider.defaultVersion` -> `this.versionProvider.bundledVersion` — ensures the displayed version/path is always the actual bundled TS
2. `!this.useWorkspaceTsdkSetting || !vscode.workspace.isTrusted` -> `this.currentVersion.eq(bundledVersion)` — matches the pattern already used by `getLocalPickItems()` for accurate active state indication