### PR TITLE
fix: preserve chat session index during workspace transition

### DIFF
--- a/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts
@@ -77,6 +77,14 @@ export class ChatSessionStore extends Disposable {
 
 		this.transferredSessionStorageRoot = joinPath(this.userDataProfilesService.defaultProfile.globalStorageHome, 'transferredChatSessions');
 
+		// Eagerly populate the index cache before the storage service
+		// switches workspace storage. storageService.switch() fires
+		// onWillSaveState before closing the old storage, so this
+		// ensures indexCache holds the old index when migration runs.
+		this._register(this.storageService.onWillSaveState(() => {
+			this.internalGetIndex();
+		}));
+
 		// Listen to workspace transitions to migrate chat sessions
 		this._register(this.workspaceEditingService.onDidEnterWorkspace(event => {
 			const transitionPromise = this.storeQueue.queue(() => this.handleWorkspaceTransition(event.oldWorkspace, event.newWorkspace));
@@ -123,12 +131,21 @@ export class ChatSessionStore extends Disposable {
 		// Update storage root for the new workspace
 		this.storageRoot = newStorageRoot;
 
-		// Migrate session files from old to new location
+		// Migrate session files from old to new location.
+		// indexCache was populated before the switch via onWillSaveState,
+		// so it still holds the old workspace's index entries.
 		await this.migrateSessionsToNewWorkspace(oldStorageRoot, wasEmptyWindow, isNewWorkspaceEmpty);
 	}
 
 	private async migrateSessionsToNewWorkspace(oldStorageRoot: URI, wasEmptyWindow: boolean, isNewWorkspaceEmpty: boolean): Promise<void> {
 		try {
+			// Use the cached index as the source of truth for old entries.
+			// The cache was eagerly populated via onWillSaveState before
+			// storageService.switch() replaced the workspace storage, so it
+			// still contains the old workspace's index regardless of whether
+			// the old scope was APPLICATION or WORKSPACE.
+			const oldIndex = this.indexCache ?? { version: 1, entries: {} };
+
 			// Check if old storage location exists
 			const oldStorageExists = await this.fileService.exists(oldStorageRoot);
 			if (!oldStorageExists) {
@@ -168,8 +185,17 @@ export class ChatSessionStore extends Disposable {
 
 			this.logService.info(`ChatSessionStore: Copied ${migratedCount} chat session files from ${wasEmptyWindow ? 'empty window' : oldStorageRoot.toString()} to ${isNewWorkspaceEmpty ? 'empty window' : this.storageRoot.toString()} (originals preserved at old location)`);
 
-			// Clear the index cache and flush it to the new storage scope
-			this.indexCache = undefined;
+			// Merge old index entries into the new workspace's index.
+			// The new scope may already have entries (e.g. if sessions were
+			// created after the workspace switch but before migration ran).
+			// Preserve those and add old entries that don't conflict.
+			this.indexCache = undefined; // force re-read from new scope
+			const newIndex = this.internalGetIndex();
+			for (const [id, entry] of Object.entries(oldIndex.entries)) {
+				if (!newIndex.entries[id]) {
+					newIndex.entries[id] = entry;
+				}
+			}
 			try {
 				await this.flushIndex();
 			} catch (e) {
@@ -536,6 +562,7 @@ export class ChatSessionStore extends Disposable {
 	}
 
 	private indexCache: IChatSessionIndexData | undefined;
+
 	private internalGetIndex(): IChatSessionIndexData {
 		if (this.indexCache) {
 			return this.indexCache;

--- a/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/model/chatSessionStore.test.ts
@@ -13,7 +13,7 @@ import { IFileService } from '../../../../../../platform/files/common/files.js';
 import { ServiceCollection } from '../../../../../../platform/instantiation/common/serviceCollection.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { ILogService, NullLogService } from '../../../../../../platform/log/common/log.js';
-import { IStorageService } from '../../../../../../platform/storage/common/storage.js';
+import { IStorageService, WillSaveStateReason } from '../../../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { IUserDataProfilesService, toUserDataProfile } from '../../../../../../platform/userDataProfile/common/userDataProfile.js';
@@ -460,6 +460,43 @@ suite('ChatSessionStore', () => {
 
 			const newStorageRoot = store.getChatStorageFolder();
 			assert.ok(newStorageRoot.path.includes('new-workspace-id'), 'Storage root should be updated to new workspace location');
+		});
+
+		test('session index is preserved after workspace transition', async () => {
+			const storageService = instantiationService.get(IStorageService) as TestStorageService;
+
+			// Create store with empty window and store sessions
+			const store = createChatSessionStore(true);
+			const model1 = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-1'), { customTitle: 'First Session' }));
+			const model2 = testDisposables.add(createMockChatModel(LocalChatSessionUri.forSession('session-2'), { customTitle: 'Second Session' }));
+
+			await store.storeSessions([model1, model2]);
+			assert.strictEqual(Object.keys(await store.getIndex()).length, 2);
+
+			// Simulate the real storageService.switch() sequence:
+			// 1. onWillSaveState fires (populates indexCache in the store)
+			// 2. Storage scope changes from APPLICATION to WORKSPACE
+			// 3. onDidEnterWorkspace fires (triggers migration)
+			storageService.testEmitWillSaveState(WillSaveStateReason.NONE);
+
+			const contextService = instantiationService.get(IWorkspaceContextService) as TestContextService;
+			contextService.setWorkspace(TestWorkspace);
+
+			const oldWorkspace: IAnyWorkspaceIdentifier = { id: 'empty-window-id' };
+			const newWorkspace: IAnyWorkspaceIdentifier = { id: TestWorkspace.id, uri: URI.file('/test/folder') };
+
+			await mockWorkspaceEditingService.fireWorkspaceTransition(oldWorkspace, newWorkspace);
+
+			// Create a fresh store to verify the index was persisted to the
+			// new WORKSPACE scope and not just cached in memory.
+			const store2 = createChatSessionStore(false);
+			const index = await store2.getIndex();
+			assert.deepStrictEqual(
+				Object.keys(index).sort(),
+				['session-1', 'session-2'],
+			);
+			assert.strictEqual(index['session-1'].title, 'First Session');
+			assert.strictEqual(index['session-2'].title, 'Second Session');
 		});
 	});
 });


### PR DESCRIPTION
## Bug

When the workspace identity changes (e.g. adding a folder to a single-folder Remote SSH session and saving as a `.code-workspace` file), all Copilot Chat history disappears from **Show Chats**. The `.jsonl` session files are correctly copied to the new workspace storage folder, but the index that maps session IDs to titles/timestamps is lost — so after the window reloads (which always happens on Remote SSH), **Show Chats** returns nothing.

### Root Cause

In `ChatSessionStore.migrateSessionsToNewWorkspace()`:

1. Session `.jsonl` files are copied from the old storage root to the new one
2. `this.indexCache = undefined` clears the in-memory index
3. `flushIndex()` is called, which internally calls `internalGetIndex()`
4. But `storageService.switch()` has already run (in `enterWorkspace()` before `fireDidEnterWorkspace`), which **closes the old workspace storage DB** and creates a new empty one
5. `StorageScope.WORKSPACE` now points to the new empty DB — `internalGetIndex()` reads nothing, creates an empty index, and flushes it
6. **All session metadata is lost** — titles, timestamps, session IDs are gone

This affects **both** workspace→workspace transitions (the primary repro) and empty window→workspace transitions.

### Fix

Register an `onWillSaveState` listener that eagerly populates `indexCache` via `internalGetIndex()`. The storage service fires `onWillSaveState` **before** closing the old workspace storage in `switch()`, so the cache captures the old index while the old DB is still open. When `migrateSessionsToNewWorkspace` runs afterward, it uses the cached index as the source of truth, then merges old entries into the new scope's index (preserving any entries that may already exist in the target).

This approach works for all transition types because the cache is populated before the storage swap — regardless of whether the old scope was `APPLICATION` (empty window) or `WORKSPACE`.

### Test

Added `session index is preserved after workspace transition` regression test that:
1. Stores sessions in an empty window
2. Fires `onWillSaveState` to simulate `storageService.switch()` populating the cache
3. Switches `TestContextService` to a non-empty workspace (simulating the scope change)
4. Fires `onDidEnterWorkspace` to trigger migration
5. Creates a **fresh** `ChatSessionStore` to verify the index was persisted to the correct `WORKSPACE` scope (not just cached in memory)

### Repro steps (before fix)

1. Connect to a remote host via **Remote SSH**
2. Open a folder — have several Copilot Chat conversations
3. **Add another folder** to the workspace (making it multi-root)
4. Save Workspace As... when prompted
5. Window reloads — all chat history is gone from **Show Chats**
6. The `.jsonl` session files exist in the new `workspaceStorage/` folder but the index is empty

Fixes #301793
Related: #285242
