### PR TITLE
customizations editor: hook up dirty state for built-in customization editing

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -328,8 +328,13 @@ export class Dialog extends Disposable {
 
 			// Handle keyboard events globally: Tab, Arrow-Left/Right
 			const window = getWindow(this.container);
+			let sawEscapeKeyDown = false;
 			this._register(addDisposableListener(window, 'keydown', e => {
 				const evt = new StandardKeyboardEvent(e);
+
+				if (evt.equals(KeyCode.Escape)) {
+					sawEscapeKeyDown = true;
+				}
 
 				if (evt.equals(KeyMod.Alt)) {
 					evt.preventDefault();
@@ -470,7 +475,7 @@ export class Dialog extends Disposable {
 				EventHelper.stop(e, true);
 				const evt = new StandardKeyboardEvent(e);
 
-				if (!this.options.disableCloseAction && evt.equals(KeyCode.Escape)) {
+				if (!this.options.disableCloseAction && evt.equals(KeyCode.Escape) && sawEscapeKeyDown) {
 					close();
 				}
 			}, true));

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -69,7 +69,7 @@ import { IResolvedTextEditorModel, ITextModelService } from '../../../../../edit
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
-import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { ConfirmResult, IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
@@ -1202,6 +1202,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.inEditorContextKey.set(true);
 		this.sectionContextKey.set(this.selectedSection);
 
+		input.setConfirmHandler(() => this.handleBuiltinCloseConfirmation());
+
 		this.telemetryService.publicLog2<CustomizationEditorOpenedEvent, CustomizationEditorOpenedClassification>('chatCustomizationEditor.opened', {
 			section: this.selectedSection,
 		});
@@ -1214,6 +1216,12 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	override clearInput(): void {
+		const input = this.input;
+		if (input instanceof AICustomizationManagementEditorInput) {
+			input.setConfirmHandler(undefined);
+			input.setDirty(false);
+		}
+
 		this.inEditorContextKey.set(false);
 		if (this.viewMode === 'editor') {
 			this.goBackToList();
@@ -1661,6 +1669,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 	}
 
 	private updateEditorActionButton(): void {
+		this.updateInputDirtyState();
+
 		if (!this.editorActionButton || !this.editorActionButtonIcon) {
 			return;
 		}
@@ -1680,6 +1690,51 @@ export class AICustomizationManagementEditor extends EditorPane {
 		return this._editorContentChanged
 			&& this.currentEditingStorage === BUILTIN_STORAGE
 			&& (this.currentEditingPromptType === PromptsType.prompt || this.currentEditingPromptType === PromptsType.skill);
+	}
+
+	private updateInputDirtyState(): void {
+		const input = this.input;
+		if (input instanceof AICustomizationManagementEditorInput) {
+			input.setDirty(this.shouldShowBuiltinSaveAction());
+		}
+	}
+
+	private async handleBuiltinCloseConfirmation(): Promise<ConfirmResult> {
+		if (!this.shouldShowBuiltinSaveAction()) {
+			return ConfirmResult.DONT_SAVE;
+		}
+
+		const displayName = this.editorItemNameElement?.textContent ?? localize('customization', "customization");
+		const confirmation = await this.fileDialogService.showSaveConfirm([displayName]);
+
+		if (confirmation === ConfirmResult.SAVE) {
+			const target = await this.pickBuiltinPromptSaveTarget();
+			if (!target || target.target === 'cancel') {
+				return ConfirmResult.CANCEL;
+			}
+
+			const saveRequest = this.createBuiltinPromptSaveRequest(target);
+			if (saveRequest) {
+				try {
+					await this.saveBuiltinPromptCopy(saveRequest);
+					this.telemetryService.publicLog2<CustomizationEditorSaveItemEvent, CustomizationEditorSaveItemClassification>('chatCustomizationEditor.saveItem', {
+						promptType: this.currentEditingPromptType ?? '',
+						storage: String(this.currentEditingStorage ?? ''),
+						saveTarget: target.target,
+					});
+				} catch (error) {
+					console.error('Failed to save built-in override:', error);
+					this.notificationService.warn(target.target === 'workspace'
+						? localize('saveBuiltinCopyFailedWorkspace', "Could not save the override to the workspace.")
+						: localize('saveBuiltinCopyFailedUser', "Could not save the override to your user folder."));
+					return ConfirmResult.CANCEL;
+				}
+			}
+
+			return ConfirmResult.DONT_SAVE;
+		}
+
+		return confirmation;
 	}
 
 	private resetEditorSaveIndicator(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -5,7 +5,7 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { RunOnceScheduler, timeout } from '../../../../../base/common/async.js';
+import { RunOnceScheduler } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
@@ -69,7 +69,7 @@ import { IResolvedTextEditorModel, ITextModelService } from '../../../../../edit
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { getSimpleEditorOptions } from '../../../codeEditor/browser/simpleEditorOptions.js';
 import { IWorkingCopyService } from '../../../../services/workingCopy/common/workingCopyService.js';
-import { ConfirmResult, IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { IFileService } from '../../../../../platform/files/common/files.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
@@ -1202,7 +1202,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 		this.inEditorContextKey.set(true);
 		this.sectionContextKey.set(this.selectedSection);
 
-		input.setConfirmHandler(() => this.handleBuiltinCloseConfirmation());
+		input.setSaveHandler(() => this.handleBuiltinSave());
 
 		this.telemetryService.publicLog2<CustomizationEditorOpenedEvent, CustomizationEditorOpenedClassification>('chatCustomizationEditor.opened', {
 			section: this.selectedSection,
@@ -1218,7 +1218,7 @@ export class AICustomizationManagementEditor extends EditorPane {
 	override clearInput(): void {
 		const input = this.input;
 		if (input instanceof AICustomizationManagementEditorInput) {
-			input.setConfirmHandler(undefined);
+			input.setSaveHandler(undefined);
 			input.setDirty(false);
 		}
 
@@ -1699,47 +1699,42 @@ export class AICustomizationManagementEditor extends EditorPane {
 		}
 	}
 
-	private async handleBuiltinCloseConfirmation(): Promise<ConfirmResult> {
+	private async handleBuiltinSave(): Promise<boolean> {
 		if (!this.shouldShowBuiltinSaveAction()) {
-			return ConfirmResult.DONT_SAVE;
+			return false;
 		}
 
-		// Wait for current keyboard events (e.g. Escape keyup) to fully
-		// propagate before opening the dialog, otherwise the same keyup
-		// event that triggered the modal close will immediately dismiss it.
-		await timeout(0);
-
-		const displayName = this.editorItemNameElement?.textContent ?? localize('customization', "customization");
-		const confirmation = await this.fileDialogService.showSaveConfirm([displayName]);
-
-		if (confirmation === ConfirmResult.SAVE) {
-			const target = await this.pickBuiltinPromptSaveTarget();
-			if (!target || target.target === 'cancel') {
-				return ConfirmResult.CANCEL;
-			}
-
-			const saveRequest = this.createBuiltinPromptSaveRequest(target);
-			if (saveRequest) {
-				try {
-					await this.saveBuiltinPromptCopy(saveRequest);
-					this.telemetryService.publicLog2<CustomizationEditorSaveItemEvent, CustomizationEditorSaveItemClassification>('chatCustomizationEditor.saveItem', {
-						promptType: this.currentEditingPromptType ?? '',
-						storage: String(this.currentEditingStorage ?? ''),
-						saveTarget: target.target,
-					});
-				} catch (error) {
-					console.error('Failed to save built-in override:', error);
-					this.notificationService.warn(target.target === 'workspace'
-						? localize('saveBuiltinCopyFailedWorkspace', "Could not save the override to the workspace.")
-						: localize('saveBuiltinCopyFailedUser', "Could not save the override to your user folder."));
-					return ConfirmResult.CANCEL;
-				}
-			}
-
-			return ConfirmResult.DONT_SAVE;
+		const target = await this.pickBuiltinPromptSaveTarget();
+		if (!target || target.target === 'cancel') {
+			return false;
 		}
 
-		return confirmation;
+		const saveRequest = this.createBuiltinPromptSaveRequest(target);
+		if (!saveRequest) {
+			return false;
+		}
+
+		try {
+			await this.saveBuiltinPromptCopy(saveRequest);
+			this.telemetryService.publicLog2<CustomizationEditorSaveItemEvent, CustomizationEditorSaveItemClassification>('chatCustomizationEditor.saveItem', {
+				promptType: this.currentEditingPromptType ?? '',
+				storage: String(this.currentEditingStorage ?? ''),
+				saveTarget: target.target,
+			});
+
+			const input = this.input;
+			if (input instanceof AICustomizationManagementEditorInput) {
+				input.setDirty(false);
+			}
+
+			return true;
+		} catch (error) {
+			console.error('Failed to save built-in override:', error);
+			this.notificationService.warn(target.target === 'workspace'
+				? localize('saveBuiltinCopyFailedWorkspace', "Could not save the override to the workspace.")
+				: localize('saveBuiltinCopyFailedUser', "Could not save the override to your user folder."));
+			return false;
+		}
 	}
 
 	private resetEditorSaveIndicator(): void {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -1722,10 +1722,8 @@ export class AICustomizationManagementEditor extends EditorPane {
 				saveTarget: target.target,
 			});
 
-			const input = this.input;
-			if (input instanceof AICustomizationManagementEditorInput) {
-				input.setDirty(false);
-			}
+			this._editorContentChanged = false;
+			this.updateEditorActionButton();
 
 			return true;
 		} catch (error) {

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor.ts
@@ -5,7 +5,7 @@
 
 import './media/aiCustomizationManagement.css';
 import * as DOM from '../../../../../base/browser/dom.js';
-import { RunOnceScheduler } from '../../../../../base/common/async.js';
+import { RunOnceScheduler, timeout } from '../../../../../base/common/async.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { onUnexpectedError } from '../../../../../base/common/errors.js';
@@ -1703,6 +1703,11 @@ export class AICustomizationManagementEditor extends EditorPane {
 		if (!this.shouldShowBuiltinSaveAction()) {
 			return ConfirmResult.DONT_SAVE;
 		}
+
+		// Wait for current keyboard events (e.g. Escape keyup) to fully
+		// propagate before opening the dialog, otherwise the same keyup
+		// event that triggered the modal close will immediately dismiss it.
+		await timeout(0);
 
 		const displayName = this.editorItemNameElement?.textContent ?? localize('customization', "customization");
 		const confirmation = await this.fileDialogService.showSaveConfirm([displayName]);

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
@@ -6,9 +6,8 @@
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
-import { ConfirmResult } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IUntypedEditorInput, EditorInputCapabilities } from '../../../../common/editor.js';
-import { EditorInput, IEditorCloseHandler } from '../../../../common/editor/editorInput.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID } from './aiCustomizationManagement.js';
 
 /**
@@ -22,14 +21,7 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 	readonly resource = undefined;
 
 	private _isDirty = false;
-	private _confirmHandler?: () => Promise<ConfirmResult>;
-
-	override readonly closeHandler: IEditorCloseHandler = {
-		showConfirm: () => this._isDirty,
-		confirm: async () => {
-			return this._confirmHandler?.() ?? ConfirmResult.DONT_SAVE;
-		},
-	};
+	private _saveHandler?: () => Promise<boolean>;
 
 	override get capabilities(): EditorInputCapabilities {
 		return super.capabilities | EditorInputCapabilities.Singleton | EditorInputCapabilities.RequiresModal;
@@ -75,6 +67,14 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 		return this._isDirty;
 	}
 
+	override async save(): Promise<EditorInput | undefined> {
+		if (this._saveHandler) {
+			const saved = await this._saveHandler();
+			return saved ? this : undefined;
+		}
+		return undefined;
+	}
+
 	override async revert(): Promise<void> {
 		this.setDirty(false);
 	}
@@ -86,7 +86,7 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 		}
 	}
 
-	setConfirmHandler(handler: (() => Promise<ConfirmResult>) | undefined): void {
-		this._confirmHandler = handler;
+	setSaveHandler(handler: (() => Promise<boolean>) | undefined): void {
+		this._saveHandler = handler;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
@@ -6,7 +6,7 @@
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
-import { IUntypedEditorInput, EditorInputCapabilities } from '../../../../common/editor.js';
+import { IUntypedEditorInput, EditorInputCapabilities, GroupIdentifier, ISaveOptions, SaveReason } from '../../../../common/editor.js';
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID } from './aiCustomizationManagement.js';
 
@@ -67,7 +67,10 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 		return this._isDirty;
 	}
 
-	override async save(): Promise<EditorInput | undefined> {
+	override async save(group: GroupIdentifier, options?: ISaveOptions): Promise<EditorInput | undefined> {
+		if (options?.reason !== undefined && options.reason !== SaveReason.EXPLICIT) {
+			return undefined;
+		}
 		if (this._saveHandler) {
 			const saved = await this._saveHandler();
 			return saved ? this : undefined;

--- a/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput.ts
@@ -6,8 +6,9 @@
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
+import { ConfirmResult } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IUntypedEditorInput, EditorInputCapabilities } from '../../../../common/editor.js';
-import { EditorInput } from '../../../../common/editor/editorInput.js';
+import { EditorInput, IEditorCloseHandler } from '../../../../common/editor/editorInput.js';
 import { AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID } from './aiCustomizationManagement.js';
 
 /**
@@ -19,6 +20,16 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 	static readonly ID: string = AI_CUSTOMIZATION_MANAGEMENT_EDITOR_INPUT_ID;
 
 	readonly resource = undefined;
+
+	private _isDirty = false;
+	private _confirmHandler?: () => Promise<ConfirmResult>;
+
+	override readonly closeHandler: IEditorCloseHandler = {
+		showConfirm: () => this._isDirty,
+		confirm: async () => {
+			return this._confirmHandler?.() ?? ConfirmResult.DONT_SAVE;
+		},
+	};
 
 	override get capabilities(): EditorInputCapabilities {
 		return super.capabilities | EditorInputCapabilities.Singleton | EditorInputCapabilities.RequiresModal;
@@ -58,5 +69,24 @@ export class AICustomizationManagementEditorInput extends EditorInput {
 
 	override async resolve(): Promise<null> {
 		return null;
+	}
+
+	override isDirty(): boolean {
+		return this._isDirty;
+	}
+
+	override async revert(): Promise<void> {
+		this.setDirty(false);
+	}
+
+	setDirty(dirty: boolean): void {
+		if (this._isDirty !== dirty) {
+			this._isDirty = dirty;
+			this._onDidChangeDirty.fire();
+		}
+	}
+
+	setConfirmHandler(handler: (() => Promise<ConfirmResult>) | undefined): void {
+		this._confirmHandler = handler;
 	}
 }


### PR DESCRIPTION
## Summary

When editing a built-in customization (prompt/skill) in the AI Customizations management editor, the embedded editor tracks content changes but does not communicate dirty state to the modal editor infrastructure. This means closing the modal (via Escape or clicking outside) silently discards edits with no save confirmation.


https://github.com/user-attachments/assets/fee2a033-082a-43f7-851f-a15c4ba24725



## Changes

### 1. `AICustomizationManagementEditorInput` — dirty state & save/revert

Implements the standard `EditorInput` dirty lifecycle:
- **`isDirty()`** — returns tracked dirty state
- **`save()`** — delegates to a save handler registered by the pane, which runs the pick-target + save-as-override flow
- **`revert()`** — clears dirty state (called by framework on "Don't Save")
- **`setDirty()` / `setSaveHandler()`** — lets the editor pane sync its internal `_editorContentChanged` state to the input

### 2. `AICustomizationManagementEditor` — wiring

- **`setInput()`** — registers `handleBuiltinSave` as the save handler
- **`clearInput()`** — clears handler and dirty state
- **`updateEditorActionButton()`** — now also calls `updateInputDirtyState()` to sync dirty state to the input whenever the action button updates
- **`handleBuiltinSave()`** — runs the existing pick-target → save-as-override flow, returns success/failure

### 3. `dialog.ts` — fix Escape keyup race condition

The dialog's `keyup` handler was closing on Escape even when the corresponding `keydown` happened before the dialog existed. When Escape closed a modal editor and the save confirmation dialog appeared in the async chain, the same Escape keyup would immediately dismiss the dialog ("flicker"). Fixed by only reacting to Escape keyup if the dialog saw the corresponding keydown first.

## Flow

1. User edits built-in → `_editorContentChanged = true` → `updateInputDirtyState()` → `input.setDirty(true)`
2. Modal close → framework's `shouldConfirmClose()` → `input.isDirty()` → `true` → standard save dialog
3. **Save** → `input.save()` → `handleBuiltinSave()` → pick target → save copy → dirty cleared
4. **Don't Save** → `input.revert()` → dirty cleared → modal closes
5. **Cancel** → close vetoed → user stays in editor