### PR TITLE
fix: resolve branch upstream in shallow clones via git config fallback

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -3211,6 +3211,25 @@ export class Repository {
 				} catch { }
 			}
 
+			// Fallback for shallow clones: for-each-ref returns empty upstream
+			// fields, so we read the branch tracking config directly
+			if (!branch.upstream && branch.type === RefType.Head && branch.name) {
+				try {
+					const remoteResult = await this.exec(['config', '--get', `branch.${branch.name}.remote`]);
+					const mergeResult = await this.exec(['config', '--get', `branch.${branch.name}.merge`]);
+
+					const remote = remoteResult.stdout.trim();
+					const merge = mergeResult.stdout.trim();
+
+					if (remote && merge) {
+						const upstreamName = merge.startsWith('refs/heads/') ? merge.substring(11) : merge;
+						(branch as Mutable<Branch>).upstream = { remote, name: upstreamName };
+					}
+				} catch {
+					// No tracking config found, upstream remains undefined
+				}
+			}
+
 			return branch;
 		}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a repository is cloned with `git clone --depth 1` (shallow clone), the branch's `upstream` property is `undefined`. This is because `git for-each-ref` with `%(upstream:short)`, `%(upstream:track)`, `%(upstream:remotename)`, and `%(upstream:remoteref)` format fields returns empty values in shallow clones, even when the branch tracking configuration exists in `.git/config`.

This causes multiple issues:
- The status bar doesn't show upstream tracking information
- Sync operations may not work correctly
- Extensions like GitHub Pull Requests can't detect the upstream branch

Closes #248328

## What is the new behavior?

After parsing `for-each-ref` output, if the upstream is still undefined for a local branch, the code now falls back to reading the branch tracking configuration directly using:
- `git config --get branch.<name>.remote`
- `git config --get branch.<name>.merge`

This correctly resolves the upstream even in shallow clones where `for-each-ref` upstream fields are empty.

## Additional context

Root cause was identified by @lszomoru in the issue comments. The `for-each-ref` command with upstream format fields relies on local reference data that is not available in shallow clones. However, the branch tracking config (`branch.<name>.remote` and `branch.<name>.merge`) is always written by `git clone` regardless of depth, making it a reliable fallback source.