### PR TITLE
Improve focus styles for action items in auxiliary bar and panel

### DIFF
--- a/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
+++ b/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
@@ -31,9 +31,14 @@
 	background-color: var(--vscode-sessionsAuxiliaryBar-background);
 }
 
-/* Hide the underline indicator entirely */
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator:before {
+/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
+.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-within):not(:focus-visible) .active-item-indicator:before {
 	display: none !important;
+}
+
+.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-within .active-item-indicator:before,
+.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
+	display: block !important;
 }
 
 /* Active/checked state: background container instead of underline */

--- a/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
+++ b/src/vs/sessions/browser/parts/media/auxiliaryBarPart.css
@@ -32,11 +32,9 @@
 }
 
 /* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-within):not(:focus-visible) .active-item-indicator:before {
+.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
 	display: none !important;
 }
-
-.agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-within .active-item-indicator:before,
 .agent-sessions-workbench .part.auxiliarybar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
 	display: block !important;
 }

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -11,11 +11,9 @@
 /* ===== Modern action label styling for sessions panel ===== */
 
 /* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-within):not(:focus-visible) .active-item-indicator:before {
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
 	display: none !important;
 }
-
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-within .active-item-indicator:before,
 .agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
 	display: block !important;
 }

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -10,11 +10,14 @@
 
 /* ===== Modern action label styling for sessions panel ===== */
 
-/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible) .active-item-indicator:before {
+/* Hide the underline indicator for non-focused, non-checked items; keep it for focus-visible and checked */
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-visible):not(.checked) .active-item-indicator:before {
 	display: none !important;
 }
 .agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
+	display: block !important;
+}
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before {
 	display: block !important;
 }
 

--- a/src/vs/sessions/browser/parts/media/panelPart.css
+++ b/src/vs/sessions/browser/parts/media/panelPart.css
@@ -10,9 +10,14 @@
 
 /* ===== Modern action label styling for sessions panel ===== */
 
-/* Hide the underline indicator entirely */
-.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator:before {
+/* Hide the underline indicator for non-focused items, but keep it for keyboard focus */
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(:focus-within):not(:focus-visible) .active-item-indicator:before {
 	display: none !important;
+}
+
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-within .active-item-indicator:before,
+.agent-sessions-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus-visible .active-item-indicator:before {
+	display: block !important;
 }
 
 /* Make icon action items 24px tall */


### PR DESCRIPTION
Enhance the focus styles for action items in the auxiliary bar and panel to display an underline indicator only when items are focused or visible. This change improves accessibility and user experience by providing clearer visual feedback during keyboard navigation.

Addressing CCR from https://github.com/microsoft/vscode/pull/303145

