### PR TITLE
Update @vscode/codicons version to 0.0.46-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@microsoft/1ds-post-js": "^3.2.13",
         "@parcel/watcher": "^2.5.6",
         "@types/semver": "^7.5.8",
-        "@vscode/codicons": "^0.0.46-0",
+        "@vscode/codicons": "^0.0.46-1",
         "@vscode/deviceid": "^0.1.1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/native-watchdog": "^1.4.6",
@@ -4202,9 +4202,9 @@
       ]
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-0",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-0.tgz",
-      "integrity": "sha512-6/ddrtzpxvUK4JSVHI0SCNXw1tI4S7KnIb28X+HWexJIv9oNQK6Mhe2qydnoGlCYt+RzqaQ0pjRS8U3smE9rrA==",
+      "version": "0.0.46-1",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-1.tgz",
+      "integrity": "sha512-BMOj3V0zXCGsBHQN18NyorO4wk+qdpmS4MLSyqZEDsixgKODA5570RspntWtIZOhmEkcOwlrTRtuZu+yiukBQQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/component-explorer": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@microsoft/1ds-post-js": "^3.2.13",
     "@parcel/watcher": "^2.5.6",
     "@types/semver": "^7.5.8",
-    "@vscode/codicons": "^0.0.46-0",
+    "@vscode/codicons": "^0.0.46-1",
     "@vscode/deviceid": "^0.1.1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/native-watchdog": "^1.4.6",

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microsoft/1ds-core-js": "^3.2.13",
         "@microsoft/1ds-post-js": "^3.2.13",
-        "@vscode/codicons": "^0.0.46-0",
+        "@vscode/codicons": "^0.0.46-1",
         "@vscode/iconv-lite-umd": "0.7.1",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.23",
@@ -73,9 +73,9 @@
       "integrity": "sha512-n1VPsljTSkthsAFYdiWfC+DKzK2WwcRp83Y1YAqdX552BstvsDjft9YXppjUzp11BPsapDoO1LDgrDB0XVsfNQ=="
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.46-0",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-0.tgz",
-      "integrity": "sha512-6/ddrtzpxvUK4JSVHI0SCNXw1tI4S7KnIb28X+HWexJIv9oNQK6Mhe2qydnoGlCYt+RzqaQ0pjRS8U3smE9rrA==",
+      "version": "0.0.46-1",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.46-1.tgz",
+      "integrity": "sha512-BMOj3V0zXCGsBHQN18NyorO4wk+qdpmS4MLSyqZEDsixgKODA5570RspntWtIZOhmEkcOwlrTRtuZu+yiukBQQ==",
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/iconv-lite-umd": {

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",
-    "@vscode/codicons": "^0.0.46-0",
+    "@vscode/codicons": "^0.0.46-1",
     "@vscode/iconv-lite-umd": "0.7.1",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.23",


### PR DESCRIPTION
Upgrade the @vscode/codicons package to version 0.0.46-1 in package.json and package-lock.json to ensure compatibility and access to the latest features and fixes. No issues are associated with this update.

