### PR TITLE
fix: resolve typescript.tsdk correctly when path starts with workspace name

### DIFF
--- a/extensions/typescript-language-features/src/test/unit/relativePathResolver.test.ts
+++ b/extensions/typescript-language-features/src/test/unit/relativePathResolver.test.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as path from 'path';
+import 'mocha';
+import { RelativeWorkspacePathResolver } from '../../utils/relativePathResolver';
+
+suite('RelativeWorkspacePathResolver', () => {
+
+	test('should resolve paths with explicit ./ prefix and folder name', () => {
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'./myFolder/node_modules/typescript/lib',
+			'myFolder',
+			'/workspace/myFolder'
+		);
+		assert.strictEqual(result, path.join('/workspace/myFolder', 'node_modules/typescript/lib'));
+	});
+
+	test('should not resolve paths that start with folder name but without ./ prefix', () => {
+		// This is the bug from issue #272761: when the workspace folder name
+		// matches the start of the relative path, the prefix should NOT be stripped
+		// unless it is explicitly prefixed with ./
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'x/.yarn/sdks/typescript/lib',
+			'x',
+			'/path/to/x'
+		);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('should resolve ./ prefixed path when folder name matches a subdirectory', () => {
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'./x/.yarn/sdks/typescript/lib',
+			'x',
+			'/path/to/x'
+		);
+		assert.strictEqual(result, path.join('/path/to/x', '.yarn/sdks/typescript/lib'));
+	});
+
+	test('should return undefined for unrelated paths', () => {
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'other/path/here',
+			'myFolder',
+			'/workspace/myFolder'
+		);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('should handle backslash paths on Windows', () => {
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'.\\myFolder\\node_modules\\typescript\\lib',
+			'myFolder',
+			'/workspace/myFolder'
+		);
+		assert.strictEqual(result, path.join('/workspace/myFolder', 'node_modules\\typescript\\lib'));
+	});
+
+	test('should not resolve backslash paths without ./ prefix', () => {
+		const result = RelativeWorkspacePathResolver.resolveForFolder(
+			'x\\.yarn\\sdks\\typescript\\lib',
+			'x',
+			'C:\\path\\to\\x'
+		);
+		assert.strictEqual(result, undefined);
+	});
+});

--- a/extensions/typescript-language-features/src/utils/relativePathResolver.ts
+++ b/extensions/typescript-language-features/src/utils/relativePathResolver.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 export class RelativeWorkspacePathResolver {
 	public static asAbsoluteWorkspacePath(relativePath: string): string | undefined {
 		for (const root of vscode.workspace.workspaceFolders || []) {
-			const rootPrefixes = [`./${root.name}/`, `${root.name}/`, `.\\${root.name}\\`, `${root.name}\\`];
+			const rootPrefixes = [`./${root.name}/`, `.\\${root.name}\\`];
 			for (const rootPrefix of rootPrefixes) {
 				if (relativePath.startsWith(rootPrefix)) {
 					return path.join(root.uri.fsPath, relativePath.replace(rootPrefix, ''));

--- a/extensions/typescript-language-features/src/utils/relativePathResolver.ts
+++ b/extensions/typescript-language-features/src/utils/relativePathResolver.ts
@@ -8,14 +8,27 @@ import * as vscode from 'vscode';
 export class RelativeWorkspacePathResolver {
 	public static asAbsoluteWorkspacePath(relativePath: string): string | undefined {
 		for (const root of vscode.workspace.workspaceFolders || []) {
-			const rootPrefixes = [`./${root.name}/`, `.\\${root.name}\\`];
-			for (const rootPrefix of rootPrefixes) {
-				if (relativePath.startsWith(rootPrefix)) {
-					return path.join(root.uri.fsPath, relativePath.replace(rootPrefix, ''));
-				}
+			const result = RelativeWorkspacePathResolver.resolveForFolder(relativePath, root.name, root.uri.fsPath);
+			if (result !== undefined) {
+				return result;
 			}
 		}
 
+		return undefined;
+	}
+
+	/**
+	 * Resolve a relative path for a given workspace folder.
+	 * Only strips explicit relative prefixes (e.g. `./folderName/`) to avoid
+	 * ambiguity when the path happens to start with the same name as the folder.
+	 */
+	public static resolveForFolder(relativePath: string, folderName: string, folderFsPath: string): string | undefined {
+		const rootPrefixes = [`./${folderName}/`, `.\\${folderName}\\`];
+		for (const rootPrefix of rootPrefixes) {
+			if (relativePath.startsWith(rootPrefix)) {
+				return path.join(folderFsPath, relativePath.replace(rootPrefix, ''));
+			}
+		}
 		return undefined;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #272761

**Bug:** `typescript.tsdk` paths like `x/.yarn/sdks/typescript/lib` were incorrectly resolved when the workspace folder name (`x`) matched the start of the path, because the resolver treated bare folder name prefixes (e.g. `x/`) as valid relative markers.

**Root Cause:** `RelativeWorkspacePathResolver.asAbsoluteWorkspacePath` matched both `./folderName/` and bare `folderName/` prefixes. The bare prefix match caused false positives when the tsdk path happened to start with the same string as the workspace folder name.

**Fix:** Removed the ambiguous bare folder name prefix patterns (`folderName/` and `folderName\`), keeping only the explicit relative prefixes (`./folderName/` and `.\folderName\`).

## Changes

- `extensions/typescript-language-features/src/utils/relativePathResolver.ts`: Removed bare `folderName/` and `folderName\` prefix matching. Extracted a new `resolveForFolder` static method to make the resolution logic independently testable.
- `extensions/typescript-language-features/src/test/unit/relativePathResolver.test.ts`: Added regression tests verifying that bare folder name prefixes are no longer matched, while explicit `./folderName/` prefixes continue to work correctly.

## Testing

- Added regression test in `extensions/typescript-language-features/src/test/unit/relativePathResolver.test.ts` that verifies paths starting with a bare folder name (e.g. `x/.yarn/sdks/typescript/lib`) are not incorrectly resolved.
- All existing tests pass.