### PR TITLE
fix: improve error text contrast in Tomorrow Night Blue theme

### DIFF
--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
@@ -2,7 +2,7 @@
 	"type": "dark",
 	"colors": {
 		"focusBorder": "#bbdaff",
-		"errorForeground": "#a92049",
+		"errorForeground": "#ff9da4",
 		"input.background": "#001733",
 		"dropdown.background": "#001733",
 		"quickInputList.focusBackground": "#ffffff60",


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (accessibility)

## What is the current behavior?
In the Tomorrow Night Blue theme, the "No results" text in the find widget (and other error messages using `errorForeground`) is nearly invisible. The current `errorForeground` color `#a92049` has a contrast ratio of only **2.18:1** against the editor background (`#002451`) and **2.41:1** against the find widget background (`#001c40`), far below the WCAG AA minimum of 4.5:1.

Closes #187861

## What is the new behavior?
Changes `errorForeground` from `#a92049` to `#ff9da4`, achieving a contrast ratio of **7.74:1** against the editor background and **8.56:1** against the widget background. Both exceed the WCAG AAA threshold of 7:1.

The new color `#ff9da4` is already present in the theme's palette as `terminal.ansiRed`, so it maintains visual consistency with the theme's existing design language.

## Additional context
Contrast ratio calculations:

| Color | Background | Ratio | WCAG |
|-------|-----------|-------|------|
| `#a92049` (old) | `#002451` (editor) | 2.18:1 | Fail |
| `#a92049` (old) | `#001c40` (widget) | 2.41:1 | Fail |
| `#ff9da4` (new) | `#002451` (editor) | 7.74:1 | AAA |
| `#ff9da4` (new) | `#001c40` (widget) | 8.56:1 | AAA |