### PR TITLE
fix: resolve #281045 - show blame decorations in third-party diff editors

### DIFF
--- a/extensions/git/src/blame.ts
+++ b/extensions/git/src/blame.ts
@@ -65,7 +65,7 @@ function getEditorDecorationRange(lineNumber: number): Range {
 }
 
 function isResourceSchemeSupported(uri: Uri): boolean {
-	return uri.scheme === 'file' || isGitUri(uri);
+	return uri.scheme === 'file' || isGitUri(uri) || uri.fsPath.length > 0;
 }
 
 function isResourceBlameInformationEqual(a: ResourceBlameInformation | undefined, b: ResourceBlameInformation | undefined): boolean {


### PR DESCRIPTION
## Summary
Fixes #281045

- **Bug:** Built-in git blame editor decorations did not appear when a diff editor was opened by a third-party extension (Git Graph, GitLens, etc.).
- **Root Cause:** `isResourceSchemeSupported()` in `blame.ts` only accepted `file` and `git` URI schemes. Third-party extensions use custom URI schemes (e.g., `git-graph`, `gitlens`) but still encode valid file paths.
- **Fix:** Extended `isResourceSchemeSupported()` to also accept URIs with a valid `fsPath`, allowing blame decorations in diff editors regardless of how they were opened.

## Test plan
- Enable `"git.blame.editorDecoration.enabled": true`
- Open a diff via the built-in Source Control Graph — verify blame works
- Open a diff via Git Graph or GitLens — verify blame now also works
- Verify blame still works in normal file editors