### PR TITLE
Add search.quickOpen.matchMode setting for word-boundary and contiguous matching

### DIFF
--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -22,7 +22,7 @@ const NO_SCORE: FuzzyScore = [NO_MATCH, []];
 // const DEBUG = true;
 // const DEBUG_MATRIX = false;
 
-export function scoreFuzzy(target: string, query: string, queryLower: string, allowNonContiguousMatches: boolean): FuzzyScore {
+export function scoreFuzzy(target: string, query: string, queryLower: string, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean = false): FuzzyScore {
 	if (!target || !query) {
 		return NO_SCORE; // return early if target or query are undefined
 	}
@@ -39,7 +39,7 @@ export function scoreFuzzy(target: string, query: string, queryLower: string, al
 	// }
 
 	const targetLower = target.toLowerCase();
-	const res = doScoreFuzzy(query, queryLower, queryLength, target, targetLower, targetLength, allowNonContiguousMatches);
+	const res = doScoreFuzzy(query, queryLower, queryLength, target, targetLower, targetLength, allowNonContiguousMatches, wordBoundaryFuzzy);
 
 	// if (DEBUG) {
 	// 	console.log(`%cFinal Score: ${res[0]}`, 'font-weight: bold');
@@ -49,7 +49,25 @@ export function scoreFuzzy(target: string, query: string, queryLower: string, al
 	return res;
 }
 
-function doScoreFuzzy(query: string, queryLower: string, queryLength: number, target: string, targetLower: string, targetLength: number, allowNonContiguousMatches: boolean): FuzzyScore {
+function isWordStart(target: string, targetIndex: number): boolean {
+	if (targetIndex === 0) {
+		return true; // start of string is always a word start
+	}
+
+	// After a separator character
+	if (scoreSeparatorAtPos(target.charCodeAt(targetIndex - 1)) > 0) {
+		return true;
+	}
+
+	// CamelCase transition: current char is uppercase and previous is not
+	if (isUpper(target.charCodeAt(targetIndex)) && !isUpper(target.charCodeAt(targetIndex - 1))) {
+		return true;
+	}
+
+	return false;
+}
+
+function doScoreFuzzy(query: string, queryLower: string, queryLength: number, target: string, targetLower: string, targetLength: number, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean = false): FuzzyScore {
 	const scores: number[] = [];
 	const matches: number[] = [];
 
@@ -114,7 +132,12 @@ function doScoreFuzzy(query: string, queryLower: string, queryLength: number, ta
 				queryIndexGtNull ||
 				// lastly check if the query is completely contiguous at this index in the target
 				targetLower.startsWith(queryLower, targetIndex)
-			)) {
+			) && (
+					// Word boundary fuzzy: when starting a new match group (not a consecutive match),
+					// require the target character to be at a word boundary (start of string, after
+					// separator, or CamelCase transition). Consecutive matches are unrestricted.
+					!wordBoundaryFuzzy || matchesSequenceLength > 0 || isWordStart(target, targetIndex)
+				)) {
 				matches[currentIndex] = matchesSequenceLength + 1;
 				scores[currentIndex] = diagScore + score;
 			}
@@ -380,20 +403,21 @@ const PATH_IDENTITY_SCORE = 1 << 18;
 const LABEL_PREFIX_SCORE_THRESHOLD = 1 << 17;
 const LABEL_SCORE_THRESHOLD = 1 << 16;
 
-function getCacheHash(label: string, description: string | undefined, allowNonContiguousMatches: boolean, query: IPreparedQuery) {
+function getCacheHash(label: string, description: string | undefined, allowNonContiguousMatches: boolean, query: IPreparedQuery, wordBoundaryFuzzy: boolean = false) {
 	const values = query.values ? query.values : [query];
 	const cacheHash = hash({
 		[query.normalized]: {
 			values: values.map(v => ({ value: v.normalized, expectContiguousMatch: v.expectContiguousMatch })),
 			label,
 			description,
-			allowNonContiguousMatches
+			allowNonContiguousMatches,
+			wordBoundaryFuzzy
 		}
 	});
 	return cacheHash;
 }
 
-export function scoreItemFuzzy<T>(item: T, query: IPreparedQuery, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>, cache: FuzzyScorerCache): IItemScore {
+export function scoreItemFuzzy<T>(item: T, query: IPreparedQuery, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>, cache: FuzzyScorerCache, wordBoundaryFuzzy: boolean = false): IItemScore {
 	if (!item || !query.normalized) {
 		return NO_ITEM_SCORE; // we need an item and query to score on at least
 	}
@@ -410,19 +434,19 @@ export function scoreItemFuzzy<T>(item: T, query: IPreparedQuery, allowNonContig
 	// - description (if provided)
 	// - whether non-contiguous matching is enabled or not
 	// - hash of the query (normalized) values
-	const cacheHash = getCacheHash(label, description, allowNonContiguousMatches, query);
+	const cacheHash = getCacheHash(label, description, allowNonContiguousMatches, query, wordBoundaryFuzzy);
 	const cached = cache[cacheHash];
 	if (cached) {
 		return cached;
 	}
 
-	const itemScore = doScoreItemFuzzy(label, description, accessor.getItemPath(item), query, allowNonContiguousMatches);
+	const itemScore = doScoreItemFuzzy(label, description, accessor.getItemPath(item), query, allowNonContiguousMatches, wordBoundaryFuzzy);
 	cache[cacheHash] = itemScore;
 
 	return itemScore;
 }
 
-function doScoreItemFuzzy(label: string, description: string | undefined, path: string | undefined, query: IPreparedQuery, allowNonContiguousMatches: boolean): IItemScore {
+function doScoreItemFuzzy(label: string, description: string | undefined, path: string | undefined, query: IPreparedQuery, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean = false): IItemScore {
 	const preferLabelMatches = !path || !query.containsPathSeparator;
 
 	// Treat identity matches on full path highest
@@ -432,20 +456,20 @@ function doScoreItemFuzzy(label: string, description: string | undefined, path: 
 
 	// Score: multiple inputs
 	if (query.values && query.values.length > 1) {
-		return doScoreItemFuzzyMultiple(label, description, path, query.values, preferLabelMatches, allowNonContiguousMatches);
+		return doScoreItemFuzzyMultiple(label, description, path, query.values, preferLabelMatches, allowNonContiguousMatches, wordBoundaryFuzzy);
 	}
 
 	// Score: single input
-	return doScoreItemFuzzySingle(label, description, path, query, preferLabelMatches, allowNonContiguousMatches);
+	return doScoreItemFuzzySingle(label, description, path, query, preferLabelMatches, allowNonContiguousMatches, wordBoundaryFuzzy);
 }
 
-function doScoreItemFuzzyMultiple(label: string, description: string | undefined, path: string | undefined, query: IPreparedQueryPiece[], preferLabelMatches: boolean, allowNonContiguousMatches: boolean): IItemScore {
+function doScoreItemFuzzyMultiple(label: string, description: string | undefined, path: string | undefined, query: IPreparedQueryPiece[], preferLabelMatches: boolean, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean = false): IItemScore {
 	let totalScore = 0;
 	const totalLabelMatches: IMatch[] = [];
 	const totalDescriptionMatches: IMatch[] = [];
 
 	for (const queryPiece of query) {
-		const { score, labelMatch, descriptionMatch } = doScoreItemFuzzySingle(label, description, path, queryPiece, preferLabelMatches, allowNonContiguousMatches);
+		const { score, labelMatch, descriptionMatch } = doScoreItemFuzzySingle(label, description, path, queryPiece, preferLabelMatches, allowNonContiguousMatches, wordBoundaryFuzzy);
 		if (score === NO_MATCH) {
 			// if a single query value does not match, return with
 			// no score entirely, we require all queries to match
@@ -471,7 +495,7 @@ function doScoreItemFuzzyMultiple(label: string, description: string | undefined
 	};
 }
 
-function doScoreItemFuzzySingle(label: string, description: string | undefined, path: string | undefined, query: IPreparedQueryPiece, preferLabelMatches: boolean, allowNonContiguousMatches: boolean): IItemScore {
+function doScoreItemFuzzySingle(label: string, description: string | undefined, path: string | undefined, query: IPreparedQueryPiece, preferLabelMatches: boolean, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean = false): IItemScore {
 
 	// Prefer label matches if told so or we have no description
 	if (preferLabelMatches || !description) {
@@ -479,7 +503,8 @@ function doScoreItemFuzzySingle(label: string, description: string | undefined, 
 			label,
 			query.normalized,
 			query.normalizedLowercase,
-			allowNonContiguousMatches && !query.expectContiguousMatch);
+			allowNonContiguousMatches && !query.expectContiguousMatch,
+			wordBoundaryFuzzy);
 		if (labelScore) {
 
 			// If we have a prefix match on the label, we give a much
@@ -521,7 +546,8 @@ function doScoreItemFuzzySingle(label: string, description: string | undefined, 
 			descriptionAndLabel,
 			query.normalized,
 			query.normalizedLowercase,
-			allowNonContiguousMatches && !query.expectContiguousMatch);
+			allowNonContiguousMatches && !query.expectContiguousMatch,
+			wordBoundaryFuzzy);
 		if (labelDescriptionScore) {
 			const labelDescriptionMatches = createMatches(labelDescriptionPositions);
 			const labelMatch: IMatch[] = [];
@@ -620,9 +646,9 @@ function matchOverlaps(matchA: IMatch, matchB: IMatch): boolean {
 
 //#region Comparers
 
-export function compareItemsByFuzzyScore<T>(itemA: T, itemB: T, query: IPreparedQuery, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>, cache: FuzzyScorerCache): number {
-	const itemScoreA = scoreItemFuzzy(itemA, query, allowNonContiguousMatches, accessor, cache);
-	const itemScoreB = scoreItemFuzzy(itemB, query, allowNonContiguousMatches, accessor, cache);
+export function compareItemsByFuzzyScore<T>(itemA: T, itemB: T, query: IPreparedQuery, allowNonContiguousMatches: boolean, accessor: IItemAccessor<T>, cache: FuzzyScorerCache, wordBoundaryFuzzy: boolean = false): number {
+	const itemScoreA = scoreItemFuzzy(itemA, query, allowNonContiguousMatches, accessor, cache, wordBoundaryFuzzy);
+	const itemScoreB = scoreItemFuzzy(itemB, query, allowNonContiguousMatches, accessor, cache, wordBoundaryFuzzy);
 
 	const scoreA = itemScoreA.score;
 	const scoreB = itemScoreB.score;

--- a/src/vs/base/test/common/fuzzyScorer.test.ts
+++ b/src/vs/base/test/common/fuzzyScorer.test.ts
@@ -1355,3 +1355,85 @@ suite('Fuzzy Scorer', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 });
+
+suite('Fuzzy Scorer - Word Boundary Mode', () => {
+
+	function doScoreWordBoundary(target: string, query: string): FuzzyScore {
+		const preparedQuery = prepareQuery(query);
+		return scoreFuzzy(target, preparedQuery.normalized, preparedQuery.normalizedLowercase, true, true);
+	}
+
+	test('matches at word starts (CamelCase)', function () {
+		// "HW" should match "HelloWorld" — H at start, W at camel boundary
+		const score = doScoreWordBoundary('HelloWorld', 'HW');
+		assert.ok(score[0] > 0, 'HW should match HelloWorld at word boundaries');
+		assert.deepStrictEqual(score[1], [0, 5]);
+	});
+
+	test('matches at word starts (case-insensitive)', function () {
+		// "hw" should match "HelloWorld" — h at start, w at camel boundary
+		const score = doScoreWordBoundary('HelloWorld', 'hw');
+		assert.ok(score[0] > 0, 'hw should match HelloWorld at word boundaries');
+		assert.deepStrictEqual(score[1], [0, 5]);
+	});
+
+	test('rejects mid-word scattered matches', function () {
+		// "eo" should NOT match "HelloWorld" — e and o are mid-word
+		const score = doScoreWordBoundary('HelloWorld', 'eo');
+		assert.strictEqual(score[0], 0, 'eo should not match HelloWorld in word boundary mode');
+	});
+
+	test('consecutive chars within a word are allowed', function () {
+		// "HeWo" should match "HelloWorld" — He starts at word start, Wo starts at word start
+		const score = doScoreWordBoundary('HelloWorld', 'HeWo');
+		assert.ok(score[0] > 0, 'HeWo should match HelloWorld');
+	});
+
+	test('rejects non-word-boundary scattered matches', function () {
+		// "abc" should NOT match "xaxbxc" — a, b, c are not at word starts
+		const score = doScoreWordBoundary('xaxbxc', 'abc');
+		assert.strictEqual(score[0], 0, 'abc should not match xaxbxc in word boundary mode');
+	});
+
+	test('matches after separator characters', function () {
+		// "abc" should match "a-b-c" — each letter is after a separator
+		const score = doScoreWordBoundary('a-b-c', 'abc');
+		assert.ok(score[0] > 0, 'abc should match a-b-c at separator boundaries');
+	});
+
+	test('matches after underscore separators', function () {
+		const score = doScoreWordBoundary('my_file_name', 'mfn');
+		assert.ok(score[0] > 0, 'mfn should match my_file_name at underscore boundaries');
+	});
+
+	test('matches after dot separators', function () {
+		const score = doScoreWordBoundary('fuzzyScorer.test.ts', 'ftt');
+		assert.ok(score[0] > 0, 'ftt should match fuzzyScorer.test.ts at dot boundaries');
+	});
+
+	test('matches with path separators', function () {
+		const score = doScoreWordBoundary('src/vs/base/common', 'svbc');
+		assert.ok(score[0] > 0, 'svbc should match src/vs/base/common at path separators');
+	});
+
+	test('contiguous substring still works', function () {
+		// "Hello" should match "HelloWorld" — contiguous from start
+		const score = doScoreWordBoundary('HelloWorld', 'Hello');
+		assert.ok(score[0] > 0, 'Hello should match HelloWorld');
+	});
+
+	test('single character at word start matches', function () {
+		const score = doScoreWordBoundary('HelloWorld', 'H');
+		assert.ok(score[0] > 0, 'H should match HelloWorld');
+	});
+
+	test('single character not at word start does not match', function () {
+		// "e" is at position 1 in "Hello" — not a word start
+		// But the scorer may find it elsewhere; in "HelloWorld" e is only mid-word
+		// Since there's no word start position with 'e', score should be 0
+		const score = doScoreWordBoundary('xyzt', 'y');
+		assert.strictEqual(score[0], 0, 'y should not match xyzt in word boundary mode (no word start has y)');
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -216,6 +216,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			includeSymbols: searchConfig?.quickOpen?.includeSymbols,
 			includeHistory: searchConfig?.quickOpen?.includeHistory ?? true,
 			historyFilterSortOrder: searchConfig?.quickOpen?.history?.filterSortOrder,
+			matchMode: searchConfig?.quickOpen?.matchMode ?? 'fuzzy',
 			preserveInput: quickAccessConfig?.preserveInput
 		};
 	}
@@ -371,6 +372,11 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			return this.pickState.lastGlobalPicks;
 		}
 
+		// Compute match mode parameters from configuration
+		const matchMode = this.configuration.matchMode;
+		const allowNonContiguousMatches = matchMode !== 'contiguous';
+		const wordBoundaryFuzzy = matchMode === 'wordBoundary';
+
 		// Otherwise return normally with history and file/symbol results
 		const historyEditorPicks = this.getEditorHistoryPicks(query);
 
@@ -386,7 +392,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 					picks.push(pick);
 					continue;
 				}
-				const { score, labelMatch, descriptionMatch } = scoreItemFuzzy(pick, query, true, quickPickItemScorerAccessor, this.pickState.scorerCache);
+				const { score, labelMatch, descriptionMatch } = scoreItemFuzzy(pick, query, allowNonContiguousMatches, quickPickItemScorerAccessor, this.pickState.scorerCache, wordBoundaryFuzzy);
 				if (!score) {
 					continue;
 				}
@@ -428,7 +434,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 					}
 				}
 
-				let additionalPicks = await this.getAdditionalPicks(query, additionalPicksExcludes, Boolean(this.configuration?.includeSymbols), token);
+				let additionalPicks = await this.getAdditionalPicks(query, additionalPicksExcludes, Boolean(this.configuration?.includeSymbols), allowNonContiguousMatches, wordBoundaryFuzzy, token);
 				if (options.filter) {
 					additionalPicks = additionalPicks.filter((p) => options.filter?.(p));
 				}
@@ -447,7 +453,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		};
 	}
 
-	private async getAdditionalPicks(query: IPreparedQuery, excludes: ResourceMap<boolean>, includeSymbols: boolean, token: CancellationToken): Promise<Array<IAnythingQuickPickItem>> {
+	private async getAdditionalPicks(query: IPreparedQuery, excludes: ResourceMap<boolean>, includeSymbols: boolean, allowNonContiguousMatches: boolean, wordBoundaryFuzzy: boolean, token: CancellationToken): Promise<Array<IAnythingQuickPickItem>> {
 
 		// Resolve file and symbol picks (if enabled)
 		const [filePicks, symbolPicks] = await Promise.all([
@@ -462,7 +468,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		// Perform sorting (top results by score)
 		const sortedAnythingPicks = top(
 			[...filePicks, ...symbolPicks],
-			(anyPickA, anyPickB) => compareItemsByFuzzyScore(anyPickA, anyPickB, query, true, quickPickItemScorerAccessor, this.pickState.scorerCache),
+			(anyPickA, anyPickB) => compareItemsByFuzzyScore(anyPickA, anyPickB, query, allowNonContiguousMatches, quickPickItemScorerAccessor, this.pickState.scorerCache, wordBoundaryFuzzy),
 			AnythingQuickAccessProvider.MAX_RESULTS
 		);
 
@@ -477,7 +483,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 			// Otherwise, do the scoring and matching here
 			else {
-				const { score, labelMatch, descriptionMatch } = scoreItemFuzzy(anythingPick, query, true, quickPickItemScorerAccessor, this.pickState.scorerCache);
+				const { score, labelMatch, descriptionMatch } = scoreItemFuzzy(anythingPick, query, allowNonContiguousMatches, quickPickItemScorerAccessor, this.pickState.scorerCache, wordBoundaryFuzzy);
 				if (!score) {
 					continue;
 				}

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -174,11 +174,6 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('search.quickOpen.includeSymbols', "Whether to include results from a global symbol search in the file results for Quick Open."),
 			default: false
 		},
-		'search.ripgrep.maxThreads': {
-			type: 'number',
-			description: nls.localize('search.ripgrep.maxThreads', "Number of threads to use for searching. When set to 0, the engine automatically determines this value."),
-			default: 0
-		},
 		'search.quickOpen.includeHistory': {
 			type: 'boolean',
 			description: nls.localize('search.quickOpen.includeHistory', "Whether to include results from recently opened files in the file results for Quick Open."),
@@ -194,6 +189,22 @@ configurationRegistry.registerConfiguration({
 				nls.localize('filterSortOrder.recency', 'History entries are sorted by recency. More recently opened entries appear first.')
 			],
 			description: nls.localize('filterSortOrder', "Controls sorting order of editor history in quick open when filtering.")
+		},
+		'search.quickOpen.matchMode': {
+			type: 'string',
+			enum: ['fuzzy', 'wordBoundary', 'contiguous'],
+			default: 'fuzzy',
+			enumDescriptions: [
+				nls.localize('matchMode.fuzzy', 'Characters can match anywhere in the file name or path, even if they are not adjacent. For example, "hw" matches "HelloWorld.ts", "showMe.ts", etc.'),
+				nls.localize('matchMode.wordBoundary', 'Each character group in the query must start at a word boundary (start of name, after a separator like "-" or "_", or at a CamelCase transition). For example, "hw" matches "HelloWorld.ts" but not "showMe.ts".'),
+				nls.localize('matchMode.contiguous', 'All query characters must appear consecutively in the file name or path. For example, "hello" matches "helloWorld.ts" but "hw" does not.')
+			],
+			description: nls.localize('search.quickOpen.matchMode', "Controls how the Quick Open file picker matches query characters against file names.")
+		},
+		'search.ripgrep.maxThreads': {
+			type: 'number',
+			description: nls.localize('search.ripgrep.maxThreads', "Number of threads to use for searching. When set to 0, the engine automatically determines this value."),
+			default: 0
 		},
 		'search.followSymlinks': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -125,6 +125,7 @@ export interface IWorkbenchSearchConfigurationProperties extends ISearchConfigur
 	quickOpen?: {
 		includeSymbols?: boolean;
 		includeHistory?: boolean;
+		matchMode?: 'fuzzy' | 'wordBoundary' | 'contiguous';
 		history?: {
 			filterSortOrder?: 'default' | 'recency';
 		};


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/305116

## Problem

Quick Open (Ctrl+P) fuzzy matching matches individual characters anywhere in file names, which produces many irrelevant results in large workspaces. For example, typing `hw` matches not only `HelloWorld.ts` but also `showMe.ts` where `h` and `w` appear mid-word.

## Solution

Adds a new `search.quickOpen.matchMode` setting with three modes:
- **`fuzzy`** (default) — current behavior, no change for existing users
- **`wordBoundary`** — each new match group must start at a word boundary (position 0, after separators like `-_./\`, or CamelCase transitions like `helloWorld` → `W`)
- **`contiguous`** — all query characters must be consecutive

### Examples

| Query | Target | fuzzy | wordBoundary | contiguous |
|-------|--------|-------|--------------|------------|
| `hw` | `HelloWorld.ts` | ✅ | ✅ H at start, W at camel boundary | ❌ |
| `hw` | `showMe.ts` | ✅ | ❌ h and w are mid-word | ❌ |
| `mfn` | `my_file_name.ts` | ✅ | ✅ each letter after `_` | ❌ |
| `eo` | `HelloWorld.ts` | ✅ | ❌ e and o not at word starts | ❌ |
| `hello` | `helloWorld.ts` | ✅ | ✅ starts at position 0 | ✅ |
| `HeWo` | `HelloWorld.ts` | ✅ | ✅ consecutive from word starts | ❌ |
| `abc` | `a-b-c.ts` | ✅ | ✅ each letter after separator | ❌ |
| `abc` | `xaxbxc.ts` | ✅ | ❌ a, b, c not at word starts | ❌ |

## Changes
- **`fuzzyScorer.ts`** — Add `isWordStart()` helper and optional `wordBoundaryFuzzy` parameter (default `false`) throughout the scoring chain. Existing callers are unaffected.
- **`search.contribution.ts`** — Register `search.quickOpen.matchMode` setting.
- **`search.ts`** — Add `matchMode` to `IWorkbenchSearchConfigurationProperties`.
- **`anythingQuickAccess.ts`** — Read setting and pass to scoring functions.
- **`fuzzyScorer.test.ts`** — 12 new tests for word-boundary mode.

## Validation
- TypeScript compilation: clean
- All 77 fuzzy scorer tests pass (65 existing + 12 new)
- No breaking changes — default is `fuzzy` (current behavior)
