### PR TITLE
fix: prevent card border from overlapping scrollbar in Getting Started

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -756,6 +756,10 @@
 	outline-offset: 0;
 }
 
+.monaco-workbench .part.editor > .content .gettingStartedContainer .step-list-container {
+	padding-right: 4px;
+}
+
 .monaco-workbench .part.editor > .content .gettingStartedContainer .step-list-container button:focus-visible {
 	box-shadow: inset 0 0 0 1px var(--vscode-focusBorder);
 	outline: none;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (CSS)

## What is the current behavior?

In the Getting Started walkthrough, when a step card is expanded, its border extends to the right edge and overlaps with the scrollbar. This makes the UI look cluttered and slightly broken.

Closes #205724

## What is the new behavior?

Added `padding-right: 4px` to the `.step-list-container` so that the card border has breathing room and does not overlap with the scrollbar.

## Additional context

- CSS-only change
- The padding is minimal (4px) to maintain the existing layout while preventing the overlap