### PR TITLE
fix: resolve #270454 - respect collapsed state during SCM auto-reveal

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1786,6 +1786,13 @@ export class SCMViewPane extends ViewPane {
 								: groupItem.resources.find(r => this.uriIdentityService.extUri.isEqual(r.sourceUri, uri));
 
 							if (resource) {
+								// Do not auto-reveal if the resource group is
+								// collapsed, as this would override the user's
+								// explicit collapse action
+								if (this.tree.hasNode(groupItem) && this.tree.isCollapsed(groupItem)) {
+									return;
+								}
+
 								await this.tree.expandTo(resource);
 								this.tree.reveal(resource);
 


### PR DESCRIPTION
## Summary
Fixes #270454

- **Bug:** SCM view did not remember collapsed state of Staged Changes. Collapsing Staged Changes, switching to another view, then returning would re-expand it.
- **Root Cause:** `onDidActiveEditorChange()` in `scmViewPane.ts` called `tree.expandTo(resource)` unconditionally, overriding the user's explicit collapse.
- **Fix:** Before auto-revealing, check if the resource's group node is collapsed. If it is, skip the reveal to respect the user's choice.

## Test plan
- Stage some changes in the SCM view
- Collapse the "Staged Changes" section
- Ensure a staged file is open in the editor
- Switch to the Explorer view, then switch back to SCM
- Verify the "Staged Changes" section remains collapsed