### PR TITLE
Try to reduce how often LocalAgentsSessionsController fires updates

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -146,7 +146,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		}));
 
 		this._register(this._chatService.onDidDisposeSession(e => {
-			for (const resource of e.sessionResource) {
+			for (const resource of e.sessionResources) {
 				this._proxy.$releaseSession(resource);
 			}
 		}));

--- a/src/vs/workbench/api/browser/mainThreadChatSessions.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSessions.ts
@@ -366,15 +366,9 @@ class MainThreadChatSessionItemController extends Disposable implements IChatSes
 		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
+
 		this._proxy = proxy;
 		this._handle = handle;
-
-		this._register(chatService.registerChatModelChangeListeners(chatSessionType, (sessionResource) => {
-			const item = this._items.get(sessionResource);
-			if (item) {
-				this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [item] });
-			}
-		}));
 	}
 
 	private readonly _items = new ResourceMap<IChatSessionItem>();

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -17,7 +17,7 @@ import { IWorkbenchContribution } from '../../../../common/contributions.js';
 import { convertLegacyChatSessionTiming, IChatDetail, IChatService, IChatSessionTiming, ResponseModelState } from '../../common/chatService/chatService.js';
 import { chatModelToChatDetail } from '../../common/chatService/chatServiceImpl.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
-import { ChatModel, IChatModel } from '../../common/model/chatModel.js';
+import { IChatModel } from '../../common/model/chatModel.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { getInProgressSessionDescription } from '../chatSessions/chatSessionDescription.js';
 
@@ -32,6 +32,8 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 
 	private readonly _modelListeners = this._register(new DisposableResourceMap());
 
+	private _isDisposed = false;
+
 	constructor(
 		@IChatService private readonly chatService: IChatService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
@@ -41,6 +43,11 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 		this._register(this.chatSessionsService.registerChatSessionItemController(this.chatSessionType, this));
 
 		this.registerListeners();
+	}
+
+	override dispose(): void {
+		this._isDisposed = true;
+		super.dispose();
 	}
 
 	private _items = new ResourceMap<LocalChatSessionItem>();
@@ -58,17 +65,17 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private registerListeners(): void {
-		const tryAddModelListeners = async (model: IChatModel) => {
+		const addModelListeners = async (model: IChatModel) => {
 			if (getChatSessionType(model.sessionResource) !== this.chatSessionType) {
 				return;
 			}
 
-			const onChange = () => {
-				this.tryUpdateLiveSessionItem(model);
-			};
-
 			await this.refresh(CancellationToken.None);
-			onChange();
+			if (this._isDisposed) {
+				return;
+			}
+
+			this.tryUpdateLiveSessionItem(model);
 
 			const requestChangeListener = model.lastRequestObs.map(last => last?.response && observableSignalFromEvent('chatSessions.modelRequestChangeListener', last.response.onDidChange));
 			const modelChangeListener = observableSignalFromEvent('chatSessions.modelChangeListener', model.onDidChange);
@@ -76,13 +83,13 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 				requestChangeListener.read(reader)?.read(reader);
 				modelChangeListener.read(reader);
 
-				onChange();
+				this.tryUpdateLiveSessionItem(model);
 			}));
 		};
 
-		this._register(this.chatService.onDidCreateModel(model => tryAddModelListeners(model)));
+		this._register(this.chatService.onDidCreateModel(model => addModelListeners(model)));
 		for (const model of this.chatService.chatModels.get()) {
-			tryAddModelListeners(model);
+			addModelListeners(model);
 		}
 
 		this._register(this.chatService.onDidDisposeSession(e => {
@@ -98,10 +105,6 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 	}
 
 	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
-		if (!(model instanceof ChatModel)) {
-			return;
-		}
-
 		const existing = this._items.get(model.sessionResource);
 		if (!existing) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/localAgentSessionsController.ts
@@ -7,16 +7,17 @@ import { coalesce } from '../../../../../base/common/arrays.js';
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { ResourceSet } from '../../../../../base/common/map.js';
-import { Schemas } from '../../../../../base/common/network.js';
+import { Disposable, DisposableResourceMap } from '../../../../../base/common/lifecycle.js';
+import { ResourceMap, ResourceSet } from '../../../../../base/common/map.js';
+import { equals } from '../../../../../base/common/objects.js';
+import { autorun, observableSignalFromEvent } from '../../../../../base/common/observable.js';
 import { isEqual } from '../../../../../base/common/resources.js';
 import { URI } from '../../../../../base/common/uri.js';
-import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IWorkbenchContribution } from '../../../../common/contributions.js';
-import { convertLegacyChatSessionTiming, IChatDetail, IChatService, ResponseModelState } from '../../common/chatService/chatService.js';
+import { convertLegacyChatSessionTiming, IChatDetail, IChatService, IChatSessionTiming, ResponseModelState } from '../../common/chatService/chatService.js';
+import { chatModelToChatDetail } from '../../common/chatService/chatServiceImpl.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionItemController, IChatSessionItemsDelta, IChatSessionsService, localChatSessionType } from '../../common/chatSessionsService.js';
-import { IChatModel } from '../../common/model/chatModel.js';
+import { ChatModel, IChatModel } from '../../common/model/chatModel.js';
 import { getChatSessionType } from '../../common/model/chatUri.js';
 import { getInProgressSessionDescription } from '../chatSessions/chatSessionDescription.js';
 
@@ -26,16 +27,14 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 
 	readonly chatSessionType = localChatSessionType;
 
-	private readonly _onDidChange = this._register(new Emitter<void>());
-	readonly onDidChange = this._onDidChange.event;
-
 	readonly _onDidChangeChatSessionItems = this._register(new Emitter<IChatSessionItemsDelta>());
 	readonly onDidChangeChatSessionItems = this._onDidChangeChatSessionItems.event;
+
+	private readonly _modelListeners = this._register(new DisposableResourceMap());
 
 	constructor(
 		@IChatService private readonly chatService: IChatService,
 		@IChatSessionsService private readonly chatSessionsService: IChatSessionsService,
-		@ILogService private readonly logService: ILogService,
 	) {
 		super();
 
@@ -44,44 +43,81 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 		this.registerListeners();
 	}
 
-	private _items: IChatSessionItem[] = [];
+	private _items = new ResourceMap<LocalChatSessionItem>();
 	get items(): readonly IChatSessionItem[] {
-		return this._items;
+		return Array.from(this._items.values());
 	}
 
 	async refresh(token: CancellationToken): Promise<void> {
-		this._items = await this.provideChatSessionItems(token);
+		const newItems = await this.provideChatSessionItems(token);
+
+		this._items.clear();
+		for (const item of newItems) {
+			this._items.set(item.resource, item);
+		}
 	}
 
 	private registerListeners(): void {
-		this._register(this.chatService.registerChatModelChangeListeners(Schemas.vscodeLocalChatSession, async sessionResource => {
-			if (getChatSessionType(sessionResource) !== this.chatSessionType) {
+		const tryAddModelListeners = async (model: IChatModel) => {
+			if (getChatSessionType(model.sessionResource) !== this.chatSessionType) {
 				return;
 			}
 
-			// TODO: This gets fired too often
-			await this.refresh(CancellationToken.None);
-			const item = this.getItem(sessionResource);
+			const onChange = () => {
+				this.tryUpdateLiveSessionItem(model);
+			};
 
-			if (item) {
-				this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [item] });
-			}
-		}));
+			await this.refresh(CancellationToken.None);
+			onChange();
+
+			const requestChangeListener = model.lastRequestObs.map(last => last?.response && observableSignalFromEvent('chatSessions.modelRequestChangeListener', last.response.onDidChange));
+			const modelChangeListener = observableSignalFromEvent('chatSessions.modelChangeListener', model.onDidChange);
+			this._modelListeners.set(model.sessionResource, autorun(reader => {
+				requestChangeListener.read(reader)?.read(reader);
+				modelChangeListener.read(reader);
+
+				onChange();
+			}));
+		};
+
+		this._register(this.chatService.onDidCreateModel(model => tryAddModelListeners(model)));
+		for (const model of this.chatService.chatModels.get()) {
+			tryAddModelListeners(model);
+		}
 
 		this._register(this.chatService.onDidDisposeSession(e => {
-			const removedSessionResources = e.sessionResource.filter(resource => getChatSessionType(resource) === this.chatSessionType);
+			for (const sessionResource of e.sessionResources) {
+				this._modelListeners.deleteAndDispose(sessionResource);
+			}
+
+			const removedSessionResources = e.sessionResources.filter(resource => getChatSessionType(resource) === this.chatSessionType);
 			if (removedSessionResources.length) {
 				this._onDidChangeChatSessionItems.fire({ removed: removedSessionResources });
 			}
 		}));
 	}
 
-	private getItem(sessionResource: URI): IChatSessionItem | undefined {
-		return this._items.find(item => isEqual(item.resource, sessionResource));
+	private async tryUpdateLiveSessionItem(model: IChatModel): Promise<void> {
+		if (!(model instanceof ChatModel)) {
+			return;
+		}
+
+		const existing = this._items.get(model.sessionResource);
+		if (!existing) {
+			return;
+		}
+
+		const updated = new LocalChatSessionItem(await chatModelToChatDetail(model), model);
+		if (existing.isEqual(updated)) {
+			return;
+		}
+
+		this._items.set(existing.resource, updated);
+		this._onDidChangeChatSessionItems.fire({ addedOrUpdated: [updated] });
 	}
 
-	private async provideChatSessionItems(token: CancellationToken): Promise<IChatSessionItem[]> {
-		const sessions: IChatSessionItem[] = [];
+	private async provideChatSessionItems(token: CancellationToken): Promise<LocalChatSessionItem[]> {
+		const sessions: LocalChatSessionItem[] = [];
 		const sessionsByResource = new ResourceSet();
 
 		for (const sessionDetail of await this.chatService.getLiveSessionItems()) {
@@ -102,7 +138,7 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 		return sessions;
 	}
 
-	private async getHistoryItems(): Promise<IChatSessionItem[]> {
+	private async getHistoryItems(): Promise<LocalChatSessionItem[]> {
 		try {
 			const historyItems = await this.chatService.getHistorySessionItems();
 
@@ -112,72 +148,90 @@ export class LocalAgentsSessionsController extends Disposable implements IChatSe
 		}
 	}
 
-	private toChatSessionItem(chat: IChatDetail): IChatSessionItem | undefined {
+	private toChatSessionItem(chat: IChatDetail): LocalChatSessionItem | undefined {
 		const model = this.chatService.getSession(chat.sessionResource);
 
-		let description: string | undefined;
 		if (model) {
 			if (!model.hasRequests) {
 				return undefined; // ignore sessions without requests
 			}
-
-			description = getInProgressSessionDescription(model);
 		} else if (chat.isActive) {
 			// Sessions that are active but don't have a chat model are ultimately untitled with no requests
 			return undefined;
 		}
 
-		return {
-			resource: chat.sessionResource,
-			label: chat.title,
-			description,
-			status: model ? this.modelToStatus(model) : this.chatResponseStateToStatus(chat.lastResponseState),
-			iconPath: Codicon.chatSparkle,
-			timing: convertLegacyChatSessionTiming(chat.timing),
-			changes: chat.stats ? {
-				insertions: chat.stats.added,
-				deletions: chat.stats.removed,
-				files: chat.stats.fileCount,
-			} : undefined
-		};
+		return new LocalChatSessionItem(chat, model);
+	}
+}
+
+class LocalChatSessionItem implements IChatSessionItem {
+	readonly resource: URI;
+	readonly iconPath = Codicon.chatSparkle;
+
+	readonly label: string;
+	readonly description: string | undefined;
+	readonly status: ChatSessionStatus | undefined;
+	readonly timing: IChatSessionTiming;
+	readonly changes: IChatSessionItem['changes'];
+
+	constructor(chatDetail: IChatDetail, model: IChatModel | undefined) {
+		this.resource = chatDetail.sessionResource;
+		this.label = chatDetail.title;
+		this.description = model ? getInProgressSessionDescription(model) : undefined;
+		this.status = (model && getSessionStatusForModel(model)) ?? chatResponseStateToSessionStatus(chatDetail.lastResponseState);
+		this.timing = convertLegacyChatSessionTiming(chatDetail.timing);
+		this.changes = chatDetail.stats ? {
+			insertions: chatDetail.stats.added,
+			deletions: chatDetail.stats.removed,
+			files: chatDetail.stats.fileCount,
+		} : undefined;
 	}
 
-	private modelToStatus(model: IChatModel): ChatSessionStatus | undefined {
-		if (model.requestInProgress.get()) {
-			this.logService.trace(`[agent sessions] Session ${model.sessionResource.toString()} request is in progress.`);
+	isEqual(other: LocalChatSessionItem): boolean {
+		return isEqual(this.resource, other.resource)
+			&& this.label === other.label
+			&& this.description === other.description
+			&& this.status === other.status
+			&& this.timing.created === other.timing.created
+			&& this.timing.lastRequestStarted === other.timing.lastRequestStarted
+			&& this.timing.lastRequestEnded === other.timing.lastRequestEnded
+			&& equals(this.changes, other.changes);
+	}
+}
+
+function getSessionStatusForModel(model: IChatModel): ChatSessionStatus | undefined {
+	if (model.requestInProgress.get()) {
+		return ChatSessionStatus.InProgress;
+	}
+
+	const lastRequest = model.getRequests().at(-1);
+	if (lastRequest?.response) {
+		if (lastRequest.response.state === ResponseModelState.NeedsInput) {
+			return ChatSessionStatus.NeedsInput;
+		} else if (lastRequest.response.isCanceled || lastRequest.response.result?.errorDetails?.code === 'canceled') {
+			return ChatSessionStatus.Completed;
+		} else if (lastRequest.response.result?.errorDetails) {
+			return ChatSessionStatus.Failed;
+		} else if (lastRequest.response.isComplete) {
+			return ChatSessionStatus.Completed;
+		} else {
 			return ChatSessionStatus.InProgress;
 		}
-
-		const lastRequest = model.getRequests().at(-1);
-		this.logService.trace(`[agent sessions] Session ${model.sessionResource.toString()} last request response: state ${lastRequest?.response?.state}, isComplete ${lastRequest?.response?.isComplete}, isCanceled ${lastRequest?.response?.isCanceled}, error: ${lastRequest?.response?.result?.errorDetails?.message}.`);
-		if (lastRequest?.response) {
-			if (lastRequest.response.state === ResponseModelState.NeedsInput) {
-				return ChatSessionStatus.NeedsInput;
-			} else if (lastRequest.response.isCanceled || lastRequest.response.result?.errorDetails?.code === 'canceled') {
-				return ChatSessionStatus.Completed;
-			} else if (lastRequest.response.result?.errorDetails) {
-				return ChatSessionStatus.Failed;
-			} else if (lastRequest.response.isComplete) {
-				return ChatSessionStatus.Completed;
-			} else {
-				return ChatSessionStatus.InProgress;
-			}
-		}
-
-		return undefined;
 	}
 
-	private chatResponseStateToStatus(state: ResponseModelState): ChatSessionStatus {
-		switch (state) {
-			case ResponseModelState.Cancelled:
-			case ResponseModelState.Complete:
-				return ChatSessionStatus.Completed;
-			case ResponseModelState.Failed:
-				return ChatSessionStatus.Failed;
-			case ResponseModelState.Pending:
-				return ChatSessionStatus.InProgress;
-			case ResponseModelState.NeedsInput:
-				return ChatSessionStatus.NeedsInput;
-		}
+	return undefined;
+}
+
+function chatResponseStateToSessionStatus(state: ResponseModelState): ChatSessionStatus {
+	switch (state) {
+		case ResponseModelState.Cancelled:
+		case ResponseModelState.Complete:
+			return ChatSessionStatus.Completed;
+		case ResponseModelState.Failed:
+			return ChatSessionStatus.Failed;
+		case ResponseModelState.Pending:
+			return ChatSessionStatus.InProgress;
+		case ResponseModelState.NeedsInput:
+			return ChatSessionStatus.NeedsInput;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingServiceImpl.ts
@@ -87,7 +87,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 
 		this._register(this._chatService.onDidDisposeSession((e) => {
 			if (e.reason === 'cleared') {
-				for (const resource of e.sessionResource) {
+				for (const resource of e.sessionResources) {
 					this.getEditingSession(resource)?.stop();
 				}
 			}

--- a/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatService.ts
@@ -1525,7 +1525,7 @@ export interface IChatService {
 	readonly onDidReceiveQuestionCarouselAnswer: Event<{ requestId: string; resolveId: string; answers: IChatQuestionAnswers | undefined }>;
 	notifyQuestionCarouselAnswer(requestId: string, resolveId: string, answers: IChatQuestionAnswers | undefined): void;
 
-	readonly onDidDisposeSession: Event<{ readonly sessionResource: readonly URI[]; readonly reason: 'cleared' }>;
+	readonly onDidDisposeSession: Event<{ readonly sessionResources: readonly URI[]; readonly reason: 'cleared' }>;
 
 	transferChatSession(transferredSessionResource: URI, toWorkspace: URI): Promise<void>;
 

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -1871,7 +1871,7 @@ export class ChatService extends Disposable implements IChatService {
 	}
 }
 
-export async function chatModelToChatDetail(model: ChatModel): Promise<IChatDetail> {
+export async function chatModelToChatDetail(model: IChatModel): Promise<IChatDetail> {
 	const title = model.title || localize('newChat', "New Chat");
 	return {
 		sessionResource: model.sessionResource,

--- a/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService/chatServiceImpl.ts
@@ -126,7 +126,7 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidReceiveQuestionCarouselAnswer = this._register(new Emitter<{ requestId: string; resolveId: string; answers: IChatQuestionAnswers | undefined }>());
 	public readonly onDidReceiveQuestionCarouselAnswer = this._onDidReceiveQuestionCarouselAnswer.event;
 
-	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResource: URI[]; reason: 'cleared' }>());
+	private readonly _onDidDisposeSession = this._register(new Emitter<{ readonly sessionResources: URI[]; reason: 'cleared' }>());
 	public readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
 	private readonly _sessionFollowupCancelTokens = this._register(new DisposableResourceMap<CancellationTokenSource>());
@@ -195,7 +195,7 @@ export class ChatService extends Disposable implements IChatService {
 		this._register(this._sessionModels.onDidDisposeModel(model => {
 			clearChatMarks(model.sessionResource);
 			this.chatDebugService.endSession(model.sessionResource);
-			this._onDidDisposeSession.fire({ sessionResource: [model.sessionResource], reason: 'cleared' });
+			this._onDidDisposeSession.fire({ sessionResources: [model.sessionResource], reason: 'cleared' });
 		}));
 
 		this._chatServiceTelemetry = this.instantiationService.createInstance(ChatServiceTelemetry);
@@ -400,18 +400,7 @@ export class ChatService extends Disposable implements IChatService {
 	async getLiveSessionItems(): Promise<IChatDetail[]> {
 		return await Promise.all(Array.from(this._sessionModels.values())
 			.filter(session => this.shouldBeInHistory(session))
-			.map(async (session): Promise<IChatDetail> => {
-				const title = session.title || localize('newChat', "New Chat");
-				return {
-					sessionResource: session.sessionResource,
-					title,
-					lastMessageDate: session.lastMessageDate,
-					timing: session.timing,
-					isActive: true,
-					stats: await awaitStatsForSession(session),
-					lastResponseState: session.lastRequest?.response?.state ?? ResponseModelState.Pending,
-				};
-			}));
+			.map(chatModelToChatDetail));
 	}
 
 	/**
@@ -452,7 +441,7 @@ export class ChatService extends Disposable implements IChatService {
 
 	async removeHistoryEntry(sessionResource: URI): Promise<void> {
 		await this._chatSessionStore.deleteSession(this.toLocalSessionId(sessionResource));
-		this._onDidDisposeSession.fire({ sessionResource: [sessionResource], reason: 'cleared' });
+		this._onDidDisposeSession.fire({ sessionResources: [sessionResource], reason: 'cleared' });
 	}
 
 	async clearAllHistoryEntries(): Promise<void> {
@@ -1880,4 +1869,17 @@ export class ChatService extends Disposable implements IChatService {
 		disposableStore.add(autoRunDisposable);
 		return disposableStore;
 	}
+}
+
+export async function chatModelToChatDetail(model: ChatModel): Promise<IChatDetail> {
+	const title = model.title || localize('newChat', "New Chat");
+	return {
+		sessionResource: model.sessionResource,
+		title,
+		lastMessageDate: model.lastMessageDate,
+		timing: model.timing,
+		isActive: true,
+		stats: await awaitStatsForSession(model),
+		lastResponseState: model.lastRequest?.response?.state ?? ResponseModelState.Pending,
+	};
 }

--- a/src/vs/workbench/contrib/chat/common/model/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/model/chatModel.ts
@@ -1392,6 +1392,7 @@ export interface IChatModel extends IDisposable {
 	readonly sessionId: string;
 	/** Milliseconds timestamp this chat model was created. */
 	readonly timestamp: number;
+	readonly lastMessageDate: number;
 	readonly timing: IChatSessionTiming;
 	readonly sessionResource: URI;
 	readonly initialLocation: ChatAgentLocation;

--- a/src/vs/workbench/contrib/chat/common/widget/chatResponseResourceFileSystemProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/widget/chatResponseResourceFileSystemProvider.ts
@@ -61,7 +61,7 @@ export class ChatResponseResourceFileSystemProvider extends Disposable implement
 	) {
 		super();
 		this._register(this.chatService.onDidDisposeSession(e => {
-			for (const sessionResource of e.sessionResource) {
+			for (const sessionResource of e.sessionResources) {
 				const uris = this._sessionAssociations.get(sessionResource);
 				if (uris) {
 					for (const uri of uris) {

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/localAgentSessionsController.test.ts
@@ -11,17 +11,18 @@ import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { runWithFakedTimers } from '../../../../../../base/test/common/timeTravelScheduler.js';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
 import { LocalAgentsSessionsController } from '../../../browser/agentSessions/localAgentSessionsController.js';
 import { IChatService, ResponseModelState } from '../../../common/chatService/chatService.js';
+import { chatModelToChatDetail } from '../../../common/chatService/chatServiceImpl.js';
 import { ChatSessionStatus, IChatSessionItem, IChatSessionsService, localChatSessionType } from '../../../common/chatSessionsService.js';
-import { ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
-import { IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
+import { ChatEditingSessionState, ModifiedFileEntryState } from '../../../common/editing/chatEditingService.js';
+import { IChatChangedRequestEvent, IChatChangeEvent, IChatModel, IChatRequestModel, IChatResponseModel } from '../../../common/model/chatModel.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
 import { MockChatService } from '../../common/chatService/mockChatService.js';
 import { MockChatSessionsService } from '../../common/mockChatSessionsService.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 
 function createTestTiming(options?: {
 	created?: number;
@@ -34,6 +35,11 @@ function createTestTiming(options?: {
 		lastRequestStarted: options?.lastRequestStarted,
 		lastRequestEnded: options?.lastRequestEnded,
 	};
+}
+
+interface MockChatModel extends IChatModel {
+	setCustomTitle(title: string): void;
+	setRequestInProgress(inProgress: boolean): void;
 }
 
 function createMockChatModel(options: {
@@ -55,7 +61,7 @@ function createMockChatModel(options: {
 			modifiedURI: URI;
 		}>;
 	};
-}): IChatModel {
+}): MockChatModel {
 	const requests: IChatRequestModel[] = [];
 
 	if (options.hasRequests !== false) {
@@ -82,27 +88,46 @@ function createMockChatModel(options: {
 		state: observableValue('state', entry.state),
 		linesAdded: observableValue('linesAdded', entry.linesAdded),
 		linesRemoved: observableValue('linesRemoved', entry.linesRemoved),
-		modifiedURI: entry.modifiedURI
+		originalURI: entry.modifiedURI,
+		modifiedURI: entry.modifiedURI,
 	}));
 
 	const mockEditingSession = options.editingSession ? {
-		entries: observableValue('entries', editingSessionEntries ?? [])
+		entries: observableValue('entries', editingSessionEntries ?? []),
+		state: observableValue('state', ChatEditingSessionState.Idle)
 	} : undefined;
 
-	const _onDidChange = new Emitter<{ kind: string } | undefined>();
+	const _onDidChange = new Emitter<IChatChangeEvent>();
 
+	let title = options.customTitle ?? 'Test Chat Title';
+	const requestInProgress = observableValue('requestInProgress', options.requestInProgress ?? false);
 	return {
+		get title() {
+			return title;
+		},
 		sessionResource: options.sessionResource,
 		hasRequests: options.hasRequests !== false,
 		timestamp: options.timestamp ?? Date.now(),
-		requestInProgress: observableValue('requestInProgress', options.requestInProgress ?? false),
+		timing: createTestTiming({ created: options.timestamp }),
+		requestInProgress,
 		getRequests: () => requests,
 		onDidChange: _onDidChange.event,
-		editingSession: mockEditingSession,
-		setCustomTitle: (_title: string) => {
-			_onDidChange.fire({ kind: 'setCustomTitle' });
-		}
-	} as unknown as IChatModel;
+		editingSession: mockEditingSession as IChatModel['editingSession'],
+		lastRequestObs: observableValue('lastRequest', undefined),
+
+		// Mock helpers
+		setCustomTitle: (newTitle: string) => {
+			title = newTitle;
+			_onDidChange.fire({ kind: 'setCustomTitle', title });
+		},
+		setRequestInProgress: (inProgress: boolean) => {
+			if (requestInProgress.get() === inProgress) {
+				return;
+			}
+			requestInProgress.set(inProgress, undefined);
+			_onDidChange.fire({ kind: 'changedRequest' } as IChatChangedRequestEvent);
+		},
+	} as Partial<IChatModel> as MockChatModel;
 }
 
 suite('LocalAgentsSessionsController', () => {
@@ -599,19 +624,21 @@ suite('LocalAgentsSessionsController', () => {
 					changeEventCount++;
 				}));
 
+				await controller.refresh(CancellationToken.None);
+
 				const onDidChangeChatSessionItems = Event.toPromise(controller.onDidChangeChatSessionItems);
 
 				// Simulate progress change by triggering the progress listener
-				mockChatService.triggerProgressEvent(sessionResource);
+				mockModel.setRequestInProgress(true);
 				await onDidChangeChatSessionItems;
 
-				assert.strictEqual(changeEventCount, 1);
+				assert.strictEqual(changeEventCount, 2);
 			});
 		});
 
 		test('should fire onDidChangeChatSessionItems when model request status changes', async () => {
 			return runWithFakedTimers({}, async () => {
-				const controller = createController();
+				const controller = disposables.add(createController());
 
 				const sessionResource = LocalChatSessionUri.forSession('status-change-session');
 				const mockModel = createMockChatModel({
@@ -622,24 +649,18 @@ suite('LocalAgentsSessionsController', () => {
 
 				// Add the session first
 				mockChatService.addSession(mockModel);
-				mockChatService.setLiveSessionItems([{
-					sessionResource,
-					title: 'Test Session',
-					lastMessageDate: Date.now(),
-					isActive: true,
-					timing: createTestTiming(),
-					lastResponseState: ResponseModelState.Complete
-				}]);
+				mockChatService.setLiveSessionItems([await chatModelToChatDetail(mockModel)]);
 
 				let changeEventCount = 0;
 				disposables.add(controller.onDidChangeChatSessionItems(() => {
 					changeEventCount++;
 				}));
+				await controller.refresh(CancellationToken.None);
+				assert.strictEqual(changeEventCount, 0);
 
 				const onDidChangeChatSessionItems = Event.toPromise(controller.onDidChangeChatSessionItems);
 
-				// Simulate progress change by triggering the progress listener
-				mockChatService.triggerProgressEvent(sessionResource);
+				mockModel.setRequestInProgress(true);
 
 				await onDidChangeChatSessionItems;
 				assert.strictEqual(changeEventCount, 1);
@@ -670,7 +691,7 @@ suite('LocalAgentsSessionsController', () => {
 					changeEventCount++;
 				}));
 
-				(mockModel as unknown as { setCustomTitle: (title: string) => void }).setCustomTitle('New Title');
+				mockModel.setCustomTitle('New Title');
 
 				assert.strictEqual(changeEventCount, 0, 'onDidChangeChatSessionItems should NOT fire after model is removed');
 			});

--- a/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/chatService.test.ts
@@ -426,7 +426,7 @@ suite('ChatService', () => {
 
 		let disposed = false;
 		testDisposables.add(testService.onDidDisposeSession(e => {
-			for (const resource of e.sessionResource) {
+			for (const resource of e.sessionResources) {
 				if (resource.toString() === model.sessionResource.toString()) {
 					disposed = true;
 				}

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -27,11 +27,11 @@ export class MockChatService implements IChatService {
 	private liveSessionItems: IChatDetail[] = [];
 	private historySessionItems: IChatDetail[] = [];
 
-	private readonly _onDidDisposeSession = new Emitter<{ sessionResource: URI[]; reason: 'cleared' }>();
+	private readonly _onDidDisposeSession = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 	readonly onDidDisposeSession = this._onDidDisposeSession.event;
 
-	fireDidDisposeSession(sessionResource: URI[]): void {
-		this._onDidDisposeSession.fire({ sessionResource, reason: 'cleared' });
+	fireDidDisposeSession(sessionResources: URI[]): void {
+		this._onDidDisposeSession.fire({ sessionResources, reason: 'cleared' });
 	}
 
 	setSaveModelsEnabled(enabled: boolean): void {

--- a/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService/mockChatService.ts
@@ -21,7 +21,9 @@ export class MockChatService implements IChatService {
 	editingSessions = [];
 	transferredSessionResource = undefined;
 	readonly onDidSubmitRequest = Event.None;
-	readonly onDidCreateModel = Event.None;
+
+	private readonly _onDidCreateModel = new Emitter<IChatModel>();
+	readonly onDidCreateModel = this._onDidCreateModel.event;
 
 	private readonly sessions = new ResourceMap<IChatModel>();
 	private liveSessionItems: IChatDetail[] = [];
@@ -54,6 +56,7 @@ export class MockChatService implements IChatService {
 		this.sessions.set(session.sessionResource, session);
 		// Update the chatModels observable
 		this._chatModels.set([...this.sessions.values()], undefined);
+		this._onDidCreateModel.fire(session);
 	}
 
 	removeSession(sessionResource: URI): void {
@@ -192,21 +195,10 @@ export class MockChatService implements IChatService {
 		throw new Error('Method not implemented.');
 	}
 
-
-	private onChange?: (sessionResource: URI) => void;
-
 	registerChatModelChangeListeners(chatSessionType: string, onChange: (sessionResource: URI) => void): IDisposable {
-		// Store the emitter so tests can trigger it
-		this.onChange = onChange;
 		return {
-			dispose: () => {
-				this.onChange = undefined;
-			}
+			dispose: () => { }
 		};
 	}
 
-	// Helper method for tests to trigger progress events
-	triggerProgressEvent(sessionResource: URI): void {
-		this.onChange?.(sessionResource);
-	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatService.ts
@@ -81,7 +81,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 
 		// Clear session auto-approve rules when chat sessions end
 		this._register(this._chatService.onDidDisposeSession(e => {
-			for (const resource of e.sessionResource) {
+			for (const resource of e.sessionResources) {
 				this._sessionAutoApproveRules.delete(resource);
 				this._sessionAutoApprovalEnabled.delete(resource);
 			}
@@ -105,7 +105,7 @@ export class TerminalChatService extends Disposable implements ITerminalChatServ
 		}));
 
 		this._register(this._chatService.onDidDisposeSession(e => {
-			for (const resource of e.sessionResource) {
+			for (const resource of e.sessionResources) {
 				if (LocalChatSessionUri.parseLocalSessionId(resource) === terminalToolSessionId) {
 					this._terminalInstancesByToolSessionId.delete(terminalToolSessionId);
 					this._toolSessionIdByTerminalInstance.delete(instance);

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool.ts
@@ -512,7 +512,7 @@ export class RunInTerminalTool extends Disposable implements IToolImpl {
 
 		// Listen for chat session disposal to clean up associated terminals
 		this._register(this._chatService.onDidDisposeSession(e => {
-			for (const resource of e.sessionResource) {
+			for (const resource of e.sessionResources) {
 				this._cleanupSessionTerminals(resource);
 			}
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chatAgentTools/test/electron-browser/runInTerminalTool.test.ts
@@ -75,7 +75,7 @@ suite('RunInTerminalTool', () => {
 	let storageService: IStorageService;
 	let workspaceContextService: TestContextService;
 	let terminalServiceDisposeEmitter: Emitter<ITerminalInstance>;
-	let chatServiceDisposeEmitter: Emitter<{ sessionResource: URI[]; reason: 'cleared' }>;
+	let chatServiceDisposeEmitter: Emitter<{ sessionResources: URI[]; reason: 'cleared' }>;
 	let chatSessionArchivedEmitter: Emitter<IAgentSession>;
 	let sandboxEnabled: boolean;
 	let terminalSandboxService: ITerminalSandboxService;
@@ -95,7 +95,7 @@ suite('RunInTerminalTool', () => {
 		setConfig(TerminalChatAgentToolsSettingId.BlockDetectedFileWrites, 'outsideWorkspace');
 		sandboxEnabled = false;
 		terminalServiceDisposeEmitter = new Emitter<ITerminalInstance>();
-		chatServiceDisposeEmitter = new Emitter<{ sessionResource: URI[]; reason: 'cleared' }>();
+		chatServiceDisposeEmitter = new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>();
 		chatSessionArchivedEmitter = new Emitter<IAgentSession>();
 
 		instantiationService = workbenchInstantiationService({
@@ -1521,7 +1521,7 @@ suite('RunInTerminalTool', () => {
 			});
 			runInTerminalTool.sessionTerminalInstances.set(sessionResource, new Set([mockTerminal1, mockTerminal2]));
 
-			chatServiceDisposeEmitter.fire({ sessionResource: [sessionResource], reason: 'cleared' });
+			chatServiceDisposeEmitter.fire({ sessionResources: [sessionResource], reason: 'cleared' });
 
 			strictEqual(terminal1Disposed, true, 'Terminal 1 should have been disposed');
 			strictEqual(terminal2Disposed, true, 'Terminal 2 should have been disposed');
@@ -1543,7 +1543,7 @@ suite('RunInTerminalTool', () => {
 
 			ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Terminal association should exist before disposal');
 
-			chatServiceDisposeEmitter.fire({ sessionResource: [sessionResource], reason: 'cleared' });
+			chatServiceDisposeEmitter.fire({ sessionResources: [sessionResource], reason: 'cleared' });
 
 			strictEqual(terminalDisposed, true, 'Terminal should have been disposed');
 			ok(!runInTerminalTool.sessionTerminalAssociations.has(sessionResource), 'Terminal association should be removed after disposal');
@@ -1574,7 +1574,7 @@ suite('RunInTerminalTool', () => {
 			ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource1), 'Session 1 terminal association should exist');
 			ok(runInTerminalTool.sessionTerminalAssociations.has(sessionResource2), 'Session 2 terminal association should exist');
 
-			chatServiceDisposeEmitter.fire({ sessionResource: [sessionResource1], reason: 'cleared' });
+			chatServiceDisposeEmitter.fire({ sessionResources: [sessionResource1], reason: 'cleared' });
 
 			strictEqual(terminal1Disposed, true, 'Terminal 1 should have been disposed');
 			strictEqual(terminal2Disposed, false, 'Terminal 2 should NOT have been disposed');
@@ -1584,7 +1584,7 @@ suite('RunInTerminalTool', () => {
 
 		test('should handle disposal of non-existent session gracefully', () => {
 			strictEqual(runInTerminalTool.sessionTerminalAssociations.size, 0, 'No associations should exist initially');
-			chatServiceDisposeEmitter.fire({ sessionResource: [LocalChatSessionUri.forSession('non-existent-session')], reason: 'cleared' });
+			chatServiceDisposeEmitter.fire({ sessionResources: [LocalChatSessionUri.forSession('non-existent-session')], reason: 'cleared' });
 			strictEqual(runInTerminalTool.sessionTerminalAssociations.size, 0, 'No associations should exist after handling non-existent session');
 		});
 	});
@@ -1921,7 +1921,7 @@ suite('ChatAgentToolsContribution - tool registration refresh', () => {
 		store.add(fileService.registerProvider(Schemas.file, fileSystemProvider));
 
 		const terminalServiceDisposeEmitter = store.add(new Emitter<ITerminalInstance>());
-		const chatServiceDisposeEmitter = store.add(new Emitter<{ sessionResource: URI[]; reason: 'cleared' }>());
+		const chatServiceDisposeEmitter = store.add(new Emitter<{ sessionResources: URI[]; reason: 'cleared' }>());
 		const chatSessionArchivedEmitter = store.add(new Emitter<IAgentSession>());
 
 		instantiationService = workbenchInstantiationService({


### PR DESCRIPTION
`LocalAgentsSessionsController` is firing updates on every single response change. This PR tries to reduce this by doing a object equality check before firing the update. In a follow up I'll also see if we can debounce listening to so many request updates

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
