### PR TITLE
fix: correct walkthrough step title truncation when collapsed

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -482,9 +482,8 @@
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	display: inline-block;
+	display: block;
 	overflow: hidden;
-	width: inherit;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-title .codicon {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (CSS)

## What is the current behavior?

When walkthrough steps are in collapsed (non-expanded) state, the step title text is truncated incorrectly. The last visible character gets cut off before the ellipsis can render properly, resulting in text like "Command Pale." instead of "Command Pal..." or "Command...".

This is because the `.step-title` element uses `display: inline-block` with `width: inherit`. The inherited width resolves to the parent's declared `width: 100%`, but as an inline-block element, this causes it to exceed the available space within the flex layout (since the checkbox codicon also takes space), leading to improper overflow behavior.

Closes #228947

## What is the new behavior?

The step title now truncates correctly with proper ellipsis placement. Changed `display: inline-block` + `width: inherit` to `display: block`. A block-level element naturally fills its parent's content area without overflowing, so `text-overflow: ellipsis` works as expected.

## Additional context

- CSS-only change, no TypeScript modifications
- The fix only affects the collapsed (`:not(.expanded)`) state of walkthrough steps
- The expanded state rendering is unaffected