### PR TITLE
Fix hover tooltip persisting when mouse leaves the window

### DIFF
--- a/src/vs/platform/hover/browser/hoverService.ts
+++ b/src/vs/platform/hover/browser/hoverService.ts
@@ -112,6 +112,7 @@ export class HoverService extends Disposable implements IHoverService {
 		super();
 
 		this._register(contextMenuService.onDidShowContextMenu(() => this.hideHover()));
+		this._register(addDisposableListener(mainWindow.document, EventType.MOUSE_LEAVE, () => this.hideHover()));
 
 		this._register(KeybindingsRegistry.registerCommandAndKeybindingRule({
 			id: 'workbench.action.showHover',


### PR DESCRIPTION
## Description

Hover tooltips (e.g. Activity Bar tooltips) persist when the mouse cursor quickly moves from VS Code to another already-focused application window. This happens because `mouseleave` events on individual target elements may not fire when the cursor exits the window boundary directly.

Added a `document`-level `mouseleave` listener in `HoverService` that dismisses active hovers when the cursor leaves the window. This follows the same pattern as the existing `contextMenu.onDidShowContextMenu` handler.

Closes #293360

## Test plan

### Before
- Place another window next to VS Code
- Hover over an Activity Bar item to show tooltip
- Quickly move mouse to the other window
- Tooltip stays visible

### After
- Same steps — tooltip dismisses when cursor leaves the VS Code window