### PR TITLE
sessions: show inline pin indicator on pinned sessions

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -55,7 +55,8 @@
 	}
 
 	.monaco-list-row:hover,
-	.monaco-list-row.focused:not(.selected) {
+	.monaco-list-row.focused:not(.selected),
+	.monaco-list-row:has(.session-item.pinned) {
 		.session-title-toolbar {
 			display: block;
 		}

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -54,9 +54,25 @@
 		}
 	}
 
+	.monaco-list-row .session-pinned-indicator {
+		display: none;
+		height: 16px;
+		align-items: center;
+		color: var(--vscode-descriptionForeground);
+		font-size: 12px;
+		pointer-events: none;
+
+		&.visible {
+			display: flex;
+		}
+	}
+
 	.monaco-list-row:hover,
-	.monaco-list-row.focused:not(.selected),
-	.monaco-list-row:has(.session-item.pinned) {
+	.monaco-list-row.focused:not(.selected) {
+		.session-pinned-indicator {
+			display: none;
+		}
+
 		.session-title-toolbar {
 			display: block;
 		}

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -757,13 +757,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 			filtered = filtered.filter(s => !this.excludedSessionTypes.has(s.sessionType));
 		}
 		if (this.excludedStatuses.size > 0) {
-			filtered = filtered.filter(s => !this.excludedStatuses.has(s.status.get()) || this.isSessionPinned(s));
+			filtered = filtered.filter(s => !this.excludedStatuses.has(s.status.get()));
 		}
 		if (this._excludeArchived) {
-			filtered = filtered.filter(s => !s.isArchived.get() || this.isSessionPinned(s));
+			filtered = filtered.filter(s => !s.isArchived.get());
 		}
 		if (this._excludeRead) {
-			filtered = filtered.filter(s => !s.isRead.get() || this.isSessionPinned(s));
+			filtered = filtered.filter(s => !s.isRead.get());
 		}
 
 		const sorted = this.sortSessions(filtered);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -210,8 +210,12 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		template.titleToolbar.context = element;
 
 		// Context key: isPinned
-		IsSessionPinnedContext.bindTo(template.contextKeyService).set(this.options.isPinned(element));
+		const isPinned = this.options.isPinned(element);
+		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
 		IsSessionArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
+
+		// Pinned styling — show toolbar persistently for pinned sessions
+		template.container.classList.toggle('pinned', isPinned);
 		IsSessionReadContext.bindTo(template.contextKeyService).set(element.isRead.get());
 
 		// Archived styling — reactive
@@ -750,13 +754,13 @@ export class SessionsList extends Disposable implements ISessionsList {
 			filtered = filtered.filter(s => !this.excludedSessionTypes.has(s.sessionType));
 		}
 		if (this.excludedStatuses.size > 0) {
-			filtered = filtered.filter(s => !this.excludedStatuses.has(s.status.get()));
+			filtered = filtered.filter(s => !this.excludedStatuses.has(s.status.get()) || this.isSessionPinned(s));
 		}
 		if (this._excludeArchived) {
-			filtered = filtered.filter(s => !s.isArchived.get());
+			filtered = filtered.filter(s => !s.isArchived.get() || this.isSessionPinned(s));
 		}
 		if (this._excludeRead) {
-			filtered = filtered.filter(s => !s.isRead.get());
+			filtered = filtered.filter(s => !s.isRead.get() || this.isSessionPinned(s));
 		}
 
 		const sorted = this.sortSessions(filtered);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -134,6 +134,7 @@ interface ISessionItemTemplate {
 	readonly container: HTMLElement;
 	readonly iconContainer: HTMLElement;
 	readonly title: HTMLElement;
+	readonly pinnedIndicator: HTMLElement;
 	readonly titleToolbar: MenuWorkbenchToolBar;
 	readonly detailsRow: HTMLElement;
 	readonly approvalRow: HTMLElement;
@@ -178,6 +179,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const mainCol = DOM.append(container, $('.session-main'));
 		const titleRow = DOM.append(mainCol, $('.session-title-row'));
 		const title = DOM.append(titleRow, $('.session-title'));
+		const pinnedIndicator = DOM.append(titleRow, $('.session-pinned-indicator'));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
 		const detailsRow = DOM.append(mainCol, $('.session-details-row'));
 
@@ -192,7 +194,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, iconContainer, title, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, iconContainer, title, pinnedIndicator, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -214,8 +216,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
 		IsSessionArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
 
-		// Pinned styling — show toolbar persistently for pinned sessions
-		template.container.classList.toggle('pinned', isPinned);
+		// Pinned indicator — inline pin icon, hidden on hover when toolbar shows
+		template.pinnedIndicator.className = 'session-pinned-indicator ' + ThemeIcon.asClassName(Codicon.pinned);
+		template.pinnedIndicator.classList.toggle('visible', isPinned);
 		IsSessionReadContext.bindTo(template.contextKeyService).set(element.isRead.get());
 
 		// Archived styling — reactive


### PR DESCRIPTION
Adds a visible pin indicator on pinned sessions in the sessions list view, matching the pattern used in the workbench agent sessions view.

## Changes

- **Inline pin indicator**: Added a `session-pinned-indicator` element (using `Codicon.pinned`) between the session title and the toolbar in each session row
- **Show/hide behavior**: The pin icon is visible by default on pinned sessions, and automatically hides on hover/focus when the action toolbar appears — consistent with the workbench agent sessions view pattern
- **CSS styling**: Pin indicator uses `descriptionForeground` color, `display: none` by default, toggled to `display: flex` via `.visible` class

This follows the same UX pattern as `agentSessionsViewer.ts` where a lightweight inline icon indicates pinned state without permanently showing the toolbar.