### PR TITLE
chat: show repository badge for pinned sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -319,9 +319,13 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 		// When grouped by repository, hide the badge only if the name it shows
 		// matches the section header (i.e. the repository name for this session).
 		// Badges with a different name (e.g. worktree name) are still shown.
-		// Archived sessions always keep their badge since they are grouped under
-		// the "Archived" section, not a repository section.
-		if (this.options.isGroupedByRepository?.() && !session.element.isArchived()) {
+		// Pinned and archived sessions always keep their badge since they are
+		// grouped under their own section, not a repository section.
+		if (
+			this.options.isGroupedByRepository?.() &&
+			!session.element.isArchived() &&
+			!session.element.isPinned()
+		) {
 			const raw = typeof badge === 'string' ? badge : badge.value;
 			const match = raw.match(/^\$\((?:repo|folder|worktree)\)\s*(.+)/);
 			if (match) {


### PR DESCRIPTION
## Summary

When agent sessions are grouped by repository/project, pinned sessions appear under the separate **Pinned** section rather than under their repository header. Because of that, hiding a badge that matches the repository name removes the only visible repository context for those sessions.

This change keeps the repository badge visible for pinned sessions in repository grouping, matching the existing archived-session behavior.

## What changed

- updated the badge-hiding logic in `agentSessionsViewer.ts`
- continue hiding repository badges for regular repository-grouped sessions when the badge matches the section header
- preserve the badge for pinned sessions, because they are rendered in the **Pinned** section instead of a repository section
- keep archived-session behavior unchanged

## Why

Pinned and archived sessions are both extracted out of repository groups into their own sections. For those sections, the repository header is no longer visible, so the badge needs to remain visible to show which repository the session belongs to.

## Validation

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts`
- reviewed the branch diff and verified the change is limited to the session badge visibility logic