### PR TITLE
fix: strip @sort qualifier from MCP Servers view search query

### DIFF
--- a/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
+++ b/src/vs/workbench/contrib/mcp/browser/mcpServersView.ts
@@ -336,7 +336,8 @@ export class McpServersListView extends AbstractExtensionsListView<IWorkbenchMcp
 	private async query(query: string): Promise<IQueryResult> {
 		const disposables = new DisposableStore();
 		if (query) {
-			const servers = await this.mcpWorkbenchService.queryGallery({ text: query.replace('@mcp', '') });
+			const text = query.replace('@mcp', '').replace(/@sort:(\w+)(-\w*)?/g, '').trim();
+			const servers = await this.mcpWorkbenchService.queryGallery({ text });
 			const model = disposables.add(new IterativePagedModel(servers));
 			return { model, disposables };
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When typing `@mcp @sort:name` in the Extensions search box, the MCP Servers view becomes empty showing "No MCP Servers found." This happens because the `query()` method only strips the `@mcp` prefix, leaving `@sort:name` as literal search text passed to `queryGallery()`, which finds no matching results.

Closes #296801

## What is the new behavior?

The `@sort:` qualifier is now stripped from the query text before it is passed to `queryGallery()`. This uses the same regex pattern (`/@sort:(\w+)(-\w*)?/g`) that the extensions view already uses to handle sort qualifiers.

After the fix, `@mcp @sort:name` correctly shows the MCP Servers list (since the gallery search text becomes empty after stripping both qualifiers).

## Additional context

- One-line change in `src/vs/workbench/contrib/mcp/browser/mcpServersView.ts`
- The regex pattern is already used across `extensionsViews.ts` in multiple places for the same purpose
- Note: This fix strips the sort qualifier from the search text but does not yet apply the sort order to the results. The actual sorting support could be added as a follow-up enhancement.