### PR TITLE
Fix chat markdown rendering regression caused by <body> wrapper in DO…

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts
@@ -90,9 +90,9 @@ export class ChatContentMarkdownRenderer implements IMarkdownRenderer {
 			{
 				...markdown,
 
-				// dompurify uses DOMParser, which strips leading comments. Wrapping it all in 'body' prevents this.
-				// The \n\n prevents marked.js from parsing the body contents as just text in an 'html' token, instead of actual markdown.
-				value: `<body>\n\n${markdown.value}</body>`,
+				// dompurify uses DOMParser, which strips leading comments. Wrapping it all in 'div' prevents this.
+				// The \n\n prevents marked.js from parsing the div contents as just text in an 'html' token, instead of actual markdown.
+				value: `<div>\n\n${markdown.value}</div>`,
 			}
 			: markdown;
 		const result = this.markdownRendererService.render(mdWithBody, options, outElement);


### PR DESCRIPTION
Fixes #305089

Problem
Since VS Code 1.112, three related regressions appeared in the GitHub Copilot Chat panel:

Markdown rendered as flat text — tables, code blocks, headings, and bold/italic formatting all collapsed to plain text in AI responses.
Agent <expression> tags invisible — expressions produced by agents (e.g., Power Automate formulas) were silently stripped and never shown.
.prompt.md / .instructions.md attachments lost between turns — files attached as prompt or instruction context were dropped after the first message.
Root Cause
In ChatContentMarkdownRenderer.render(), a recent change wrapped supportHtml markdown in a <body> tag to prevent DOMPurify/DOMParser from stripping leading HTML comments:

ts
value: `<body>\n\n${markdown.value}</body>`
However, body is not in allowedChatMarkdownHtmlTags. With replaceWithPlaintext: true configured, DOMPurify stripped the <body>/</body> tags and output the inner content as raw text nodes — destroying all markdown structure and silently dropping any unrecognized tags.

Fix
Replace <body> with <div>, which is in allowedChatMarkdownHtmlTags and therefore passes through DOMPurify cleanly:

ts
// Before
value: `<body>\n\n${markdown.value}</body>`
// After
value: `<div>\n\n${markdown.value}</div>`
The \n\n boundary is preserved so Marked.js still parses the inner content as markdown rather than a raw HTML block.

Files Changed
src/vs/workbench/contrib/chat/browser/widget/chatContentMarkdownRenderer.ts