### PR TITLE
Fix inline suggestion toolbar not hiding on last line

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant.ts
@@ -66,7 +66,8 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 		}
 		if (target.type === MouseTargetType.CONTENT_EMPTY) {
 			// handle the case where the mouse is over the empty portion of a line following ghost text
-			if (controller.shouldShowHoverAt(target.range)) {
+			// but not when the mouse is below the last line (isAfterLines)
+			if (!target.detail.isAfterLines && controller.shouldShowHoverAt(target.range)) {
 				return new HoverForeignElementAnchor(1000, this, target.range, mouseEvent.event.posx, mouseEvent.event.posy, false);
 			}
 		}


### PR DESCRIPTION
## Description

When the inline suggestion toolbar is displayed on the last line and the mouse moves below it, the toolbar does not disappear. This happens because the editor reports mouse targets below the last line as `CONTENT_EMPTY` with the range still pointing to the last line — so `shouldShowHoverAt` keeps matching.

Added an `isAfterLines` guard in `suggestHoverAnchor` so the hover anchor is not created when the mouse is below all content. This is consistent with how folding, breakpoints, and content hover already handle this case.

Closes #286701

## Test plan

### Before
- Open a file, type some code on the last line
- Wait for an inline suggestion to appear
- Hover over the suggestion to show the toolbar
- Move the mouse below the last line
- Toolbar stays visible (bug)

### After
- Same steps — toolbar now hides when the mouse moves below the last line
- Toolbar still shows correctly when hovering the suggestion on any line
- Toolbar still shows when hovering the empty area after text on the same line