### PR TITLE
fix: offer stash/migrate options when creating a branch with dirty worktree

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3112,7 +3112,31 @@ export class CommandCenter {
 			return;
 		}
 
-		await repository.branch(branchName, true, target);
+		try {
+			await repository.branch(branchName, true, target);
+		} catch (err) {
+			if (err.gitErrorCode !== GitErrorCodes.DirtyWorkTree) {
+				throw err;
+			}
+
+			const stash = l10n.t('Stash & Checkout');
+			const migrate = l10n.t('Migrate Changes');
+			const force = l10n.t('Force Checkout');
+			const choice = await window.showWarningMessage(l10n.t('Your local changes would be overwritten by checkout.'), { modal: true }, stash, migrate, force);
+
+			if (choice === force) {
+				await this.cleanAll(repository);
+				await repository.branch(branchName, true, target);
+			} else if (choice === stash || choice === migrate) {
+				if (await this._stash(repository, true)) {
+					await repository.branch(branchName, true, target);
+
+					if (choice === migrate) {
+						await this.stashPopLatest(repository);
+					}
+				}
+			}
+		}
 	}
 
 	private async pickRef<T extends QuickPickItem>(items: Promise<T[]>, placeHolder: string): Promise<T | undefined> {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When using "Git: Create Branch From..." with uncommitted changes, if the target ref differs from the current HEAD, git fails with a DirtyWorkTree error that is not handled gracefully. The user sees a generic error without any option to stash, migrate, or discard their changes.

This is inconsistent with the regular checkout behavior, which presents a dialog with "Stash & Checkout", "Migrate Changes", and "Force Checkout" options.

Closes #191900

## What is the new behavior?

The `_branch()` method now catches `DirtyWorkTree` errors and presents the same dialog as the checkout command:
- **Stash & Checkout**: Stashes changes, creates the branch, and keeps the stash
- **Migrate Changes**: Stashes changes, creates the branch, then pops the stash to carry changes forward
- **Force Checkout**: Discards all local changes and creates the branch

This mirrors the existing error handling in `_checkout()`.

## Additional context

The fix follows the exact same pattern used in `_checkout()` (around line 2960 of commands.ts) for handling DirtyWorkTree errors, ensuring consistent behavior across all branch switching operations.