### PR TITLE
fix: use conic-gradient for image preview transparency checkerboard

### DIFF
--- a/extensions/media-preview/media/imagePreview.css
+++ b/extensions/media-preview/media/imagePreview.css
@@ -33,21 +33,16 @@ body img {
 
 .container.image img {
 	padding: 0;
-	background-position: 0 0, 8px 8px;
 	background-size: 16px 16px;
 	border: 1px solid var(--vscode-imagePreview-border);
 }
 
 .container.image img {
-	background-image:
-		linear-gradient(45deg, rgb(230, 230, 230) 25%, transparent 25%, transparent 75%, rgb(230, 230, 230) 75%, rgb(230, 230, 230)),
-		linear-gradient(45deg, rgb(230, 230, 230) 25%, transparent 25%, transparent 75%, rgb(230, 230, 230) 75%, rgb(230, 230, 230));
+	background-image: conic-gradient(rgb(230, 230, 230) 25%, transparent 25% 50%, rgb(230, 230, 230) 50% 75%, transparent 75%);
 }
 
 .vscode-dark.container.image img {
-	background-image:
-		linear-gradient(45deg, rgb(20, 20, 20) 25%, transparent 25%, transparent 75%, rgb(20, 20, 20) 75%, rgb(20, 20, 20)),
-		linear-gradient(45deg, rgb(20, 20, 20) 25%, transparent 25%, transparent 75%, rgb(20, 20, 20) 75%, rgb(20, 20, 20));
+	background-image: conic-gradient(rgb(20, 20, 20) 25%, transparent 25% 50%, rgb(20, 20, 20) 50% 75%, transparent 75%);
 }
 
 .container img.pixelated {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The transparency checkerboard pattern in the image preview shows triangular artifacts at certain zoom levels. This happens because the pattern uses two overlapping `linear-gradient(45deg, ...)` backgrounds with offset positions, and subpixel rendering at non-integer zoom factors causes the diagonal gradient edges to misalign, creating visible triangles instead of clean squares.

Closes #229565

## What is the new behavior?

Replaced the two `linear-gradient(45deg, ...)` backgrounds with a single `conic-gradient(...)` per theme. The conic gradient creates a clean four-square checkerboard tile using 90-degree segments (25% each), which eliminates diagonal edges entirely. This renders correctly at all zoom levels without subpixel artifacts.

The `background-position` offset is also removed since a single conic-gradient tile already produces the full checkerboard pattern without needing two overlapping layers.

## Additional context

The `conic-gradient` approach is the standard modern CSS technique for checkerboard patterns. It is supported in all Chromium-based browsers (which VS Code uses via Electron).

**Before (at certain zoom levels):**
Triangular artifacts visible at tile boundaries

**After:**
Clean square checkerboard at all zoom levels