### PR TITLE
fix: keep deletion gutter marker visible when adjacent fold is collapsed

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts
@@ -168,17 +168,21 @@ class QuickDiffDecorator extends Disposable {
 							: pattern.added ? this.addedSecondaryPatternOptions : this.addedSecondaryOptions
 					});
 					break;
-				case ChangeType.Delete:
+				case ChangeType.Delete: {
+					const totalLines = this.codeEditor.getModel()!.getLineCount();
+					const deleteEndLine = startLineNumber < totalLines ? startLineNumber + 1 : startLineNumber;
+					const deleteEndColumn = startLineNumber < totalLines ? 1 : Number.MAX_VALUE;
 					decorations.push({
 						range: {
 							startLineNumber: startLineNumber, startColumn: Number.MAX_VALUE,
-							endLineNumber: startLineNumber, endColumn: Number.MAX_VALUE
+							endLineNumber: deleteEndLine, endColumn: deleteEndColumn
 						},
 						options: quickDiff.kind === 'primary' || quickDiff.kind === 'contributed'
 							? this.deletedOptions
 							: this.deletedSecondaryOptions
 					});
 					break;
+				}
 				case ChangeType.Modify:
 					decorations.push({
 						range: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When a line is deleted between two foldable regions (e.g., between two `#region` blocks in HTML), the red deletion marker in the gutter disappears when the region above the deletion is folded. This happens because the deletion decoration is a zero-width range at the end of the last line of the fold, and that line becomes hidden when the fold is collapsed.

Closes #246388

## What is the new behavior?
The deletion decoration range now extends from the end of `startLineNumber` to the beginning of `startLineNumber + 1` (when a next line exists). This ensures that if the line before the deletion is hidden by folding, the marker still appears on the next visible line.

For the last line of the file (no next line), the behavior remains unchanged.

## Additional context
- The change is in `QuickDiffDecorator.onDidChange()` in `src/vs/workbench/contrib/scm/browser/quickDiffDecorator.ts`
- Only the `ChangeType.Delete` case is affected; Add and Modify decorations are unchanged
- The decoration still uses `isWholeLine: false` so it appears as the small deletion indicator, not a full-line decoration