### PR TITLE
fix: strip null characters from clipboard text to prevent truncation

### DIFF
--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -126,6 +126,15 @@ interface InMemoryClipboardMetadata {
 	data: ClipboardStoredMetadata;
 }
 
+/**
+ * Strip null characters from text before writing to the clipboard.
+ * The system clipboard on Windows uses null-terminated strings, which
+ * causes text to be truncated at the first null character (see #249508).
+ */
+function stripNullCharacters(text: string): string {
+	return text.replaceAll(String.fromCharCode(0), '');
+}
+
 const ClipboardEventUtils = {
 
 	getTextData(clipboardData: IReadableClipboardData | DataTransfer): [string, ClipboardStoredMetadata | null] {
@@ -151,7 +160,7 @@ const ClipboardEventUtils = {
 	},
 
 	setTextData(clipboardData: IWritableClipboardData, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
-		clipboardData.setData(Mimes.text, text);
+		clipboardData.setData(Mimes.text, stripNullCharacters(text));
 		if (typeof html === 'string') {
 			clipboardData.setData('text/html', html);
 		}

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -204,7 +204,7 @@ function executeClipboardCopyWithWorkaround(editor: IActiveCodeEditor, clipboard
 		// As a workaround, we will write (only the plaintext data) to the clipboard in a different way
 		// We will use the clipboard service (which in the native case will go to electron's clipboard API)
 		const { dataToCopy } = generateDataToCopyAndStoreInMemory(editor._getViewModel(), undefined, browser.isFirefox);
-		clipboardService.writeText(dataToCopy.text);
+		clipboardService.writeText(dataToCopy.text.replaceAll(String.fromCharCode(0), ''));
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When copying text that contains null characters (U+0000) from the editor, the system clipboard on Windows truncates the text at the first null character. This is because the Windows clipboard API uses null-terminated strings (CF_UNICODETEXT).

For example, copying a line like `szDisposeFlag=nul` followed by more text only puts the text up to the null character on the clipboard.

Closes #249508

## What is the new behavior?

Null characters are stripped from text before it is written to the system clipboard. This ensures the complete text is copied and can be pasted elsewhere. The null characters are preserved in the editor's internal text model — only the clipboard output is affected.

The fix is applied in two places:
1. `ClipboardEventUtils.setTextData()` — the primary path used when the DOM `copy` event fires
2. `executeClipboardCopyWithWorkaround()` — the Electron bug workaround path that uses `clipboardService.writeText()`

## Additional context

The root cause was identified in the issue comments: the clipboard text is written via `clipboardData.setData('text/plain', text)` which passes through to the OS clipboard API. On Windows, `CF_UNICODETEXT` is null-terminated, so any `\0` in the string acts as an early terminator.