### PR TITLE
fix: rename 'Execute Using Profile' to 'Execute Using Test Profile'

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -208,7 +208,7 @@ export class RunUsingProfileAction extends Action2 {
 	constructor() {
 		super({
 			id: TestCommandId.RunUsingProfileAction,
-			title: localize2('testing.runUsing', 'Execute Using Profile...'),
+			title: localize2('testing.runUsing', 'Execute Using Test Profile...'),
 			icon: icons.testingDebugIcon,
 			menu: {
 				id: MenuId.TestItem,

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -1052,7 +1052,7 @@ abstract class RunTestDecoration {
 		});
 
 		if (capabilities & TestRunProfileBitset.HasNonDefaultProfile) {
-			testActions.push(new Action('testing.runUsing', localize('testing.runUsing', 'Execute Using Profile...'), undefined, undefined, async () => {
+			testActions.push(new Action('testing.runUsing', localize('testing.runUsing', 'Execute Using Test Profile...'), undefined, undefined, async () => {
 				const profile: ITestRunProfile | undefined = await this.commandService.executeCommand('vscode.pickTestProfile', { onlyForTest: test });
 				if (!profile) {
 					return;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Polish

## What is the current behavior?

The command "Execute Using Profile..." in the test explorer and inline editor decorations does not include the word "Test" before "Profile", which can be confusing as users may think it refers to a general profile rather than a test-specific profile.

Closes #227700

## What is the new behavior?

The command is renamed to "Execute Using Test Profile..." in both locations where it appears:
- Test Explorer context menu (via `testExplorerActions.ts`)
- Inline editor test decoration menu (via `testingDecorations.ts`)

This follows the naming convention established for terminal profiles where the prefix is always included to prevent confusion.

## Additional context

Two-file change, both in `src/vs/workbench/contrib/testing/browser/`:
- `testExplorerActions.ts` (line 211)
- `testingDecorations.ts` (line 1055)