### PR TITLE
ButtonBar - if a submenu only has one item, render it as a button and not as a dropdown with an empty context menu

### DIFF
--- a/src/vs/platform/actions/browser/buttonbar.ts
+++ b/src/vs/platform/actions/browser/buttonbar.ts
@@ -76,7 +76,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 
 	update(actions: IAction[], secondary: IAction[]): void {
 
-		const conifgProvider: IButtonConfigProvider = this._options?.buttonConfigProvider ?? (() => ({ showLabel: true }));
+		const configProvider: IButtonConfigProvider = this._options?.buttonConfigProvider ?? (() => ({ showLabel: true }));
 
 		this._updateStore.clear();
 		this.clear();
@@ -100,7 +100,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 				tooltip = this._keybindingService.appendKeybinding(tooltip, action.id);
 
 				btn = this.addButtonWithDropdown({
-					secondary: conifgProvider(action, i)?.isSecondary ?? secondary,
+					secondary: configProvider(action, i)?.isSecondary ?? secondary,
 					actionRunner: this._actionRunner,
 					actions: rest,
 					contextMenuProvider: this._contextMenuService,
@@ -117,7 +117,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 				tooltip = this._keybindingService.appendKeybinding(tooltip, action.id);
 
 				btn = this.addButton({
-					secondary: conifgProvider(action, i)?.isSecondary ?? secondary,
+					secondary: configProvider(action, i)?.isSecondary ?? secondary,
 					ariaLabel: tooltip,
 					supportIcons: true,
 					small: this._options?.small,
@@ -127,9 +127,9 @@ export class WorkbenchButtonBar extends ButtonBar {
 			btn.enabled = action.enabled;
 			btn.checked = action.checked ?? false;
 			btn.element.classList.add('default-colors');
-			const showLabel = conifgProvider(action, i)?.showLabel ?? true;
-			const customClass = conifgProvider(action, i)?.customClass;
-			const customLabel = conifgProvider(action, i)?.customLabel;
+			const showLabel = configProvider(action, i)?.showLabel ?? true;
+			const customClass = configProvider(action, i)?.customClass;
+			const customLabel = configProvider(action, i)?.customLabel;
 
 			if (customClass) {
 				btn.element.classList.add(customClass);
@@ -140,7 +140,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 			} else {
 				btn.element.classList.add('monaco-text-button');
 			}
-			if (conifgProvider(action, i)?.showIcon) {
+			if (configProvider(action, i)?.showIcon) {
 				if (action instanceof MenuItemAction && ThemeIcon.isThemeIcon(action.item.icon)) {
 					if (!showLabel) {
 						btn.icon = action.item.icon;

--- a/src/vs/platform/actions/browser/buttonbar.ts
+++ b/src/vs/platform/actions/browser/buttonbar.ts
@@ -81,7 +81,7 @@ export class WorkbenchButtonBar extends ButtonBar {
 		this._updateStore.clear();
 		this.clear();
 
-		// Support instamt hover between buttons
+		// Support instant hover between buttons
 		const hoverDelegate = this._updateStore.add(createInstantHoverDelegate());
 
 		for (let i = 0; i < actions.length; i++) {
@@ -90,13 +90,15 @@ export class WorkbenchButtonBar extends ButtonBar {
 			const actionOrSubmenu = actions[i];
 			let action: IAction;
 			let btn: IButton;
-			let tooltip = actionOrSubmenu.tooltip || actionOrSubmenu.label;
-			if (!(actionOrSubmenu instanceof SubmenuAction)) {
-				tooltip = this._keybindingService.appendKeybinding(tooltip, actionOrSubmenu.id);
-			}
-			if (actionOrSubmenu instanceof SubmenuAction && actionOrSubmenu.actions.length > 0) {
+			let tooltip: string;
+
+			if (actionOrSubmenu instanceof SubmenuAction && actionOrSubmenu.actions.length > 1) {
 				const [first, ...rest] = actionOrSubmenu.actions;
 				action = <MenuItemAction>first;
+
+				tooltip = action.tooltip || action.label;
+				tooltip = this._keybindingService.appendKeybinding(tooltip, action.id);
+
 				btn = this.addButtonWithDropdown({
 					secondary: conifgProvider(action, i)?.isSecondary ?? secondary,
 					actionRunner: this._actionRunner,
@@ -107,7 +109,13 @@ export class WorkbenchButtonBar extends ButtonBar {
 					small: this._options?.small,
 				});
 			} else {
-				action = actionOrSubmenu;
+				action = actionOrSubmenu instanceof SubmenuAction && actionOrSubmenu.actions.length === 1
+					? actionOrSubmenu.actions[0]
+					: actionOrSubmenu;
+
+				tooltip = action.tooltip || action.label;
+				tooltip = this._keybindingService.appendKeybinding(tooltip, action.id);
+
 				btn = this.addButton({
 					secondary: conifgProvider(action, i)?.isSecondary ?? secondary,
 					ariaLabel: tooltip,


### PR DESCRIPTION
//cc @jrieken 