### PR TITLE
fix: only remove innermost manual folding range at cursor position

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -1206,7 +1206,25 @@ class RemoveFoldRangeFromSelectionAction extends FoldingAction<void> {
 			const ranges: ILineRange[] = [];
 			for (const selection of selections) {
 				const { startLineNumber, endLineNumber } = selection;
-				ranges.push(endLineNumber >= startLineNumber ? { startLineNumber, endLineNumber } : { endLineNumber, startLineNumber });
+				if (selection.isEmpty()) {
+					// For empty selections (cursor only), find the innermost manual
+					// folding range containing the cursor line instead of removing all
+					// intersecting manual ranges
+					const regions = foldingModel.regions;
+					let index = regions.findRange(startLineNumber);
+					while (index !== -1) {
+						if (regions.getSource(index) !== FoldSource.provider) {
+							ranges.push({
+								startLineNumber: regions.getStartLineNumber(index),
+								endLineNumber: regions.getEndLineNumber(index)
+							});
+							break;
+						}
+						index = regions.getParentIndex(index);
+					}
+				} else {
+					ranges.push(endLineNumber >= startLineNumber ? { startLineNumber, endLineNumber } : { endLineNumber, startLineNumber });
+				}
 			}
 			foldingModel.removeManualRanges(ranges);
 			foldingController.triggerFoldingModelChanged();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Enhancement

## What is the current behavior?

When the cursor is inside nested manual folding ranges and `editor.removeManualFoldingRanges` is executed, **all** manual folding ranges that intersect with the cursor line are removed. This makes it impossible to precisely remove just one specific manual range in a nested hierarchy — the user loses all containing manual ranges at once.

Closes #212599

## What is the new behavior?

When executing `editor.removeManualFoldingRanges` with an empty selection (cursor only), only the **innermost** manual folding range containing the cursor is removed. Outer manual folding ranges are preserved.

For non-empty selections, the existing behavior of removing all manual ranges intersecting the selection is preserved.

## Additional context

The implementation walks up the folding region tree from the innermost range found by `findRange()`, looking for the first region whose source is not `FoldSource.provider` (i.e., a manual/user-defined range). Only that specific range is targeted for removal. This matches the user expectation described in the issue: when the cursor is inside nested manual folds, running the command should peel off one layer at a time from the inside out.