### PR TITLE
Git: show commit amend option on detached HEAD

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -186,17 +186,31 @@ export class ActionButton {
 			return [];
 		}
 
-		// Not a branch (tag, detached)
-		if (this.state.HEAD?.type === RefType.Tag || !this.state.HEAD?.name) {
-			return [];
-		}
-
 		// Commit
 		const commandGroups: Command[][] = [];
-		for (const commands of this.postCommitCommandCenter.getSecondaryCommands()) {
-			commandGroups.push(commands.map(c => {
-				return { command: c.command, title: c.title, tooltip: c.tooltip, arguments: c.arguments };
-			}));
+
+		if (this.state.HEAD?.type === RefType.Tag || !this.state.HEAD?.name) {
+			// Not a branch (tag, detached) - show commit/amend commands
+			// but not post-commit commands (push/sync)
+			const commitCommand: Command = {
+				command: 'git.commit',
+				title: l10n.t('{0} Commit', '$(check)'),
+				tooltip: l10n.t('Commit Changes'),
+				arguments: [this.repository.sourceControl, null]
+			};
+			const amendCommand: Command = {
+				command: 'git.commitAmend',
+				title: l10n.t('{0} Commit (Amend)', '$(check)'),
+				tooltip: l10n.t('Commit Changes'),
+				arguments: [this.repository.sourceControl, null]
+			};
+			commandGroups.push([commitCommand, amendCommand]);
+		} else {
+			for (const commands of this.postCommitCommandCenter.getSecondaryCommands()) {
+				commandGroups.push(commands.map(c => {
+					return { command: c.command, title: c.title, tooltip: c.tooltip, arguments: c.arguments };
+				}));
+			}
 		}
 
 		return commandGroups;


### PR DESCRIPTION
Fixes #247936

## Problem

When working on a detached HEAD (e.g., `git checkout HEAD~1`), the commit button dropdown in the Source Control view shows no secondary commands. This means the "Commit (Amend)" option is not available, even though amending commits is a common and valid workflow on detached HEADs.

## Root Cause

In `actionButton.ts`, `getCommitActionButtonSecondaryCommands()` returns an empty array when `HEAD` is a tag or has no branch name (detached HEAD). This was likely done to avoid showing post-commit commands like "Push" and "Sync" that don't apply without a tracking branch, but it also incorrectly hid the basic "Commit" and "Commit (Amend)" options.

## Fix

Instead of returning an empty array for detached HEAD, the method now returns a command group containing the "Commit" and "Commit (Amend)" commands. Post-commit commands (push/sync from providers) are still excluded since they require a tracking branch.

The fix matches the existing patterns in `getCommitActionButtonPrimaryCommand()` (which already correctly shows a plain "Commit" command for detached HEAD) and `postCommitCommands.ts` `getCommitCommands()` (which already defines both commit and amend commands).

## Test Plan

- Checkout a detached HEAD (`git checkout HEAD~1`)
- Open Source Control view
- Click the dropdown on the commit button
- Verify "Commit" and "Commit (Amend)" options are now shown
- Verify push/sync options are NOT shown (correct, since there's no tracking branch)
- Switch back to a branch and verify all options (commit, amend, push, sync) still appear normally