### PR TITLE
fix: display git warning messages with warning styling (#280834)

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -14,7 +14,7 @@ import { Model } from './model';
 import { GitResourceGroup, Repository, Resource, ResourceGroupType } from './repository';
 import { DiffEditorSelectionHunkToolbarContext, LineChange, applyLineChanges, getIndexDiffInformation, getModifiedRange, getWorkingTreeDiffInformation, intersectDiffWithRange, invertLineChange, toLineChanges, toLineRanges, compareLineChanges } from './staging';
 import { fromGitUri, toGitUri, isGitUri, toMergeUris, toMultiFileDiffEditorUris } from './uri';
-import { coalesce, DiagnosticSeverityConfig, dispose, fromNow, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
+import { classifyGitStderrMessage, coalesce, DiagnosticSeverityConfig, dispose, fromNow, getHistoryItemDisplayName, getStashDescription, grep, isDefined, isDescendant, isLinuxSnap, isRemote, isWindows, pathEquals, relativePath, subject, toDiagnosticSeverity, truncate } from './util';
 import { GitTimelineItem } from './timelineProvider';
 import { ApiRepository } from './api/api1';
 import { getRemoteSourceActions, pickRemoteSource } from './remoteSource';
@@ -5644,14 +5644,18 @@ export class CommandCenter {
 						options.modal = false;
 						break;
 					default: {
-						const hintLines = (err.stderr || err.stdout || err.message || String(err))
-							.replace(/^error: /mi, '')
-							.replace(/^> husky.*$/mi, '')
-							.split(/[\r\n]/)
-							.filter((line: string) => !!line);
+						const classification = classifyGitStderrMessage(
+							err.stderr || err.stdout || err.message || String(err),
+							!!err.stdout
+						);
 
-						message = hintLines.length > 0
-							? l10n.t('Git: {0}', err.stdout ? hintLines[hintLines.length - 1] : hintLines[0])
+						if (classification.type === 'warning') {
+							type = 'warning';
+							options.modal = false;
+						}
+
+						message = classification.message
+							? l10n.t('Git: {0}', classification.message)
 							: l10n.t('Git error');
 
 						break;

--- a/extensions/git/src/test/util.test.ts
+++ b/extensions/git/src/test/util.test.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'mocha';
+import * as assert from 'assert';
+import { classifyGitStderrMessage } from '../util';
+
+suite('classifyGitStderrMessage', () => {
+	test('should classify SSH warning as warning type', () => {
+		const stderr = "warning: permanently added 'gitlab.com' to the list of known hosts.";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'warning');
+		assert.strictEqual(result.message, "permanently added 'gitlab.com' to the list of known hosts.");
+	});
+
+	test('should classify multiple warning-only lines as warning type', () => {
+		const stderr = "warning: first warning\nwarning: second warning";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'warning');
+		assert.strictEqual(result.message, 'first warning');
+	});
+
+	test('should classify fatal error as error type', () => {
+		const stderr = "fatal: repository 'https://example.com/repo.git/' not found";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, "fatal: repository 'https://example.com/repo.git/' not found");
+	});
+
+	test('should classify mixed warning and error as error, excluding warning lines', () => {
+		const stderr = "warning: permanently added 'gitlab.com' to the list of known hosts.\nfatal: Could not read from remote repository.";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'fatal: Could not read from remote repository.');
+	});
+
+	test('should strip "error: " prefix from messages', () => {
+		const stderr = "error: failed to push some refs";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'failed to push some refs');
+	});
+
+	test('should strip husky lines', () => {
+		const stderr = "> husky - something\nfatal: actual error";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'fatal: actual error');
+	});
+
+	test('should use last line when hasStdout is true', () => {
+		const stderr = "first line\nsecond line\nthird line";
+		const result = classifyGitStderrMessage(stderr, true);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'third line');
+	});
+
+	test('should use first line when hasStdout is false', () => {
+		const stderr = "first line\nsecond line\nthird line";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'first line');
+	});
+
+	test('should return empty message for empty input', () => {
+		const result = classifyGitStderrMessage('', false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, '');
+	});
+
+	test('should handle case-insensitive warning prefix', () => {
+		const stderr = "Warning: something happened";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'warning');
+		assert.strictEqual(result.message, 'something happened');
+	});
+
+	test('should prefer non-warning lines for error message when mixed', () => {
+		const stderr = "warning: some warning\nPermission denied (publickey).";
+		const result = classifyGitStderrMessage(stderr, false);
+
+		assert.strictEqual(result.type, 'error');
+		assert.strictEqual(result.message, 'Permission denied (publickey).');
+	});
+});

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -870,3 +870,40 @@ export function getStashDescription(stash: Stash): string | undefined {
 export function isCopilotWorktreeFolder(path: string): boolean {
 	return basename(path).startsWith('copilot-');
 }
+
+export interface GitErrorClassification {
+	readonly type: 'error' | 'warning';
+	readonly message: string;
+}
+
+/**
+ * Classifies git stderr output to determine whether it represents a warning
+ * or an error. Git and SSH write informational warnings (e.g., "warning:
+ * permanently added 'host' to the list of known hosts") to stderr, which
+ * should not be surfaced as errors.
+ */
+export function classifyGitStderrMessage(stderrOrMessage: string, hasStdout: boolean): GitErrorClassification {
+	const hintLines = stderrOrMessage
+		.replace(/^error: /mi, '')
+		.replace(/^> husky.*$/mi, '')
+		.split(/[\r\n]/)
+		.filter((line: string) => !!line);
+
+	const warningLines = hintLines.filter((line: string) => /^warning:/i.test(line.trim()));
+	const nonWarningLines = hintLines.filter((line: string) => !/^warning:/i.test(line.trim()));
+
+	if (nonWarningLines.length === 0 && warningLines.length > 0) {
+		return {
+			type: 'warning',
+			message: warningLines[0].replace(/^warning:\s*/i, '').trim()
+		};
+	}
+
+	const displayLines = nonWarningLines.length > 0 ? nonWarningLines : hintLines;
+	return {
+		type: 'error',
+		message: displayLines.length > 0
+			? (hasStdout ? displayLines[displayLines.length - 1] : displayLines[0])
+			: ''
+	};
+}


### PR DESCRIPTION
## Summary

Fixes #280834

**Bug:** Git warning messages (e.g., SSH host key warnings) written to stderr were incorrectly displayed with red error styling in VS Code notifications.

**Root Cause:** The git error handler in `commands.ts` treated all stderr output uniformly as errors, without distinguishing between actual errors and informational warnings that git/SSH write to stderr.

**Fix:** Introduced `classifyGitStderrMessage()` in `util.ts` that parses stderr lines and classifies them as warnings or errors based on the `warning:` prefix. When all stderr lines are warnings, the notification uses yellow warning styling instead of red error styling.

## Changes

- `extensions/git/src/util.ts`: Added `classifyGitStderrMessage()` function and `GitErrorClassification` interface that separates warning-prefixed lines from error lines and returns the appropriate classification
- `extensions/git/src/commands.ts`: Updated the default error handler to use `classifyGitStderrMessage()` and switch notification type to `'warning'` when appropriate
- `extensions/git/src/test/util.test.ts`: Added 11 regression tests covering pure warnings, pure errors, mixed output, case-insensitive prefixes, husky line stripping, empty input, and stdout/stderr line selection

## Testing

- Added regression test suite in `extensions/git/src/test/util.test.ts` that verifies correct classification of warning-only, error-only, and mixed stderr output
- All existing tests pass