### PR TITLE
fix: select full folded range when clicking line number in gutter

### DIFF
--- a/src/vs/editor/common/cursor/cursorMoveCommands.ts
+++ b/src/vs/editor/common/cursor/cursorMoveCommands.ts
@@ -188,6 +188,17 @@ export class CursorMoveCommands {
 
 			let selectToLineNumber = position.lineNumber + 1;
 			let selectToColumn = 1;
+
+			// If the clicked line has a folded region immediately after it,
+			// extend the selection to cover the entire folded range
+			const hiddenAreas = viewModel.getHiddenAreas();
+			for (const hiddenArea of hiddenAreas) {
+				if (hiddenArea.startLineNumber === position.lineNumber + 1) {
+					selectToLineNumber = hiddenArea.endLineNumber + 1;
+					break;
+				}
+			}
+
 			if (selectToLineNumber > lineCount) {
 				selectToLineNumber = lineCount;
 				selectToColumn = viewModel.model.getLineMaxColumn(selectToLineNumber);


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix / UX improvement

## What is the current behavior?
When clicking on the line number of a folded line in the gutter, only the first visible line (the fold header) is selected. This makes it difficult to select, delete, or cut entire folded code blocks by clicking the line number.

Closes #59657

## What is the new behavior?
When clicking on the line number of a folded line, the entire folded range is selected — including all hidden lines within the fold. This matches the behavior of Visual Studio and makes it much easier to work with folded code blocks.

The fix works by checking if the clicked line has a hidden area (folded region) immediately following it, and if so, extending the selection to cover the entire folded range.

## Additional context
- The change is in `CursorMoveCommands.line()` which handles line selection triggered by gutter clicks
- Only affects the initial click; drag behavior already works correctly via view positions
- Hidden areas are retrieved from `viewModel.getHiddenAreas()` which returns the folded regions