### PR TITLE
fix: respect git.requireGitUserConfig setting on commit errors

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2126,7 +2126,7 @@ export class Repository {
 		try {
 			await this.exec(args, options);
 		} catch (commitErr) {
-			await this.handleCommitError(commitErr);
+			await this.handleCommitError(commitErr, opts.requireUserConfig ?? true);
 		}
 	}
 
@@ -2145,7 +2145,7 @@ export class Repository {
 	}
 
 
-	private async handleCommitError(commitErr: unknown): Promise<void> {
+	private async handleCommitError(commitErr: unknown, requireUserConfig = true): Promise<void> {
 		if (commitErr instanceof GitError && /not possible because you have unmerged files/.test(commitErr.stderr || '')) {
 			commitErr.gitErrorCode = GitErrorCodes.UnmergedChanges;
 			throw commitErr;
@@ -2154,18 +2154,20 @@ export class Repository {
 			throw commitErr;
 		}
 
-		try {
-			await this.exec(['config', '--get-all', 'user.name']);
-		} catch (err) {
-			err.gitErrorCode = GitErrorCodes.NoUserNameConfigured;
-			throw err;
-		}
+		if (requireUserConfig) {
+			try {
+				await this.exec(['config', '--get-all', 'user.name']);
+			} catch (err) {
+				err.gitErrorCode = GitErrorCodes.NoUserNameConfigured;
+				throw err;
+			}
 
-		try {
-			await this.exec(['config', '--get-all', 'user.email']);
-		} catch (err) {
-			err.gitErrorCode = GitErrorCodes.NoUserEmailConfigured;
-			throw err;
+			try {
+				await this.exec(['config', '--get-all', 'user.email']);
+			} catch (err) {
+				err.gitErrorCode = GitErrorCodes.NoUserEmailConfigured;
+				throw err;
+			}
 		}
 
 		throw commitErr;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `git.requireGitUserConfig` is set to `false`, committing still shows the error message "Make sure you configure your user.name and user.email in git" if any commit error occurs and user.name or user.email is not configured.

The issue is in `handleCommitError()`: regardless of the `requireUserConfig` setting, it always checks for `user.name` and `user.email` on any commit failure and throws `NoUserNameConfigured`/`NoUserEmailConfigured` errors, masking the actual commit error.

Closes #194102

## What is the new behavior?

The `requireUserConfig` flag is now passed from the `commit()` method to `handleCommitError()`. When `git.requireGitUserConfig` is `false`, the user config validation is skipped and the actual commit error is surfaced to the user instead.

The `rebaseContinue()` method continues to use the default `requireUserConfig = true` behavior since it has no corresponding setting.

## Additional context

The `commit()` method correctly respects the setting by conditionally adding `-c user.useConfigOnly=true`, but the error handler was independently checking user config and overriding the actual error. This fix aligns the error handling with the commit configuration.