### PR TITLE
sessions - hide 2nd row stuff when session in progress

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -349,6 +349,8 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 					timeEl.textContent = formatTime();
 				}, 60_000);
 				timeDisposable.value = toDisposable(() => targetWindow.clearInterval(interval));
+			} else {
+				timeDisposable.clear();
 			}
 		}));
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -256,11 +256,14 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			const changes = element.changes.read(reader);
 			const workspace = element.workspace.read(reader);
 			const description = element.description.read(reader);
-			const timeDate = this.options.sorting() === SessionsSorting.Updated ? element.updatedAt.read(reader) : element.createdAt;
+			let timeDate: Date | undefined;
 
 			// When the session is InProgress or NeedsInput, hide workspace/diff/time details in this row
 			const hideDetails = sessionStatus === SessionStatus.InProgress || sessionStatus === SessionStatus.NeedsInput;
 
+			if (!hideDetails) {
+				timeDate = this.options.sorting() === SessionsSorting.Updated ? element.updatedAt.read(reader) : element.createdAt;
+			}
 			// Clear and rebuild details row
 			DOM.clearNode(template.detailsRow);
 			const parts: HTMLElement[] = [];

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -337,14 +337,15 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}
 
 			// Timestamp — visible when not hiding details
-			if (!hideDetails) {
+			if (!hideDetails && timeDate) {
 				if (parts.length > 0) {
 					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
 				}
 				const timeEl = DOM.append(template.detailsRow, $('span.session-time'));
+				const definiteTimeDate = timeDate;
 				const formatTime = () => {
-					const seconds = Math.round((Date.now() - timeDate.getTime()) / 1000);
-					return seconds < 60 ? localize('secondsDuration', "now") : fromNow(timeDate, true);
+					const seconds = Math.round((Date.now() - definiteTimeDate.getTime()) / 1000);
+					return seconds < 60 ? localize('secondsDuration', "now") : fromNow(definiteTimeDate, true);
 				};
 				timeEl.textContent = formatTime();
 				const targetWindow = DOM.getWindow(timeEl);

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -258,6 +258,9 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			const description = element.description.read(reader);
 			const timeDate = this.options.sorting() === SessionsSorting.Updated ? element.updatedAt.read(reader) : element.createdAt;
 
+			// When in progress with a description, only show description in the details row
+			const hideDetails = sessionStatus === SessionStatus.InProgress || sessionStatus === SessionStatus.NeedsInput;
+
 			// Clear and rebuild details row
 			DOM.clearNode(template.detailsRow);
 			const parts: HTMLElement[] = [];
@@ -273,7 +276,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			// Workspace badge — show when not grouped by workspace,
 			// or when the session is pinned/archived (their section headers
 			// don't carry the workspace name)
-			if (workspace && (
+			if (!hideDetails && workspace && (
 				this.options.grouping() !== SessionsGrouping.Workspace ||
 				this.options.isPinned(element) ||
 				element.isArchived.read(reader)
@@ -287,7 +290,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			}
 
 			// Diff stats
-			if (changes.length > 0 && sessionStatus !== SessionStatus.InProgress) {
+			if (!hideDetails && changes.length > 0) {
 				let insertions = 0;
 				let deletions = 0;
 				for (const change of changes) {
@@ -330,21 +333,23 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 				parts.push(statusEl);
 			}
 
-			// Timestamp — always visible
-			if (parts.length > 0) {
-				DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
-			}
-			const timeEl = DOM.append(template.detailsRow, $('span.session-time'));
-			const formatTime = () => {
-				const seconds = Math.round((Date.now() - timeDate.getTime()) / 1000);
-				return seconds < 60 ? localize('secondsDuration', "now") : fromNow(timeDate, true);
-			};
-			timeEl.textContent = formatTime();
-			const targetWindow = DOM.getWindow(timeEl);
-			const interval = targetWindow.setInterval(() => {
+			// Timestamp — visible when not hiding details
+			if (!hideDetails) {
+				if (parts.length > 0) {
+					DOM.append(template.detailsRow, $('span.session-separator.has-separator'));
+				}
+				const timeEl = DOM.append(template.detailsRow, $('span.session-time'));
+				const formatTime = () => {
+					const seconds = Math.round((Date.now() - timeDate.getTime()) / 1000);
+					return seconds < 60 ? localize('secondsDuration', "now") : fromNow(timeDate, true);
+				};
 				timeEl.textContent = formatTime();
-			}, 60_000);
-			timeDisposable.value = toDisposable(() => targetWindow.clearInterval(interval));
+				const targetWindow = DOM.getWindow(timeEl);
+				const interval = targetWindow.setInterval(() => {
+					timeEl.textContent = formatTime();
+				}, 60_000);
+				timeDisposable.value = toDisposable(() => targetWindow.clearInterval(interval));
+			}
 		}));
 
 		// Approval row — reactive

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -258,7 +258,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			const description = element.description.read(reader);
 			const timeDate = this.options.sorting() === SessionsSorting.Updated ? element.updatedAt.read(reader) : element.createdAt;
 
-			// When in progress with a description, only show description in the details row
+			// When the session is InProgress or NeedsInput, hide workspace/diff/time details in this row
 			const hideDetails = sessionStatus === SessionStatus.InProgress || sessionStatus === SessionStatus.NeedsInput;
 
 			// Clear and rebuild details row


### PR DESCRIPTION
Updates the Sessions window list item "details" row rendering so that when a session is active (in progress / needs input), secondary metadata in the second row is suppressed to emphasize the status/description.

## Changes Made

- Introduces a `hideDetails` flag to suppress workspace badge and diff stats while a session is active (`InProgress` or `NeedsInput`).
- Hides the timestamp when `hideDetails` is enabled.
- Keeps the status description visible for `InProgress` / `NeedsInput` states while reducing other detail noise.
- Fixes a timer leak: added `timeDisposable.clear()` in the `else` branch so that when a session transitions to `hideDetails === true`, any previously running timestamp interval is properly cleared instead of continuing to update a detached DOM element.

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.