### PR TITLE
sessions: collapse customization shortcuts by default

### DIFF
--- a/src/vs/sessions/AI_CUSTOMIZATIONS.md
+++ b/src/vs/sessions/AI_CUSTOMIZATIONS.md
@@ -57,6 +57,12 @@ src/vs/sessions/contrib/sessions/browser/
 └── customizationsToolbar.contribution.ts       # Sidebar customization links
 ```
 
+### Sessions Sidebar Shortcuts Widget
+
+The primary Sessions sidebar embeds `AICustomizationShortcutsWidget` at the bottom of the sessions view. It renders the `Menus.SidebarCustomizations` actions as quick links into the Chat Customizations editor and keeps a total-count badge in the header.
+
+The widget is **collapsed by default** in a fresh profile. Once the user expands or collapses it, the choice is persisted in profile storage under `agentSessions.customizationsCollapsed` and restored on subsequent launches.
+
 ### IAICustomizationWorkspaceService
 
 The `IAICustomizationWorkspaceService` interface controls per-window behavior:

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -440,6 +440,8 @@ The `AuxiliaryBarPart` provides a custom `DropdownWithPrimaryActionViewItem` for
 
 The `SidebarPart` includes a footer section (35px height) positioned below the pane composite content. The sidebar uses a custom `layout()` override that reduces the content height by `FOOTER_HEIGHT` and renders a `MenuWorkbenchToolBar` driven by `Menus.SidebarFooter`. The footer hosts the account widget (see Section 3.6).
 
+Inside the Sessions view itself, the primary sidebar also renders an `AICustomizationShortcutsWidget` beneath the sessions list. That shortcuts widget is collapsed by default for new profiles and persists its expanded/collapsed state in profile storage (`agentSessions.customizationsCollapsed`).
+
 On macOS native with custom titlebar, the sidebar title area includes a traffic light spacer (70px) to push content past the system window controls. The spacer is hidden in fullscreen mode and is not created when using native titlebar (since the OS renders traffic lights in its own title bar).
 
 ---
@@ -640,6 +642,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-03-26 | Changed the Sessions sidebar customization shortcuts widget to start collapsed by default for new profiles while preserving the persisted `agentSessions.customizationsCollapsed` preference after the user toggles it. |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |
 | 2026-02-17 | Added `-webkit-app-region: drag` to sidebar title area so it can be used to drag the window; interactive children (actions, composite bar, labels) marked `no-drag`; CSS rules scoped to `.agent-sessions-workbench` in `parts/media/sidebarPart.css` |

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -52,7 +52,7 @@ export class AICustomizationShortcutsWidget extends Disposable {
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
 		// Get initial collapsed state
-		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, false);
+		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));
 		if (isCollapsed) {

--- a/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
+++ b/src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts
@@ -51,7 +51,9 @@ export class AICustomizationShortcutsWidget extends Disposable {
 	}
 
 	private _render(parent: HTMLElement, options: IAICustomizationShortcutsWidgetOptions | undefined): void {
-		// Get initial collapsed state
+		// New profiles start with the shortcuts collapsed so the sessions list remains the primary
+		// focus in the sidebar. Once the user toggles the section, the stored profile value on this
+		// key takes precedence, so changing the fallback only affects users without a saved choice.
 		const isCollapsed = this.storageService.getBoolean(CUSTOMIZATIONS_COLLAPSED_KEY, StorageScope.PROFILE, true);
 
 		const container = DOM.append(parent, $('.ai-customization-toolbar'));

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -216,7 +216,10 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 		}));
 	}
 
-	// Override storage to set initial collapsed state
+	// The widget reads its initial state from profile storage. The fixture needs to be able to force
+	// both explicit states so screenshots stay stable even though the production fallback is now
+	// collapsed-by-default. Only override the storage service when the fixture provided a concrete
+	// value; otherwise, let the real fallback path run unchanged.
 	if (options?.collapsed !== undefined) {
 		const storageService = instantiationService.get(IStorageService);
 		instantiationService.set(IStorageService, new class extends mock<IStorageService>() {

--- a/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts
@@ -217,12 +217,14 @@ function renderWidget(ctx: ComponentFixtureContext, options?: { mcpServerCount?:
 	}
 
 	// Override storage to set initial collapsed state
-	if (options?.collapsed) {
+	if (options?.collapsed !== undefined) {
 		const storageService = instantiationService.get(IStorageService);
 		instantiationService.set(IStorageService, new class extends mock<IStorageService>() {
-			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean) {
+			override getBoolean(key: string, scope: StorageScope, fallbackValue: boolean): boolean;
+			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean): boolean | undefined;
+			override getBoolean(key: string, scope: StorageScope, fallbackValue?: boolean): boolean | undefined {
 				if (key === 'agentSessions.customizationsCollapsed') {
-					return true;
+					return options.collapsed;
 				}
 				return storageService.getBoolean(key, scope, fallbackValue!);
 			}
@@ -244,7 +246,7 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
 	Expanded: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx),
+		render: ctx => renderWidget(ctx, { collapsed: false }),
 	}),
 
 	Collapsed: defineComponentFixture({
@@ -254,7 +256,7 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
 	WithMcpServers: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, { mcpServerCount: 3 }),
+		render: ctx => renderWidget(ctx, { mcpServerCount: 3, collapsed: false }),
 	}),
 
 	CollapsedWithMcpServers: defineComponentFixture({
@@ -264,8 +266,9 @@ export default defineThemedFixtureGroup({ path: 'sessions/' }, {
 
 	WithCounts: defineComponentFixture({
 		labels: { kind: 'screenshot' },
-		render: (ctx) => renderWidget(ctx, {
+		render: ctx => renderWidget(ctx, {
 			mcpServerCount: 2,
+			collapsed: false,
 			counts: { agents: 2, skills: 30, instructions: 16, prompts: 17, hooks: 4 },
 		}),
 	}),


### PR DESCRIPTION
## Summary

This changes the Sessions sidebar customization shortcuts widget to start collapsed by default for new profiles.

## What Changed

- changed `AICustomizationShortcutsWidget` to use a collapsed fallback when no profile preference is stored
- preserved the existing `agentSessions.customizationsCollapsed` setting so user toggles continue to persist
- updated the Sessions widget fixture to explicitly render both expanded and collapsed states, keeping screenshots stable after the default changed
- documented the behavior in `src/vs/sessions/AI_CUSTOMIZATIONS.md` and `src/vs/sessions/LAYOUT.md`
- added explanatory comments around the new default and fixture override path based on review feedback

## Why

The customization shortcuts live below the main sessions list in the primary Sessions sidebar. Starting them collapsed keeps the sessions list as the primary focus while still letting users expand the section and keep their preference.

## Validation

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget.ts src/vs/sessions/contrib/sessions/test/browser/aiCustomizationShortcutsWidget.fixture.ts`
- `npm run valid-layers-check`