### PR TITLE
fix: resolve #263226 - show correct active version in TS version picker

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -108,7 +108,7 @@ export class TypeScriptVersionManager extends Disposable {
 	private getBundledPickItem(): QuickPickItem {
 		const bundledVersion = this.versionProvider.defaultVersion;
 		return {
-			label: (!this.useWorkspaceTsdkSetting || !vscode.workspace.isTrusted
+			label: (this.currentVersion.eq(bundledVersion)
 				? '• '
 				: '') + vscode.l10n.t("Use VS Code's Version"),
 			description: bundledVersion.displayName,
@@ -123,7 +123,7 @@ export class TypeScriptVersionManager extends Disposable {
 	private getLocalPickItems(): QuickPickItem[] {
 		return this.versionProvider.localVersions.map(version => {
 			return {
-				label: (this.useWorkspaceTsdkSetting && vscode.workspace.isTrusted && this.currentVersion.eq(version)
+				label: (this.currentVersion.eq(version)
 					? '• '
 					: '') + vscode.l10n.t("Use Workspace Version"),
 				description: version.displayName,


### PR DESCRIPTION
## Summary
Fixes #263226

- **Bug:** "Select TypeScript Version" picker showed incorrect active version indicator when `typescript.tsdk` was configured in settings without using the picker.
- **Root Cause:** The bullet indicator (•) used `useWorkspaceTsdkSetting` storage key instead of checking the actual current version. When tsdk was set directly in settings, this key remained false.
- **Fix:** Changed both `getBundledPickItem()` and `getLocalPickItems()` to use `this.currentVersion.eq(version)` to accurately reflect which version is in use.

## Test plan
- Set `"typescript.tsdk": "node_modules/typescript/lib"` in workspace settings
- Run "TypeScript: Select TypeScript Version"
- Verify the bullet (•) appears on "Use Workspace Version", not "Use VS Code's Version"