### PR TITLE
Increase default tree indentation and always show indent guides

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -342,7 +342,7 @@ class EventCollection<T> implements Collection<T>, IDisposable {
 
 export class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer<ITreeNode<T, TFilterData>, ITreeListTemplateData<TTemplateData>> {
 
-	private static readonly DefaultIndent = 8;
+	private static readonly DefaultIndent = 16;
 
 	readonly templateId: string;
 	private renderedElements = new Map<T, ITreeNode<T, TFilterData>>();

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -1408,7 +1408,7 @@ configurationRegistry.registerConfiguration({
 		},
 		[treeIndentKey]: {
 			type: 'number',
-			default: 8,
+			default: 16,
 			minimum: 4,
 			maximum: 40,
 			description: localize('tree indent setting', "Controls tree indentation in pixels.")
@@ -1416,7 +1416,7 @@ configurationRegistry.registerConfiguration({
 		[treeRenderIndentGuidesKey]: {
 			type: 'string',
 			enum: ['none', 'onHover', 'always'],
-			default: 'onHover',
+			default: 'always',
 			description: localize('render tree indent guides', "Controls whether the tree should render indent guides.")
 		},
 		[listSmoothScrolling]: {

--- a/src/vs/platform/theme/common/colors/listColors.ts
+++ b/src/vs/platform/theme/common/colors/listColors.ts
@@ -132,7 +132,7 @@ export const treeIndentGuidesStroke = registerColor('tree.indentGuidesStroke',
 	nls.localize('treeIndentGuidesStroke', "Tree stroke color for the indentation guides."));
 
 export const treeInactiveIndentGuidesStroke = registerColor('tree.inactiveIndentGuidesStroke',
-	transparent(treeIndentGuidesStroke, 0.4),
+	transparent(treeIndentGuidesStroke, 0.6),
 	nls.localize('treeInactiveIndentGuidesStroke', "Tree stroke color for the indentation guides that are not active."));
 
 


### PR DESCRIPTION
Fixes #305170

Summary
Improves the visual hierarchy of tree views (Explorer, SCM, etc.) by increasing the default indentation and making indent guide lines always visible. This brings the out-of-the-box experience closer to the clarity of JetBrains-style project trees, reducing cognitive load when navigating deeply nested structures.

Changes
Default indent: 8px → 16px
src/vs/platform/list/browser/listService.ts
 — workbench.tree.indent default changed from 8 to 16
src/vs/base/browser/ui/tree/abstractTree.ts
 — TreeRenderer.DefaultIndent fallback changed from 8 to 16
Indent guides always visible
src/vs/platform/list/browser/listService.ts
 — workbench.tree.renderIndentGuides default changed from onHover to always
More visible inactive guide lines
src/vs/platform/theme/common/colors/listColors.ts
 — tree.inactiveIndentGuidesStroke opacity raised from 0.4 to 0.6