### PR TITLE
fix: improve Kimbie Dark diff editor colors for keyword visibility

### DIFF
--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -51,7 +51,11 @@
 		"inputValidation.errorBackground": "#5f0d0d",
 		"inputValidation.errorBorder": "#9d2f23",
 		"badge.background": "#7f5d38",
-		"progressBar.background": "#7f5d38"
+		"progressBar.background": "#7f5d38",
+		"diffEditor.insertedTextBackground": "#889b4a30",
+		"diffEditor.removedTextBackground": "#dc395830",
+		"diffEditor.insertedLineBackground": "#889b4a20",
+		"diffEditor.removedLineBackground": "#dc395820"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When using the Kimbie Dark theme, brown/mauve keyword text (`#98676a`) becomes nearly invisible against the default green diff editor background in the diff view. The default `diffEditor.insertedTextBackground` (`#9ccc2c33`) and `diffEditor.insertedLineBackground` (`rgba(155, 185, 85, 0.2)`) create a green tint that clashes with the warm Kimbie palette, making keywords like `try`, `catch`, `if`, etc. very hard to read on inserted lines.

Closes #282526

## What is the new behavior?
Adds explicit diff editor color customizations to the Kimbie Dark theme using the theme's own palette colors:
- `diffEditor.insertedTextBackground`: `#889b4a30` (theme's green string color with low alpha)
- `diffEditor.removedTextBackground`: `#dc395830` (theme's red variable color with low alpha)
- `diffEditor.insertedLineBackground`: `#889b4a20` (even more subtle for full-line highlights)
- `diffEditor.removedLineBackground`: `#dc395820` (matching subtle red for removed lines)

These colors maintain the warm Kimbie aesthetic while ensuring all token colors remain readable in the diff editor.

## Additional context
The fix uses colors already present in the Kimbie Dark palette (`#889b4a` for strings/green, `#dc3958` for variables/red) to keep the diff highlighting visually consistent with the rest of the theme.