### PR TITLE
fix: resolve #305050 - handle empty string progress location gracefully

### DIFF
--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -74,6 +74,10 @@ export class ProgressService extends Disposable implements IProgressService {
 		};
 
 		if (typeof location === 'string') {
+			if (location.length === 0) {
+				console.warn(`Bad progress location: empty string`);
+				return task({ report() { } }) as Promise<R>;
+			}
 			return handleStringLocation(location);
 		}
 

--- a/src/vs/workbench/services/progress/test/browser/progressService.test.ts
+++ b/src/vs/workbench/services/progress/test/browser/progressService.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { ProgressService } from '../../browser/progressService.js';
+import { IViewDescriptorService } from '../../../../common/views.js';
+import { IActivityService } from '../../../activity/common/activity.js';
+import { IPaneCompositePartService } from '../../../panecomposite/browser/panecomposite.js';
+import { IViewsService } from '../../../views/common/viewsService.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { IStatusbarService } from '../../../statusbar/browser/statusbar.js';
+import { ILayoutService } from '../../../../../platform/layout/browser/layoutService.js';
+import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
+import { IUserActivityService } from '../../../userActivity/common/userActivityService.js';
+import { IHostService } from '../../../host/browser/host.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+
+suite('ProgressService', () => {
+
+	const disposables = new DisposableStore();
+
+	teardown(() => {
+		disposables.clear();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function createProgressService(): ProgressService {
+		const instantiationService = disposables.add(new TestInstantiationService());
+
+		instantiationService.stub(IActivityService, {});
+		instantiationService.stub(IPaneCompositePartService, {});
+		instantiationService.stub(IViewDescriptorService, {
+			getViewContainerById: () => null,
+			getViewDescriptorById: () => null,
+		});
+		instantiationService.stub(IViewsService, {});
+		instantiationService.stub(INotificationService, {});
+		instantiationService.stub(IStatusbarService, {});
+		instantiationService.stub(ILayoutService, {});
+		instantiationService.stub(IKeybindingService, {});
+		instantiationService.stub(IUserActivityService, {
+			markActive: () => ({ dispose() { } } as IDisposable),
+		});
+		instantiationService.stub(IHostService, {});
+
+		return disposables.add(instantiationService.createInstance(ProgressService));
+	}
+
+	test('withProgress - empty string location should not throw', async () => {
+		const progressService = createProgressService();
+
+		let taskExecuted = false;
+		const result = await progressService.withProgress(
+			{ location: '' as any },
+			async () => {
+				taskExecuted = true;
+				return 42;
+			}
+		);
+
+		assert.ok(taskExecuted, 'Task should have been executed');
+		assert.strictEqual(result, 42, 'Task result should be returned');
+	});
+
+	test('withProgress - unknown string location should throw', async () => {
+		const progressService = createProgressService();
+
+		await assert.rejects(
+			() => progressService.withProgress(
+				{ location: 'some.unknown.view' },
+				async () => 'result'
+			),
+			/Bad progress location/
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #305050

**Bug:** Extensions passing an empty string as a progress location caused an unhandled "Bad progress location" error, leading to a confusing crash.

**Root Cause:** `ProgressService.withProgress()` treated empty strings the same as any other string location, attempting to resolve a view container or view descriptor for it, which always failed and threw an uncaught error.

**Fix:** Added a guard clause at the beginning of the string-location handling path. When an empty string is detected, a warning is logged and the task is executed with a no-op progress reporter (consistent with existing patterns in the file), preventing the error from propagating.

## Changes

- `src/vs/workbench/services/progress/browser/progressService.ts`: Added an early return for empty string locations that logs a warning and runs the task with a no-op progress reporter.
- `src/vs/workbench/services/progress/test/browser/progressService.test.ts`: Added regression tests verifying that empty string locations execute the task without throwing, and that unknown string locations still throw the expected error.

## Testing

- Added regression test `withProgress - empty string location should not throw` that verifies the task executes and returns its result when given an empty string location.
- Added test `withProgress - unknown string location should throw` that verifies the existing error behavior is preserved for non-empty unknown locations.
- All existing tests continue to pass.