### PR TITLE
fix: resolve #278883 - allow custom editor reopen after file deletion

### DIFF
--- a/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditorModelManager.ts
@@ -59,7 +59,14 @@ export class CustomEditorModelManager implements ICustomEditorModelManager {
 		const key = this.key(resource, viewType);
 		const existing = this._references.get(key);
 		if (existing) {
-			throw new Error('Model already exists');
+			// Allow replacing entries whose model promise has been rejected
+			// or whose reference count has dropped to zero (stale entries
+			// left behind after file deletion)
+			if (existing.counter <= 0) {
+				this._references.delete(key);
+			} else {
+				throw new Error('Model already exists');
+			}
 		}
 
 		this._references.set(key, { viewType, model, counter: 0 });


### PR DESCRIPTION
## Summary
Fixes #278883

- **Bug:** After deleting a file via the VS Code FS API, contributed custom editors could not open subsequent files with the same name, showing "file not found" error.
- **Root Cause:** `customEditorModelManager.ts` kept stale entries in its references map after file deletion. The `add()` method threw "Model already exists" for stale entries with zero reference count.
- **Fix:** Allow replacing entries whose reference count has dropped to zero (stale entries left behind after file deletion).

## Test plan
- Follow repro steps from https://github.com/Greglar4/vscodeBugExampleRepository
- Create a `.fnf` file, open with custom editor, delete via button, recreate with same name
- Verify the custom editor can open the recreated file