### PR TITLE
fix: resolve #268301 - clear cached error on custom editor reopen

### DIFF
--- a/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
@@ -52,6 +52,11 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 					}
 				}),
 			};
+		}, err => {
+			// Clear the cached rejected promise so subsequent attempts
+			// can create a fresh model instead of reusing the stale error
+			this._references.delete(key);
+			throw err;
 		});
 	}
 


### PR DESCRIPTION
## Summary
Fixes #268301

- **Bug:** Custom editor retains previous error on reopen. If a custom editor failed to open (e.g., file not found), every subsequent reopen attempt failed with the same cached error.
- **Root Cause:** `customEditorModelManager.ts` cached the rejected model promise in its references map. `tryRetain()` returned the stale rejected promise on every call.
- **Fix:** Added a rejection handler in `tryRetain()` that removes the entry from the cache when the model promise rejects, allowing the next attempt to create a fresh model.

## Test plan
- Install the repro extension from https://github.com/vaclavHala/vscode-stale-custom-editor-error
- Run the "Hello World" command — first open fails (expected, file doesn't exist yet)
- Run it again — second open should succeed since the file was created