### PR TITLE
menu: fix missing icons for plain Action items in context menus

### DIFF
--- a/.github/skills/chat-customizations-editor/SKILL.md
+++ b/.github/skills/chat-customizations-editor/SKILL.md
@@ -53,6 +53,7 @@ The management editor fixture supports a `selectedSection` option to render any 
 | `chat/aiCustomizations/aiCustomizationManagementEditor/CliHarness/{Dark,Light}` | Default (Agents, CLI harness) |
 | `chat/aiCustomizations/aiCustomizationManagementEditor/ClaudeHarness/{Dark,Light}` | Default (Agents, Claude harness) |
 | `chat/aiCustomizations/aiCustomizationManagementEditor/Sessions/{Dark,Light}` | Sessions window variant |
+| `chat/aiCustomizations/aiCustomizationManagementEditor/HarnessMenu/{Dark,Light}` | Standalone harness dropdown menu with icons |
 
 **Adding a new tab fixture:** Add a variant to the `defineThemedFixtureGroup` in `aiCustomizationManagementEditor.fixture.ts`:
 ```typescript
@@ -180,3 +181,7 @@ Fixtures render at a fixed size (default 900×600) with many mock items. They wo
 - **Reflow timing** — the real product's `display:none → visible` transition may not have reflowed before `layout()` fires
 - **Narrow windows** — add narrow fixture variants (e.g., `width: 550, height: 400`)
 - **Real data counts** — a user with 1 MCP server sees very different layout than a fixture with 12
+
+### Context menu icons for plain Actions
+
+`Menu.doGetActionViewItem` in `src/vs/base/browser/ui/menu/menu.ts` now auto-enables icon rendering when `action.class` is set (`icon: !!action.class`). Before this fix, `BaseMenuActionViewItem` defaulted `icon` to `false`, so codicon classes from `ThemeIcon.asClassName()` were silently ignored. If you create context menu actions with icon CSS classes, icons will render automatically. The `HarnessMenu` fixture verifies this.

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1246,6 +1246,10 @@ ${formatRule(Codicon.menuSubmenu)}
 	justify-content: center;
 }
 
+.monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-check:has(+ .menu-item-icon) {
+	visibility: hidden;
+}
+
 /* Context Menu */
 
 .context-view.monaco-menu-container {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -448,6 +448,7 @@ class BaseMenuActionViewItem extends BaseActionViewItem {
 	private runOnceToEnableMouseUp: RunOnceScheduler;
 	private label: HTMLElement | undefined;
 	private check: HTMLElement | undefined;
+	private iconElement: HTMLElement | undefined;
 	private mnemonic: string | undefined;
 	private cssClass: string;
 
@@ -547,6 +548,10 @@ class BaseMenuActionViewItem extends BaseActionViewItem {
 		this.check = append(this.item, $('span.menu-item-check' + ThemeIcon.asCSSSelector(Codicon.menuSelection)));
 		this.check.setAttribute('role', 'none');
 
+		if (this.options.icon && this.action.class) {
+			this.iconElement = append(this.item, $('span.menu-item-icon'));
+		}
+
 		this.label = append(this.item, $('span.action-label'));
 
 		if (this.options.label && this.options.keybinding) {
@@ -641,18 +646,15 @@ class BaseMenuActionViewItem extends BaseActionViewItem {
 	}
 
 	protected override updateClass(): void {
-		if (this.cssClass && this.item) {
-			this.item.classList.remove(...this.cssClass.split(' '));
+		if (this.cssClass && this.iconElement) {
+			this.iconElement.classList.remove(...this.cssClass.split(' '));
 		}
-		if (this.options.icon && this.label) {
+		if (this.options.icon && this.iconElement) {
 			this.cssClass = this.action.class || '';
-			this.label.classList.add('icon');
 			if (this.cssClass) {
-				this.label.classList.add(...this.cssClass.split(' '));
+				this.iconElement.classList.add(...this.cssClass.split(' '));
 			}
 			this.updateEnabled();
-		} else if (this.label) {
-			this.label.classList.remove('icon');
 		}
 	}
 
@@ -1226,6 +1228,23 @@ ${formatRule(Codicon.menuSubmenu)}
 	visibility: hidden;
 	width: 1em;
 	height: 100%;
+}
+
+.monaco-menu .monaco-action-bar.vertical .menu-item-icon {
+	width: 1em;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: 4px;
+}
+
+.monaco-menu .monaco-action-bar.vertical .menu-item-icon + .action-label {
+	padding-left: 6px;
+}
+
+.monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-icon {
+	display: none;
 }
 
 .monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-check {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1231,20 +1231,16 @@ ${formatRule(Codicon.menuSubmenu)}
 }
 
 .monaco-menu .monaco-action-bar.vertical .menu-item-icon {
+	position: absolute;
 	width: 1em;
 	height: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin-left: 4px;
-}
-
-.monaco-menu .monaco-action-bar.vertical .menu-item-icon + .action-label {
-	padding-left: 6px;
 }
 
 .monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-icon {
-	display: none;
+	visibility: hidden;
 }
 
 .monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-check {

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -412,6 +412,7 @@ export class Menu extends ActionBar {
 				enableMnemonics: options.enableMnemonics,
 				useEventAsContext: options.useEventAsContext,
 				keybinding: keybindingLabel,
+				icon: !!action.class,
 			};
 
 			const menuActionViewItem = new BaseMenuActionViewItem(options.context, action, menuItemOptions, this.menuStyles);

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1239,10 +1239,6 @@ ${formatRule(Codicon.menuSubmenu)}
 	justify-content: center;
 }
 
-.monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-icon {
-	visibility: hidden;
-}
-
 .monaco-menu .monaco-action-bar.vertical .action-menu-item.checked .menu-item-check {
 	visibility: visible;
 	display: flex;

--- a/src/vs/workbench/test/browser/componentFixtures/aiCustomizationManagementEditor.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/aiCustomizationManagementEditor.fixture.ts
@@ -6,11 +6,14 @@
 import * as DOM from '../../../../base/browser/dom.js';
 import { Dimension } from '../../../../base/browser/dom.js';
 import { IRenderedMarkdown } from '../../../../base/browser/markdownRenderer.js';
+import { Menu } from '../../../../base/browser/ui/menu/menu.js';
 import { mainWindow } from '../../../../base/browser/window.js';
+import { Action } from '../../../../base/common/actions.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { ResourceMap, ResourceSet } from '../../../../base/common/map.js';
 import { constObservable, observableValue } from '../../../../base/common/observable.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 import { URI } from '../../../../base/common/uri.js';
 import { mock } from '../../../../base/test/common/mock.js';
 import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
@@ -54,6 +57,7 @@ import { CodeReviewStateKind, ICodeReviewService, ICodeReviewState, IPRReviewSta
 import { IChatEditingService } from '../../../contrib/chat/common/editing/chatEditingService.js';
 import { IAgentSessionsService } from '../../../contrib/chat/browser/agentSessions/agentSessionsService.js';
 import { ComponentFixtureContext, createEditorServices, defineComponentFixture, defineThemedFixtureGroup, registerWorkbenchServices } from './fixtureUtils.js';
+import { defaultMenuStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 
 // Ensure theme colors & widget CSS are loaded
 import '../../../../platform/theme/common/colors/inputColors.js';
@@ -773,6 +777,30 @@ async function renderPluginBrowseMode(ctx: ComponentFixtureContext): Promise<voi
 }
 
 // ============================================================================
+// Harness Dropdown Menu — standalone menu with harness icons
+// ============================================================================
+
+function renderHarnessMenu(ctx: ComponentFixtureContext, activeHarness: CustomizationHarness): void {
+	ctx.container.style.width = '220px';
+	ctx.container.style.padding = '4px';
+
+	const descriptors = [
+		createVSCodeHarnessDescriptor([PromptsStorage.extension, BUILTIN_STORAGE]),
+		createCliHarnessDescriptor(getCliUserRoots(userHome), []),
+		createClaudeHarnessDescriptor(getClaudeUserRoots(userHome), []),
+	];
+
+	const actions = descriptors.map(h => {
+		const action = new Action(h.id, h.label, ThemeIcon.asClassName(h.icon), true, () => { });
+		action.checked = h.id === activeHarness;
+		return action;
+	});
+
+	const menu = ctx.disposableStore.add(new Menu(ctx.container, actions, {}, defaultMenuStyles));
+	menu.focus(false);
+}
+
+// ============================================================================
 // Fixtures
 // ============================================================================
 
@@ -970,5 +998,12 @@ export default defineThemedFixtureGroup({ path: 'chat/aiCustomizations/' }, {
 			width: 550,
 			height: 400,
 		}),
+	}),
+
+	// Harness dropdown menu — standalone menu showing Local (checked), CLI, and Claude
+	// with their codicon icons. Verifies icons render in plain Action-based menus.
+	HarnessMenu: defineComponentFixture({
+		labels: { kind: 'screenshot' },
+		render: ctx => renderHarnessMenu(ctx, CustomizationHarness.VSCode),
 	}),
 });

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -582,7 +582,7 @@ export class TestMenuService implements IMenuService {
 	}
 
 	getMenuActions(id: MenuId, contextKeyService: IContextKeyService, options?: IMenuActionOptions): [string, Array<MenuItemAction | SubmenuItemAction>][] {
-		throw new Error('Method not implemented.');
+		return [];
 	}
 
 	getMenuContexts(id: MenuId): ReadonlySet<string> {


### PR DESCRIPTION
## Problem

Icons on individual harness items in the Chat Customizations editor dropdown menu were not rendering. When clicking the harness selector (Local / Copilot CLI / Claude), the context menu showed labels and radio checks but no codicon icons.

## Root Cause

In `src/vs/base/browser/ui/menu/menu.ts`, `Menu.doGetActionViewItem()` constructs `menuItemOptions` without an `icon` property. `BaseMenuActionViewItem`'s constructor then defaults `icon` to `false`, so `updateClass()` never applied the codicon CSS classes — even when the `Action` has a valid `class` string from `ThemeIcon.asClassName()`.

This affects **all** context menus using plain `Action` objects with icon CSS classes, not just the harness menu.

## Fix

**1. Auto-enable icon rendering** — `doGetActionViewItem()` now sets `icon: !!action.class` so actions with CSS classes get icon rendering automatically.

**2. Separate icon element** — Instead of applying codicon classes to the label element (which caused text to render in the codicon font), a new `<span class="menu-item-icon">` is created between the check mark and the label. This keeps icons and text on separate elements with correct fonts.

**3. Always-visible icons, hidden check when icon present** — Icons stay visible regardless of checked state. When a menu item has both an icon and a check mark, the check is hidden via `:has(+ .menu-item-icon)` CSS to prevent overlap. The icon element uses `position: absolute` to occupy the same left slot as the check mark, so alignment is consistent across all menu items.

DOM structure when an action has a CSS class:
```html
<a class="action-menu-item checked">
  <span class="menu-item-check">✓</span>      <!-- hidden when icon present -->
  <span class="menu-item-icon codicon codicon-copilot"></span>
  <span class="action-label">Local</span>
</a>
```

## Other changes

- **`TestMenuService.getMenuActions`** — returns `[]` instead of throwing, fixing fixture rendering after a recent upstream change added a `getMenuActions` call in `AICustomizationListWidget.buildCreateActions`.
- **`HarnessMenu` fixture** — standalone `Menu` widget with the three harness actions (Local, Copilot CLI, Claude) for screenshot testing.
- **Skill doc** — updated with the new fixture ID and a note about the icon rendering behavior.