### PR TITLE
sessions: show agent feedback count per file in changes view

### DIFF
--- a/src/vs/sessions/contrib/changes/browser/changesView.ts
+++ b/src/vs/sessions/contrib/changes/browser/changesView.ts
@@ -61,6 +61,7 @@ import { IExtensionService } from '../../../../workbench/services/extensions/com
 import { IWorkbenchLayoutService } from '../../../../workbench/services/layout/browser/layoutService.js';
 import { ISessionsManagementService } from '../../sessions/browser/sessionsManagementService.js';
 import { CodeReviewStateKind, getCodeReviewFilesFromSessionChanges, getCodeReviewVersion, ICodeReviewService, PRReviewStateKind } from '../../codeReview/browser/codeReviewService.js';
+import { IAgentFeedbackService } from '../../agentFeedback/browser/agentFeedbackService.js';
 import { IGitRepository, IGitService } from '../../../../workbench/contrib/git/common/gitService.js';
 import { IGitHubService } from '../../github/browser/githubService.js';
 import { CIStatusWidget } from './ciStatusWidget.js';
@@ -121,6 +122,7 @@ interface IChangesFileItem {
 	readonly linesAdded: number;
 	readonly linesRemoved: number;
 	readonly reviewCommentCount: number;
+	readonly agentFeedbackCount: number;
 }
 
 interface IChangesFolderItem {
@@ -356,6 +358,7 @@ export class ChangesViewPane extends ViewPane {
 		@ILabelService private readonly labelService: ILabelService,
 		@ICodeReviewService private readonly codeReviewService: ICodeReviewService,
 		@IGitHubService private readonly gitHubService: IGitHubService,
+		@IAgentFeedbackService private readonly agentFeedbackService: IAgentFeedbackService,
 	) {
 		super({ ...options, titleMenuId: MenuId.ChatEditingSessionTitleToolbar }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, hoverService);
 
@@ -568,9 +571,29 @@ export class ChangesViewPane extends ViewPane {
 			return result;
 		});
 
+		const agentFeedbackCountByFileObs = derived(reader => {
+			const sessionResource = this.viewModel.activeSessionResourceObs.read(reader);
+			if (!sessionResource) {
+				return new Map<string, number>();
+			}
+
+			observableSignalFromEvent(this, this.agentFeedbackService.onDidChangeFeedback).read(reader);
+
+			const feedbackItems = this.agentFeedbackService.getFeedback(sessionResource);
+			const result = new Map<string, number>();
+			for (const item of feedbackItems) {
+				if (!item.sourcePRReviewCommentId) {
+					const uriKey = item.resourceUri.fsPath;
+					result.set(uriKey, (result.get(uriKey) ?? 0) + 1);
+				}
+			}
+			return result;
+		});
+
 		// Convert session file changes to list items (cloud/background sessions)
 		const sessionFilesObs = derived(reader => {
 			const reviewCommentCountByFile = reviewCommentCountByFileObs.read(reader);
+			const agentFeedbackCountByFile = agentFeedbackCountByFileObs.read(reader);
 			const changes = [...this.viewModel.activeSessionChangesObs.read(reader)];
 
 			return changes.map((entry): IChangesFileItem => {
@@ -589,6 +612,7 @@ export class ChangesViewPane extends ViewPane {
 					linesAdded: entry.insertions,
 					linesRemoved: entry.deletions,
 					reviewCommentCount: reviewCommentCountByFile.get(uri.fsPath) ?? 0,
+					agentFeedbackCount: agentFeedbackCountByFile.get(uri.fsPath) ?? 0,
 				};
 			});
 		});
@@ -697,6 +721,7 @@ export class ChangesViewPane extends ViewPane {
 						linesAdded: change.insertions,
 						linesRemoved: change.deletions,
 						reviewCommentCount: 0,
+						agentFeedbackCount: 0,
 					} satisfies IChangesFileItem;
 				});
 			} else {
@@ -1174,6 +1199,7 @@ interface IChangesTreeTemplate {
 	readonly toolbar: MenuWorkbenchToolBar | undefined;
 	readonly contextKeyService: IContextKeyService | undefined;
 	readonly reviewCommentsBadge: HTMLElement;
+	readonly agentFeedbackBadge: HTMLElement;
 	readonly decorationBadge: HTMLElement;
 	readonly addedSpan: HTMLElement;
 	readonly removedSpan: HTMLElement;
@@ -1199,6 +1225,9 @@ class ChangesTreeRenderer implements ICompressibleTreeRenderer<ChangesTreeElemen
 		const reviewCommentsBadge = dom.$('.changes-review-comments-badge');
 		label.element.appendChild(reviewCommentsBadge);
 
+		const agentFeedbackBadge = dom.$('.changes-agent-feedback-badge');
+		label.element.appendChild(agentFeedbackBadge);
+
 		const lineCountsContainer = $('.working-set-line-counts');
 		const addedSpan = dom.$('.working-set-lines-added');
 		const removedSpan = dom.$('.working-set-lines-removed');
@@ -1219,7 +1248,7 @@ class ChangesTreeRenderer implements ICompressibleTreeRenderer<ChangesTreeElemen
 			label.element.appendChild(actionBarContainer);
 		}
 
-		return { templateDisposables, label, toolbar, contextKeyService, reviewCommentsBadge, decorationBadge, addedSpan, removedSpan, lineCountsContainer };
+		return { templateDisposables, label, toolbar, contextKeyService, reviewCommentsBadge, agentFeedbackBadge, decorationBadge, addedSpan, removedSpan, lineCountsContainer };
 	}
 
 	renderElement(node: ITreeNode<ChangesTreeElement, void>, _index: number, templateData: IChangesTreeTemplate): void {
@@ -1252,6 +1281,7 @@ class ChangesTreeRenderer implements ICompressibleTreeRenderer<ChangesTreeElemen
 
 			// Hide file-specific decorations for folders
 			templateData.reviewCommentsBadge.style.display = 'none';
+			templateData.agentFeedbackBadge.style.display = 'none';
 			templateData.decorationBadge.style.display = 'none';
 			templateData.lineCountsContainer.style.display = 'none';
 
@@ -1286,6 +1316,18 @@ class ChangesTreeRenderer implements ICompressibleTreeRenderer<ChangesTreeElemen
 		} else {
 			templateData.reviewCommentsBadge.style.display = 'none';
 			templateData.reviewCommentsBadge.replaceChildren();
+		}
+
+		if (data.agentFeedbackCount > 0) {
+			templateData.agentFeedbackBadge.style.display = '';
+			templateData.agentFeedbackBadge.className = 'changes-agent-feedback-badge';
+			templateData.agentFeedbackBadge.replaceChildren(
+				dom.$('.codicon.codicon-comment'),
+				dom.$('span', undefined, `${data.agentFeedbackCount}`)
+			);
+		} else {
+			templateData.agentFeedbackBadge.style.display = 'none';
+			templateData.agentFeedbackBadge.replaceChildren();
 		}
 
 		// Update decoration badge (A/M/D)
@@ -1328,6 +1370,7 @@ class ChangesTreeRenderer implements ICompressibleTreeRenderer<ChangesTreeElemen
 
 		// Hide file-specific decorations for folders
 		templateData.reviewCommentsBadge.style.display = 'none';
+		templateData.agentFeedbackBadge.style.display = 'none';
 		templateData.decorationBadge.style.display = 'none';
 		templateData.lineCountsContainer.style.display = 'none';
 

--- a/src/vs/sessions/contrib/changes/browser/media/changesView.css
+++ b/src/vs/sessions/contrib/changes/browser/media/changesView.css
@@ -297,6 +297,19 @@
 	font-size: 12px;
 }
 
+.changes-view-body .chat-editing-session-list .changes-agent-feedback-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	margin-right: 6px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.changes-view-body .chat-editing-session-list .changes-agent-feedback-badge .codicon {
+	font-size: 12px;
+}
+
 .changes-view-body .chat-editing-session-list .working-set-lines-added {
 	color: var(--vscode-chat-linesAddedForeground);
 }


### PR DESCRIPTION
## Summary

Adds an agent feedback count badge per file in the changes view tree, alongside the existing code review comment count badge.

## What changed

- Added `agentFeedbackCount` field to `IChangesFileItem` to track per-file feedback counts
- Created a reactive `agentFeedbackCountByFileObs` observable that:
  - Reads feedback items from `IAgentFeedbackService.getFeedback()`
  - **Excludes** items with `sourcePRReviewCommentId` (those are PR/code review comments, not agent feedback)
  - Reactively updates via `observableSignalFromEvent` on `onDidChangeFeedback`
- Added `agentFeedbackBadge` DOM element to `IChangesTreeTemplate`
- Renders with `codicon-comment` icon + count (distinct from review comments which use `codicon-comment-unresolved`)
- Badge is hidden for folder and compressed folder elements
- Added matching CSS for `.changes-agent-feedback-badge`

## Visual layout per file row

`[file-icon] filename [💬 N] [🗨 N] +X -Y [M]`
- 💬 = agent feedback (`codicon-comment`)
- 🗨 = review comments (`codicon-comment-unresolved`)
