### PR TITLE
fix: stop model removal from invalidating prompt caches (#304857)

### DIFF
--- a/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl.ts
@@ -1774,20 +1774,26 @@ class ModelChangeTracker extends Disposable {
 				this.listeners.set(model.uri, model.onDidChangeContent(() => this.onDidPromptModelChange.fire({ uri: model.uri, promptType })));
 			}
 		};
-		const onRemove = (languageId: string, uri: URI) => {
+		const stopListening = (languageId: string, uri: URI) => {
 			const promptType = getPromptsTypeForLanguageId(languageId);
 			if (promptType !== undefined) {
 				this.listeners.get(uri)?.dispose();
 				this.listeners.delete(uri);
-				this.onDidPromptModelChange.fire({ uri, promptType });
 			}
 		};
 		this._register(modelService.onModelAdded(model => onAdd(model)));
 		this._register(modelService.onModelLanguageChanged(e => {
-			onRemove(e.oldLanguageId, e.model.uri);
+			stopListening(e.oldLanguageId, e.model.uri);
 			onAdd(e.model);
 		}));
-		this._register(modelService.onModelRemoved(model => onRemove(model.getLanguageId(), model.uri)));
+		// Model removal only cleans up the content-change listener. It does NOT
+		// fire onDidPromptModelChange because the underlying file has not changed —
+		// parseNew() falls back to fileService.readFile() when the model is gone,
+		// and file-system changes are already covered by getFileLocatorEvent().
+		// Firing here would cause a feedback loop when BoundModelReferenceCollection
+		// evicts models (50-reference cap), since the eviction triggers cache
+		// invalidation that re-opens documents and evicts more models.
+		this._register(modelService.onModelRemoved(model => stopListening(model.getLanguageId(), model.uri)));
 	}
 
 	public override dispose(): void {

--- a/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/promptSyntax/service/promptsService.test.ts
@@ -16,6 +16,10 @@ import { URI } from '../../../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { Range } from '../../../../../../../editor/common/core/range.js';
 import { ILanguageService } from '../../../../../../../editor/common/languages/language.js';
+import { ILanguageConfigurationService } from '../../../../../../../editor/common/languages/languageConfigurationRegistry.js';
+import { TestLanguageConfigurationService } from '../../../../../../../editor/test/common/modes/testLanguageConfigurationService.js';
+import { ITreeSitterLibraryService } from '../../../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
+import { TestTreeSitterLibraryService } from '../../../../../../../editor/test/common/services/testTreeSitterLibraryService.js';
 import { IModelService } from '../../../../../../../editor/common/services/model.js';
 import { ModelService } from '../../../../../../../editor/common/services/modelService.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
@@ -35,12 +39,12 @@ import { IWorkbenchEnvironmentService } from '../../../../../../services/environ
 import { IFilesConfigurationService } from '../../../../../../services/filesConfiguration/common/filesConfigurationService.js';
 import { IUserDataProfileService } from '../../../../../../services/userDataProfile/common/userDataProfile.js';
 import { toUserDataProfile } from '../../../../../../../platform/userDataProfile/common/userDataProfile.js';
-import { TestContextService, TestUserDataProfileService, TestWorkspaceTrustManagementService } from '../../../../../../test/common/workbenchTestServices.js';
+import { TestContextService, TestTextResourcePropertiesService, TestUserDataProfileService, TestWorkspaceTrustManagementService } from '../../../../../../test/common/workbenchTestServices.js';
 import { ChatRequestVariableSet, isPromptFileVariableEntry, toFileVariableEntry } from '../../../../common/attachments/chatVariableEntries.js';
 import { ComputeAutomaticInstructions, newInstructionsCollectionEvent } from '../../../../common/promptSyntax/computeAutomaticInstructions.js';
 import { PromptsConfig } from '../../../../common/promptSyntax/config/config.js';
 import { AGENTS_SOURCE_FOLDER, CLAUDE_CONFIG_FOLDER, HOOKS_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION } from '../../../../common/promptSyntax/config/promptFileLocations.js';
-import { INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID, PromptsType, Target } from '../../../../common/promptSyntax/promptTypes.js';
+import { AGENT_LANGUAGE_ID, INSTRUCTIONS_LANGUAGE_ID, PROMPT_LANGUAGE_ID, PromptsType, Target } from '../../../../common/promptSyntax/promptTypes.js';
 import { ExtensionAgentSourceType, ICustomAgent, IPromptFileContext, IPromptsService, PromptsStorage } from '../../../../common/promptSyntax/service/promptsService.js';
 import { PromptsService } from '../../../../common/promptSyntax/service/promptsServiceImpl.js';
 import { mockFiles } from '../testUtils/mockFilesystem.js';
@@ -49,6 +53,13 @@ import { IPathService } from '../../../../../../services/path/common/pathService
 import { IFileMatch, IFileQuery, ISearchService } from '../../../../../../services/search/common/search.js';
 import { IExtensionService } from '../../../../../../services/extensions/common/extensions.js';
 import { IRemoteAgentService } from '../../../../../../services/remote/common/remoteAgentService.js';
+import { ITextResourcePropertiesService } from '../../../../../../../editor/common/services/textResourceConfiguration.js';
+import { IUndoRedoService } from '../../../../../../../platform/undoRedo/common/undoRedo.js';
+import { UndoRedoService } from '../../../../../../../platform/undoRedo/common/undoRedoService.js';
+import { IDialogService } from '../../../../../../../platform/dialogs/common/dialogs.js';
+import { TestDialogService } from '../../../../../../../platform/dialogs/test/common/testDialogService.js';
+import { INotificationService } from '../../../../../../../platform/notification/common/notification.js';
+import { TestNotificationService } from '../../../../../../../platform/notification/test/common/testNotificationService.js';
 import { ChatModeKind } from '../../../../common/constants.js';
 import { HookType } from '../../../../common/promptSyntax/hookTypes.js';
 import { IContextKeyService, IContextKeyChangeEvent } from '../../../../../../../platform/contextkey/common/contextkey.js';
@@ -99,8 +110,7 @@ suite('PromptsService', () => {
 		fileService = disposables.add(instaService.createInstance(FileService));
 		instaService.stub(IFileService, fileService);
 
-		const modelService = disposables.add(instaService.createInstance(ModelService));
-		instaService.stub(IModelService, modelService);
+		instaService.stub(ITextResourcePropertiesService, new TestTextResourcePropertiesService(testConfigService));
 		instaService.stub(ILanguageService, {
 			guessLanguageIdByFilepathOrFirstLine(uri: URI) {
 				if (uri.path.endsWith(PROMPT_FILE_EXTENSION)) {
@@ -111,9 +121,24 @@ suite('PromptsService', () => {
 					return INSTRUCTIONS_LANGUAGE_ID;
 				}
 
+				if (uri.path.endsWith('.agent.md')) {
+					return AGENT_LANGUAGE_ID;
+				}
+
 				return 'plaintext';
-			}
+			},
+			requestRichLanguageFeatures() { }
 		});
+		const testLangConfig = new TestLanguageConfigurationService();
+		disposables.add(testLangConfig);
+		instaService.stub(ILanguageConfigurationService, testLangConfig);
+		instaService.stub(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
+		instaService.stub(INotificationService, new TestNotificationService());
+		instaService.stub(IDialogService, new TestDialogService());
+		const undoRedoService = instaService.createInstance(UndoRedoService);
+		instaService.stub(IUndoRedoService, undoRedoService);
+		const modelService = disposables.add(instaService.createInstance(ModelService));
+		instaService.stub(IModelService, modelService);
 		instaService.stub(ILabelService, { getUriLabel: (uri: URI) => uri.path });
 
 		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());
@@ -1490,6 +1515,60 @@ suite('PromptsService', () => {
 			const simpleUserAgent = userAgents.find(a => a.name === 'simple-user-agent');
 			assert.ok(simpleUserAgent, 'Should find simple user agent');
 			assert.strictEqual(simpleUserAgent.agentInstructions.content, 'A simple user agent without header.');
+		});
+
+		test('model removal does not trigger onDidChangeCustomAgents', async () => {
+			// This test verifies that when a model (text document) is removed/disposed,
+			// it does NOT cause the custom agents cache to invalidate. This prevents
+			// the feedback loop where BoundModelReferenceCollection evicting models
+			// (50-reference cap) triggers repeated cache invalidation.
+
+			const rootFolder = '/model-removal-test';
+			const rootFolderUri = URI.file(rootFolder);
+			workspaceContextService.setWorkspace(testWorkspace(rootFolderUri));
+
+			const agentUri = URI.joinPath(rootFolderUri, '.github/agents/test.agent.md');
+			await mockFiles(fileService, [
+				{
+					path: agentUri.path,
+					contents: [
+						'---',
+						'description: \'Test agent\'',
+						'---',
+						'Test agent body.',
+					]
+				}
+			]);
+
+			// Initial fetch to populate cache
+			const agents = await service.getCustomAgents(CancellationToken.None);
+			assert.strictEqual(agents.length, 1);
+
+			// Create a model for the agent file (simulates vscode.workspace.openTextDocument)
+			const modelService = instaService.get(IModelService);
+			const model = modelService.createModel(
+				'---\ndescription: \'Test agent\'\n---\nTest agent body.',
+				{ languageId: AGENT_LANGUAGE_ID, onDidChange: Event.None },
+				agentUri
+			);
+
+			// Wait for model creation to propagate (onModelAdded fires change)
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			let changeCount = 0;
+			disposables.add(service.onDidChangeCustomAgents(() => {
+				changeCount++;
+			}));
+
+			// Content change SHOULD trigger onDidChangeCustomAgents
+			model.applyEdits([{ range: new Range(4, 1, 4, 17), text: 'Updated body.' }]);
+			await new Promise(resolve => setTimeout(resolve, 50));
+			assert.strictEqual(changeCount, 1, 'Content change should trigger onDidChangeCustomAgents');
+
+			// Now destroy the model (simulates BoundModelReferenceCollection eviction)
+			modelService.destroyModel(agentUri);
+			await new Promise(resolve => setTimeout(resolve, 50));
+			assert.strictEqual(changeCount, 1, 'Model removal should NOT trigger onDidChangeCustomAgents');
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR addresses the high CPU usage reported in #304857 when multiple extensions register `chatAgent` / `chatSkill` prompt files.

## Root Cause Analysis

Through investigation, we believe the high CPU stems from a feedback loop in the prompt caching system, specifically involving `ModelChangeTracker` in `PromptsService`:

1. **`$acceptCustomAgents`** pushes agents to the extension host, firing `onDidChangeCustomAgents` on the API
2. **Extensions** (e.g., Copilot Chat's `ChatCustomAgentsService`) respond by calling `vscode.workspace.openTextDocument()` for each agent URI to parse them
3. **`BoundModelReferenceCollection`** in `mainThreadDocuments.ts` has a **50-document cap** (`_maxSize = 50`). When 60+ agent/skill documents accumulate, the oldest references are evicted
4. **Model eviction** fires `IModelService.onModelRemoved`, which `ModelChangeTracker` was treating as a content change signal — firing `onDidPromptModelChange`
5. **`CachedPromise`** invalidates the agents/skills cache on this signal
6. **Cache invalidation** fires `onDidChangeCustomAgents` again → sends `$acceptCustomAgents` to the extension host → **GOTO 1**

The key insight is that model removal (step 4) is a **memory management concern**, not a content change. When a model is evicted, the underlying file hasn't changed — `parseNew()` already falls back to `fileService.readFile()` when no in-memory model exists, and actual file-system changes are separately covered by the file locator events via `getFileLocatorEvent()`.

## Fix

`ModelChangeTracker`'s `onModelRemoved` handler no longer fires `onDidPromptModelChange`. It only cleans up the per-model content-change listener and removes the entry from its tracking map. This breaks the feedback loop at step 4→5.

**What still works:**
- Model **content changes** (edits while a document is open) still trigger cache invalidation ✅
- Model **addition** (opening a new prompt file) still triggers cache invalidation ✅
- Model **language changes** still trigger cache invalidation ✅
- File-system changes (create/delete/rename of prompt files) still trigger cache invalidation via `getFileLocatorEvent()` ✅

## Testing

- **Unit test added**: "model removal does not trigger onDidChangeCustomAgents" — creates a real model via `ModelService`, verifies content edits DO trigger `onDidChangeCustomAgents`, then verifies `destroyModel` does NOT
- **Full test suite**: All 69 `PromptsService` tests pass, zero regressions
- **Manual testing**: Verified with extensions registering 49+ agents and 17+ skills (the same configuration described in the issue) — CPU usage remains stable, no feedback loop observed

## Caveat

While this fix resolves the issue in our testing and we believe the reasoning is sound, **we acknowledge this may not be the direction the team would prefer**. There may be edge cases we haven't considered where model removal should signal a cache refresh, or the team may prefer to address this at a different layer (e.g., deduplication in `_pushCustomAgents`, increasing the `BoundModelReferenceCollection` cap, or debouncing the cache invalidation). We're happy to adjust the approach based on feedback.

Fixes #304857
