### PR TITLE
Implement migration for legacy color theme defaults

### DIFF
--- a/src/vs/platform/configuration/test/common/testConfigurationService.ts
+++ b/src/vs/platform/configuration/test/common/testConfigurationService.ts
@@ -6,7 +6,7 @@
 import { Emitter } from '../../../../base/common/event.js';
 import { TernarySearchTree } from '../../../../base/common/ternarySearchTree.js';
 import { URI } from '../../../../base/common/uri.js';
-import { getConfigurationValue, IConfigurationChangeEvent, IConfigurationOverrides, IConfigurationService, IConfigurationValue, isConfigurationOverrides } from '../../common/configuration.js';
+import { ConfigurationTarget, getConfigurationValue, IConfigurationChangeEvent, IConfigurationOverrides, IConfigurationService, IConfigurationUpdateOptions, IConfigurationUpdateOverrides, IConfigurationValue, isConfigurationOverrides } from '../../common/configuration.js';
 import { Extensions, IConfigurationRegistry } from '../../common/configurationRegistry.js';
 import { Registry } from '../../../registry/common/platform.js';
 
@@ -42,7 +42,7 @@ export class TestConfigurationService implements IConfigurationService {
 		return configuration as T;
 	}
 
-	public updateValue(key: string, value: unknown): Promise<void> {
+	public updateValue(key: string, value: unknown, arg1?: ConfigurationTarget | IConfigurationOverrides | IConfigurationUpdateOverrides, target?: ConfigurationTarget, options?: IConfigurationUpdateOptions): Promise<void> {
 		return Promise.resolve(undefined);
 	}
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -325,7 +325,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 
 		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
-		if (!colorThemeInspection.userValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue) {
+		if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
 			// Existing user on the old default — figure out which theme they had.
 			// The stored theme data tells us what was actually applied last session.
 			const storedTheme = ColorThemeData.fromStorageData(this.storageService);
@@ -338,7 +338,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			} else {
 				// No stored theme data but existing user — pin the old default
 				// based on the current color scheme so they keep their appearance.
-				const prefersDark = this.hostColorSchemeService.dark;
+				const prefersDark = this.hostColorService.dark;
 				const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
 				await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
 			}
@@ -354,7 +354,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			];
 			for (const { key, oldDefault } of preferredSettings) {
 				const inspection = this.configurationService.inspect<string>(key);
-				if (!inspection.userValue && !inspection.userRemoteValue && !inspection.workspaceValue) {
+				if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
 					await this.configurationService.updateValue(key, oldDefault, ConfigurationTarget.USER);
 				}
 			}

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -322,8 +322,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		// Wait for settings sync so we don't overwrite values arriving from another device.
 		await this.userDataInitializationService.whenInitializationFinished();
 
-		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
-
 		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
 		if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
 			// Existing user on the old default — figure out which theme they had.
@@ -338,7 +336,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			} else {
 				// No stored theme data but existing user — pin the old default
 				// based on the current color scheme so they keep their appearance.
-				// In high-contrast mode, avoid pinning a non–high-contrast theme and
+				// In high-contrast mode, avoid pinning a non-high-contrast theme and
 				// let the system's high-contrast behavior take precedence.
 				if (!this.hostColorService.highContrast) {
 					const prefersDark = this.hostColorService.dark;
@@ -363,6 +361,10 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				}
 			}
 		}
+
+		// Mark migration complete only after all updates succeed, so a partial
+		// failure (or crash) will retry on the next startup.
+		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	/**

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -314,15 +314,15 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	 * their appearance. Runs after settings sync completes to avoid conflicts.
 	 */
 	private async migrateColorThemeDefaults(): Promise<void> {
-		if (this.storageService.isNew(StorageScope.APPLICATION)
-			|| this.storageService.getBoolean(WorkbenchThemeService.THEME_MIGRATION_KEY, StorageScope.APPLICATION)) {
+		if (this.storageService.isNew(StorageScope.PROFILE)
+			|| this.storageService.getBoolean(WorkbenchThemeService.THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
 			return; // new install or already migrated
 		}
 
 		// Wait for settings sync so we don't overwrite values arriving from another device.
 		await this.userDataInitializationService.whenInitializationFinished();
 
-		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 
 		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
 		if (!colorThemeInspection.userValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue) {

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -100,6 +100,8 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	private readonly productIconThemeWatcher: ThemeFileWatcher;
 	private readonly productIconThemeSequencer: Sequencer;
 
+	private hasDefaultUpdated: boolean = false;
+
 	constructor(
 		@IExtensionService extensionService: IExtensionService,
 		@IStorageService private readonly storageService: IStorageService,
@@ -148,6 +150,10 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		let themeData: ColorThemeData | undefined = ColorThemeData.fromStorageData(this.storageService);
 		const colorThemeSetting = this.settings.colorTheme;
 		if (themeData && colorThemeSetting !== themeData.settingsId) {
+			if (this.settings.isDefaultColorTheme()) {
+				this.hasDefaultUpdated = themeData.settingsId === ThemeSettingDefaults.COLOR_THEME_DARK_OLD || themeData.settingsId === ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+			}
+			// the web has different defaults than the desktop, therefore do not restore when the setting is the default theme and the storage doesn't match that.
 			themeData = undefined;
 		}
 
@@ -247,7 +253,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 		this.migrateColorThemeSettings();
 		await this.migrateAutoDetectColorScheme();
-		await this.migrateColorThemeDefaults();
 		const result = await Promise.all([initializeColorTheme(), initializeFileIconTheme(), initializeProductIconTheme()]);
 		this.showNewDefaultThemeNotification();
 		return result;
@@ -256,9 +261,8 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	private static readonly NEW_THEME_NOTIFICATION_KEY = 'workbench.newDefaultThemeNotification';
 
 	private showNewDefaultThemeNotification(): void {
-		const newDefaultThemes = new Set([ThemeSettingDefaults.COLOR_THEME_DARK, ThemeSettingDefaults.COLOR_THEME_LIGHT]);
-		if (newDefaultThemes.has(this.currentColorTheme.settingsId)) {
-			return; // already using a new default theme
+		if (!this.hasDefaultUpdated) {
+			return;
 		}
 		if (this.storageService.getBoolean(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, StorageScope.APPLICATION)) {
 			return; // already shown
@@ -276,8 +280,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			this.storageService.store(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 		}));
 	}
-
-	private static readonly THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
 
 	/**
 	 * Migrates legacy theme setting values to their current equivalents,
@@ -306,65 +308,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				}
 			}
 		}
-	}
-
-	/**
-	 * Pins the previous default theme for existing users who never explicitly
-	 * chose a theme, so changing the schema default does not silently alter
-	 * their appearance. Runs after settings sync completes to avoid conflicts.
-	 */
-	private async migrateColorThemeDefaults(): Promise<void> {
-		if (this.storageService.isNew(StorageScope.PROFILE)
-			|| this.storageService.getBoolean(WorkbenchThemeService.THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
-			return; // new install or already migrated
-		}
-
-		// Wait for settings sync so we don't overwrite values arriving from another device.
-		await this.userDataInitializationService.whenInitializationFinished();
-
-		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
-		if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
-			// Existing user on the old default — figure out which theme they had.
-			// The stored theme data tells us what was actually applied last session.
-			const storedTheme = ColorThemeData.fromStorageData(this.storageService);
-			if (storedTheme) {
-				const previousId = migrateThemeSettingsId(storedTheme.settingsId);
-				if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
-					// Their previous theme differs from the new default — pin it.
-					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
-				}
-			} else {
-				// No stored theme data but existing user — pin the old default
-				// based on the current color scheme so they keep their appearance.
-				// In high-contrast mode, avoid pinning a non-high-contrast theme and
-				// let the system's high-contrast behavior take precedence.
-				if (!this.hostColorService.highContrast) {
-					const prefersDark = this.hostColorService.dark;
-					const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
-					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
-				}
-			}
-		}
-
-		// Pin preferred light/dark settings only when auto-detect is enabled,
-		// to avoid writing unnecessary settings for users who never used it.
-		const detectInspection = this.configurationService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
-		if (detectInspection.value === true) {
-			const preferredSettings = [
-				{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
-				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
-			];
-			for (const { key, oldDefault } of preferredSettings) {
-				const inspection = this.configurationService.inspect<string>(key);
-				if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
-					await this.configurationService.updateValue(key, oldDefault, ConfigurationTarget.USER);
-				}
-			}
-		}
-
-		// Mark migration complete only after all updates succeed, so a partial
-		// failure (or crash) will retry on the next startup.
-		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	/**

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -247,6 +247,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 		this.migrateColorThemeSettings();
 		await this.migrateAutoDetectColorScheme();
+		await this.migrateColorThemeDefaults();
 		const result = await Promise.all([initializeColorTheme(), initializeFileIconTheme(), initializeProductIconTheme()]);
 		this.showNewDefaultThemeNotification();
 		return result;
@@ -276,6 +277,8 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		}));
 	}
 
+	private static readonly THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
+
 	/**
 	 * Migrates legacy theme setting values to their current equivalents,
 	 * writing back the migrated value so settings sync distributes the correct ID.
@@ -300,6 +303,58 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 					if (migrated !== value) {
 						this.configurationService.updateValue(key, migrated, target);
 					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Pins the previous default theme for existing users who never explicitly
+	 * chose a theme, so changing the schema default does not silently alter
+	 * their appearance. Runs after settings sync completes to avoid conflicts.
+	 */
+	private async migrateColorThemeDefaults(): Promise<void> {
+		if (this.storageService.isNew(StorageScope.APPLICATION)
+			|| this.storageService.getBoolean(WorkbenchThemeService.THEME_MIGRATION_KEY, StorageScope.APPLICATION)) {
+			return; // new install or already migrated
+		}
+
+		// Wait for settings sync so we don't overwrite values arriving from another device.
+		await this.userDataInitializationService.whenInitializationFinished();
+
+		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
+
+		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
+		if (!colorThemeInspection.userValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue) {
+			// Existing user on the old default — figure out which theme they had.
+			// The stored theme data tells us what was actually applied last session.
+			const storedTheme = ColorThemeData.fromStorageData(this.storageService);
+			if (storedTheme) {
+				const previousId = migrateThemeSettingsId(storedTheme.settingsId);
+				if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
+					// Their previous theme differs from the new default — pin it.
+					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
+				}
+			} else {
+				// No stored theme data but existing user — pin the old default
+				// based on color scheme so they keep their current appearance.
+				const oldDefault = isWeb ? ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD : ThemeSettingDefaults.COLOR_THEME_DARK_OLD;
+				await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+			}
+		}
+
+		// Pin preferred light/dark settings only when auto-detect is enabled,
+		// to avoid writing unnecessary settings for users who never used it.
+		const detectInspection = this.configurationService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
+		if (detectInspection.userValue || detectInspection.userRemoteValue) {
+			const preferredSettings = [
+				{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
+				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
+			];
+			for (const { key, oldDefault } of preferredSettings) {
+				const inspection = this.configurationService.inspect<string>(key);
+				if (!inspection.userValue && !inspection.userRemoteValue && !inspection.workspaceValue) {
+					await this.configurationService.updateValue(key, oldDefault, ConfigurationTarget.USER);
 				}
 			}
 		}

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -346,7 +346,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		// Pin preferred light/dark settings only when auto-detect is enabled,
 		// to avoid writing unnecessary settings for users who never used it.
 		const detectInspection = this.configurationService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
-		if (detectInspection.userValue || detectInspection.userRemoteValue) {
+		if (detectInspection.value === true) {
 			const preferredSettings = [
 				{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
 				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -100,8 +100,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	private readonly productIconThemeWatcher: ThemeFileWatcher;
 	private readonly productIconThemeSequencer: Sequencer;
 
-	private hasDefaultUpdated: boolean = false;
-
 	constructor(
 		@IExtensionService extensionService: IExtensionService,
 		@IStorageService private readonly storageService: IStorageService,
@@ -150,10 +148,6 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		let themeData: ColorThemeData | undefined = ColorThemeData.fromStorageData(this.storageService);
 		const colorThemeSetting = this.settings.colorTheme;
 		if (themeData && colorThemeSetting !== themeData.settingsId) {
-			if (this.settings.isDefaultColorTheme()) {
-				this.hasDefaultUpdated = themeData.settingsId === ThemeSettingDefaults.COLOR_THEME_DARK_OLD || themeData.settingsId === ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
-			}
-			// the web has different defaults than the desktop, therefore do not restore when the setting is the default theme and the storage doesn't match that.
 			themeData = undefined;
 		}
 
@@ -253,6 +247,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 		this.migrateColorThemeSettings();
 		await this.migrateAutoDetectColorScheme();
+		await this.migrateColorThemeDefaults();
 		const result = await Promise.all([initializeColorTheme(), initializeFileIconTheme(), initializeProductIconTheme()]);
 		this.showNewDefaultThemeNotification();
 		return result;
@@ -261,8 +256,9 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	private static readonly NEW_THEME_NOTIFICATION_KEY = 'workbench.newDefaultThemeNotification';
 
 	private showNewDefaultThemeNotification(): void {
-		if (!this.hasDefaultUpdated) {
-			return;
+		const newDefaultThemes = new Set([ThemeSettingDefaults.COLOR_THEME_DARK, ThemeSettingDefaults.COLOR_THEME_LIGHT]);
+		if (newDefaultThemes.has(this.currentColorTheme.settingsId)) {
+			return; // already using a new default theme
 		}
 		if (this.storageService.getBoolean(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, StorageScope.APPLICATION)) {
 			return; // already shown
@@ -280,6 +276,8 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			this.storageService.store(WorkbenchThemeService.NEW_THEME_NOTIFICATION_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 		}));
 	}
+
+	private static readonly THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
 
 	/**
 	 * Migrates legacy theme setting values to their current equivalents,
@@ -308,6 +306,65 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				}
 			}
 		}
+	}
+
+	/**
+	 * Pins the previous default theme for existing users who never explicitly
+	 * chose a theme, so changing the schema default does not silently alter
+	 * their appearance. Runs after settings sync completes to avoid conflicts.
+	 */
+	private async migrateColorThemeDefaults(): Promise<void> {
+		if (this.storageService.isNew(StorageScope.PROFILE)
+			|| this.storageService.getBoolean(WorkbenchThemeService.THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
+			return; // new install or already migrated
+		}
+
+		// Wait for settings sync so we don't overwrite values arriving from another device.
+		await this.userDataInitializationService.whenInitializationFinished();
+
+		const colorThemeInspection = this.configurationService.inspect<string>(ThemeSettings.COLOR_THEME);
+		if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
+			// Existing user on the old default — figure out which theme they had.
+			// The stored theme data tells us what was actually applied last session.
+			const storedTheme = ColorThemeData.fromStorageData(this.storageService);
+			if (storedTheme) {
+				const previousId = migrateThemeSettingsId(storedTheme.settingsId);
+				if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
+					// Their previous theme differs from the new default — pin it.
+					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
+				}
+			} else {
+				// No stored theme data but existing user — pin the old default
+				// based on the current color scheme so they keep their appearance.
+				// In high-contrast mode, avoid pinning a non-high-contrast theme and
+				// let the system's high-contrast behavior take precedence.
+				if (!this.hostColorService.highContrast) {
+					const prefersDark = this.hostColorService.dark;
+					const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+				}
+			}
+		}
+
+		// Pin preferred light/dark settings only when auto-detect is enabled,
+		// to avoid writing unnecessary settings for users who never used it.
+		const detectInspection = this.configurationService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
+		if (detectInspection.value === true) {
+			const preferredSettings = [
+				{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
+				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
+			];
+			for (const { key, oldDefault } of preferredSettings) {
+				const inspection = this.configurationService.inspect<string>(key);
+				if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
+					await this.configurationService.updateValue(key, oldDefault, ConfigurationTarget.USER);
+				}
+			}
+		}
+
+		// Mark migration complete only after all updates succeed, so a partial
+		// failure (or crash) will retry on the next startup.
+		this.storageService.store(WorkbenchThemeService.THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
 	}
 
 	/**

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -338,9 +338,13 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			} else {
 				// No stored theme data but existing user — pin the old default
 				// based on the current color scheme so they keep their appearance.
-				const prefersDark = this.hostColorService.dark;
-				const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
-				await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+				// In high-contrast mode, avoid pinning a non–high-contrast theme and
+				// let the system's high-contrast behavior take precedence.
+				if (!this.hostColorService.highContrast) {
+					const prefersDark = this.hostColorService.dark;
+					const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+					await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+				}
 			}
 		}
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -337,8 +337,9 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				}
 			} else {
 				// No stored theme data but existing user — pin the old default
-				// based on color scheme so they keep their current appearance.
-				const oldDefault = isWeb ? ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD : ThemeSettingDefaults.COLOR_THEME_DARK_OLD;
+				// based on the current color scheme so they keep their appearance.
+				const prefersDark = this.hostColorSchemeService.dark;
+				const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
 				await this.configurationService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
 			}
 		}

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -44,6 +44,11 @@ export namespace ThemeSettingDefaults {
 	export const COLOR_THEME_HC_DARK = 'Default High Contrast';
 	export const COLOR_THEME_HC_LIGHT = 'Default High Contrast Light';
 
+	/** Previous dark default before the VS Code 2026 theme update. */
+	export const COLOR_THEME_DARK_OLD = 'Dark Modern';
+	/** Previous light default before the VS Code 2026 theme update. */
+	export const COLOR_THEME_LIGHT_OLD = 'Light Modern';
+
 	export const FILE_ICON_THEME = 'vs-seti';
 	export const PRODUCT_ICON_THEME = 'Default';
 }

--- a/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
+++ b/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
@@ -4,17 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { migrateThemeSettingsId, ThemeSettingDefaults, ThemeSettings } from '../../common/workbenchThemeService.js';
+import { migrateThemeSettingsId, ThemeSettingDefaults } from '../../common/workbenchThemeService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ThemeConfiguration } from '../../common/themeConfiguration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IHostColorSchemeService } from '../../common/hostColorSchemeService.js';
 import { ColorScheme } from '../../../../../platform/theme/common/theme.js';
 import { Event } from '../../../../../base/common/event.js';
-import { ConfigurationTarget, IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
-import { InMemoryStorageService, IS_NEW_KEY, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
-import { ColorThemeData } from '../../common/colorThemeData.js';
-import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
 
 suite('WorkbenchThemeService', () => {
 
@@ -164,228 +161,63 @@ suite('WorkbenchThemeService', () => {
 		});
 	});
 
-	suite('migrateColorThemeDefaults', () => {
-
-		const disposables = new DisposableStore();
-
-		teardown(() => disposables.clear());
+	suite('hasDefaultUpdated detection', () => {
 
 		/**
-		 * Creates a migration context that mirrors the services used by
-		 * WorkbenchThemeService.migrateColorThemeDefaults, with mocks
-		 * tracking all updateValue calls for assertions.
+		 * Simulates the inline detection logic from the WorkbenchThemeService constructor.
+		 * When the stored theme doesn't match the current color theme setting and the
+		 * setting is at its default, checks whether the stored theme was one of the old defaults.
+		 *
+		 * When auto-detect is enabled, {@link ThemeConfiguration.colorTheme} routes through
+		 * the preferred theme setting for the active color scheme, so the same condition
+		 * handles both direct and auto-detect scenarios transparently.
 		 */
-		function createMigrationContext(options: {
-			isNewProfile?: boolean;
-			alreadyMigrated?: boolean;
-			dark?: boolean;
-			highContrast?: boolean;
-			existingUserConfig?: Record<string, unknown>;
-			storedThemeSettingsId?: string;
-		}) {
-			const storageService = disposables.add(new InMemoryStorageService());
-
-			if (options.isNewProfile) {
-				storageService.store(IS_NEW_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+		function detectDefaultUpdated(storedThemeSettingsId: string | undefined, colorThemeSetting: string, isDefaultColorTheme: boolean): boolean {
+			if (storedThemeSettingsId && colorThemeSetting !== storedThemeSettingsId && isDefaultColorTheme) {
+				return storedThemeSettingsId === ThemeSettingDefaults.COLOR_THEME_DARK_OLD || storedThemeSettingsId === ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
 			}
-			if (options.alreadyMigrated) {
-				storageService.store('workbench.colorThemeDefaultMigrated', true, StorageScope.PROFILE, StorageTarget.USER);
-			}
-			if (options.storedThemeSettingsId) {
-				// Minimal stored theme data that ColorThemeData.fromStorageData will parse
-				storageService.store(ColorThemeData.STORAGE_KEY, JSON.stringify({
-					id: `vs-dark test-theme`,
-					settingsId: options.storedThemeSettingsId,
-					themeTokenColors: [],
-				}), StorageScope.PROFILE, StorageTarget.USER);
-			}
-
-			const userConfig = options.existingUserConfig ?? {};
-			const configService = new TestConfigurationService(userConfig);
-			const updates: { key: string; value: unknown; target: ConfigurationTarget }[] = [];
-			configService.updateValue = (key: string, value: unknown, target?: ConfigurationTarget) => {
-				updates.push({ key, value, target: target ?? ConfigurationTarget.USER });
-				return Promise.resolve();
-			};
-
-			// When the user has no explicit config value for a key, inspect should return
-			// userValue=undefined (not the value itself) to match production behavior.
-			const originalInspect = configService.inspect.bind(configService);
-			configService.inspect = <T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> => {
-				if (Object.prototype.hasOwnProperty.call(userConfig, key)) {
-					return originalInspect(key, overrides);
-				}
-				return {
-					value: undefined as T,
-					defaultValue: undefined,
-					userValue: undefined,
-					userLocalValue: undefined,
-					userRemoteValue: undefined,
-					workspaceValue: undefined,
-					workspaceFolderValue: undefined,
-				};
-			};
-
-			const hostColorService: IHostColorSchemeService = {
-				_serviceBrand: undefined,
-				dark: options.dark ?? false,
-				highContrast: options.highContrast ?? false,
-				onDidChangeColorScheme: Event.None,
-			};
-
-			const userDataInitializationService = {
-				whenInitializationFinished: () => Promise.resolve(),
-			};
-
-			return { storageService, configService, hostColorService, userDataInitializationService, updates };
+			return false;
 		}
 
-		/**
-		 * Runs the migration logic extracted from WorkbenchThemeService.migrateColorThemeDefaults.
-		 */
-		async function runMigration(ctx: ReturnType<typeof createMigrationContext>): Promise<void> {
-			const { storageService, configService, hostColorService, userDataInitializationService } = ctx;
-			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
-
-			if (storageService.isNew(StorageScope.PROFILE)
-				|| storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
-				return;
-			}
-
-			await userDataInitializationService.whenInitializationFinished();
-
-			const colorThemeInspection = configService.inspect<string>(ThemeSettings.COLOR_THEME);
-			if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
-				const storedTheme = ColorThemeData.fromStorageData(storageService);
-				if (storedTheme) {
-					const previousId = migrateThemeSettingsId(storedTheme.settingsId);
-					if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
-						await configService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
-					}
-				} else {
-					if (!hostColorService.highContrast) {
-						const prefersDark = hostColorService.dark;
-						const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
-						await configService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
-					}
-				}
-			}
-
-			const detectInspection = configService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
-			if (detectInspection.value === true) {
-				const preferredSettings = [
-					{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
-					{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
-				];
-				for (const { key, oldDefault } of preferredSettings) {
-					const inspection = configService.inspect<string>(key);
-					if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
-						await configService.updateValue(key, oldDefault, ConfigurationTarget.USER);
-					}
-				}
-			}
-
-			storageService.store(THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
-		}
-
-		test('existing dark user with no explicit theme and no stored data pins Dark Modern', async () => {
-			const ctx = createMigrationContext({ dark: true });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, [
-				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
-			]);
+		test('detects Dark Modern stored theme as updated default', () => {
+			assert.strictEqual(detectDefaultUpdated('Dark Modern', ThemeSettingDefaults.COLOR_THEME_DARK, true), true);
 		});
 
-		test('existing light user with no explicit theme and no stored data pins Light Modern', async () => {
-			const ctx = createMigrationContext({ dark: false });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, [
-				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
-			]);
+		test('detects Light Modern stored theme as updated default', () => {
+			assert.strictEqual(detectDefaultUpdated('Light Modern', ThemeSettingDefaults.COLOR_THEME_LIGHT, true), true);
 		});
 
-		test('existing user with stored Dark Modern theme pins Dark Modern', async () => {
-			const ctx = createMigrationContext({ storedThemeSettingsId: 'Dark Modern' });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, [
-				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
-			]);
+		test('does not detect when stored theme matches current setting', () => {
+			assert.strictEqual(detectDefaultUpdated(ThemeSettingDefaults.COLOR_THEME_DARK, ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
 		});
 
-		test('existing user with stored theme matching new default does not pin', async () => {
-			const ctx = createMigrationContext({ storedThemeSettingsId: ThemeSettingDefaults.COLOR_THEME_DARK });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, []);
+		test('does not detect when color theme is not at default', () => {
+			assert.strictEqual(detectDefaultUpdated('Dark Modern', 'Monokai', false), false);
 		});
 
-		test('existing user with stored Default Dark Modern theme migrates and pins Dark Modern', async () => {
-			const ctx = createMigrationContext({ storedThemeSettingsId: 'Default Dark Modern' });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, [
-				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
-			]);
+		test('does not detect for non-old-default stored themes', () => {
+			assert.strictEqual(detectDefaultUpdated('Some Custom Theme', ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
 		});
 
-		test('existing user with explicit theme setting does not pin', async () => {
-			const ctx = createMigrationContext({
-				existingUserConfig: { [ThemeSettings.COLOR_THEME]: 'Monokai' },
-			});
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, []);
+		test('does not detect when no stored theme exists', () => {
+			assert.strictEqual(detectDefaultUpdated(undefined, ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
 		});
 
-		test('high contrast user does not get non-HC theme pinned', async () => {
-			const ctx = createMigrationContext({ highContrast: true, dark: true });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, []);
+		test('detects with auto-detect on dark OS (preferred dark at default)', () => {
+			// When auto-detect is on and OS is dark, colorThemeSetting comes from
+			// preferredDarkColorTheme which defaults to COLOR_THEME_DARK
+			assert.strictEqual(detectDefaultUpdated('Dark Modern', ThemeSettingDefaults.COLOR_THEME_DARK, true), true);
 		});
 
-		test('new profile does not run migration', async () => {
-			const ctx = createMigrationContext({ isNewProfile: true });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, []);
+		test('detects with auto-detect on light OS (preferred light at default)', () => {
+			// When auto-detect is on and OS is light, colorThemeSetting comes from
+			// preferredLightColorTheme which defaults to COLOR_THEME_LIGHT
+			assert.strictEqual(detectDefaultUpdated('Light Modern', ThemeSettingDefaults.COLOR_THEME_LIGHT, true), true);
 		});
 
-		test('already migrated does not run again', async () => {
-			const ctx = createMigrationContext({ alreadyMigrated: true });
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, []);
-		});
-
-		test('auto-detect enabled pins preferred dark and light themes', async () => {
-			const ctx = createMigrationContext({
-				dark: true,
-				existingUserConfig: { [ThemeSettings.DETECT_COLOR_SCHEME]: true },
-			});
-			await runMigration(ctx);
-
-			assert.deepStrictEqual(ctx.updates, [
-				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
-				{ key: ThemeSettings.PREFERRED_DARK_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
-				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
-			]);
-		});
-
-		test('migration flag is stored only after all updates succeed', async () => {
-			const ctx = createMigrationContext({ dark: true });
-			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
-
-			// Before migration, flag is not set
-			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), undefined);
-
-			await runMigration(ctx);
-
-			// After migration, flag is set
-			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), true);
+		test('does not detect with auto-detect when user explicitly set preferred theme', () => {
+			// User explicitly set preferredDarkColorTheme, so isDefaultColorTheme is false
+			assert.strictEqual(detectDefaultUpdated('Dark Modern', 'Monokai', false), false);
 		});
 	});
 });

--- a/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
+++ b/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
@@ -4,14 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { migrateThemeSettingsId } from '../../common/workbenchThemeService.js';
+import { migrateThemeSettingsId, ThemeSettingDefaults, ThemeSettings } from '../../common/workbenchThemeService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ThemeConfiguration } from '../../common/themeConfiguration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IHostColorSchemeService } from '../../common/hostColorSchemeService.js';
 import { ColorScheme } from '../../../../../platform/theme/common/theme.js';
 import { Event } from '../../../../../base/common/event.js';
-import { IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { InMemoryStorageService, IS_NEW_KEY, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ColorThemeData } from '../../common/colorThemeData.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
 suite('WorkbenchThemeService', () => {
 
@@ -158,6 +161,231 @@ suite('WorkbenchThemeService', () => {
 
 			assert.deepStrictEqual(config.getPreferredColorScheme(), ColorScheme.HIGH_CONTRAST_LIGHT);
 			assert.deepStrictEqual(config.isDetectingColorScheme(), true);
+		});
+	});
+
+	suite('migrateColorThemeDefaults', () => {
+
+		const disposables = new DisposableStore();
+
+		teardown(() => disposables.clear());
+
+		/**
+		 * Creates a migration context that mirrors the services used by
+		 * WorkbenchThemeService.migrateColorThemeDefaults, with mocks
+		 * tracking all updateValue calls for assertions.
+		 */
+		function createMigrationContext(options: {
+			isNewProfile?: boolean;
+			alreadyMigrated?: boolean;
+			dark?: boolean;
+			highContrast?: boolean;
+			existingUserConfig?: Record<string, unknown>;
+			storedThemeSettingsId?: string;
+		}) {
+			const storageService = disposables.add(new InMemoryStorageService());
+
+			if (options.isNewProfile) {
+				storageService.store(IS_NEW_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+			}
+			if (options.alreadyMigrated) {
+				storageService.store('workbench.colorThemeDefaultMigrated', true, StorageScope.PROFILE, StorageTarget.USER);
+			}
+			if (options.storedThemeSettingsId) {
+				// Minimal stored theme data that ColorThemeData.fromStorageData will parse
+				storageService.store(ColorThemeData.STORAGE_KEY, JSON.stringify({
+					id: `vs-dark test-theme`,
+					settingsId: options.storedThemeSettingsId,
+					themeTokenColors: [],
+				}), StorageScope.PROFILE, StorageTarget.USER);
+			}
+
+			const userConfig = options.existingUserConfig ?? {};
+			const configService = new TestConfigurationService(userConfig);
+			const updates: { key: string; value: unknown; target: ConfigurationTarget }[] = [];
+			configService.updateValue = (key: string, value: unknown, target?: ConfigurationTarget) => {
+				updates.push({ key, value, target: target ?? ConfigurationTarget.USER });
+				return Promise.resolve();
+			};
+
+			// When the user has no explicit config value for a key, inspect should return
+			// userValue=undefined (not the value itself) to match production behavior.
+			const originalInspect = configService.inspect.bind(configService);
+			configService.inspect = <T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> => {
+				if (Object.prototype.hasOwnProperty.call(userConfig, key)) {
+					return originalInspect(key, overrides);
+				}
+				return {
+					value: undefined as T,
+					defaultValue: undefined,
+					userValue: undefined,
+					userLocalValue: undefined,
+					userRemoteValue: undefined,
+					workspaceValue: undefined,
+					workspaceFolderValue: undefined,
+				};
+			};
+
+			const hostColorService: IHostColorSchemeService = {
+				_serviceBrand: undefined,
+				dark: options.dark ?? false,
+				highContrast: options.highContrast ?? false,
+				onDidChangeColorScheme: Event.None,
+			};
+
+			const userDataInitializationService = {
+				whenInitializationFinished: () => Promise.resolve(),
+			};
+
+			return { storageService, configService, hostColorService, userDataInitializationService, updates };
+		}
+
+		/**
+		 * Runs the migration logic extracted from WorkbenchThemeService.migrateColorThemeDefaults.
+		 */
+		async function runMigration(ctx: ReturnType<typeof createMigrationContext>): Promise<void> {
+			const { storageService, configService, hostColorService, userDataInitializationService } = ctx;
+			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
+
+			if (storageService.isNew(StorageScope.PROFILE)
+				|| storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
+				return;
+			}
+
+			await userDataInitializationService.whenInitializationFinished();
+
+			const colorThemeInspection = configService.inspect<string>(ThemeSettings.COLOR_THEME);
+			if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
+				const storedTheme = ColorThemeData.fromStorageData(storageService);
+				if (storedTheme) {
+					const previousId = migrateThemeSettingsId(storedTheme.settingsId);
+					if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
+						await configService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
+					}
+				} else {
+					if (!hostColorService.highContrast) {
+						const prefersDark = hostColorService.dark;
+						const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+						await configService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+					}
+				}
+			}
+
+			const detectInspection = configService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
+			if (detectInspection.value === true) {
+				const preferredSettings = [
+					{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
+					{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
+				];
+				for (const { key, oldDefault } of preferredSettings) {
+					const inspection = configService.inspect<string>(key);
+					if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
+						await configService.updateValue(key, oldDefault, ConfigurationTarget.USER);
+					}
+				}
+			}
+
+			storageService.store(THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+		}
+
+		test('existing dark user with no explicit theme and no stored data pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ dark: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('existing light user with no explicit theme and no stored data pins Light Modern', async () => {
+			const ctx = createMigrationContext({ dark: false });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('existing user with stored Dark Modern theme pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: 'Dark Modern' });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('existing user with stored theme matching new default does not pin', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: ThemeSettingDefaults.COLOR_THEME_DARK });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('existing user with stored Default Dark Modern theme migrates and pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: 'Default Dark Modern' });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('existing user with explicit theme setting does not pin', async () => {
+			const ctx = createMigrationContext({
+				existingUserConfig: { [ThemeSettings.COLOR_THEME]: 'Monokai' },
+			});
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('high contrast user does not get non-HC theme pinned', async () => {
+			const ctx = createMigrationContext({ highContrast: true, dark: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('new profile does not run migration', async () => {
+			const ctx = createMigrationContext({ isNewProfile: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('already migrated does not run again', async () => {
+			const ctx = createMigrationContext({ alreadyMigrated: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('auto-detect enabled pins preferred dark and light themes', async () => {
+			const ctx = createMigrationContext({
+				dark: true,
+				existingUserConfig: { [ThemeSettings.DETECT_COLOR_SCHEME]: true },
+			});
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+				{ key: ThemeSettings.PREFERRED_DARK_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('migration flag is stored only after all updates succeed', async () => {
+			const ctx = createMigrationContext({ dark: true });
+			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
+
+			// Before migration, flag is not set
+			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), undefined);
+
+			await runMigration(ctx);
+
+			// After migration, flag is set
+			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), true);
 		});
 	});
 });

--- a/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
+++ b/src/vs/workbench/services/themes/test/common/workbenchThemeService.test.ts
@@ -4,14 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { migrateThemeSettingsId, ThemeSettingDefaults } from '../../common/workbenchThemeService.js';
+import { migrateThemeSettingsId, ThemeSettingDefaults, ThemeSettings } from '../../common/workbenchThemeService.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { ThemeConfiguration } from '../../common/themeConfiguration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IHostColorSchemeService } from '../../common/hostColorSchemeService.js';
 import { ColorScheme } from '../../../../../platform/theme/common/theme.js';
 import { Event } from '../../../../../base/common/event.js';
-import { IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationOverrides, IConfigurationValue } from '../../../../../platform/configuration/common/configuration.js';
+import { InMemoryStorageService, IS_NEW_KEY, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ColorThemeData } from '../../common/colorThemeData.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
 suite('WorkbenchThemeService', () => {
 
@@ -161,63 +164,228 @@ suite('WorkbenchThemeService', () => {
 		});
 	});
 
-	suite('hasDefaultUpdated detection', () => {
+	suite('migrateColorThemeDefaults', () => {
+
+		const disposables = new DisposableStore();
+
+		teardown(() => disposables.clear());
 
 		/**
-		 * Simulates the inline detection logic from the WorkbenchThemeService constructor.
-		 * When the stored theme doesn't match the current color theme setting and the
-		 * setting is at its default, checks whether the stored theme was one of the old defaults.
-		 *
-		 * When auto-detect is enabled, {@link ThemeConfiguration.colorTheme} routes through
-		 * the preferred theme setting for the active color scheme, so the same condition
-		 * handles both direct and auto-detect scenarios transparently.
+		 * Creates a migration context that mirrors the services used by
+		 * WorkbenchThemeService.migrateColorThemeDefaults, with mocks
+		 * tracking all updateValue calls for assertions.
 		 */
-		function detectDefaultUpdated(storedThemeSettingsId: string | undefined, colorThemeSetting: string, isDefaultColorTheme: boolean): boolean {
-			if (storedThemeSettingsId && colorThemeSetting !== storedThemeSettingsId && isDefaultColorTheme) {
-				return storedThemeSettingsId === ThemeSettingDefaults.COLOR_THEME_DARK_OLD || storedThemeSettingsId === ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+		function createMigrationContext(options: {
+			isNewProfile?: boolean;
+			alreadyMigrated?: boolean;
+			dark?: boolean;
+			highContrast?: boolean;
+			existingUserConfig?: Record<string, unknown>;
+			storedThemeSettingsId?: string;
+		}) {
+			const storageService = disposables.add(new InMemoryStorageService());
+
+			if (options.isNewProfile) {
+				storageService.store(IS_NEW_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
 			}
-			return false;
+			if (options.alreadyMigrated) {
+				storageService.store('workbench.colorThemeDefaultMigrated', true, StorageScope.PROFILE, StorageTarget.USER);
+			}
+			if (options.storedThemeSettingsId) {
+				// Minimal stored theme data that ColorThemeData.fromStorageData will parse
+				storageService.store(ColorThemeData.STORAGE_KEY, JSON.stringify({
+					id: `vs-dark test-theme`,
+					settingsId: options.storedThemeSettingsId,
+					themeTokenColors: [],
+				}), StorageScope.PROFILE, StorageTarget.USER);
+			}
+
+			const userConfig = options.existingUserConfig ?? {};
+			const configService = new TestConfigurationService(userConfig);
+			const updates: { key: string; value: unknown; target: ConfigurationTarget }[] = [];
+			configService.updateValue = (key: string, value: unknown, target?: ConfigurationTarget) => {
+				updates.push({ key, value, target: target ?? ConfigurationTarget.USER });
+				return Promise.resolve();
+			};
+
+			// When the user has no explicit config value for a key, inspect should return
+			// userValue=undefined (not the value itself) to match production behavior.
+			const originalInspect = configService.inspect.bind(configService);
+			configService.inspect = <T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> => {
+				if (Object.prototype.hasOwnProperty.call(userConfig, key)) {
+					return originalInspect(key, overrides);
+				}
+				return {
+					value: undefined as T,
+					defaultValue: undefined,
+					userValue: undefined,
+					userLocalValue: undefined,
+					userRemoteValue: undefined,
+					workspaceValue: undefined,
+					workspaceFolderValue: undefined,
+				};
+			};
+
+			const hostColorService: IHostColorSchemeService = {
+				_serviceBrand: undefined,
+				dark: options.dark ?? false,
+				highContrast: options.highContrast ?? false,
+				onDidChangeColorScheme: Event.None,
+			};
+
+			const userDataInitializationService = {
+				whenInitializationFinished: () => Promise.resolve(),
+			};
+
+			return { storageService, configService, hostColorService, userDataInitializationService, updates };
 		}
 
-		test('detects Dark Modern stored theme as updated default', () => {
-			assert.strictEqual(detectDefaultUpdated('Dark Modern', ThemeSettingDefaults.COLOR_THEME_DARK, true), true);
+		/**
+		 * Runs the migration logic extracted from WorkbenchThemeService.migrateColorThemeDefaults.
+		 */
+		async function runMigration(ctx: ReturnType<typeof createMigrationContext>): Promise<void> {
+			const { storageService, configService, hostColorService, userDataInitializationService } = ctx;
+			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
+
+			if (storageService.isNew(StorageScope.PROFILE)
+				|| storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE)) {
+				return;
+			}
+
+			await userDataInitializationService.whenInitializationFinished();
+
+			const colorThemeInspection = configService.inspect<string>(ThemeSettings.COLOR_THEME);
+			if (!colorThemeInspection.userValue && !colorThemeInspection.userLocalValue && !colorThemeInspection.userRemoteValue && !colorThemeInspection.workspaceValue && !colorThemeInspection.workspaceFolderValue) {
+				const storedTheme = ColorThemeData.fromStorageData(storageService);
+				if (storedTheme) {
+					const previousId = migrateThemeSettingsId(storedTheme.settingsId);
+					if (previousId !== ThemeSettingDefaults.COLOR_THEME_DARK && previousId !== ThemeSettingDefaults.COLOR_THEME_LIGHT) {
+						await configService.updateValue(ThemeSettings.COLOR_THEME, previousId, ConfigurationTarget.USER);
+					}
+				} else {
+					if (!hostColorService.highContrast) {
+						const prefersDark = hostColorService.dark;
+						const oldDefault = prefersDark ? ThemeSettingDefaults.COLOR_THEME_DARK_OLD : ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD;
+						await configService.updateValue(ThemeSettings.COLOR_THEME, oldDefault, ConfigurationTarget.USER);
+					}
+				}
+			}
+
+			const detectInspection = configService.inspect<boolean>(ThemeSettings.DETECT_COLOR_SCHEME);
+			if (detectInspection.value === true) {
+				const preferredSettings = [
+					{ key: ThemeSettings.PREFERRED_DARK_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_DARK_OLD },
+					{ key: ThemeSettings.PREFERRED_LIGHT_THEME, oldDefault: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD },
+				];
+				for (const { key, oldDefault } of preferredSettings) {
+					const inspection = configService.inspect<string>(key);
+					if (!inspection.userValue && !inspection.userLocalValue && !inspection.userRemoteValue && !inspection.workspaceValue && !inspection.workspaceFolderValue) {
+						await configService.updateValue(key, oldDefault, ConfigurationTarget.USER);
+					}
+				}
+			}
+
+			storageService.store(THEME_MIGRATION_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+		}
+
+		test('existing dark user with no explicit theme and no stored data pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ dark: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+			]);
 		});
 
-		test('detects Light Modern stored theme as updated default', () => {
-			assert.strictEqual(detectDefaultUpdated('Light Modern', ThemeSettingDefaults.COLOR_THEME_LIGHT, true), true);
+		test('existing light user with no explicit theme and no stored data pins Light Modern', async () => {
+			const ctx = createMigrationContext({ dark: false });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
+			]);
 		});
 
-		test('does not detect when stored theme matches current setting', () => {
-			assert.strictEqual(detectDefaultUpdated(ThemeSettingDefaults.COLOR_THEME_DARK, ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
+		test('existing user with stored Dark Modern theme pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: 'Dark Modern' });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
+			]);
 		});
 
-		test('does not detect when color theme is not at default', () => {
-			assert.strictEqual(detectDefaultUpdated('Dark Modern', 'Monokai', false), false);
+		test('existing user with stored theme matching new default does not pin', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: ThemeSettingDefaults.COLOR_THEME_DARK });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
 		});
 
-		test('does not detect for non-old-default stored themes', () => {
-			assert.strictEqual(detectDefaultUpdated('Some Custom Theme', ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
+		test('existing user with stored Default Dark Modern theme migrates and pins Dark Modern', async () => {
+			const ctx = createMigrationContext({ storedThemeSettingsId: 'Default Dark Modern' });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: 'Dark Modern', target: ConfigurationTarget.USER },
+			]);
 		});
 
-		test('does not detect when no stored theme exists', () => {
-			assert.strictEqual(detectDefaultUpdated(undefined, ThemeSettingDefaults.COLOR_THEME_DARK, true), false);
+		test('existing user with explicit theme setting does not pin', async () => {
+			const ctx = createMigrationContext({
+				existingUserConfig: { [ThemeSettings.COLOR_THEME]: 'Monokai' },
+			});
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
 		});
 
-		test('detects with auto-detect on dark OS (preferred dark at default)', () => {
-			// When auto-detect is on and OS is dark, colorThemeSetting comes from
-			// preferredDarkColorTheme which defaults to COLOR_THEME_DARK
-			assert.strictEqual(detectDefaultUpdated('Dark Modern', ThemeSettingDefaults.COLOR_THEME_DARK, true), true);
+		test('high contrast user does not get non-HC theme pinned', async () => {
+			const ctx = createMigrationContext({ highContrast: true, dark: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
 		});
 
-		test('detects with auto-detect on light OS (preferred light at default)', () => {
-			// When auto-detect is on and OS is light, colorThemeSetting comes from
-			// preferredLightColorTheme which defaults to COLOR_THEME_LIGHT
-			assert.strictEqual(detectDefaultUpdated('Light Modern', ThemeSettingDefaults.COLOR_THEME_LIGHT, true), true);
+		test('new profile does not run migration', async () => {
+			const ctx = createMigrationContext({ isNewProfile: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
 		});
 
-		test('does not detect with auto-detect when user explicitly set preferred theme', () => {
-			// User explicitly set preferredDarkColorTheme, so isDefaultColorTheme is false
-			assert.strictEqual(detectDefaultUpdated('Dark Modern', 'Monokai', false), false);
+		test('already migrated does not run again', async () => {
+			const ctx = createMigrationContext({ alreadyMigrated: true });
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, []);
+		});
+
+		test('auto-detect enabled pins preferred dark and light themes', async () => {
+			const ctx = createMigrationContext({
+				dark: true,
+				existingUserConfig: { [ThemeSettings.DETECT_COLOR_SCHEME]: true },
+			});
+			await runMigration(ctx);
+
+			assert.deepStrictEqual(ctx.updates, [
+				{ key: ThemeSettings.COLOR_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+				{ key: ThemeSettings.PREFERRED_DARK_THEME, value: ThemeSettingDefaults.COLOR_THEME_DARK_OLD, target: ConfigurationTarget.USER },
+				{ key: ThemeSettings.PREFERRED_LIGHT_THEME, value: ThemeSettingDefaults.COLOR_THEME_LIGHT_OLD, target: ConfigurationTarget.USER },
+			]);
+		});
+
+		test('migration flag is stored only after all updates succeed', async () => {
+			const ctx = createMigrationContext({ dark: true });
+			const THEME_MIGRATION_KEY = 'workbench.colorThemeDefaultMigrated';
+
+			// Before migration, flag is not set
+			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), undefined);
+
+			await runMigration(ctx);
+
+			// After migration, flag is set
+			assert.strictEqual(ctx.storageService.getBoolean(THEME_MIGRATION_KEY, StorageScope.PROFILE), true);
 		});
 	});
 });


### PR DESCRIPTION
Migrate legacy color theme settings to ensure users retain their previous theme preferences after updates. This change prevents silent alterations to user appearances by pinning the last applied theme for existing users who haven't explicitly chosen a new theme. Additionally, it sets appropriate defaults for light and dark themes based on user settings.

