### PR TITLE
fix: resolve #276999 - preserve special chars in terminal drag-drop paths

### DIFF
--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -65,9 +65,9 @@ export function escapeNonWindowsPath(path: string, shellType?: TerminalShellType
 			break;
 	}
 
-	// Remove dangerous characters except single and double quotes, which we'll escape properly
-	const bannedChars = /[\`\$\|\&\>\~\#\!\^\*\;\<]/g;
-	newPath = newPath.replace(bannedChars, '');
+	// Special characters are safe inside single quotes in POSIX shells
+	// (everything is literal except ' itself). Rather than stripping them,
+	// we rely on the quoting below to make the path safe.
 
 	// Apply shell-specific escaping based on quote content
 	if (newPath.includes('\'') && newPath.includes('"')) {

--- a/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/common/terminalEnvironment.test.ts
@@ -91,9 +91,14 @@ suite('terminalEnvironment', () => {
 			strictEqual(escapeNonWindowsPath('/foo/bar\'baz'), '\'/foo/bar\\\'baz\'');
 		});
 
-		test('should remove dangerous characters', () => {
-			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar(echo evil)\'');
-			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/barwhoami\'');
+		test('should preserve special characters inside quotes', () => {
+			strictEqual(escapeNonWindowsPath('/foo/bar$(echo evil)', PosixShellType.Bash), '\'/foo/bar$(echo evil)\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar`whoami`', PosixShellType.Bash), '\'/foo/bar`whoami`\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar~baz', PosixShellType.Bash), '\'/foo/bar~baz\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar#comment', PosixShellType.Bash), '\'/foo/bar#comment\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar!bang', PosixShellType.Bash), '\'/foo/bar!bang\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar&bg', PosixShellType.Bash), '\'/foo/bar&bg\'');
+			strictEqual(escapeNonWindowsPath('/foo/bar*glob', PosixShellType.Bash), '\'/foo/bar*glob\'');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixes #276999

- **Bug:** Dragging a file with special characters (~, `, !, #, $, ^, &, *, |, ;, <, >) into the terminal silently dropped those characters, corrupting the path.
- **Root Cause:** `escapeNonWindowsPath()` in `terminalEnvironment.ts` stripped these characters via a regex before quoting. But since the path is already wrapped in single quotes, these characters are safe (everything is literal inside single quotes in POSIX shells except `'` itself).
- **Fix:** Removed the character stripping. The existing quoting logic already handles all these characters safely.

## Test plan
- Create a file with a tilde in its name (e.g., `test~file.txt`)
- Drag it from the Explorer into the terminal
- Verify the tilde is preserved in the pasted path
- Repeat with other special chars: `` ` ``, `!`, `#`, `$`, `^`, `&`, `*`, `|`, `;`, `<`, `>`