### PR TITLE
feat: add Escape keybinding to clear test explorer filter text

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -10,6 +10,8 @@ import { registerAction2 } from '../../../../platform/actions/common/actions.js'
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { KeyCode } from '../../../../base/common/keyCodes.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -46,6 +48,7 @@ import { allTestActions, discoverAndRunTests } from './testExplorerActions.js';
 import './testingConfigurationUi.js';
 import { TestingDecorations, TestingDecorationService } from './testingDecorations.js';
 import { TestingExplorerView } from './testingExplorerView.js';
+import { ViewAction } from '../../../browser/parts/views/viewPane.js';
 import { CloseTestPeek, CollapsePeekStack, GoToNextMessageAction, GoToPreviousMessageAction, OpenMessageInEditorAction, TestingOutputPeekController, TestingPeekOpener, TestResultsView, ToggleTestingPeekHistory } from './testingOutputPeek.js';
 import { TestingProgressTrigger } from './testingProgressUiService.js';
 import { TestingViewPaneContainer } from './testingViewPaneContainer.js';
@@ -138,6 +141,25 @@ registerAction2(GoToNextMessageAction);
 registerAction2(CloseTestPeek);
 registerAction2(ToggleTestingPeekHistory);
 registerAction2(CollapsePeekStack);
+
+registerAction2(class extends ViewAction<TestingExplorerView> {
+	constructor() {
+		super({
+			id: TestCommandId.ClearFilterText,
+			title: localize('testing.clearFilterText', "Clear filter text"),
+			category: localize2('testing', 'Testing'),
+			keybinding: {
+				when: TestingContextKeys.explorerFilterInputFocus,
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyCode.Escape
+			},
+			viewId: Testing.ExplorerViewId
+		});
+	}
+	async runInView(_accessor: ServicesAccessor, view: TestingExplorerView): Promise<void> {
+		view.clearFilterText();
+	}
+});
 
 registerWorkbenchContribution2(TestingContentProvider.ID, TestingContentProvider, WorkbenchPhase.AfterRestored);
 registerWorkbenchContribution2(TestingPeekOpener.ID, TestingPeekOpener, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts
@@ -15,10 +15,12 @@ import { Iterable } from '../../../../base/common/iterator.js';
 import { localize } from '../../../../nls.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { ContextScopedSuggestEnabledInputWithHistory, SuggestEnabledInputWithHistory, SuggestResultsProvider } from '../../codeEditor/browser/suggestEnabledInput/suggestEnabledInput.js';
 import { testingFilterIcon } from './icons.js';
+import { TestingContextKeys } from '../common/testingContextKeys.js';
 import { StoredValue } from '../common/storedValue.js';
 import { ITestExplorerFilterState, TestFilterTerm } from '../common/testExplorerFilterState.js';
 import { ITestService } from '../common/testService.js';
@@ -47,6 +49,7 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 		@ITestExplorerFilterState private readonly state: ITestExplorerFilterState,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ITestService private readonly testService: ITestService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super(null, action, options);
 		this.history = this._register(instantiationService.createInstance(StoredValue, {
@@ -113,8 +116,13 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 			input.focus();
 		}));
 
+		const filterFocusContextKey = TestingContextKeys.explorerFilterInputFocus.bindTo(this.contextKeyService);
 		this._register(input.onDidFocus(() => {
+			filterFocusContextKey.set(true);
 			this.focusEmitter.fire();
+		}));
+		this._register(input.onDidBlur(() => {
+			filterFocusContextKey.set(false);
 		}));
 
 		this._register(input.onInputDidChange(() => updateDelayer.trigger(() => {
@@ -158,6 +166,14 @@ export class TestingExplorerFilter extends BaseActionViewItem {
 	}
 
 	/**
+	 * Clears the filter input text.
+	 */
+	public clearText() {
+		this.input.setValue('');
+		this.state.setText('');
+	}
+
+	/**
 	 * @override
 	 */
 	public override dispose() {
@@ -183,6 +199,7 @@ class FiltersDropdownMenuActionViewItem extends DropdownMenuActionViewItem {
 		actionRunner: IActionRunner,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@ITestService private readonly testService: ITestService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super(action,
 			{ getActions: () => this.getActions() },

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -536,6 +536,10 @@ export class TestingExplorerView extends ViewPane {
 		this.viewModel?.layout(height - this.treeHeader.clientHeight, width);
 		this.filter.value?.layout(width);
 	}
+
+	public clearFilterText(): void {
+		this.filter.value?.clearText();
+	}
 }
 
 const SUMMARY_RENDER_INTERVAL = 200;

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -56,6 +56,7 @@ export const testConfigurationGroupNames: Partial<Record<TestRunProfileBitset, s
 
 export const enum TestCommandId {
 	CancelTestRefreshAction = 'testing.cancelTestRefresh',
+	ClearFilterText = 'testing.clearFilterText',
 	CancelTestRunAction = 'testing.cancelRun',
 	ClearTestResultsAction = 'testing.clearTestResults',
 	CollapseAllAction = 'testing.collapseAll',

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -9,6 +9,7 @@ import { TestExplorerViewMode, TestExplorerViewSorting } from './constants.js';
 import { TestRunProfileBitset } from './testTypes.js';
 
 export namespace TestingContextKeys {
+	export const explorerFilterInputFocus = new RawContextKey<boolean>('testing.explorerFilterInputFocus', false, { type: 'boolean', description: localize('testing.explorerFilterInputFocus', 'Whether the test explorer filter input has focus') });
 	export const providerCount = new RawContextKey('testing.providerCount', 0);
 	export const canRefreshTests = new RawContextKey('testing.canRefresh', false, { type: 'boolean', description: localize('testing.canRefresh', 'Indicates whether any test controller has an attached refresh handler.') });
 	export const isRefreshingTests = new RawContextKey('testing.isRefreshing', false, { type: 'boolean', description: localize('testing.isRefreshing', 'Indicates whether any test controller is currently refreshing tests.') });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (small enhancement)

## What is the current behavior?

When a filter keyword is entered in the Test Explorer View, clearing it requires either pressing backspace repeatedly or selecting all text and deleting it. There is no quick way to clear the filter, unlike the Problems panel which supports pressing Escape to clear the filter text.

Closes #271567

## What is the new behavior?

Pressing Escape while the test explorer filter input is focused clears the current filter text and shows all tests again. This matches the behavior already present in the Problems panel.

### Changes:
- Added `testing.explorerFilterInputFocus` context key that tracks whether the filter input has focus
- Added `testing.clearFilterText` command bound to Escape when the filter input is focused
- Added `clearText()` method to `TestingExplorerFilter` and `clearFilterText()` to `TestingExplorerView`

## Additional context

Files changed:
- `src/vs/workbench/contrib/testing/common/constants.ts` - new command ID
- `src/vs/workbench/contrib/testing/common/testingContextKeys.ts` - new context key
- `src/vs/workbench/contrib/testing/browser/testingExplorerFilter.ts` - context key management, clearText method
- `src/vs/workbench/contrib/testing/browser/testingExplorerView.ts` - clearFilterText method
- `src/vs/workbench/contrib/testing/browser/testing.contribution.ts` - action registration

TypeScript compilation passes with no errors.