### PR TITLE
fix: remove left offset on right-aligned hover to prevent border clipping

### DIFF
--- a/src/vs/platform/hover/browser/hover.css
+++ b/src/vs/platform/hover/browser/hover.css
@@ -133,8 +133,7 @@
 }
 
 .monaco-hover.workbench-hover.right-aligned {
-	/* The context view service wraps strangely when it's right up against the edge without this */
-	left: 1px;
+	/* Positioned via JS in computeXCordinate with HoverWindowEdgeMargin */
 }
 
 .monaco-hover.workbench-hover.right-aligned .hover-row.status-bar .actions {


### PR DESCRIPTION
## Summary
Fixes the right border being clipped on right-aligned hover widgets when the window is narrow.

**Root cause:** The `.monaco-hover.workbench-hover.right-aligned` CSS rule had a `left: 1px` hack that shifted the hover 1px to the right. When the hover was already positioned at the right edge of the viewport (via `computeXCordinate` with `HoverWindowEdgeMargin`), this extra 1px offset pushed the right border outside the visible area.

**Fix:** Removed the `left: 1px` CSS offset. The JS positioning logic in `computeXCordinate` already handles edge margins correctly via `Constants.HoverWindowEdgeMargin`, making the CSS offset unnecessary.

Fixes #127438

## Test plan
- [ ] Open VS Code with a narrow window
- [ ] Hover over a status bar item that has a long `tooltip2` (markdown tooltip)
- [ ] Verify the right border of the hover is fully visible
- [ ] Resize the window to various widths and confirm the border remains intact
- [ ] Verify right-aligned hovers still position correctly without wrapping issues