### PR TITLE
fix: allow parentheses in terminal link paths

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -342,12 +342,12 @@ enum RegexPathConstants {
 	PathSeparatorClause = '\\/',
 	// '":; are allowed in paths but they are often separators so ignore them
 	// Also disallow \\ to prevent a catastropic backtracking case #24795
-	ExcludedPathCharactersClause = '[^\\0<>\\?\\s!`&*()\'":;\\\\]',
+	ExcludedPathCharactersClause = '[^\\0<>\\?\\s!`&*\'":;\\\\]',
 	ExcludedStartPathCharactersClause = '[^\\0<>\\?\\s!`&*()\\[\\]\'":;\\\\]',
 
 	WinOtherPathPrefix = '\\.\\.?|\\~',
 	WinPathSeparatorClause = '(?:\\\\|\\/)',
-	WinExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\'":;]',
+	WinExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*\'":;]',
 	WinExcludedStartPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\\[\\]\'":;]',
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

File paths containing parentheses like `./src/(hello)/[world]/file.tsx` (common in Next.js route groups) are not properly recognized as clickable links in the terminal. The path gets split at `(` and `)` characters because they are excluded from the `ExcludedPathCharactersClause` regex.

For example, `echo "./src/(hello)/[world]/file.tsx"` in the terminal produces segmented links instead of one clickable path:

```
./src/(hello)/[world]/file.tsx
------ ----- - ----- ---------
```

Closes #212109

## What is the new behavior?

Parentheses `()` are now allowed in the **middle** of terminal link paths. They remain excluded from **start** positions via `ExcludedStartPathCharactersClause`, preventing false positives.

The suffix-based link detection (which handles patterns like `file(339,12)`) is unaffected since it uses its own dedicated regex that works backwards from detected suffixes.

## Additional context

The fix removes `()` from `ExcludedPathCharactersClause` and `WinExcludedPathCharactersClause` (2 lines changed). The `ExcludedStartPathCharactersClause` variants still exclude `()[]` from the first character of a path.

Code pointer from @Tyriar: https://github.com/microsoft/vscode/issues/212109#issuecomment-2558270966