### PR TITLE
fix: resolve #268776 - show JSDoc descriptions for JS in HTML script tags

### DIFF
--- a/extensions/html-language-features/server/src/modes/javascriptMode.ts
+++ b/extensions/html-language-features/server/src/modes/javascriptMode.ts
@@ -186,9 +186,14 @@ export function getJavaScriptMode(documentRegions: LanguageModelCache<HTMLDocume
 			const info = jsLanguageService.getQuickInfoAtPosition(jsDocument.uri, jsDocument.offsetAt(position));
 			if (info) {
 				const contents = ts.displayPartsToString(info.displayParts);
+				const documentation = ts.displayPartsToString(info.documentation);
+				const parts = ['```typescript', contents, '```'];
+				if (documentation) {
+					parts.push(documentation);
+				}
 				return {
 					range: convertRange(jsDocument, info.textSpan),
-					contents: ['```typescript', contents, '```'].join('\n')
+					contents: parts.join('\n')
 				};
 			}
 			return null;


### PR DESCRIPTION
## Summary
Fixes #268776

- **Bug:** Hovering over JS classes/methods inside HTML `<script>` tags showed only the type signature, not the JSDoc description or MDN links.
- **Root Cause:** The `doHover` handler in `javascriptMode.ts` only included `info.displayParts` (type signature) but ignored `info.documentation` (JSDoc comments).
- **Fix:** Added `info.documentation` to the hover output when available, so JSDoc descriptions and MDN reference links are now shown.

## Test plan
- Open an HTML file with a `<script>` tag containing `const dt = new DataTransfer();`
- Hover over `DataTransfer`
- Verify the hover shows the JSDoc description and MDN link (same as in `.js`/`.ts` files)