### PR TITLE
Fix deleteWordRight treating single whitespace differently from multiple

### DIFF
--- a/src/vs/editor/common/cursor/cursorWordOperations.ts
+++ b/src/vs/editor/common/cursor/cursorWordOperations.ts
@@ -628,7 +628,7 @@ export class WordOperations {
 		const lineContent = model.getLineContent(position.lineNumber);
 		const startIndex = position.column - 1;
 		const firstNonWhitespace = this._findFirstNonWhitespaceChar(lineContent, startIndex);
-		if (startIndex + 1 < firstNonWhitespace) {
+		if (startIndex + 1 <= firstNonWhitespace) {
 			// bingo
 			return new Range(position.lineNumber, position.column, position.lineNumber, firstNonWhitespace + 1);
 		}

--- a/src/vs/editor/contrib/wordOperations/test/browser/wordOperations.test.ts
+++ b/src/vs/editor/contrib/wordOperations/test/browser/wordOperations.test.ts
@@ -665,6 +665,27 @@ suite('WordOperations', () => {
 		});
 	});
 
+	test('deleteWordRight for cursor at beginning of single whitespace', () => {
+		withTestCodeEditor([
+			' foo.bar()',
+			'  foo.bar()',
+		], {}, (editor, _) => {
+			const model = editor.getModel()!;
+
+			// single whitespace should only delete the space, not the word
+			editor.setPosition(new Position(1, 1));
+			deleteWordRight(editor);
+			assert.strictEqual(model.getLineContent(1), 'foo.bar()');
+			assert.deepStrictEqual(editor.getPosition(), new Position(1, 1));
+
+			// double whitespace should also only delete the spaces
+			editor.setPosition(new Position(2, 1));
+			deleteWordRight(editor);
+			assert.strictEqual(model.getLineContent(2), 'foo.bar()');
+			assert.deepStrictEqual(editor.getPosition(), new Position(2, 1));
+		});
+	});
+
 	test('deleteWordRight for cursor just before a word', () => {
 		withTestCodeEditor([
 			'    \tMy First Line\t ',
@@ -775,7 +796,7 @@ suite('WordOperations', () => {
 	});
 
 	test('deleteWordRight - issue #832', () => {
-		const EXPECTED = '   |/*| Just| some| text| a|+=| 3| +|5|-|3| */|  |';
+		const EXPECTED = '   |/*| |Just| |some| |text| |a|+=| |3| |+|5|-|3| |*/|  |';
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(
 			text,


### PR DESCRIPTION
## Description

`deleteWordRight` (Ctrl+Delete) behaves differently with 1 whitespace vs 2+ whitespace at the beginning of a line:
- ` foo.bar()` (1 space) — deletes both the space and `foo`
- `  foo.bar()` (2 spaces) — deletes only the spaces

The whitespace heuristic in `_deleteWordRightWhitespace` used `startIndex + 1 < firstNonWhitespace`, which requires 2+ whitespace characters to trigger. Changed to `<=` so a single whitespace character also triggers the heuristic.

Note: `_deleteWordLeftWhitespace` has the same off-by-one but is left unchanged to keep this PR focused. Can be addressed separately.

Closes #259145

## Test plan

### Before
- Type ` foo` (1 space + word) and place cursor at beginning
- Ctrl+Delete deletes both space and word

### After
- Same setup — Ctrl+Delete now deletes only the space
- Consistent with 2+ spaces behavior
- Added test for single whitespace case
- Updated issue #832 test expectations