### PR TITLE
Fix: improve editor hint tabbing behavior

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -267,8 +267,15 @@ class EmptyTextEditorHintContentWidget extends Disposable implements IContentWid
 		// eslint-disable-next-line no-restricted-syntax
 		for (const anchor of hintElement.querySelectorAll('a')) {
 			anchor.style.cursor = 'pointer';
+			anchor.tabIndex = 0;
+			anchor.setAttribute('role', 'button');
+			this._register(addDisposableListener(anchor, 'keydown', (e) => {
+				if (e.key === 'Enter' || e.key === ' ') {
+					anchor.click();
+					e.preventDefault();
+				}
+			}));
 		}
-
 		return { hintElement, ariaLabel };
 	}
 


### PR DESCRIPTION
### Problem

The empty editor hint actions could only be triggered via mouse clicks.
Users navigating with the keyboard (e.g., using Tab) were unable to access or activate these links.

### Solution

* Added `tabIndex = 0` to make hint anchors focusable
* Added keyboard support for `Enter` and `Space` keys to trigger the action
* Set `role="button"` for better accessibility semantics
* Updated cursor to indicate interactivity

### Result

Users can now:

* Navigate to hint actions using Tab
* Activate them using keyboard (Enter / Space)

This improves accessibility and aligns with expected keyboard navigation behavior.

