### PR TITLE
fix: respect files.enableTrash when discarding untracked changes

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2330,7 +2330,8 @@ export class CommandCenter {
 
 	private getDiscardUntrackedChangesDialogDetails(resources: Resource[]): [string, string, string] {
 		const config = workspace.getConfiguration('git');
-		const discardUntrackedChangesToTrash = config.get<boolean>('discardUntrackedChangesToTrash', true) && !isRemote && !isLinuxSnap;
+		const enableTrash = workspace.getConfiguration('files').get<boolean>('enableTrash', true);
+		const discardUntrackedChangesToTrash = config.get<boolean>('discardUntrackedChangesToTrash', true) && enableTrash && !isRemote && !isLinuxSnap;
 
 		const messageWarning = !discardUntrackedChangesToTrash
 			? resources.length === 1

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1512,7 +1512,8 @@ export class Repository implements Disposable {
 
 	async clean(resources: Uri[]): Promise<void> {
 		const config = workspace.getConfiguration('git');
-		const discardUntrackedChangesToTrash = config.get<boolean>('discardUntrackedChangesToTrash', true) && !isRemote && !isLinuxSnap;
+		const enableTrash = workspace.getConfiguration('files').get<boolean>('enableTrash', true);
+		const discardUntrackedChangesToTrash = config.get<boolean>('discardUntrackedChangesToTrash', true) && enableTrash && !isRemote && !isLinuxSnap;
 
 		await this.run(
 			Operation.Clean(!this.optimisticUpdateEnabled()),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the `files.enableTrash` setting is set to `false` (to delete files directly instead of using the recycle bin/trash), discarding untracked changes fails with an error because the git extension unconditionally attempts to move files to the trash via `workspace.fs.delete(uri, { useTrash: true })`.

The git extension only checks its own `git.discardUntrackedChangesToTrash` setting but ignores the general `files.enableTrash` setting.

Closes #246259

## What is the new behavior?

The `files.enableTrash` setting is now checked alongside `git.discardUntrackedChangesToTrash` when determining whether to use the trash for discarding untracked files. When either setting disables trash usage, files are deleted directly instead of attempting to move them to the trash.

The fix is applied in two places:
- `repository.ts` — the `clean()` method that performs the actual file deletion
- `commands.ts` — the `getDiscardUntrackedChangesDialogDetails()` method that determines the confirmation dialog text (showing "Delete File" vs "Move to Trash" messaging)

## Additional context

The `files.enableTrash` setting is already respected by the Explorer view for file deletion. This change brings the git extension's untracked file discard behavior in line with the Explorer's behavior.