### PR TITLE
fix: add CP857 (Turkish DOS) to supported document encodings

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -772,6 +772,11 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
 		order: 48
+	},
+	cp857: {
+		labelLong: 'Turkish DOS (CP 857)',
+		labelShort: 'CP 857',
+		order: 49
 	}
 };
 

--- a/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
+++ b/src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts
@@ -453,6 +453,13 @@ suite('Encoding', () => {
 		});
 	});
 
+	test('cp857 encoding is supported', async function () {
+		assert.ok('cp857' in encoding.SUPPORTED_ENCODINGS, 'cp857 should be in SUPPORTED_ENCODINGS');
+		assert.strictEqual(encoding.SUPPORTED_ENCODINGS['cp857'].labelShort, 'CP 857');
+		const iconv = await importAMDNodeModule<typeof import('@vscode/iconv-lite-umd')>('@vscode/iconv-lite-umd', 'lib/iconv-lite-umd.js');
+		assert.strictEqual(iconv.encodingExists('cp857'), true, 'iconv-lite should support cp857');
+	});
+
 	test('encodingExists', async function () {
 		for (const enc in encoding.SUPPORTED_ENCODINGS) {
 			if (enc === encoding.UTF8_with_bom) {


### PR DESCRIPTION
## Summary

Fixes #300041

**Bug:** CP857 (Turkish DOS) encoding is missing from the list of supported document encodings, preventing users from opening or saving files with this encoding.

**Root Cause:** The `SUPPORTED_ENCODINGS` map in the text file service did not include a `cp857` entry, even though the underlying `iconv-lite` library supports it and adjacent codepages (CP850, CP852, CP865) were already present.

**Fix:** Added the `cp857` entry to the `SUPPORTED_ENCODINGS` map with the appropriate label and order value, following the exact pattern of the neighboring CP850/CP852/CP865 entries.

## Changes

- `src/vs/workbench/services/textfile/common/encoding.ts`: Added `cp857` entry to `SUPPORTED_ENCODINGS` with `labelLong: 'Turkish DOS (CP 857)'`, `labelShort: 'CP 857'`, and `order: 49`.
- `src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts`: Added regression test verifying that `cp857` is present in `SUPPORTED_ENCODINGS`, has the correct label, and is recognized by `iconv-lite`.

## Testing

- Added regression test in `src/vs/workbench/services/textfile/test/node/encoding/encoding.test.ts` that verifies:
  - `cp857` exists in `SUPPORTED_ENCODINGS`
  - `labelShort` is `'CP 857'`
  - `iconv-lite` recognizes `cp857` as a valid encoding
- All existing tests pass

## How to Test Manually

1. Open VS Code
2. Open a file and use the encoding picker (click the encoding indicator in the status bar)
3. Search for "CP 857" or "Turkish DOS" — it should now appear in the list
4. Reopen/save a file with CP857 encoding to verify it works correctly