### PR TITLE
fix: show correct version info in TypeScript version picker

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -106,9 +106,9 @@ export class TypeScriptVersionManager extends Disposable {
 	}
 
 	private getBundledPickItem(): QuickPickItem {
-		const bundledVersion = this.versionProvider.defaultVersion;
+		const bundledVersion = this.versionProvider.bundledVersion;
 		return {
-			label: (!this.useWorkspaceTsdkSetting || !vscode.workspace.isTrusted
+			label: (this.currentVersion.eq(bundledVersion)
 				? '• '
 				: '') + vscode.l10n.t("Use VS Code's Version"),
 			description: bundledVersion.displayName,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user has \`typescript.tsdk\` set (e.g., to \`node_modules/typescript/lib\`), the "TypeScript: Select TypeScript Version..." quick pick shows incorrect information for the "Use VS Code's Version" option:

1. **Wrong version/path**: It uses \`versionProvider.defaultVersion\` which may return a global tsdk version rather than the actual bundled VS Code TypeScript, causing the description and detail to show the workspace version's info instead.
2. **Wrong active indicator**: The bullet indicator (\`•\`) uses \`!useWorkspaceTsdkSetting || !workspace.isTrusted\` to determine if the bundled version is active, which doesn't correctly handle all states (e.g., when the workspace tsdk is configured but the user is actually using the bundled version).

Closes #263226

## What is the new behavior?

1. The bundled pick item now uses \`versionProvider.bundledVersion\` which always returns the actual VS Code bundled TypeScript version, regardless of tsdk settings.
2. The active indicator now directly compares \`this.currentVersion.eq(bundledVersion)\` to determine if the bundled version is the one currently in use, which is accurate in all cases.

## Additional context

Two-line change in \`extensions/typescript-language-features/src/tsServer/versionManager.ts\`:
- \`versionProvider.defaultVersion\` → \`versionProvider.bundledVersion\`
- \`!this.useWorkspaceTsdkSetting || !vscode.workspace.isTrusted\` → \`this.currentVersion.eq(bundledVersion)\`

This matches the pattern already used in \`getLocalPickItems()\` (line 126) where the bullet indicator correctly uses \`this.currentVersion.eq(version)\`.