### PR TITLE
fix: change git.detectWorktrees default to false

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3694,7 +3694,7 @@
         "git.detectWorktrees": {
           "type": "boolean",
           "scope": "resource",
-          "default": true,
+          "default": false,
           "description": "%config.detectWorktrees%"
         },
         "git.detectWorktreesLimit": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (configuration default change)

## What is the current behavior?

The `git.detectWorktrees` setting defaults to `true`, which causes an unhelpful notification message ("the repository ___ has ___ worktrees which won't be opened automatically") for users who have repositories with multiple worktrees. This clutters the UI and confuses users who did not ask to open those worktrees.

Closes #278774

## What is the new behavior?

The `git.detectWorktrees` setting now defaults to `false`, providing a cleaner experience out of the box. Users who want automatic worktree detection can still opt-in by setting `git.detectWorktrees` to `true` in their settings.

## Additional context

The issue reporter and multiple commenters confirmed that the default-on behavior is surprising and unhelpful — the notification message appears unsolicited and clutters the Source Control UI. Changing the default to `false` aligns with the principle that features which generate notifications should be opt-in rather than opt-out.