### PR TITLE
Preserve quick pick target when opening agent sessions in background

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker.ts
@@ -62,6 +62,16 @@ export function getSessionButtons(session: IAgentSession): IQuickInputButton[] {
 	return buttons;
 }
 
+export function getQuickPickSessionOpenOptions(inBackground: boolean): ISessionOpenOptions {
+	return {
+		sideBySide: false,
+		editorOptions: {
+			preserveFocus: inBackground,
+			pinned: inBackground
+		}
+	};
+}
+
 export interface IAgentSessionsPickerOptions {
 	overrideSessionOpen?(session: IAgentSession, openOptions?: ISessionOpenOptions): Promise<void>;
 }
@@ -92,13 +102,7 @@ export class AgentSessionsPicker {
 		disposables.add(picker.onDidAccept(e => {
 			const pick = picker.selectedItems[0];
 			if (pick) {
-				const openOptions: ISessionOpenOptions = {
-					sideBySide: e.inBackground,
-					editorOptions: {
-						preserveFocus: e.inBackground,
-						pinned: e.inBackground
-					}
-				};
+				const openOptions = getQuickPickSessionOpenOptions(e.inBackground);
 
 				if (this.options?.overrideSessionOpen) {
 					this.options.overrideSessionOpen(pick.session, openOptions);

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsQuickAccess.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentSessionsQuickAccess.ts
@@ -15,7 +15,7 @@ import { IAgentSession } from './agentSessionsModel.js';
 import { openSession } from './agentSessionsOpener.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { AGENT_SESSION_DELETE_ACTION_ID, AGENT_SESSION_RENAME_ACTION_ID } from './agentSessions.js';
-import { archiveButton, deleteButton, getSessionButtons, getSessionDescription, renameButton, unarchiveButton } from './agentSessionsPicker.js';
+import { archiveButton, deleteButton, getQuickPickSessionOpenOptions, getSessionButtons, getSessionDescription, renameButton, unarchiveButton } from './agentSessionsPicker.js';
 import { AgentSessionsFilter } from './agentSessionsFilter.js';
 
 export const AGENT_SESSIONS_QUICK_ACCESS_PREFIX = 'agent ';
@@ -94,13 +94,7 @@ export class AgentSessionsQuickAccessProvider extends PickerQuickAccessProvider<
 				}
 			},
 			accept: (keyMods: IKeyMods, event: IQuickPickDidAcceptEvent) => {
-				this.instantiationService.invokeFunction(openSession, session, {
-					sideBySide: event.inBackground,
-					editorOptions: {
-						preserveFocus: event.inBackground,
-						pinned: event.inBackground
-					}
-				});
+				this.instantiationService.invokeFunction(openSession, session, getQuickPickSessionOpenOptions(event.inBackground));
 			}
 		};
 	}

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentSessionsPicker.test.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { getQuickPickSessionOpenOptions } from '../../../browser/agentSessions/agentSessionsPicker.js';
+
+suite('agentSessionsPicker', () => {
+	test('background quick pick accept preserves focus without forcing side-by-side', () => {
+		const options = getQuickPickSessionOpenOptions(true);
+
+		assert.strictEqual(options.sideBySide, false);
+		assert.strictEqual(options.editorOptions?.preserveFocus, true);
+		assert.strictEqual(options.editorOptions?.pinned, true);
+	});
+
+	test('foreground quick pick accept keeps the default open target', () => {
+		const options = getQuickPickSessionOpenOptions(false);
+
+		assert.strictEqual(options.sideBySide, false);
+		assert.strictEqual(options.editorOptions?.preserveFocus, false);
+		assert.strictEqual(options.editorOptions?.pinned, false);
+	});
+});


### PR DESCRIPTION
## Summary\n- stop mapping background quick pick acceptance to side-by-side session opening\n- reuse a helper for session picker and quick access open options\n- add coverage for background vs foreground quick pick opens\n\n## Testing\n- NODE_OPTIONS='--max-old-space-size=8192' ./node_modules/.bin/tsc -p src/tsconfig.json --noEmit --pretty false --skipLibCheck\n