### PR TITLE
fix: use outline instead of border for diff editor text borders

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -482,9 +482,8 @@
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	display: inline-block;
+	display: block;
 	overflow: hidden;
-	width: inherit;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-title .codicon {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `diffEditor.removedTextBorder` or `diffEditor.insertedTextBorder` theme colors are set to a visible value, the diff editor uses CSS `border` to render the highlighting. The `border` property takes up space in the box model, causing the line content to shift/displace. The removed text side is especially noticeable, where lines shift down and right by 1px when the border appears.

This is also visually inconsistent between insertions and deletions, and creates strange overlapping artifacts, particularly with semi-transparent border colors.

Closes #277259

## What is the new behavior?

The CSS `border` is replaced with `outline` for the `.line-insert`, `.char-insert`, `.line-delete`, and `.char-delete` selectors. `outline` renders visually identical to `border` but does not affect the element's layout, so lines are no longer displaced when borders are enabled.

`outline-offset: -1px` is used to position the outline inside the element, matching the visual appearance of the previous `border` + `box-sizing: border-box` approach.

The high contrast theme dashed styles are also updated from `border-style: dashed` to `outline-style: dashed`.

## Additional context

This is a CSS-only change affecting `src/vs/editor/browser/widget/diffEditor/style.css`. The fix removes `box-sizing: border-box` (no longer needed since outlines don't participate in the box model) and replaces 4 style rules.