### PR TITLE
fix: increase hover widget background contrast in 2026 Dark theme

### DIFF
--- a/extensions/theme-defaults/themes/2026-dark.json
+++ b/extensions/theme-defaults/themes/2026-dark.json
@@ -137,7 +137,7 @@
 		"editorSuggestWidget.foreground": "#bfbfbf",
 		"editorSuggestWidget.highlightForeground": "#bfbfbf",
 		"editorSuggestWidget.selectedBackground": "#3994BC26",
-		"editorHoverWidget.background": "#202122",
+		"editorHoverWidget.background": "#2A2B2C",
 		"editorHoverWidget.border": "#2A2B2CFF",
 		"widget.border": "#2A2B2CFF",
 		"peekView.border": "#2A2B2CFF",


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
In the 2026 Dark experimental theme, the `editorHoverWidget.background` is set to `#202122`, which is too close to the editor background (`#121314`). This makes the hover widget content difficult to read as it visually blends into the underlying code.

Closes #297791

## What is the new behavior?
Increases `editorHoverWidget.background` from `#202122` to `#2A2B2C`, which matches the existing `editorWidget.background` value used by the suggest widget and other editor widgets in this theme. This provides better visual separation between the hover widget and the editor content while maintaining consistency with other widget backgrounds in the theme.

## Additional context
The value `#2A2B2C` is already used as the border color (`editorHoverWidget.border: #2A2B2CFF`) and as the general `editorWidget.background` in this theme, making the hover widget visually consistent with other overlay widgets.