### PR TITLE
Sessions: Refactor and move session status toggle to the left

### DIFF
--- a/src/vs/sessions/browser/layoutActions.ts
+++ b/src/vs/sessions/browser/layoutActions.ts
@@ -21,7 +21,7 @@ import { SessionsWelcomeVisibleContext } from '../common/contextkeys.js';
 // Register Icons
 const panelCloseIcon = registerIcon('agent-panel-close', Codicon.close, localize('agentPanelCloseIcon', "Icon to close the panel."));
 
-class ToggleSidebarVisibilityAction extends Action2 {
+export class ToggleSidebarVisibilityAction extends Action2 {
 
 	static readonly ID = 'workbench.action.agentToggleSidebarVisibility';
 	static readonly LABEL = localize('compositePart.hideSideBarLabel', "Hide Primary Side Bar");

--- a/src/vs/sessions/browser/menus.ts
+++ b/src/vs/sessions/browser/menus.ts
@@ -19,6 +19,7 @@ export const Menus = {
 	TitleBarRightLayout: new MenuId('SessionsTitleBarRightLayout'),
 	PanelTitle: new MenuId('SessionsPanelTitle'),
 	SidebarTitle: new MenuId('SessionsSidebarTitle'),
+	SidebarTitleLeft: new MenuId('SessionsSidebarTitleLeft'),
 	AuxiliaryBarTitle: new MenuId('SessionsAuxiliaryBarTitle'),
 	AuxiliaryBarTitleLeft: new MenuId('SessionsAuxiliaryBarTitleLeft'),
 	SidebarFooter: new MenuId('SessionsSidebarFooter'),

--- a/src/vs/sessions/browser/parts/media/sidebarPart.css
+++ b/src/vs/sessions/browser/parts/media/sidebarPart.css
@@ -24,8 +24,7 @@
 }
 
 /* Interactive elements in the title area must not be draggable */
-.agent-sessions-workbench .part.sidebar > .composite.title .action-item,
-.agent-sessions-workbench .part.sidebar > .composite.title > .session-status-toggle {
+.agent-sessions-workbench .part.sidebar > .composite.title .action-item {
 	-webkit-app-region: no-drag;
 }
 
@@ -74,24 +73,16 @@
 	cursor: default;
 }
 
-/* Session status toggle — standalone button in sidebar title area */
+/* Session status toggle — action view item in global-actions-left toolbar */
 .agent-sessions-workbench .part.sidebar .session-status-toggle {
 	display: flex;
 	align-items: center;
-	align-self: center;
 	gap: 3px;
 	height: 22px;
 	padding: 0 4px;
-	margin-right: 4px;
-	border: none;
 	border-radius: 4px;
 	cursor: pointer;
-	color: inherit;
-	font: inherit;
 	background: var(--vscode-toolbar-activeBackground);
-	outline: none;
-	position: relative;
-	z-index: 1;
 }
 
 .agent-sessions-workbench .part.sidebar .session-status-toggle:hover {

--- a/src/vs/sessions/browser/parts/sidebarPart.ts
+++ b/src/vs/sessions/browser/parts/sidebarPart.ts
@@ -32,19 +32,13 @@ import { Separator } from '../../../base/common/actions.js';
 import { IHoverService } from '../../../platform/hover/browser/hover.js';
 import { Extensions } from '../../../workbench/browser/panecomposite.js';
 import { Menus } from '../menus.js';
-import { $, addDisposableListener, append, EventType, getWindowId, prepend } from '../../../base/browser/dom.js';
+import { $, append, getWindowId, prepend } from '../../../base/browser/dom.js';
 import { HiddenItemStrategy, MenuWorkbenchToolBar } from '../../../platform/actions/browser/toolbar.js';
 import { isMacintosh, isNative } from '../../../base/common/platform.js';
 import { isFullscreen, onDidChangeFullscreen } from '../../../base/browser/browser.js';
 import { mainWindow } from '../../../base/browser/window.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
 import { hasNativeTitlebar, getTitleBarStyle } from '../../../platform/window/common/window.js';
-import { ThemeIcon } from '../../../base/common/themables.js';
-import { Codicon } from '../../../base/common/codicons.js';
-import { DisposableStore } from '../../../base/common/lifecycle.js';
-import { IAgentSessionsService } from '../../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
-import { countUnreadSessions } from '../../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
-import { localize } from '../../../nls.js';
 
 /**
  * Sidebar part specifically for agent sessions workbench.
@@ -127,7 +121,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			ViewContainerLocation.Sidebar,
 			Extensions.Viewlets,
 			Menus.SidebarTitle,
-			Menus.TitleBarLeftLayout,
+			Menus.SidebarTitleLeft,
 			notificationService,
 			storageService,
 			contextMenuService,
@@ -158,11 +152,6 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			prepend(titleArea, $('div.titlebar-drag-region'));
 		}
 
-		// Session toggle widget (right side of title area)
-		if (titleArea) {
-			this.createSessionsToggle(titleArea);
-		}
-
 		// macOS native: the sidebar spans full height and the traffic lights
 		// overlay the top-left corner. Add a fixed-width spacer inside the
 		// title area to push content horizontally past the traffic lights.
@@ -187,49 +176,6 @@ export class SidebarPart extends AbstractPaneCompositePart {
 		}
 
 		return titleArea;
-	}
-
-	/**
-	 * Creates a standalone session toggle widget appended to the sidebar title area.
-	 * Displays a tasklist icon with an optional unread badge. Clicking hides the sidebar.
-	 */
-	private createSessionsToggle(titleArea: HTMLElement): void {
-		const widgetDisposables = this._register(new DisposableStore());
-
-		const widget = append(titleArea, $('button.session-status-toggle')) as HTMLButtonElement;
-		widget.type = 'button';
-		widget.tabIndex = 0;
-		widget.setAttribute('aria-label', localize('hideSidebar', "Hide Side Bar"));
-		append(widget, $(ThemeIcon.asCSSSelector(Codicon.tasklist)));
-		const badge = append(widget, $('span.session-status-toggle-badge'));
-
-		// Toggle sidebar on click
-		widgetDisposables.add(addDisposableListener(widget, EventType.CLICK, (e) => {
-			e.preventDefault();
-			e.stopPropagation();
-			this.layoutService.setPartHidden(true, Parts.SIDEBAR_PART);
-		}));
-
-		// Update badge on session changes (deferred to avoid service unavailability)
-		const updateBadge = (svc: IAgentSessionsService) => {
-			const unread = countUnreadSessions(svc.model.sessions);
-			badge.textContent = unread > 0 ? `${unread}` : '';
-			badge.style.display = unread > 0 ? '' : 'none';
-			widget.setAttribute('aria-label', unread > 0
-				? localize('hideSidebarUnread', "Hide Side Bar, {0} unread session(s)", unread)
-				: localize('hideSidebar', "Hide Side Bar"));
-		};
-
-		setTimeout(() => {
-			try {
-				const svc = this.instantiationService.invokeFunction(accessor => accessor.get(IAgentSessionsService));
-				updateBadge(svc);
-				widgetDisposables.add(svc.model.onDidChangeSessions(() => updateBadge(svc)));
-			} catch {
-				// Service not yet available
-				badge.style.display = 'none';
-			}
-		}, 0);
 	}
 
 	private createFooter(parent: HTMLElement): void {

--- a/src/vs/sessions/browser/sidebarToggleWidget.ts
+++ b/src/vs/sessions/browser/sidebarToggleWidget.ts
@@ -81,6 +81,8 @@ class SessionStatusToggleViewItem extends BaseActionViewItem {
 		this._indicatorDisposables.add(this.hoverService.setupManagedHover(
 			this._hoverDelegate, this._container, hoverText
 		));
+
+		this._container.setAttribute('aria-label', hoverText);
 	}
 }
 
@@ -89,7 +91,7 @@ class SessionStatusToggleViewItem extends BaseActionViewItem {
  * (`SidebarTitleLeft`) and provides a custom action view item to render
  * the tasklist icon with an unread badge.
  */
-export class SessionStatusToggleContribution extends Disposable implements IWorkbenchContribution {
+class SessionStatusToggleContribution extends Disposable implements IWorkbenchContribution {
 
 	static readonly ID = 'workbench.contrib.sessionStatusToggle';
 

--- a/src/vs/sessions/browser/sidebarToggleWidget.ts
+++ b/src/vs/sessions/browser/sidebarToggleWidget.ts
@@ -16,7 +16,7 @@ import { IActionViewItemService } from '../../platform/actions/browser/actionVie
 import { IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
 import { IHoverService } from '../../platform/hover/browser/hover.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../workbench/common/contributions.js';
-import { IsAuxiliaryWindowContext, SideBarVisibleContext } from '../../workbench/common/contextkeys.js';
+import { IsAuxiliaryWindowContext } from '../../workbench/common/contextkeys.js';
 import { IAgentSessionsService } from '../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { countUnreadSessions } from '../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
 import { Menus } from './menus.js';
@@ -52,6 +52,7 @@ class SessionStatusToggleViewItem extends BaseActionViewItem {
 
 		this._container = container;
 		container.classList.add('session-status-toggle');
+		container.setAttribute('role', 'button');
 
 		append(container, $(ThemeIcon.asCSSSelector(Codicon.tasklist)));
 		this._badge = append(container, $('span.session-status-toggle-badge'));
@@ -106,7 +107,6 @@ class SessionStatusToggleContribution extends Disposable implements IWorkbenchCo
 				id: ToggleSidebarVisibilityAction.ID,
 				title: localize('hideSidebar', "Hide Side Bar"),
 				icon: Codicon.tasklist,
-				toggled: SideBarVisibleContext,
 			},
 			group: 'navigation',
 			order: 0,

--- a/src/vs/sessions/browser/sidebarToggleWidget.ts
+++ b/src/vs/sessions/browser/sidebarToggleWidget.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { $, append } from '../../base/browser/dom.js';
+import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../base/browser/ui/actionbar/actionViewItems.js';
+import { createInstantHoverDelegate } from '../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { IAction } from '../../base/common/actions.js';
+import { Codicon } from '../../base/common/codicons.js';
+import { Disposable, DisposableStore } from '../../base/common/lifecycle.js';
+import { ThemeIcon } from '../../base/common/themables.js';
+import { localize } from '../../nls.js';
+import { MenuRegistry } from '../../platform/actions/common/actions.js';
+import { IActionViewItemService } from '../../platform/actions/browser/actionViewItemService.js';
+import { IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
+import { IHoverService } from '../../platform/hover/browser/hover.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../workbench/common/contributions.js';
+import { IsAuxiliaryWindowContext, SideBarVisibleContext } from '../../workbench/common/contextkeys.js';
+import { IAgentSessionsService } from '../../workbench/contrib/chat/browser/agentSessions/agentSessionsService.js';
+import { countUnreadSessions } from '../../workbench/contrib/chat/browser/agentSessions/agentSessionsModel.js';
+import { Menus } from './menus.js';
+import { ToggleSidebarVisibilityAction } from './layoutActions.js';
+
+/**
+ * Action view item that renders the session status toggle with an unread badge
+ * in the sidebar title area. Shows [tasklist icon] {unread count}.
+ * Clicking toggles the sidebar visibility.
+ */
+class SessionStatusToggleViewItem extends BaseActionViewItem {
+
+	private _container: HTMLElement | undefined;
+	private _badge: HTMLElement | undefined;
+	private readonly _indicatorDisposables = this._register(new DisposableStore());
+	private readonly _hoverDelegate = this._register(createInstantHoverDelegate());
+
+	constructor(
+		action: IAction,
+		options: IBaseActionViewItemOptions | undefined,
+		@IHoverService private readonly hoverService: IHoverService,
+		@IAgentSessionsService private readonly agentSessionsService: IAgentSessionsService,
+	) {
+		super(undefined, action, options);
+
+		this._register(this.agentSessionsService.model.onDidChangeSessions(() => {
+			this._updateBadge();
+		}));
+	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+
+		this._container = container;
+		container.classList.add('session-status-toggle');
+
+		append(container, $(ThemeIcon.asCSSSelector(Codicon.tasklist)));
+		this._badge = append(container, $('span.session-status-toggle-badge'));
+
+		this._updateBadge();
+	}
+
+	override onClick(): void {
+		this._action.run();
+	}
+
+	private _updateBadge(): void {
+		if (!this._container || !this._badge) {
+			return;
+		}
+
+		this._indicatorDisposables.clear();
+
+		const unread = countUnreadSessions(this.agentSessionsService.model.sessions);
+		this._badge.textContent = unread > 0 ? `${unread}` : '';
+		this._badge.style.display = unread > 0 ? '' : 'none';
+
+		const hoverText = unread > 0
+			? localize('hideSidebarUnread', "Hide Side Bar, {0} unread session(s)", unread)
+			: localize('hideSidebar', "Hide Side Bar");
+
+		this._indicatorDisposables.add(this.hoverService.setupManagedHover(
+			this._hoverDelegate, this._container, hoverText
+		));
+	}
+}
+
+/**
+ * Registers the session status toggle in the sidebar's left toolbar
+ * (`SidebarTitleLeft`) and provides a custom action view item to render
+ * the tasklist icon with an unread badge.
+ */
+export class SessionStatusToggleContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.sessionStatusToggle';
+
+	constructor(
+		@IActionViewItemService actionViewItemService: IActionViewItemService,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this._register(MenuRegistry.appendMenuItem(Menus.SidebarTitleLeft, {
+			command: {
+				id: ToggleSidebarVisibilityAction.ID,
+				title: localize('hideSidebar', "Hide Side Bar"),
+				icon: Codicon.tasklist,
+				toggled: SideBarVisibleContext,
+			},
+			group: 'navigation',
+			order: 0,
+			when: IsAuxiliaryWindowContext.toNegated(),
+		}));
+
+		this._register(actionViewItemService.register(Menus.SidebarTitleLeft, ToggleSidebarVisibilityAction.ID, (action, options) => {
+			return instantiationService.createInstance(SessionStatusToggleViewItem, action, options);
+		}));
+	}
+}
+
+registerWorkbenchContribution2(SessionStatusToggleContribution.ID, SessionStatusToggleContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsTitleBarWidget.css
@@ -11,7 +11,7 @@
 	flex-wrap: nowrap;
 	align-items: center;
 	justify-content: flex-start;
-	padding-left: 16px;
+	padding-left: 8px;
 	height: 22px;
 	border-radius: 4px;
 	-webkit-app-region: no-drag;

--- a/src/vs/sessions/sessions.common.main.ts
+++ b/src/vs/sessions/sessions.common.main.ts
@@ -448,6 +448,7 @@ import '../workbench/contrib/opener/browser/opener.contribution.js';
 
 import './browser/paneCompositePartService.js';
 import './browser/layoutActions.js';
+import './browser/sidebarToggleWidget.js';
 
 import './contrib/accountMenu/browser/account.contribution.js';
 import './contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView.contribution.js';


### PR DESCRIPTION
Move the session status toggle in the sidebar for better visibility and enhance accessibility by adding an aria-label. This change improves the user experience for all users, particularly those using assistive technologies.

**Before**

https://github.com/user-attachments/assets/8a4ce896-af5c-4a15-9ffe-f5d740520bf3

**After**

https://github.com/user-attachments/assets/25f16749-97e3-4019-a652-3c0347738e2b

_Note: a future PR will address the panel animation affecting the control_

