### PR TITLE
fix: resolve #277259 - use outline for diff editor text borders

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/style.css
+++ b/src/vs/editor/browser/widget/diffEditor/style.css
@@ -253,22 +253,22 @@
 
 .monaco-editor .line-insert,
 .monaco-editor .char-insert {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-insertedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-insertedTextBorder);
+	outline-offset: -1px;
 }
 .monaco-editor.hc-black .line-insert, .monaco-editor.hc-light .line-insert,
 .monaco-editor.hc-black .char-insert, .monaco-editor.hc-light .char-insert {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .line-delete,
 .monaco-editor .char-delete {
-	box-sizing: border-box;
-	border: 1px solid var(--vscode-diffEditor-removedTextBorder);
+	outline: 1px solid var(--vscode-diffEditor-removedTextBorder);
+	outline-offset: -1px;
 }
 .monaco-editor.hc-black .line-delete, .monaco-editor.hc-light .line-delete,
 .monaco-editor.hc-black .char-delete, .monaco-editor.hc-light .char-delete {
-	border-style: dashed;
+	outline-style: dashed;
 }
 
 .monaco-editor .inline-added-margin-view-zone,


### PR DESCRIPTION
## Summary
Fixes #277259

- **Bug:** `diffEditor.removedTextBorder` caused line displacement and overlap in the diff editor, while `insertedTextBorder` didn't exhibit the same issue consistently.
- **Root Cause:** CSS `border` adds to element layout even with `box-sizing: border-box` on inline decorations that don't have explicit dimensions.
- **Fix:** Changed `border` to `outline` with `outline-offset: -1px` for both inserted and removed text decorations. `outline` never affects layout, eliminating the displacement. High contrast themes use `outline-style: dashed` instead of `border-style: dashed`.

## Test plan
- Set `"diffEditor.removedTextBorder": "#ff07076c"` and `"diffEditor.insertedTextBorder": "#bcdbc9"` in settings
- Open a diff with adjacent additions and removals
- Verify borders appear without displacing or overlapping lines
- Test in high contrast theme to verify dashed outlines