### PR TITLE
fix: persist test coverage sort order across sessions

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -39,6 +39,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { WorkbenchCompressibleObjectTree } from '../../../../platform/list/browser/listService.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IQuickInputService, IQuickPickItem, QuickPickInput } from '../../../../platform/quickinput/common/quickInput.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IResourceLabel, ResourceLabels } from '../../../browser/labels.js';
@@ -78,12 +79,22 @@ export class TestCoverageView extends ViewPane {
 		@IThemeService themeService: IThemeService,
 		@IHoverService hoverService: IHoverService,
 		@ITestCoverageService private readonly coverageService: ITestCoverageService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
+		const storedOrder = this.storageService.getNumber('testing.coverageSortOrder', StorageScope.WORKSPACE);
+		if (storedOrder !== undefined && storedOrder in CoverageSortOrder) {
+			this.sortOrder.set(storedOrder, undefined);
+		}
 	}
 
 	protected override renderBody(container: HTMLElement): void {
 		super.renderBody(container);
+
+		this._register(autorun(reader => {
+			const order = this.sortOrder.read(reader);
+			this.storageService.store('testing.coverageSortOrder', order, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}));
 
 		const labels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility }));
 

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -83,7 +83,7 @@ export class TestCoverageView extends ViewPane {
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 		const storedOrder = this.storageService.getNumber('testing.coverageSortOrder', StorageScope.WORKSPACE);
-		if (storedOrder !== undefined && storedOrder in CoverageSortOrder) {
+		if (storedOrder !== undefined && storedOrder >= CoverageSortOrder.Coverage && storedOrder <= CoverageSortOrder.Name) {
 			this.sortOrder.set(storedOrder, undefined);
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Test Coverage view's sort order resets to "Sort by Location" every time the view is reopened (e.g., after running tests without coverage and then re-running with coverage). The sort order selection is not persisted.

Closes #249442

## What is the new behavior?

The sort order is now persisted to workspace storage using `IStorageService`. When the Test Coverage view is created, it reads the previously stored sort order. An `autorun` watcher saves the sort order to storage whenever it changes.

## Additional context

Single file change: `src/vs/workbench/contrib/testing/browser/testCoverageView.ts`

- Added `IStorageService` injection
- Load stored sort order in constructor
- Persist sort order changes via `autorun` in `renderBody`
- Storage key: `testing.coverageSortOrder` (workspace scope, machine target)

TypeScript compilation passes with no errors.