### PR TITLE
chore: additional error categories for macOS cert api

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://electronjs.org/headers"
 target="39.8.3"
-ms_build_id="13620978"
+ms_build_id="13658728"
 runtime="electron"
 ignore-scripts=false
 build_from_source="true"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.114.0",
-  "distro": "d48ce3e61fa56a702d13bb450ceb3532620dbd46",
+  "distro": "a305f48172def2b6e043c61177258d2d1abe7c0b",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/remote/.npmrc
+++ b/remote/.npmrc
@@ -1,6 +1,6 @@
 disturl="https://nodejs.org/dist"
 target="22.22.1"
-ms_build_id="422160"
+ms_build_id="424223"
 runtime="node"
 build_from_source="true"
 legacy-peer-deps="true"


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/287739

Additional error categories to `tls.getSystemCACertificatesErrors` api

```
TotalCertsToProcess      - Total keychain certs before filtering
                             (error_code = count)

  SecItemCopyMatching      - Keychain query failed entirely (fatal)

  SecCertificateCopyData   - Failed to extract DER data from
                             SecCertificateRef

  DERDecode                - OpenSSL d2i_X509 failed to parse DER bytes

  TrustSettingsCopy        - SecTrustSettingsCopyTrustSettings returned
                             unexpected OSStatus

  TrustEvaluation          - Certificate rejected by
                             IsCertificateTrustedForPolicy (excluded
                             from final cert list)

  TrustDictDefaultTrustRoot - Self-issued cert with absent
                              kSecTrustSettingsResult key: Apple docs
                              default to TrustRoot (Chromium returns
                              TRUSTED), Node.js returns UNSPECIFIED

  TrustPolicyComparison    - Compares SecPolicyCreateSSL(false) vs
                             SecPolicyCreateSSL(true) results per cert.
                             error_code: 0=both fail, 1=server-only,
                             2=client-only, 3=both pass

  TrustEvalFallback        - Cert had no explicit trust settings, fell
                             through to SecTrustEvaluateWithError
                             (no Chromium equivalent). error_code:
                             1=trusted, 0=rejected

  Duplicate                - Same cert found in multiple keychains

  Expired                  - Trusted cert with notAfter in the past
                             (Chromium would filter; Node.js still
                             includes)

  UnsupportedKeyUsage      - Trusted cert lacking SSL key usage flags
                             (Chromium would filter; Node.js still
                             includes)
```