### PR TITLE
sessions: refine project grouping in agent sessions view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -450,6 +450,16 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			return true;
 		}
 
+		// Show repository name for pinned sessions when grouped by repository,
+		// since they are not placed under a repository section header.
+		if (session.element.isPinned() && this.options.isGroupedByRepository?.()) {
+			const repoName = getRepositoryName(session.element);
+			if (repoName) {
+				template.description.textContent = repoName;
+				return true;
+			}
+		}
+
 		template.description.textContent = '';
 		return false;
 	}
@@ -1171,13 +1181,9 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 
 		const result: AgentSessionListItem[] = [];
 
-		if (pinnedSessions.length > 0) {
-			result.push({
-				section: AgentSessionSection.Pinned,
-				label: AgentSessionSectionLabels[AgentSessionSection.Pinned],
-				sessions: pinnedSessions,
-			});
-		}
+		// Pinned sessions are added directly (no section header) so they
+		// appear at the top without a "PINNED" group label.
+		result.push(...pinnedSessions);
 
 		const sortedRepoGroups = [...repoMap.values()].sort((a, b) =>
 			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -49,6 +49,7 @@ import { Button } from '../../../../../base/browser/ui/button/button.js';
 import { defaultButtonStyles } from '../../../../../platform/theme/browser/defaultStyles.js';
 import { AgentSessionApprovalModel } from './agentSessionApprovalModel.js';
 import { BugIndicatingError } from '../../../../../base/common/errors.js';
+import { compareIgnoreCase } from '../../../../../base/common/strings.js';
 
 export type AgentSessionListItem = IAgentSession | IAgentSessionSection | IAgentSessionShowMore | IAgentSessionShowLess;
 
@@ -1181,9 +1182,7 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 		// appear at the top without a "PINNED" group label.
 		result.push(...pinnedSessions);
 
-		const sortedRepoGroups = [...repoMap.values()].sort((a, b) =>
-			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-		);
+		const sortedRepoGroups = [...repoMap.values()].sort((a, b) => compareIgnoreCase(a.label, b.label));
 
 		for (const { label, sessions } of sortedRepoGroups) {
 			result.push({

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -450,16 +450,6 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 			return true;
 		}
 
-		// Show repository name for pinned sessions when grouped by repository,
-		// since they are not placed under a repository section header.
-		if (session.element.isPinned() && this.options.isGroupedByRepository?.()) {
-			const repoName = getRepositoryName(session.element);
-			if (repoName) {
-				template.description.textContent = repoName;
-				return true;
-			}
-		}
-
 		template.description.textContent = '';
 		return false;
 	}
@@ -475,7 +465,13 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 
 	private renderStatus(session: ITreeNode<IAgentSession, FuzzyScore>, template: IAgentSessionItemTemplate): boolean {
 
-		const getTimeLabel = (session: IAgentSession) => {
+		// Show repository name for pinned sessions when grouped by repository,
+		// since they are not placed under a repository section header.
+		const repoPrefix = (session.element.isPinned() && this.options.isGroupedByRepository?.())
+			? getRepositoryName(session.element)
+			: undefined;
+
+		const getStatusText = (session: IAgentSession) => {
 			let timeLabel: string | undefined;
 			if (session.status === AgentSessionStatus.InProgress && session.timing.lastRequestStarted) {
 				timeLabel = this.toDuration(session.timing.lastRequestStarted, Date.now(), false, false);
@@ -493,13 +489,13 @@ export class AgentSessionRenderer extends Disposable implements ICompressibleTre
 				}
 			}
 
-			return timeLabel;
+			return repoPrefix ? `${repoPrefix} \u00B7 ${timeLabel}` : timeLabel;
 		};
 
 		// Time label
-		template.statusTime.textContent = getTimeLabel(session.element);
+		template.statusTime.textContent = getStatusText(session.element);
 		const timer = template.elementDisposable.add(new IntervalTimer());
-		timer.cancelAndSet(() => template.statusTime.textContent = getTimeLabel(session.element), session.element.status === AgentSessionStatus.InProgress ? 1000 /* every second */ : 60 * 1000 /* every minute */);
+		timer.cancelAndSet(() => template.statusTime.textContent = getStatusText(session.element), session.element.status === AgentSessionStatus.InProgress ? 1000 /* every second */ : 60 * 1000 /* every minute */);
 
 		return true;
 	}

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts
@@ -1179,7 +1179,11 @@ export class AgentSessionsDataSource extends Disposable implements IAsyncDataSou
 			});
 		}
 
-		for (const [, { label, sessions }] of repoMap) {
+		const sortedRepoGroups = [...repoMap.values()].sort((a, b) =>
+			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+		);
+
+		for (const { label, sessions } of sortedRepoGroups) {
 			result.push({
 				section: AgentSessionSection.Repository,
 				label,

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsDataSource.test.ts
@@ -7,7 +7,7 @@ import assert from 'assert';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { AgentSessionsDataSource, AgentSessionListItem, IAgentSessionsFilter, sessionDateFromNow, getRepositoryName, AgentSessionsSorter, groupAgentSessionsByDate } from '../../../browser/agentSessions/agentSessionsViewer.js';
-import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
+import { AgentSessionSection, IAgentSession, IAgentSessionSection, IAgentSessionsModel, isAgentSession, isAgentSessionSection, isAgentSessionShowLess, isAgentSessionShowMore } from '../../../browser/agentSessions/agentSessionsModel.js';
 import { ChatSessionStatus } from '../../../common/chatSessionsService.js';
 import { ITreeSorter } from '../../../../../../base/browser/ui/tree/tree.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
@@ -982,6 +982,33 @@ suite('AgentSessionsDataSource', () => {
 
 			// Archived must come after Other
 			assert.ok(archivedIndex > otherIndex, 'Archived section should come after Other');
+		});
+
+		test('pinned sessions are top-level items before alphabetized repository sections', () => {
+			const now = Date.now();
+			const pinnedSession = createMockSession({ id: 'pinned', isPinned: true, startTime: now + 10, metadata: { repositoryPath: '/path/zebra' } });
+			const sessions = [
+				createMockSession({ id: 'other', startTime: now + 9 }),
+				createMockSession({ id: 'zebra', startTime: now + 8, metadata: { repositoryPath: '/path/zebra' } }),
+				createMockSession({ id: 'alpha', startTime: now + 7, metadata: { repositoryPath: '/path/Alpha' } }),
+				createMockSession({ id: 'archived', isArchived: true, startTime: now + 6, metadata: { repositoryPath: '/path/middle' } }),
+				pinnedSession,
+			];
+
+			const filter = createMockFilter({ groupBy: AgentSessionsGrouping.Repository });
+			const dataSource = disposables.add(new AgentSessionsDataSource(filter, createMockSorter()));
+			const result = Array.from(dataSource.getChildren(createMockModel(sessions)));
+
+			assert.ok(isAgentSession(result[0]), 'first item should be the pinned session');
+			assert.strictEqual(result[0].resource.toString(), pinnedSession.resource.toString());
+
+			const sections = result.filter((item): item is IAgentSessionSection => isAgentSessionSection(item));
+			assert.deepStrictEqual(sections.map(section => ({ label: section.label, section: section.section, count: section.sessions.length })), [
+				{ label: 'Alpha', section: AgentSessionSection.Repository, count: 1 },
+				{ label: 'zebra', section: AgentSessionSection.Repository, count: 1 },
+				{ label: 'Other', section: AgentSessionSection.Repository, count: 1 },
+				{ label: 'Archived', section: AgentSessionSection.Archived, count: 1 },
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

This updates the dedicated agent sessions window behavior when sessions are grouped by project.

- sort project groups alphabetically instead of letting the created/updated sort mode drive group order
- keep pinned sessions at the top without rendering a separate `Pinned` section header
- include the repository name inline for pinned sessions so they still show project context before the timestamp
- keep the created/updated sort mode scoped to ordering sessions within each project group
- continue to keep `Other` above `Archived`, with archived sessions always last

## Why

When grouping by project, the created/updated setting should only affect session ordering inside each group. Project group names should stay stable and alphabetical, and pinned sessions should stay prominent without losing project context.

## Validation

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer.ts`