### PR TITLE
sessions: fix sticky section padding in sessions list

### DIFF
--- a/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
+++ b/src/vs/sessions/contrib/sessions/browser/media/sessionsList.css
@@ -12,6 +12,10 @@
 		padding: 0 6px;
 	}
 
+	.pane-body & .monaco-tree-sticky-container {
+		padding: 0 6px;
+	}
+
 	.monaco-list-row {
 		border-radius: 6px;
 	}


### PR DESCRIPTION
The sticky scroll container in the sessions list was missing horizontal padding, causing section headers to render with different alignment when pinned as sticky vs when scrolled normally.

The scrollable element has `padding: 0 6px` applied, but the sticky container (`.monaco-tree-sticky-container`) is absolutely positioned and therefore ignores the parent's padding. This adds matching `padding: 0 6px` to the sticky container so sticky section headers align consistently with their non-sticky counterparts.