### PR TITLE
Fix sash hover flicker at T-junctions

### DIFF
--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -617,7 +617,7 @@ export class Sash extends Disposable {
 
 	private static onMouseLeave(sash: Sash, fromLinkedSash: boolean = false): void {
 		sash.hoverDelayer.cancel();
-		sash.el.classList.remove('hover');
+		sash.hoverDelayer.trigger(() => sash.el.classList.remove('hover'), 0).then(undefined, () => { });
 
 		if (!fromLinkedSash && sash.linkedSash) {
 			Sash.onMouseLeave(sash.linkedSash, true);


### PR DESCRIPTION
Fixes #305055

Summary
When moving the pointer from a through-going sash toward a T-junction, the sash briefly loses its hover highlight before both sashes light up. This is a directional bug: moving in from the terminating sash does not exhibit the issue.

Root cause: Sash.onMouseLeave removed the hover CSS class synchronously. When the pointer crossed into the orthogonal drag handle overlay, the browser fired mouseleave on the through-going sash first. By the time mouseenter fired on the orthogonal handle, the hover state was already gone, causing a visible flash before the delayed hoverDelayer re-added it.

Change
src/vs/base/browser/ui/sash/sash.ts
 — Sash.onMouseLeave

diff
- sash.el.classList.remove('hover');
+ sash.hoverDelayer.trigger(() => sash.el.classList.remove('hover'), 0).then(undefined, () => { });
The removal is now scheduled through the same hoverDelayer instance used by 
onMouseEnter
. Because both enter and leave share the delayer, a synchronously-following mouseenter on the drag handle will cancel the pending removal — keeping the hover class on the element with no visible flicker.