### PR TITLE
sessions: refactor branch/isolation pickers to use session as source of truth

### DIFF
--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -36,6 +36,7 @@ export class BranchPicker extends Disposable {
 	private _selectedBranch: string | undefined;
 	private _branches: string[] = [];
 	private _loading = false;
+	private _disabled = false;
 
 	private readonly _onDidChange = this._register(new Emitter<string | undefined>());
 	readonly onDidChange: Event<string | undefined> = this._onDidChange.event;
@@ -56,18 +57,26 @@ export class BranchPicker extends Disposable {
 			const session = this.sessionsManagementService.activeSession.read(reader);
 			if (session instanceof CopilotCLISession) {
 				const isLoading = session.loading.read(reader);
-				if (!isLoading && session.gitRepository) {
+				const isolationMode = session.isolationModeObservable.read(reader);
+				if (isolationMode === 'workspace') {
+					this._disabled = true;
+					this._updateTriggerLabel();
+				} else if (!isLoading && session.gitRepository) {
+					this._disabled = false;
 					this._loadBranches(session);
 				} else if (isLoading) {
 					// Session is still loading — show disabled state
+					this._disabled = false;
 					this._loading = true;
 					this._branches = [];
 					this._updateTriggerLabel();
 				} else {
 					// No git repo
+					this._disabled = false;
 					this._clearBranches();
 				}
 			} else {
+				this._disabled = false;
 				this._clearBranches();
 			}
 		}));
@@ -149,7 +158,7 @@ export class BranchPicker extends Disposable {
 	}
 
 	showPicker(): void {
-		if (!this._triggerElement || this.actionWidgetService.isVisible || this._branches.length === 0) {
+		if (!this._triggerElement || this.actionWidgetService.isVisible || this._branches.length === 0 || this._disabled) {
 			return;
 		}
 
@@ -219,12 +228,14 @@ export class BranchPicker extends Disposable {
 			return;
 		}
 
-		const isDisabled = this._branches.length === 0;
+		const isDisabled = this._disabled || this._branches.length === 0;
 		const label = this._selectedBranch ?? localize('branchPicker.select', "Branch");
 		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
 		this._slotElement?.classList.toggle('disabled', isDisabled);
+		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
+		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/branchPicker.ts
@@ -5,8 +5,7 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IActionWidgetService } from '../../../../platform/actionWidget/browser/actionWidget.js';
@@ -14,35 +13,21 @@ import { ActionListItemKind, IActionListDelegate, IActionListItem } from '../../
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { CopilotCLISession } from './copilotChatSessionsProvider.js';
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 
 const FILTER_THRESHOLD = 10;
-const COPILOT_WORKTREE_PATTERN = 'copilot-worktree-';
 
 interface IBranchItem {
 	readonly name: string;
 }
 
 /**
- * A self-contained widget for selecting a git branch.
- * Observes the active session from {@link ISessionsManagementService} to get
- * the current project, opens the git repository via {@link IGitService},
- * and loads branches automatically.
- *
- * Emits `onDidChange` with the selected branch name.
+ * A widget for selecting a git branch.
+ * Reads branch list and selected branch from the active {@link CopilotCLISession},
+ * which is the source of truth for branch state.
  */
 export class BranchPicker extends Disposable {
 
-	private _selectedBranch: string | undefined;
-	private _branches: string[] = [];
-	private _loading = false;
-	private _disabled = false;
-
-	private readonly _onDidChange = this._register(new Emitter<string | undefined>());
-	readonly onDidChange: Event<string | undefined> = this._onDidChange.event;
-
 	private readonly _renderDisposables = this._register(new DisposableStore());
-	private readonly _loadCts = this._register(new MutableDisposable<CancellationTokenSource>());
 	private _slotElement: HTMLElement | undefined;
 	private _triggerElement: HTMLElement | undefined;
 
@@ -52,83 +37,22 @@ export class BranchPicker extends Disposable {
 	) {
 		super();
 
-		// Watch the active session — load branches when a CopilotCLISession finishes loading
 		this._register(autorun(reader => {
 			const session = this.sessionsManagementService.activeSession.read(reader);
 			if (session instanceof CopilotCLISession) {
-				const isLoading = session.loading.read(reader);
-				const isolationMode = session.isolationModeObservable.read(reader);
-				if (isolationMode === 'workspace') {
-					this._disabled = true;
-					this._updateTriggerLabel();
-				} else if (!isLoading && session.gitRepository) {
-					this._disabled = false;
-					this._loadBranches(session);
-				} else if (isLoading) {
-					// Session is still loading — show disabled state
-					this._disabled = false;
-					this._loading = true;
-					this._branches = [];
-					this._updateTriggerLabel();
-				} else {
-					// No git repo
-					this._disabled = false;
-					this._clearBranches();
-				}
-			} else {
-				this._disabled = false;
-				this._clearBranches();
+				session.loading.read(reader);
+				session.branches.read(reader);
+				session.branchesLoading.read(reader);
+				session.branchObservable.read(reader);
+				session.isolationModeObservable.read(reader);
 			}
+			this._updateTriggerLabel();
 		}));
 	}
 
-	private _loadBranches(session: CopilotCLISession): void {
-		const repo = session.gitRepository;
-		if (!repo) {
-			this._clearBranches();
-			return;
-		}
-
-		this._loadCts.value?.cancel();
-		const cts = this._loadCts.value = new CancellationTokenSource();
-
-		this._loading = true;
-		this._updateTriggerLabel();
-
-		repo.getRefs({ pattern: 'refs/heads' }, cts.token).then(refs => {
-			if (cts.token.isCancellationRequested) {
-				return;
-			}
-			this._branches = refs
-				.map(r => r.name)
-				.filter((name): name is string => !!name)
-				.filter(name => !name.includes(COPILOT_WORKTREE_PATTERN));
-			this._loading = false;
-			this._updateTriggerLabel();
-
-			// Auto-select the best default branch
-			const defaultBranch = this._branches.find(b => b === repo.state.get().HEAD?.name)
-				?? this._branches.find(b => b === 'main')
-				?? this._branches.find(b => b === 'master')
-				?? this._branches[0];
-			if (defaultBranch) {
-				this._selectBranch(defaultBranch);
-			}
-		}).catch(() => {
-			if (!cts.token.isCancellationRequested) {
-				this._branches = [];
-				this._loading = false;
-				this._updateTriggerLabel();
-			}
-		});
-	}
-
-	private _clearBranches(): void {
-		this._loadCts.value?.cancel();
-		this._branches = [];
-		this._selectedBranch = undefined;
-		this._loading = false;
-		this._updateTriggerLabel();
+	private _getSession(): CopilotCLISession | undefined {
+		const session = this.sessionsManagementService.activeSession.get();
+		return session instanceof CopilotCLISession ? session : undefined;
 	}
 
 	render(container: HTMLElement): void {
@@ -158,16 +82,25 @@ export class BranchPicker extends Disposable {
 	}
 
 	showPicker(): void {
-		if (!this._triggerElement || this.actionWidgetService.isVisible || this._branches.length === 0 || this._disabled) {
+		const session = this._getSession();
+		const branches = session?.branches.get() ?? [];
+		if (!this._triggerElement || this.actionWidgetService.isVisible || branches.length === 0 || session?.isolationMode === 'workspace') {
 			return;
 		}
 
-		const items = this._buildItems();
+		const selectedBranch = session?.branch;
+		const items: IActionListItem<IBranchItem>[] = branches.map(branch => ({
+			kind: ActionListItemKind.Action,
+			label: branch,
+			group: { title: '', icon: Codicon.gitBranch },
+			item: { name: branch, checked: branch === selectedBranch || undefined },
+		}));
+
 		const triggerElement = this._triggerElement;
 		const delegate: IActionListDelegate<IBranchItem> = {
 			onSelect: (item) => {
 				this.actionWidgetService.hide();
-				this._selectBranch(item.name);
+				session?.setBranch(item.name);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
@@ -190,52 +123,25 @@ export class BranchPicker extends Disposable {
 		);
 	}
 
-	private _buildItems(): IActionListItem<IBranchItem>[] {
-		return this._branches.map(branch => ({
-			kind: ActionListItemKind.Action,
-			label: branch,
-			group: { title: '', icon: Codicon.gitBranch },
-			item: { name: branch, checked: branch === this._selectedBranch || undefined },
-		}));
-	}
-
-	private _selectBranch(branch: string): void {
-		if (this._selectedBranch !== branch) {
-			this._selectedBranch = branch;
-			this._onDidChange.fire(branch);
-			this._updateTriggerLabel();
-
-			const session = this.sessionsManagementService.activeSession.get();
-			if (!(session instanceof CopilotCLISession)) {
-				throw new Error('BranchPicker requires a CopilotCLISession');
-			}
-			session.setBranch(branch);
-		}
-	}
-
 	private _updateTriggerLabel(): void {
 		if (!this._triggerElement) {
 			return;
 		}
 		dom.clearNode(this._triggerElement);
 
-		if (this._loading) {
-			dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
-			const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
-			labelSpan.textContent = this._selectedBranch ?? localize('branchPicker.select', "Branch");
-			dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
-			this._slotElement?.classList.toggle('disabled', true);
-			return;
-		}
+		const session = this._getSession();
+		const branches = session?.branches.get() ?? [];
+		const isLoading = session?.branchesLoading.get() ?? false;
+		const isDisabled = session?.isolationMode === 'workspace' || branches.length === 0;
+		const label = session?.branch ?? localize('branchPicker.select', "Branch");
 
-		const isDisabled = this._disabled || this._branches.length === 0;
-		const label = this._selectedBranch ?? localize('branchPicker.select', "Branch");
 		dom.append(this._triggerElement, renderIcon(Codicon.gitBranch));
 		const labelSpan = dom.append(this._triggerElement, dom.$('span.sessions-chat-dropdown-label'));
 		labelSpan.textContent = label;
 		dom.append(this._triggerElement, renderIcon(Codicon.chevronDown));
-		this._slotElement?.classList.toggle('disabled', isDisabled);
-		this._triggerElement.setAttribute('aria-disabled', String(isDisabled));
-		this._triggerElement.tabIndex = isDisabled ? -1 : 0;
+
+		this._slotElement?.classList.toggle('disabled', isLoading || isDisabled);
+		this._triggerElement.setAttribute('aria-disabled', String(isLoading || isDisabled));
+		this._triggerElement.tabIndex = (isLoading || isDisabled) ? -1 : 0;
 	}
 }

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -34,6 +34,7 @@ import { CloudModelPicker } from './modelPicker.js';
 import { NewChatPermissionPicker } from '../../chat/browser/newChatPermissionPicker.js';
 
 const ActiveSessionHasGitRepositoryContext = new RawContextKey<boolean>('activeSessionHasGitRepository', false);
+const ActiveSessionIsolationIsFolderContext = new RawContextKey<boolean>('activeSessionIsolationIsFolder', false);
 const IsActiveSessionCopilotCLI = ContextKeyExpr.equals('activeSessionType', COPILOT_CLI_SESSION_TYPE);
 const IsActiveSessionCopilotCloud = ContextKeyExpr.equals('activeSessionType', COPILOT_CLOUD_SESSION_TYPE);
 const IsActiveCopilotChatSessionProvider = ContextKeyExpr.equals('activeSessionProviderId', COPILOT_PROVIDER_ID);
@@ -68,7 +69,7 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.branchPicker',
 			title: localize2('branchPicker', "Branch"),
 			f1: false,
-			precondition: ActiveSessionHasGitRepositoryContext,
+			precondition: ContextKeyExpr.and(ActiveSessionHasGitRepositoryContext, ActiveSessionIsolationIsFolderContext.toNegated()),
 			menu: [{
 				id: Menus.NewSessionRepositoryConfig,
 				group: 'navigation',
@@ -285,14 +286,18 @@ class CopilotActiveSessionContribution extends Disposable implements IWorkbenchC
 		super();
 
 		const hasRepositoryKey = ActiveSessionHasGitRepositoryContext.bindTo(contextKeyService);
+		const isolationIsFolderKey = ActiveSessionIsolationIsFolderContext.bindTo(contextKeyService);
 
 		this._register(autorun((reader: IReader) => {
 			const session = sessionsManagementService.activeSession.read(reader);
 			if (session instanceof CopilotCLISession) {
 				const isLoading = session.loading.read(reader);
 				hasRepositoryKey.set(!isLoading && !!session.gitRepository);
+				const isolationMode = session.isolationModeObservable.read(reader);
+				isolationIsFolderKey.set(isolationMode === 'workspace');
 			} else {
 				hasRepositoryKey.set(false);
+				isolationIsFolderKey.set(false);
 			}
 		}));
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions.ts
@@ -34,7 +34,6 @@ import { CloudModelPicker } from './modelPicker.js';
 import { NewChatPermissionPicker } from '../../chat/browser/newChatPermissionPicker.js';
 
 const ActiveSessionHasGitRepositoryContext = new RawContextKey<boolean>('activeSessionHasGitRepository', false);
-const ActiveSessionIsolationIsFolderContext = new RawContextKey<boolean>('activeSessionIsolationIsFolder', false);
 const IsActiveSessionCopilotCLI = ContextKeyExpr.equals('activeSessionType', COPILOT_CLI_SESSION_TYPE);
 const IsActiveSessionCopilotCloud = ContextKeyExpr.equals('activeSessionType', COPILOT_CLOUD_SESSION_TYPE);
 const IsActiveCopilotChatSessionProvider = ContextKeyExpr.equals('activeSessionProviderId', COPILOT_PROVIDER_ID);
@@ -69,7 +68,7 @@ registerAction2(class extends Action2 {
 			id: 'sessions.defaultCopilot.branchPicker',
 			title: localize2('branchPicker', "Branch"),
 			f1: false,
-			precondition: ContextKeyExpr.and(ActiveSessionHasGitRepositoryContext, ActiveSessionIsolationIsFolderContext.toNegated()),
+			precondition: ActiveSessionHasGitRepositoryContext,
 			menu: [{
 				id: Menus.NewSessionRepositoryConfig,
 				group: 'navigation',
@@ -286,18 +285,14 @@ class CopilotActiveSessionContribution extends Disposable implements IWorkbenchC
 		super();
 
 		const hasRepositoryKey = ActiveSessionHasGitRepositoryContext.bindTo(contextKeyService);
-		const isolationIsFolderKey = ActiveSessionIsolationIsFolderContext.bindTo(contextKeyService);
 
 		this._register(autorun((reader: IReader) => {
 			const session = sessionsManagementService.activeSession.read(reader);
 			if (session instanceof CopilotCLISession) {
 				const isLoading = session.loading.read(reader);
 				hasRepositoryKey.set(!isLoading && !!session.gitRepository);
-				const isolationMode = session.isolationModeObservable.read(reader);
-				isolationIsFolderKey.set(isolationMode === 'workspace');
 			} else {
 				hasRepositoryKey.set(false);
-				isolationIsFolderKey.set(false);
 			}
 		}));
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -204,6 +204,7 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 	setIsolationMode(mode: IsolationMode): void {
 		if (this._isolationMode !== mode) {
 			this._isolationMode = mode;
+			this._isolationModeObservable.set(mode, undefined);
 			this.setOption(ISOLATION_OPTION_ID, mode);
 		}
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -106,7 +106,7 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 	private readonly _branchObservable = observableValue<string | undefined>(this, undefined);
 	readonly branchObservable: IObservable<string | undefined> = this._branchObservable;
 
-	private readonly _isolationModeObservable = observableValue<string | undefined>(this, undefined);
+	private readonly _isolationModeObservable = observableValue<string | undefined>(this, 'worktree');
 	readonly isolationModeObservable: IObservable<string | undefined> = this._isolationModeObservable;
 
 	readonly changes: IObservable<readonly IChatSessionFileChange[]> = observableValue<readonly IChatSessionFileChange[]>(this, []);

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { IObservable, observableValue, transaction } from '../../../../base/common/observable.js';
 import { themeColorFromId, ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -27,7 +27,7 @@ import { IsolationMode } from './isolationPicker.js';
 import { ChatViewPaneTarget, IChatWidgetService } from '../../../../workbench/contrib/chat/browser/chat.js';
 import { ILanguageModelToolsService } from '../../../../workbench/contrib/chat/common/tools/languageModelToolsService.js';
 import { isBuiltinChatMode, IChatMode } from '../../../../workbench/contrib/chat/common/chatModes.js';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { ResourceSet } from '../../../../base/common/map.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { ILanguageModelsService } from '../../../../workbench/contrib/chat/common/languageModels.js';
@@ -80,6 +80,8 @@ export interface ICopilotNewSessionData extends ISessionData {
  */
 export class CopilotCLISession extends Disposable implements ISessionData {
 
+	static readonly COPILOT_WORKTREE_PATTERN = 'copilot-worktree-';
+
 	// -- ISessionData fields --
 
 	readonly sessionId: string;
@@ -128,6 +130,17 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 	readonly pullRequestStateIcon: IObservable<ThemeIcon | undefined> = observableValue(this, undefined);
 
 	private _gitRepository: IGitRepository | undefined;
+	private readonly _loadBranchesCts = this._register(new MutableDisposable<CancellationTokenSource>());
+
+	// -- Branch state --
+
+	private readonly _branches = observableValue<readonly string[]>(this, []);
+	readonly branches: IObservable<readonly string[]> = this._branches;
+
+	private readonly _branchesLoading = observableValue(this, false);
+	readonly branchesLoading: IObservable<boolean> = this._branchesLoading;
+
+	private _defaultBranch: string | undefined;
 
 	// -- New session configuration fields --
 
@@ -199,6 +212,55 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 			}
 		}
 		this._loading.set(false, undefined);
+
+		if (this._gitRepository) {
+			this._loadBranches();
+		}
+	}
+
+	private _loadBranches(): void {
+		const repo = this._gitRepository;
+		if (!repo) {
+			return;
+		}
+
+		this._loadBranchesCts.value?.cancel();
+		const cts = this._loadBranchesCts.value = new CancellationTokenSource();
+
+		this._branchesLoading.set(true, undefined);
+
+		repo.getRefs({ pattern: 'refs/heads' }, cts.token).then(refs => {
+			if (cts.token.isCancellationRequested) {
+				return;
+			}
+			const branches = refs
+				.map(r => r.name)
+				.filter((name): name is string => !!name)
+				.filter(name => !name.includes(CopilotCLISession.COPILOT_WORKTREE_PATTERN));
+
+			const defaultBranch = branches.find(b => b === repo.state.get().HEAD?.name)
+				?? branches.find(b => b === 'main')
+				?? branches.find(b => b === 'master')
+				?? branches[0];
+
+			this._defaultBranch = defaultBranch;
+
+			transaction(tx => {
+				this._branches.set(branches, tx);
+				this._branchesLoading.set(false, tx);
+			});
+
+			if (defaultBranch && !this._branch) {
+				this.setBranch(defaultBranch);
+			}
+		}).catch(() => {
+			if (!cts.token.isCancellationRequested) {
+				transaction(tx => {
+					this._branches.set([], tx);
+					this._branchesLoading.set(false, tx);
+				});
+			}
+		});
 	}
 
 	setIsolationMode(mode: IsolationMode): void {
@@ -206,12 +268,17 @@ export class CopilotCLISession extends Disposable implements ISessionData {
 			this._isolationMode = mode;
 			this._isolationModeObservable.set(mode, undefined);
 			this.setOption(ISOLATION_OPTION_ID, mode);
+
+			if (mode === 'workspace' && this._defaultBranch) {
+				this.setBranch(this._defaultBranch);
+			}
 		}
 	}
 
 	setBranch(branch: string | undefined): void {
 		if (this._branch !== branch) {
 			this._branch = branch;
+			this._branchObservable.set(branch, undefined);
 			this.setOption(BRANCH_OPTION_ID, branch ?? '');
 		}
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -77,7 +77,12 @@ export class IsolationPicker extends Disposable {
 		if (!hasRepo) {
 			this._setMode('workspace');
 		} else {
-			this._setMode('worktree');
+			// Restore the session's current isolation mode rather than
+			// unconditionally resetting to 'worktree', so user selection
+			// survives picker recreation.
+			const session = this.sessionsManagementService.activeSession.get();
+			const currentMode = session instanceof CopilotCLISession ? session.isolationMode : 'worktree';
+			this._setMode(currentMode);
 		}
 		this._updateTriggerLabel();
 	}

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/isolationPicker.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { autorun } from '../../../../base/common/observable.js';
 import { renderIcon } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
@@ -32,12 +31,8 @@ export type IsolationMode = 'worktree' | 'workspace';
  */
 export class IsolationPicker extends Disposable {
 
-	private _isolationMode: IsolationMode = 'worktree';
 	private _hasGitRepo = false;
 	private _isolationOptionEnabled: boolean;
-
-	private readonly _onDidChange = this._register(new Emitter<IsolationMode>());
-	readonly onDidChange: Event<IsolationMode> = this._onDidChange.event;
 
 	private readonly _renderDisposables = this._register(new DisposableStore());
 	private _slotElement: HTMLElement | undefined;
@@ -55,7 +50,7 @@ export class IsolationPicker extends Disposable {
 			if (e.affectsConfiguration('github.copilot.chat.cli.isolationOption.enabled')) {
 				this._isolationOptionEnabled = this.configurationService.getValue<boolean>('github.copilot.chat.cli.isolationOption.enabled') !== false;
 				if (!this._isolationOptionEnabled) {
-					this._setMode('worktree');
+					this._setModeOnSession('worktree');
 				}
 				this._updateTriggerLabel();
 			}
@@ -65,26 +60,19 @@ export class IsolationPicker extends Disposable {
 			const session = this.sessionsManagementService.activeSession.read(reader);
 			if (session instanceof CopilotCLISession) {
 				const isLoading = session.loading.read(reader);
-				this.setHasGitRepo(!isLoading && !!session.gitRepository);
+				this._hasGitRepo = !isLoading && !!session.gitRepository;
+				// Read isolation mode from session — session is the source of truth
+				session.isolationModeObservable.read(reader);
 			} else {
-				this.setHasGitRepo(false);
+				this._hasGitRepo = false;
 			}
+			this._updateTriggerLabel();
 		}));
 	}
 
-	private setHasGitRepo(hasRepo: boolean): void {
-		this._hasGitRepo = hasRepo;
-		if (!hasRepo) {
-			this._setMode('workspace');
-		} else {
-			// Restore the session's current isolation mode rather than
-			// unconditionally resetting to 'worktree', so user selection
-			// survives picker recreation.
-			const session = this.sessionsManagementService.activeSession.get();
-			const currentMode = session instanceof CopilotCLISession ? session.isolationMode : 'worktree';
-			this._setMode(currentMode);
-		}
-		this._updateTriggerLabel();
+	private _getSessionIsolationMode(): IsolationMode {
+		const session = this.sessionsManagementService.activeSession.get();
+		return session instanceof CopilotCLISession ? session.isolationMode : 'worktree';
 	}
 
 	render(container: HTMLElement): void {
@@ -141,7 +129,7 @@ export class IsolationPicker extends Disposable {
 		const delegate: IActionListDelegate<IsolationMode> = {
 			onSelect: (mode) => {
 				this.actionWidgetService.hide();
-				this._setMode(mode);
+				this._setModeOnSession(mode);
 			},
 			onHide: () => { triggerElement.focus(); },
 		};
@@ -161,18 +149,12 @@ export class IsolationPicker extends Disposable {
 		);
 	}
 
-	private _setMode(mode: IsolationMode): void {
-		if (this._isolationMode !== mode) {
-			this._isolationMode = mode;
-			this._updateTriggerLabel();
-			this._onDidChange.fire(mode);
-
-			const session = this.sessionsManagementService.activeSession.get();
-			if (!(session instanceof CopilotCLISession)) {
-				throw new Error('IsolationPicker requires a CopilotCLISession');
-			}
-			session.setIsolationMode(mode);
+	private _setModeOnSession(mode: IsolationMode): void {
+		const session = this.sessionsManagementService.activeSession.get();
+		if (!(session instanceof CopilotCLISession)) {
+			throw new Error('IsolationPicker requires a CopilotCLISession');
 		}
+		session.setIsolationMode(mode);
 	}
 
 	private _updateTriggerLabel(): void {
@@ -182,10 +164,11 @@ export class IsolationPicker extends Disposable {
 
 		dom.clearNode(this._triggerElement);
 
+		const isolationMode = this._getSessionIsolationMode();
 		let modeIcon;
 		let modeLabel: string;
 
-		switch (this._isolationMode) {
+		switch (isolationMode) {
 			case 'workspace':
 				modeIcon = Codicon.folder;
 				modeLabel = localize('isolationMode.folder', "Folder");


### PR DESCRIPTION
## Summary

Refactors the branch picker and isolation picker in the Copilot Chat sessions provider so that `CopilotCLISession` is the single source of truth for all branch and isolation state.

## What changed

### `CopilotCLISession` — now owns branch loading
- Branches are loaded inside the session object after git repository resolves (moved from `BranchPicker`)
- Added `branches` (observable list), `branchesLoading` (observable), and `_defaultBranch` fields
- `setBranch()` now updates `_branchObservable` so the picker reacts
- `setIsolationMode()` resets branch to `_defaultBranch` when switching to folder mode
- `_isolationModeObservable` initialized to `'worktree'` to match the internal default

### `BranchPicker` — simplified to a pure view
- Removed all local state (`_branches`, `_selectedBranch`, `_loading`, `_disabled`, CTS, event emitters)
- Reads everything from session observables (`branches`, `branchesLoading`, `branchObservable`, `isolationModeObservable`)
- Disables itself when isolation mode is `'workspace'` (folder)

### `IsolationPicker` — no longer duplicates state
- Removed local `_isolationMode` field; reads from session via `session.isolationMode`
- No longer writes back to session during initialization (which was causing the reset bug)
- Only writes to session on explicit user selection

## Why

Previously, pickers maintained their own local state and wrote it back to the session. This caused several bugs:
1. **Isolation reset**: Changing isolation to "Folder" triggered a context key change → toolbar recreation → new IsolationPicker with default `'worktree'`, overwriting the user's selection
2. **Branch state duplication**: Branch loading logic lived in the UI widget, making it hard to coordinate with isolation mode changes
3. **Observable not updated**: `_isolationModeObservable` and `_branchObservable` were never set, so reactive consumers couldn't track changes