### PR TITLE
sessions - show pinned action from toolbar

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -54,31 +54,23 @@
 		}
 	}
 
-	.monaco-list-row .session-pinned-indicator {
-		display: none;
-		height: 16px;
-		align-items: center;
-		color: var(--vscode-descriptionForeground);
-		font-size: 12px;
-		pointer-events: none;
-
-		&.visible {
-			display: flex;
-		}
-	}
-
 	.monaco-list-row:hover,
 	.monaco-list-row.focused:not(.selected) {
-		.session-pinned-indicator {
-			display: none;
-		}
-
 		.session-title-toolbar {
 			display: block;
 		}
 
 		.session-title {
 			margin-right: 8px;
+		}
+	}
+
+	/* Show toolbar persistently for pinned sessions, but only the pinned action */
+	.monaco-list-row:not(:hover):not(.focused):has(.pinned) .session-title-toolbar {
+		display: block;
+
+		.action-item:not(:has(.codicon-pinned)) {
+			display: none;
 		}
 	}
 }

--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -66,7 +66,7 @@
 	}
 
 	/* Show toolbar persistently for pinned sessions, but only the pinned action */
-	.monaco-list-row:not(:hover):not(.focused):has(.pinned) .session-title-toolbar {
+	.monaco-list-row:not(:hover):not(.focused) .session-item.pinned .session-title-toolbar {
 		display: block;
 
 		.action-item:not(:has(.codicon-pinned)) {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -209,18 +209,24 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		// Toolbar context
 		template.titleToolbar.context = element;
 
-		// Context key: isPinned
-		const isPinned = this.options.isPinned(element);
-		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
-		IsSessionArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
-		IsSessionReadContext.bindTo(template.contextKeyService).set(element.isRead.get());
+		// Context keys and styling — reactive
+		const pinnedContextKey = IsSessionPinnedContext.bindTo(template.contextKeyService);
+		const archivedContextKey = IsSessionArchivedContext.bindTo(template.contextKeyService);
+		const readContextKey = IsSessionReadContext.bindTo(template.contextKeyService);
 
-		// Show toolbar persistently when pinned so the unpin action is visible
-		template.container.classList.toggle('pinned', isPinned);
-
-		// Archived styling — reactive
 		template.elementDisposables.add(autorun(reader => {
-			template.container.classList.toggle('archived', element.isArchived.read(reader));
+			const isArchived = element.isArchived.read(reader);
+			const isRead = element.isRead.read(reader);
+			const isPinned = this.options.isPinned(element);
+
+			pinnedContextKey.set(isPinned);
+			archivedContextKey.set(isArchived);
+			readContextKey.set(isRead);
+
+			// Show toolbar persistently when pinned so the unpin action is visible,
+			// but avoid pinned styling for archived sessions where pin/unpin is hidden.
+			template.container.classList.toggle('pinned', isPinned && !isArchived);
+			template.container.classList.toggle('archived', isArchived);
 		}));
 
 

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsList.ts
@@ -134,7 +134,6 @@ interface ISessionItemTemplate {
 	readonly container: HTMLElement;
 	readonly iconContainer: HTMLElement;
 	readonly title: HTMLElement;
-	readonly pinnedIndicator: HTMLElement;
 	readonly titleToolbar: MenuWorkbenchToolBar;
 	readonly detailsRow: HTMLElement;
 	readonly approvalRow: HTMLElement;
@@ -179,7 +178,6 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const mainCol = DOM.append(container, $('.session-main'));
 		const titleRow = DOM.append(mainCol, $('.session-title-row'));
 		const title = DOM.append(titleRow, $('.session-title'));
-		const pinnedIndicator = DOM.append(titleRow, $('.session-pinned-indicator'));
 		const titleToolbarContainer = DOM.append(titleRow, $('.session-title-toolbar'));
 		const detailsRow = DOM.append(mainCol, $('.session-details-row'));
 
@@ -194,7 +192,7 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 			menuOptions: { shouldForwardArgs: true },
 		}));
 
-		return { container, iconContainer, title, pinnedIndicator, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
+		return { container, iconContainer, title, titleToolbar, detailsRow, approvalRow, approvalLabel, approvalButtonContainer, contextKeyService, disposables, elementDisposables };
 	}
 
 	renderElement(node: ITreeNode<SessionListItem, FuzzyScore>, _index: number, template: ISessionItemTemplate): void {
@@ -215,11 +213,10 @@ class SessionItemRenderer implements ITreeRenderer<SessionListItem, FuzzyScore, 
 		const isPinned = this.options.isPinned(element);
 		IsSessionPinnedContext.bindTo(template.contextKeyService).set(isPinned);
 		IsSessionArchivedContext.bindTo(template.contextKeyService).set(element.isArchived.get());
-
-		// Pinned indicator — inline pin icon, hidden on hover when toolbar shows
-		template.pinnedIndicator.className = 'session-pinned-indicator ' + ThemeIcon.asClassName(Codicon.pinned);
-		template.pinnedIndicator.classList.toggle('visible', isPinned);
 		IsSessionReadContext.bindTo(template.contextKeyService).set(element.isRead.get());
+
+		// Show toolbar persistently when pinned so the unpin action is visible
+		template.container.classList.toggle('pinned', isPinned);
 
 		// Archived styling — reactive
 		template.elementDisposables.add(autorun(reader => {

--- a/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
+++ b/src/vs/sessions/contrib/sessions/browser/views/sessionsViewActions.ts
@@ -384,7 +384,7 @@ registerAction2(class PinSessionAction extends Action2 {
 			menu: [{
 				id: SessionItemToolbarMenuId,
 				group: 'navigation',
-				order: 0,
+				order: 2,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals(IsSessionPinnedContext.key, false),
 					ContextKeyExpr.equals(IsSessionArchivedContext.key, false),
@@ -419,7 +419,7 @@ registerAction2(class UnpinSessionAction extends Action2 {
 			menu: [{
 				id: SessionItemToolbarMenuId,
 				group: 'navigation',
-				order: 0,
+				order: 2,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals(IsSessionPinnedContext.key, true),
 					ContextKeyExpr.equals(IsSessionArchivedContext.key, false),


### PR DESCRIPTION
Adjusts the Sessions window list UI so pinned sessions expose an always-visible "unpin" affordance via the existing title toolbar (instead of an inline pin indicator), improving discoverability of the pinned state/actions.

## Changes Made

- Reorders Pin/Unpin actions within the session item toolbar menu.
- Removes the inline pinned indicator element from session list rows.
- Adds a `pinned` state class to session rows to drive persistent toolbar visibility, showing only the unpin action when not hovered/focused.
- Simplifies the CSS selector for persistent toolbar visibility from `:has(.pinned)` on `.monaco-list-row` to a direct `.session-item.pinned` descendant selector, avoiding relational selectors and naturally excluding archived items.
- Consolidates context key updates (`IsSessionPinnedContext`, `IsSessionArchivedContext`, `IsSessionReadContext`) and class toggles into a single reactive `autorun`, ensuring the `pinned` class is only applied when the session is pinned **and not archived** — preventing archived-but-pinned sessions from incorrectly receiving the persistent toolbar styling.

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.