### PR TITLE
fix: add input border to Light VS theme for chat input visibility

### DIFF
--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -15,6 +15,7 @@
 		"list.hoverBackground": "#E8E8E8",
 		"menu.border": "#D4D4D4",
 		"input.placeholderForeground": "#767676",
+		"input.border": "#CECECE",
 		"searchEditor.textInputBorder": "#CECECE",
 		"settings.textInputBorder": "#CECECE",
 		"settings.numberInputBorder": "#CECECE",


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
In the Light+ (Default Light+) theme, the chat input area in the Chat in Editor view is indistinguishable from the white editor background when unfocused. This is because the `input.border` color is not defined in the Light VS theme (which Light+ extends), causing the CSS `var(--vscode-input-border, transparent)` to fall back to transparent.

Closes #234866

## What is the new behavior?
Adds `input.border: #CECECE` to the Light VS theme definition. This value matches the `searchEditor.textInputBorder` and `settings.textInputBorder` already defined in the same theme, and is consistent with the `input.border` value used in the Light Modern theme. This provides a subtle but visible border around all input fields, including the chat input area, even when unfocused.

## Additional context
- The Light Modern theme already defines `input.border: #CECECE` and does not have this problem
- The `searchEditor.textInputBorder` and `settings.numberInputBorder` in the same theme already use `#CECECE`, so this value is consistent with the existing light theme palette
- This affects all input fields in the Light+ theme, not just the chat input, which improves visual clarity throughout the UI