### PR TITLE
fix: notebook Cmd+D immediately finds next match when word is already selected

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -540,6 +540,14 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 
 			this._onDidChangeAnchorCell.fire();
 
+			// If the selection already covered the word, the user had explicitly
+			// selected it before pressing Cmd/Ctrl+D.  Mirror the regular editor
+			// behaviour: immediately find and select the *next* match as well,
+			// instead of requiring a second invocation.
+			if (!inputSelection.isEmpty()) {
+				return this.findAndTrackNextSelection(focusedCell);
+			}
+
 		} else if (this.state === NotebookMultiCursorState.Selecting) { // use the word we stored from idle state transition to find next match, track it
 			const notebookTextModel = this.notebookEditor.textModel;
 			if (!notebookTextModel) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When pressing Cmd/Ctrl+D in a notebook cell editor after selecting a word, the first invocation only transitions from `Idle` to `Selecting` state by re-selecting the word under the cursor. The user has to press Cmd/Ctrl+D a second time to actually find and select the next match.

In a regular editor, if a word is already selected, the first Cmd/Ctrl+D immediately adds the next match to the selection.

Closes #235123

## What is the new behavior?

After transitioning from `Idle` to `Selecting` state, if the input selection was non-empty (meaning the user had already selected the word), the method recursively calls itself. Since the state is now `Selecting`, the recursive call enters the Selecting branch and immediately finds the next match.

This matches the regular editor's behavior: when the cursor has an empty selection, the first Cmd/Ctrl+D selects the word; when the word is already selected, the first Cmd/Ctrl+D immediately finds and selects the next match.

## Additional context

The regular editor achieves this through `MultiCursorSession.create()` which sets `currentMatch` to `null` when the selection is non-empty, causing `_getNextMatch()` to search for the next match on the first invocation. The notebook implementation uses a state machine (`Idle`/`Selecting`/`Editing`) instead, so the equivalent fix is to re-enter the `Selecting` state in the same invocation when the initial selection already covered the word.