### PR TITLE
fix: distinguish word highlight from selection in Dark VS themes

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -9,6 +9,7 @@
 		"editorIndentGuide.background1": "#404040",
 		"editorIndentGuide.activeBackground1": "#707070",
 		"editor.selectionHighlightBackground": "#ADD6FF26",
+		"editor.wordHighlightBackground": "#7C5C3E80",
 		"list.dropBackground": "#383B3D",
 		"activityBarBadge.background": "#007ACC",
 		"sideBarTitle.foreground": "#BBBBBB",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (theme color improvement)

## What is the current behavior?

In the Dark+ and Dark VS themes, the word highlight background (when cursor is on a word, other occurrences are highlighted) is nearly indistinguishable from the text selection background. The default word highlight `#575757B8` blends to approximately `#474747` on the `#1E1E1E` editor background, while the selection is `#264F78`. These two colors have a contrast ratio of only **1.09:1** against each other and share similar perceived brightness, making it very hard to tell which tokens are selected vs which are word-highlighted.

This causes frequent maloperations when editing code using keyboard navigation, as reported in the issue.

Closes #178145

## What is the new behavior?

Added explicit `editor.wordHighlightBackground: #7C5C3E80` to the Dark VS base theme (which Dark+ inherits from). This warm brown tone is clearly distinguishable from the blue selection `#264F78` through **hue contrast** -- brown/amber vs blue -- even though they share similar luminance levels. This matches the approach used in other VS Code themes where distinct hues differentiate selection from highlights.

Text readability is maintained:
- Main text (`#D4D4D4`) on word highlight: **7.00:1** contrast ratio

## Additional context

- Changed file: `extensions/theme-defaults/themes/dark_vs.json`
- Only added one new color key; no existing behavior modified
- The warm brown is intentionally chosen to be visually distinct from the blue selection through hue difference, which is the most effective way to distinguish overlapping highlight regions at similar brightness levels