### PR TITLE
Enhance accessibility for changes title bar widget with ARIA attributes

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
@@ -5,7 +5,7 @@
 
 import './media/changesTitleBarWidget.css';
 
-import { $, append, EventLike } from '../../../../base/browser/dom.js';
+import { $, append } from '../../../../base/browser/dom.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { createInstantHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IAction } from '../../../../base/common/actions.js';
@@ -79,18 +79,15 @@ class ChangesTitleBarActionViewItem extends BaseActionViewItem {
 		this._container = container;
 		container.classList.add('changes-titlebar-indicator');
 		container.setAttribute('role', 'button');
-		container.setAttribute('aria-label', localize('showChanges', "Show Changes"));
 
 		this._rebuildIndicators();
 		this._updateActiveState();
 	}
 
-	override onClick(event: EventLike, preserveFocus?: boolean): void {
-		super.onClick(event, preserveFocus);
-	}
-
 	private _updateActiveState(): void {
-		this._container?.classList.toggle('active', this.layoutService.isVisible(Parts.AUXILIARYBAR_PART));
+		const isVisible = this.layoutService.isVisible(Parts.AUXILIARYBAR_PART);
+		this._container?.classList.toggle('toggled', isVisible);
+		this._container?.setAttribute('aria-pressed', String(isVisible));
 	}
 
 	private _rebuildIndicators(): void {

--- a/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesTitleBarWidget.ts
@@ -5,7 +5,7 @@
 
 import './media/changesTitleBarWidget.css';
 
-import { $, append } from '../../../../base/browser/dom.js';
+import { $, append, EventLike } from '../../../../base/browser/dom.js';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
 import { createInstantHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IAction } from '../../../../base/common/actions.js';
@@ -78,13 +78,15 @@ class ChangesTitleBarActionViewItem extends BaseActionViewItem {
 
 		this._container = container;
 		container.classList.add('changes-titlebar-indicator');
+		container.setAttribute('role', 'button');
+		container.setAttribute('aria-label', localize('showChanges', "Show Changes"));
 
 		this._rebuildIndicators();
 		this._updateActiveState();
 	}
 
-	override onClick(): void {
-		this._action.run();
+	override onClick(event: EventLike, preserveFocus?: boolean): void {
+		super.onClick(event, preserveFocus);
 	}
 
 	private _updateActiveState(): void {
@@ -121,11 +123,13 @@ class ChangesTitleBarActionViewItem extends BaseActionViewItem {
 		}
 
 		if (summary) {
+			const label = localize('changesSummary', "{0} file(s) changed, {1} insertion(s), {2} deletion(s)", summary.files, summary.insertions, summary.deletions);
+			btn.setAttribute('aria-label', label);
 			this._indicatorDisposables.add(this.hoverService.setupManagedHover(
-				this._hoverDelegate, btn,
-				localize('changesSummary', "{0} file(s) changed, {1} insertion(s), {2} deletion(s)", summary.files, summary.insertions, summary.deletions)
+				this._hoverDelegate, btn, label
 			));
 		} else {
+			btn.setAttribute('aria-label', localize('showChanges', "Show Changes"));
 			this._indicatorDisposables.add(this.hoverService.setupManagedHover(
 				this._hoverDelegate, btn,
 				localize('showChanges', "Show Changes")

--- a/src/vs/sessions/contrib/changes/browser/media/changesTitleBarWidget.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesTitleBarWidget.css
@@ -21,7 +21,8 @@
 	background: var(--vscode-toolbar-hoverBackground);
 }
 
-.agent-sessions-workbench .changes-titlebar-indicator.active {
+.agent-sessions-workbench .changes-titlebar-indicator.toggled,
+.agent-sessions-workbench .changes-titlebar-indicator.toggled:hover {
 	background: var(--vscode-toolbar-activeBackground);
 }
 


### PR DESCRIPTION
Improve accessibility by adding ARIA attributes to the changes title bar widget, ensuring better screen reader support and user interaction.

Responding to CCR in https://github.com/microsoft/vscode/pull/304433

