### PR TITLE
fix: break feedback loop in chat agent/skill/instruction push to extension host

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -105,6 +105,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	private readonly _pendingProgress = new Map<string, { progress: (parts: IChatProgress[]) => void; chatSession: IChatModel | undefined }>();
 	private readonly _proxy: ExtHostChatAgentsShape2;
 
+	/** Last-pushed URI sets, used to suppress no-op pushes that would cause a feedback loop. */
+	private _lastPushedAgentUris: string | undefined;
+	private _lastPushedInstructionUris: string | undefined;
+	private _lastPushedSkillUris: string | undefined;
+
 	private readonly _activeTasks = new Map<string, IChatTask>();
 
 	private readonly _unresolvedAnchors = new Map</* requestId */string, Map</* id */ string, IChatContentInlineReference>>();
@@ -184,6 +189,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		try {
 			const customAgents = await this._promptsService.getCustomAgents(CancellationToken.None);
 			const dtos: ICustomAgentDto[] = customAgents.map(agent => ({ uri: agent.uri }));
+			const key = dtos.map(d => d.uri.toString()).sort().join('\n');
+			if (key === this._lastPushedAgentUris) {
+				return;
+			}
+			this._lastPushedAgentUris = key;
 			this._proxy.$acceptCustomAgents(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push custom agents to extension host', error);
@@ -194,6 +204,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		try {
 			const instructions = await this._promptsService.getInstructionFiles(CancellationToken.None);
 			const dtos: IInstructionDto[] = instructions.map(instruction => ({ uri: instruction.uri }));
+			const key = dtos.map(d => d.uri.toString()).sort().join('\n');
+			if (key === this._lastPushedInstructionUris) {
+				return;
+			}
+			this._lastPushedInstructionUris = key;
 			this._proxy.$acceptInstructions(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push instructions to extension host', error);
@@ -204,6 +219,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		try {
 			const skills = await this._promptsService.findAgentSkills(CancellationToken.None) ?? [];
 			const dtos: ISkillDto[] = skills.map(skill => ({ uri: skill.uri }));
+			const key = dtos.map(d => d.uri.toString()).sort().join('\n');
+			if (key === this._lastPushedSkillUris) {
+				return;
+			}
+			this._lastPushedSkillUris = key;
 			this._proxy.$acceptSkills(dtos);
 		} catch (error) {
 			this._logService.error('[chat] Failed to push skills to extension host', error);

--- a/src/vs/workbench/api/test/browser/mainThreadChatAgents2.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadChatAgents2.test.ts
@@ -1,0 +1,208 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../platform/log/common/log.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
+import { IChatService } from '../../../contrib/chat/common/chatService/chatService.js';
+import { IChatSessionsService } from '../../../contrib/chat/common/chatSessionsService.js';
+import { IChatWidgetService } from '../../../contrib/chat/browser/chat.js';
+import { IChatAgentService } from '../../../contrib/chat/common/participants/chatAgents.js';
+import { IPromptsService } from '../../../contrib/chat/common/promptSyntax/service/promptsService.js';
+import { ILanguageModelToolsService } from '../../../contrib/chat/common/tools/languageModelToolsService.js';
+import { mock, TestExtensionService } from '../../../test/common/workbenchTestServices.js';
+import { MainThreadChatAgents2 } from '../../browser/mainThreadChatAgents2.js';
+import { ExtHostChatAgentsShape2 } from '../../common/extHost.protocol.js';
+import { AnyCallRPCProtocol } from '../common/testRPCProtocol.js';
+
+suite('MainThreadChatAgents2', function () {
+
+	let disposables: DisposableStore;
+	let onDidChangeCustomAgents: Emitter<void>;
+	let onDidChangeInstructions: Emitter<void>;
+	let onDidChangeSkills: Emitter<void>;
+	let customAgents: { uri: URI }[];
+	let instructionFiles: { uri: URI }[];
+	let agentSkills: { uri: URI }[];
+	let acceptCustomAgentsStub: sinon.SinonStub;
+	let acceptInstructionsStub: sinon.SinonStub;
+	let acceptSkillsStub: sinon.SinonStub;
+
+	setup(function () {
+		disposables = new DisposableStore();
+
+		onDidChangeCustomAgents = disposables.add(new Emitter<void>());
+		onDidChangeInstructions = disposables.add(new Emitter<void>());
+		onDidChangeSkills = disposables.add(new Emitter<void>());
+
+		customAgents = [];
+		instructionFiles = [];
+		agentSkills = [];
+
+		acceptCustomAgentsStub = sinon.stub();
+		acceptInstructionsStub = sinon.stub();
+		acceptSkillsStub = sinon.stub();
+	});
+
+	teardown(function () {
+		disposables.dispose();
+		sinon.restore();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createMainThread(): MainThreadChatAgents2 {
+		const rpc = AnyCallRPCProtocol<ExtHostChatAgentsShape2>({
+			$acceptCustomAgents: acceptCustomAgentsStub,
+			$acceptInstructions: acceptInstructionsStub,
+			$acceptSkills: acceptSkillsStub,
+		} as Partial<ExtHostChatAgentsShape2> as ExtHostChatAgentsShape2);
+
+		const promptsService = new class extends mock<IPromptsService>() {
+			override onDidChangeCustomAgents = onDidChangeCustomAgents.event;
+			override onDidChangeInstructions = onDidChangeInstructions.event;
+			override onDidChangeSkills = onDidChangeSkills.event;
+			override async getCustomAgents() { return customAgents as never; }
+			override async getInstructionFiles() { return instructionFiles as never; }
+			override async findAgentSkills() { return agentSkills as never; }
+		};
+
+		const chatService = new class extends mock<IChatService>() {
+			override onDidDisposeSession = Event.None;
+			override onDidPerformUserAction = Event.None;
+			override onDidReceiveQuestionCarouselAnswer = Event.None;
+		};
+
+		const chatWidgetService = new class extends mock<IChatWidgetService>() {
+			override onDidChangeFocusedSession = Event.None;
+			override lastFocusedWidget = undefined;
+		};
+
+		return disposables.add(new MainThreadChatAgents2(
+			rpc,
+			new class extends mock<IChatAgentService>() { },
+			new class extends mock<IChatSessionsService>() { },
+			chatService,
+			new class extends mock<ILanguageFeaturesService>() { },
+			chatWidgetService,
+			new class extends mock<IInstantiationService>() { },
+			new NullLogService(),
+			new TestExtensionService(),
+			new class extends mock<IUriIdentityService>() { },
+			promptsService,
+			new class extends mock<ILanguageModelToolsService>() { },
+		));
+	}
+
+	test('initial push sends agents to extension host', async function () {
+		customAgents = [
+			{ uri: URI.parse('file:///agents/agent1.md') },
+			{ uri: URI.parse('file:///agents/agent2.md') },
+		];
+
+		createMainThread();
+
+		// Wait for async initial push
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+	});
+
+	test('suppresses duplicate push when URIs have not changed', async function () {
+		customAgents = [
+			{ uri: URI.parse('file:///agents/agent1.md') },
+		];
+
+		createMainThread();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+
+		// Fire change event with same data
+		onDidChangeCustomAgents.fire();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Should NOT have pushed again
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+	});
+
+	test('pushes again when agent URIs change', async function () {
+		customAgents = [
+			{ uri: URI.parse('file:///agents/agent1.md') },
+		];
+
+		createMainThread();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+
+		// Change the agents
+		customAgents = [
+			{ uri: URI.parse('file:///agents/agent1.md') },
+			{ uri: URI.parse('file:///agents/agent2.md') },
+		];
+		onDidChangeCustomAgents.fire();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 2);
+	});
+
+	test('suppresses duplicate instruction push', async function () {
+		instructionFiles = [
+			{ uri: URI.parse('file:///instructions/copilot.md') },
+		];
+
+		createMainThread();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(acceptInstructionsStub.callCount, 1);
+
+		onDidChangeInstructions.fire();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(acceptInstructionsStub.callCount, 1);
+	});
+
+	test('suppresses duplicate skill push', async function () {
+		agentSkills = [
+			{ uri: URI.parse('file:///skills/search.md') },
+		];
+
+		createMainThread();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(acceptSkillsStub.callCount, 1);
+
+		onDidChangeSkills.fire();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(acceptSkillsStub.callCount, 1);
+	});
+
+	test('dedup is order-independent', async function () {
+		customAgents = [
+			{ uri: URI.parse('file:///agents/b.md') },
+			{ uri: URI.parse('file:///agents/a.md') },
+		];
+
+		createMainThread();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+
+		// Same URIs but in different order
+		customAgents = [
+			{ uri: URI.parse('file:///agents/a.md') },
+			{ uri: URI.parse('file:///agents/b.md') },
+		];
+		onDidChangeCustomAgents.fire();
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		// Should NOT push again — sorted keys match
+		assert.strictEqual(acceptCustomAgentsStub.callCount, 1);
+	});
+});


### PR DESCRIPTION
## Fix: Break feedback loop in chat agent/skill/instruction push to extension host

Fixes https://github.com/microsoft/vscode/issues/304857

### Problem

When multiple extensions register many `.chatAgent.md` and `.chatSkill.md` prompt files (e.g. 49+ agents and 17+ skills), an infinite feedback loop forms between `MainThreadChatAgents2` and the extension host:

1. `PromptsService` fires `onDidChangeCustomAgents`
2. `MainThreadChatAgents2._pushCustomAgents()` pushes agent DTOs to extension host
3. Extension receives, re-parses all files, fires provider's `onDidChangeCustomAgents`
4. Extension host forwards back via `$onDidChangePromptFiles(handle)`
5. `PromptsService` invalidates its cache and fires `onDidChangeCustomAgents` again
6. **GOTO 1** — infinite loop causing sustained CPU usage

### Fix

Add URI-set deduplication to `_pushCustomAgents()`, `_pushInstructions()`, and `_pushSkills()`. Before pushing to the extension host, each method computes a sorted string key from the current URIs and compares it to the last-pushed key. If unchanged, the push is suppressed.

This is a minimal, targeted fix — the loop terminates after at most 2 iterations (initial push + one bounce-back that matches).

### Changes

- **`src/vs/workbench/api/browser/mainThreadChatAgents2.ts`** (20 lines added):
  - Three new fields: `_lastPushedAgentUris`, `_lastPushedInstructionUris`, `_lastPushedSkillUris`
  - Dedup guard in each of the three push methods

- **`src/vs/workbench/api/test/browser/mainThreadChatAgents2.test.ts`** (new, 208 lines):
  - 6 unit tests covering: initial push, duplicate suppression, push on change, instruction dedup, skill dedup, order-independent dedup

### Testing

- All existing tests pass (68 chat unit tests + 144 test suite)
- New unit tests all pass (7/7 including framework check)
- Manually verified with two extensions contributing 49 agents + 17 skills: CPU returns to idle after window reload
- Verified clean baseline (without fix) reproduces the sustained high CPU
