### PR TITLE
extensions: fix disable dropdown showing wrong primary action for wor…

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1751,7 +1751,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
Fixes #244138

When an extension has `EnablementState.EnabledWorkspace` (globally disabled
with a workspace override), the Disable dropdown incorrectly showed "Disable"
(globally) as the primary action. Since the extension is already globally
disabled, only "Disable (Workspace)" should appear.

Removed `EnabledWorkspace` from the `DisableGloballyAction` condition so it
is hidden when the extension is already globally disabled, letting
`DisableForWorkspaceAction` become the primary dropdown action.