### PR TITLE
sessions: only animate sidebar body on reveal

### DIFF
--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -642,8 +642,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
-| 2026-03-26 | Removed the remaining sidebar header/footer motion during reveal by limiting the appear animation to `.part.sidebar > .content` and disabling transitions/animations in the sidebar title/toolbar/footer region |
-| 2026-03-26 | Updated the sessions sidebar appear animation so the sidebar title/header and footer stay fixed while only the body content (`.part.sidebar > .content`) slides/fades in during reveal |
+| 2026-03-26 | Updated the sessions sidebar appear animation so only the body content (`.part.sidebar > .content`) slides/fades in during reveal while the sidebar title/header and footer remain fixed |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |
 | 2026-02-17 | Added `-webkit-app-region: drag` to sidebar title area so it can be used to drag the window; interactive children (actions, composite bar, labels) marked `no-drag`; CSS rules scoped to `.agent-sessions-workbench` in `parts/media/sidebarPart.css` |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -442,7 +442,7 @@ The `SidebarPart` includes a footer section (35px height) positioned below the p
 
 On macOS native with custom titlebar, the sidebar title area includes a traffic light spacer (70px) to push content past the system window controls. The spacer is hidden in fullscreen mode and is not created when using native titlebar (since the OS renders traffic lights in its own title bar).
 
-The sessions appear animation applies only to the sidebar body (`.part.sidebar > .content`). The sidebar container, title area, toolbar actions, and footer do not animate during reveal, so the header region remains completely static while the body slides/fades in.
+The sessions appear animation applies only to the sidebar body (`.part.sidebar > .content`). The sidebar container, title area, and footer do not participate in the reveal animation, so the header region stays visually fixed while the body slides/fades in. Normal hover and pressed feedback for header/footer controls is preserved.
 
 ---
 

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -442,6 +442,8 @@ The `SidebarPart` includes a footer section (35px height) positioned below the p
 
 On macOS native with custom titlebar, the sidebar title area includes a traffic light spacer (70px) to push content past the system window controls. The spacer is hidden in fullscreen mode and is not created when using native titlebar (since the OS renders traffic lights in its own title bar).
 
+The sessions appear animation keeps the sidebar container, title area, and footer visually pinned. Only the sidebar body (`.part.sidebar > .content`) animates in with the left-to-right slide/fade effect, so the header actions do not shift during reveal.
+
 ---
 
 ## 10. Workbench Contributions
@@ -640,6 +642,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-03-26 | Updated the sessions sidebar appear animation so the sidebar title/header and footer stay fixed while only the body content (`.part.sidebar > .content`) slides/fades in during reveal |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |
 | 2026-02-17 | Added `-webkit-app-region: drag` to sidebar title area so it can be used to drag the window; interactive children (actions, composite bar, labels) marked `no-drag`; CSS rules scoped to `.agent-sessions-workbench` in `parts/media/sidebarPart.css` |

--- a/src/vs/sessions/LAYOUT.md
+++ b/src/vs/sessions/LAYOUT.md
@@ -442,7 +442,7 @@ The `SidebarPart` includes a footer section (35px height) positioned below the p
 
 On macOS native with custom titlebar, the sidebar title area includes a traffic light spacer (70px) to push content past the system window controls. The spacer is hidden in fullscreen mode and is not created when using native titlebar (since the OS renders traffic lights in its own title bar).
 
-The sessions appear animation keeps the sidebar container, title area, and footer visually pinned. Only the sidebar body (`.part.sidebar > .content`) animates in with the left-to-right slide/fade effect, so the header actions do not shift during reveal.
+The sessions appear animation applies only to the sidebar body (`.part.sidebar > .content`). The sidebar container, title area, toolbar actions, and footer do not animate during reveal, so the header region remains completely static while the body slides/fades in.
 
 ---
 
@@ -642,6 +642,7 @@ interface IPartVisibilityState {
 
 | Date | Change |
 |------|--------|
+| 2026-03-26 | Removed the remaining sidebar header/footer motion during reveal by limiting the appear animation to `.part.sidebar > .content` and disabling transitions/animations in the sidebar title/toolbar/footer region |
 | 2026-03-26 | Updated the sessions sidebar appear animation so the sidebar title/header and footer stay fixed while only the body content (`.part.sidebar > .content`) slides/fades in during reveal |
 | 2026-03-02 | Fixed macOS sidebar traffic light spacer to only render with custom titlebar; added `!hasNativeTitlebar()` guard to `SidebarPart.createTitleArea()` so the 70px spacer is not created when using native titlebar (traffic lights are in the OS title bar, not overlapping the sidebar) |
 | 2026-02-20 | Replaced custom `EditorModal` with standard `ModalEditorPart` via `MODAL_GROUP`; main editor part created but hidden; changed `workbench.editor.useModal` from boolean to enum (`off`/`some`/`all`); sessions config uses `all`; removed `editorModal.ts` and editor modal CSS |

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -153,11 +153,15 @@
  * Subtle appear animation when parts transition from display:none → visible
  * (via split-view-view .visible class).
  *
- * Animated properties: opacity, margin, border-color, background.
+ * Auxiliary bar, panel, and chat bar animate their container via opacity,
+ * margin, border-color, and background. The sidebar reveal animation applies
+ * only to `.part.sidebar > .content`, using opacity + transform so the
+ * sidebar container, header, and footer stay visually fixed.
+ *
  * Opacity transiently creates a stacking context while it animates from 0 to 1
  * over 250ms — once settled at opacity: 1, no additional stacking context is
- * introduced by this animation. Margin shifts are purely visual within the
- * grid-allocated space.
+ * introduced by this animation. Margin and transform shifts are purely visual
+ * within the grid-allocated space.
  */
 
 .agent-sessions-workbench .part.auxiliarybar,

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -160,7 +160,6 @@
  * grid-allocated space.
  */
 
-.agent-sessions-workbench .part.sidebar,
 .agent-sessions-workbench .part.auxiliarybar,
 .agent-sessions-workbench .part.panel,
 .agent-sessions-workbench .part.chatbar {
@@ -173,8 +172,7 @@
 		background 250ms ease-out;
 }
 
-/* Sidebar & auxiliary bar also transition margin-left */
-.agent-sessions-workbench .part.sidebar,
+/* Auxiliary bar also transitions horizontal margin */
 .agent-sessions-workbench .part.auxiliarybar {
 	transition:
 		opacity 250ms ease-out,
@@ -183,9 +181,21 @@
 		background 250ms ease-out;
 }
 
+/* Sidebar keeps its title/footer pinned while its body content animates */
+.agent-sessions-workbench .part.sidebar {
+	transition:
+		border-color 250ms ease-out,
+		background 250ms ease-out;
+}
+
+.agent-sessions-workbench .part.sidebar > .content {
+	transition:
+		opacity 250ms ease-out,
+		transform 250ms ease-out;
+}
+
 @starting-style {
 	/* Shared starting values */
-	.agent-sessions-workbench .part.sidebar,
 	.agent-sessions-workbench .part.auxiliarybar,
 	.agent-sessions-workbench .part.panel,
 	.agent-sessions-workbench .part.chatbar {
@@ -200,10 +210,9 @@
 		background: color-mix(in srgb, var(--part-background) 60%, var(--vscode-sideBar-background));
 	}
 
-	/* Per-part margin shifts — each part settles into its resting margin */
-	/* Sidebar (left): slides in from 6px left → margin: 0 */
-	.agent-sessions-workbench .part.sidebar {
-		margin-left: -6px;
+	.agent-sessions-workbench .part.sidebar > .content {
+		opacity: 0;
+		transform: translateX(-6px);
 	}
 
 	/* Panel (bottom): slides down from 6px above → margin: 0 16px 18px 16px */
@@ -223,10 +232,17 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.agent-sessions-workbench .part.sidebar,
 	.agent-sessions-workbench .part.auxiliarybar,
 	.agent-sessions-workbench .part.panel,
 	.agent-sessions-workbench .part.chatbar {
+		transition: none;
+	}
+
+	.agent-sessions-workbench .part.sidebar {
+		transition: none;
+	}
+
+	.agent-sessions-workbench .part.sidebar > .content {
 		transition: none;
 	}
 }

--- a/src/vs/sessions/browser/media/style.css
+++ b/src/vs/sessions/browser/media/style.css
@@ -181,13 +181,6 @@
 		background 250ms ease-out;
 }
 
-/* Sidebar keeps its title/footer pinned while its body content animates */
-.agent-sessions-workbench .part.sidebar {
-	transition:
-		border-color 250ms ease-out,
-		background 250ms ease-out;
-}
-
 .agent-sessions-workbench .part.sidebar > .content {
 	transition:
 		opacity 250ms ease-out,
@@ -235,10 +228,6 @@
 	.agent-sessions-workbench .part.auxiliarybar,
 	.agent-sessions-workbench .part.panel,
 	.agent-sessions-workbench .part.chatbar {
-		transition: none;
-	}
-
-	.agent-sessions-workbench .part.sidebar {
 		transition: none;
 	}
 

--- a/src/vs/sessions/browser/parts/media/sidebarPart.css
+++ b/src/vs/sessions/browser/parts/media/sidebarPart.css
@@ -29,36 +29,6 @@
 	-webkit-app-region: no-drag;
 }
 
-/* Keep the sidebar header/footer containers static during sidebar reveal
- * without disabling normal hover/pressed feedback on their interactive children. */
-.agent-sessions-workbench .part.sidebar > .composite.title,
-.agent-sessions-workbench .part.sidebar > .sidebar-footer,
-.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions,
-.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left {
-	transition-property: none !important;
-	transition-duration: 0s !important;
-	transition-delay: 0s !important;
-	animation: none !important;
-}
-
-/* Avoid title action fade artifacts from pane composite drag-indicator pseudo-elements,
- * but keep the action items themselves free to use normal interaction feedback. */
-.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::before,
-.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::before,
-.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::before,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::before,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::after {
-	transition-property: none !important;
-	transition-duration: 0s !important;
-	transition-delay: 0s !important;
-	animation: none !important;
-}
-
 /* Sidebar Footer Container */
 .agent-sessions-workbench .part.sidebar > .sidebar-footer {
 	display: flex;

--- a/src/vs/sessions/browser/parts/media/sidebarPart.css
+++ b/src/vs/sessions/browser/parts/media/sidebarPart.css
@@ -29,36 +29,34 @@
 	-webkit-app-region: no-drag;
 }
 
-/* Keep the sidebar header/footer fully static during sidebar reveal */
+/* Keep the sidebar header/footer containers static during sidebar reveal
+ * without disabling normal hover/pressed feedback on their interactive children. */
 .agent-sessions-workbench .part.sidebar > .composite.title,
-.agent-sessions-workbench .part.sidebar > .composite.title *,
 .agent-sessions-workbench .part.sidebar > .sidebar-footer,
-.agent-sessions-workbench .part.sidebar > .sidebar-footer * {
-	transition: none !important;
+.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions,
+.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left {
+	transition-property: none !important;
+	transition-duration: 0s !important;
+	transition-delay: 0s !important;
 	animation: none !important;
 }
 
-.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions,
-.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions *,
+/* Avoid title action fade artifacts from pane composite drag-indicator pseudo-elements,
+ * but keep the action items themselves free to use normal interaction feedback. */
 .agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::before,
 .agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container,
-.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container *,
 .agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::before,
 .agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions *,
 .agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::before,
 .agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::after,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left,
-.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left *,
 .agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::before,
 .agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::after {
 	transition-property: none !important;
 	transition-duration: 0s !important;
 	transition-delay: 0s !important;
 	animation: none !important;
-	opacity: 1 !important;
 }
 
 /* Sidebar Footer Container */

--- a/src/vs/sessions/browser/parts/media/sidebarPart.css
+++ b/src/vs/sessions/browser/parts/media/sidebarPart.css
@@ -29,6 +29,15 @@
 	-webkit-app-region: no-drag;
 }
 
+/* Keep the sidebar header/footer fully static during sidebar reveal */
+.agent-sessions-workbench .part.sidebar > .composite.title,
+.agent-sessions-workbench .part.sidebar > .composite.title *,
+.agent-sessions-workbench .part.sidebar > .sidebar-footer,
+.agent-sessions-workbench .part.sidebar > .sidebar-footer * {
+	transition: none !important;
+	animation: none !important;
+}
+
 /* Sidebar Footer Container */
 .agent-sessions-workbench .part.sidebar > .sidebar-footer {
 	display: flex;

--- a/src/vs/sessions/browser/parts/media/sidebarPart.css
+++ b/src/vs/sessions/browser/parts/media/sidebarPart.css
@@ -38,6 +38,29 @@
 	animation: none !important;
 }
 
+.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions,
+.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions *,
+.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::before,
+.agent-sessions-workbench .part.sidebar > .composite.title > .title-actions .action-item::after,
+.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container,
+.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container *,
+.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::before,
+.agent-sessions-workbench .part.sidebar > .composite.title > .composite-bar-container .action-item::after,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions *,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::before,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions .action-item::after,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left *,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::before,
+.agent-sessions-workbench .part.sidebar > .composite.title > .global-actions-left .action-item::after {
+	transition-property: none !important;
+	transition-duration: 0s !important;
+	transition-delay: 0s !important;
+	animation: none !important;
+	opacity: 1 !important;
+}
+
 /* Sidebar Footer Container */
 .agent-sessions-workbench .part.sidebar > .sidebar-footer {
 	display: flex;


### PR DESCRIPTION
## Summary

This updates the Sessions app sidebar reveal animation so only the sidebar body animates in.

- moves the reveal animation to `.part.sidebar > .content`
- keeps the sidebar header and footer visually fixed during reveal
- preserves normal hover, pressed, and drag/drop feedback for sidebar controls
- updates `src/vs/sessions/LAYOUT.md` to document the final behavior

## Why

The previous behavior animated the whole sidebar surface, which made the header/title area shift during reveal. The intended behavior is for the header to stay put while only the body content slides/fades in.

## Validation

- `npm run compile-check-ts-native`
- `node --experimental-strip-types build/hygiene.ts src/vs/sessions/browser/media/style.css src/vs/sessions/LAYOUT.md`

## Reviewer notes

There are no functional code changes outside the Sessions sidebar animation and its related layout documentation.