### PR TITLE
Support rename and delete actions for chats

### DIFF
--- a/src/vs/sessions/browser/parts/sessionCompositeBar.ts
+++ b/src/vs/sessions/browser/parts/sessionCompositeBar.ts
@@ -6,10 +6,15 @@
 import './media/sessionCompositeBar.css';
 import { Disposable, DisposableStore } from '../../../base/common/lifecycle.js';
 import { Emitter, Event } from '../../../base/common/event.js';
-import { $, addDisposableListener, EventType, reset } from '../../../base/browser/dom.js';
+import { $, addDisposableListener, EventType, getWindow, reset } from '../../../base/browser/dom.js';
 import { autorun } from '../../../base/common/observable.js';
 import { IThemeService } from '../../../platform/theme/common/themeService.js';
 import { PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND, SIDE_BAR_BACKGROUND } from '../../../workbench/common/theme.js';
+import { Action } from '../../../base/common/actions.js';
+import { IContextMenuService } from '../../../platform/contextview/browser/contextView.js';
+import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
+import { localize } from '../../../nls.js';
+import { IQuickInputService } from '../../../platform/quickinput/common/quickInput.js';
 // TODO: we should move the sessions management service to a more core location so that we don't have to depend on the entire sessions contrib in this common/browser component
 // eslint-disable-next-line local/code-import-patterns
 import { ISessionsManagementService } from '../../contrib/sessions/browser/sessionsManagementService.js';
@@ -50,6 +55,8 @@ export class SessionCompositeBar extends Disposable {
 	constructor(
 		@IThemeService private readonly _themeService: IThemeService,
 		@ISessionsManagementService private readonly _sessionsManagementService: ISessionsManagementService,
+		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 	) {
 		super();
 
@@ -61,13 +68,14 @@ export class SessionCompositeBar extends Disposable {
 		this._register(autorun(reader => {
 			const activeSession = this._sessionsManagementService.activeSession.read(reader);
 			if (!activeSession) {
-				this._rebuildTabs([], '');
+				this._rebuildTabs([], '', undefined);
 				return;
 			}
 
 			const chats = activeSession.chats.read(reader);
 			const activeChatId = activeSession.activeChat.map(c => c.chatId).read(reader);
-			this._rebuildTabs(chats, activeChatId);
+			const mainChatId = activeSession.mainChat.chatId;
+			this._rebuildTabs(chats, activeChatId, mainChatId);
 		}));
 
 
@@ -75,20 +83,20 @@ export class SessionCompositeBar extends Disposable {
 		this._register(this._themeService.onDidColorThemeChange(() => this._updateStyles()));
 	}
 
-	private _rebuildTabs(chats: readonly IChatData[], activeChatId: string): void {
+	private _rebuildTabs(chats: readonly IChatData[], activeChatId: string, mainChatId?: string): void {
 		this._tabDisposables.clear();
 		this._tabs.length = 0;
 		reset(this._tabsContainer);
 
 		for (const chat of chats) {
-			this._createTab(chat);
+			this._createTab(chat, chat.chatId === mainChatId);
 		}
 
 		this._updateActiveTab(activeChatId);
 		this._updateVisibility();
 	}
 
-	private _createTab(chat: IChatData): void {
+	private _createTab(chat: IChatData, isMainChat: boolean): void {
 		const tab = $('.session-composite-bar-tab');
 		tab.tabIndex = 0;
 		tab.setAttribute('role', 'tab');
@@ -114,6 +122,31 @@ export class SessionCompositeBar extends Disposable {
 				e.preventDefault();
 				this._onTabClicked(chat);
 			}
+		}));
+
+		const renameAction = this._tabDisposables.add(new Action('sessionCompositeBar.renameChat', localize('renameChat', "Rename"), undefined, true, async () => {
+			const newTitle = await this._quickInputService.input({
+				value: chat.title.get(),
+				prompt: localize('renameChat.prompt', "Rename Chat"),
+			});
+			if (newTitle) {
+				await this._sessionsManagementService.renameChat(chat, newTitle);
+			}
+		}));
+
+		const deleteAction = this._tabDisposables.add(new Action('sessionCompositeBar.deleteChat', localize('deleteChat', "Delete"), undefined, !isMainChat, () => this._sessionsManagementService.deleteChat(chat)));
+
+		this._tabDisposables.add(addDisposableListener(tab, EventType.CONTEXT_MENU, (e: MouseEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			const event = new StandardMouseEvent(getWindow(tab), e);
+			this._contextMenuService.showContextMenu({
+				getAnchor: () => event,
+				getActions: () => [
+					renameAction,
+					deleteAction,
+				]
+			});
 		}));
 
 		this._tabs.push({ chat: chat, element: tab });

--- a/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionsConfigurationService.test.ts
@@ -57,7 +57,7 @@ function makeSession(opts: { repository?: URI; worktree?: URI } = {}): ISessionD
 		description: observableValue('description', undefined),
 		pullRequest: observableValue('pullRequest', undefined),
 	};
-	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('chats', [chat]), activeChat: observableValue('activeChat', chat) };
+	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('chats', [chat]), activeChat: observableValue('activeChat', chat), mainChat: chat };
 	return session;
 }
 

--- a/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
+++ b/src/vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider.ts
@@ -967,15 +967,23 @@ export class CopilotChatSessionsProvider extends Disposable implements ISessions
 	async deleteSession(chatId: string): Promise<void> {
 		const agentSession = this._findAgentSession(chatId);
 		if (agentSession) {
-			await this.chatService.removeHistoryEntry(agentSession.resource);
-			this._refreshSessionCache();
+			if (agentSession.providerType === CopilotCLISessionType.id) {
+				this.commandService.executeCommand('github.copilot.cli.sessions.delete', { resource: agentSession.resource });
+			} else {
+				await this.chatService.removeHistoryEntry(agentSession.resource);
+				this._refreshSessionCache();
+			}
 		}
 	}
 
 	async renameSession(chatId: string, title: string): Promise<void> {
 		const agentSession = this._findAgentSession(chatId);
 		if (agentSession) {
-			this.chatService.setChatSessionTitle(agentSession.resource, title);
+			if (agentSession.providerType === CopilotCLISessionType.id) {
+				this.commandService.executeCommand('github.copilot.cli.sessions.setTitle', { resource: agentSession.resource }, title);
+			} else {
+				this.chatService.setChatSessionTitle(agentSession.resource, title);
+			}
 		}
 	}
 

--- a/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
+++ b/src/vs/sessions/contrib/sessions/browser/sessionsManagementService.ts
@@ -188,8 +188,10 @@ export interface ISessionsManagementService {
 	unarchiveSession(session: ISessionData): Promise<void>;
 	/** Delete a session. */
 	deleteSession(session: ISessionData): Promise<void>;
-	/** Rename a session. */
-	renameSession(session: ISessionData, title: string): Promise<void>;
+	/** Delete a single chat from a session. */
+	deleteChat(chat: IChatData): Promise<void>;
+	/** Rename a chat. */
+	renameChat(chat: IChatData, title: string): Promise<void>;
 	/** Mark a session as read or unread. */
 	setRead(session: ISessionData, read: boolean): void;
 }
@@ -794,13 +796,15 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		const updatedAtObs = chatsObs.map(chats => latestDateAcrossChats(chats, c => c.updatedAt.get())!);
 		const lastTurnEndObs = chatsObs.map(chats => latestDateAcrossChats(chats, c => c.lastTurnEnd.get()));
 
+		const mainChat = chatsObs.get()[0];
 		const sessionData: ISessionData = {
-			...chatsObs.get()[0], // Inherit properties from the primary chat
+			...mainChat, // Inherit properties from the primary chat
 			sessionId,
 			updatedAt: updatedAtObs,
 			lastTurnEnd: lastTurnEndObs,
 			chats: chatsObs,
 			activeChat: activeChatObs,
+			mainChat,
 		};
 		this._sessionDataCache.set(sessionId, sessionData);
 		return sessionData;
@@ -848,8 +852,23 @@ export class SessionsManagementService extends Disposable implements ISessionsMa
 		}
 	}
 
-	async renameSession(session: ISessionData, title: string): Promise<void> {
-		await this.sessionsProvidersService.renameSession(session.chats.get()[0].chatId, title);
+	async deleteChat(chat: IChatData): Promise<void> {
+		const session = this.getSession(chat.resource);
+		if (!session) {
+			throw new Error(`Session for chat ${chat.chatId} not found`);
+		}
+		if (session.mainChat.chatId === chat.chatId) {
+			throw new Error('Cannot delete the main chat of a session. Use deleteSession to delete the entire session.');
+		}
+		await this.chatWidgetService.getWidgetBySessionResource(chat.resource)?.clear();
+		await this.sessionsProvidersService.deleteSession(chat.chatId);
+		if (this.activeSession.get()?.sessionId === session.sessionId) {
+			await this.openSession(session.mainChat.resource);
+		}
+	}
+
+	async renameChat(chat: IChatData, title: string): Promise<void> {
+		await this.sessionsProvidersService.renameSession(chat.chatId, title);
 	}
 
 	setRead(session: ISessionData, read: boolean): void {

--- a/src/vs/sessions/contrib/sessions/common/sessionData.ts
+++ b/src/vs/sessions/contrib/sessions/common/sessionData.ts
@@ -165,4 +165,6 @@ export interface ISessionData {
 	readonly chats: IObservable<readonly IChatData[]>;
 	/** The currently active chat within this session group. */
 	readonly activeChat: IObservable<IChatData>;
+	/** The main chat within this session group (the first chat of the session). */
+	readonly mainChat: IChatData;
 }

--- a/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
+++ b/src/vs/sessions/contrib/sessions/test/browser/sessionsList.test.ts
@@ -46,6 +46,7 @@ function createSession(id: string, opts: {
 		pullRequest: observableValue(`pullRequest-${id}`, undefined),
 		chats: observableValue<readonly IChatData[]>(`chats-${id}`, []),
 		activeChat: observableValue<IChatData>(`activeChat-${id}`, undefined!),
+		mainChat: undefined!,
 	};
 }
 

--- a/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
+++ b/src/vs/sessions/contrib/terminal/test/browser/sessionsTerminalContribution.test.ts
@@ -75,7 +75,7 @@ function makeAgentSession(opts: {
 		description: observableValue('test.description', undefined),
 		pullRequest: observableValue('test.pullRequest', undefined),
 	};
-	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('test.chats', [chat]), activeChat: observableValue('test.activeChat', chat) };
+	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('test.chats', [chat]), activeChat: observableValue('test.activeChat', chat), mainChat: chat };
 	return session;
 }
 
@@ -108,7 +108,7 @@ function makeNonAgentSession(opts: { repository?: URI; worktree?: URI; providerT
 		description: observableValue('test.description', undefined),
 		pullRequest: observableValue('test.pullRequest', undefined),
 	};
-	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('test.chats', [chat]), activeChat: observableValue('test.activeChat', chat) };
+	const session: ISessionData = { ...chat, sessionId: chat.chatId, chats: observableValue('test.chats', [chat]), activeChat: observableValue('test.activeChat', chat), mainChat: chat };
 	return session;
 }
 


### PR DESCRIPTION
```Copilot Generated Description:``` Introduce functionality to rename and delete chats within a session. Implement context menu actions for renaming and deleting chats, ensuring that the main chat cannot be deleted. Update session management services to handle chat renaming and deletion appropriately.

