### PR TITLE
fix: prevent duplicate Disable action in extension dropdown for workspace-enabled extensions

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1751,7 +1751,7 @@ export class DisableGloballyAction extends ExtensionAction {
 		this.enabled = false;
 		if (this.extension && this.extension.local && !this.extension.isWorkspaceScoped && this.extensionService.extensions.some(e => areSameExtensions({ id: e.identifier.value, uuid: e.uuid }, this.extension!.identifier))) {
 			this.enabled = this.extension.state === ExtensionState.Installed
-				&& (this.extension.enablementState === EnablementState.EnabledGlobally || this.extension.enablementState === EnablementState.EnabledWorkspace)
+				&& this.extension.enablementState === EnablementState.EnabledGlobally
 				&& this.extensionEnablementService.canChangeEnablement(this.extension.local);
 		}
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When an extension is disabled globally and then enabled for a workspace (EnabledWorkspace state), the Disable button dropdown incorrectly shows both "Disable" and "Disable (Workspace)" items.

Closes #244138

## What is the new behavior?

The `DisableGloballyAction` now only enables when the extension's enablement state is `EnabledGlobally`. When the extension is in `EnabledWorkspace` state (meaning it is already disabled globally but overridden to be enabled for the workspace), only the "Disable (Workspace)" action appears, since disabling globally is redundant — the extension is already disabled at the global level.

This makes the Disable dropdown consistent: it shows a single "Disable (Workspace)" button without a dropdown when the only meaningful action is to undo the workspace-level enablement override.

## Additional context

The root cause was in `DisableGloballyAction.update()`, which checked for both `EnabledGlobally` and `EnabledWorkspace` states. For the `EnabledWorkspace` case, the extension is already in the global disabled list — the workspace override is the only thing enabling it. Offering "Disable" (globally) alongside "Disable (Workspace)" is confusing and redundant.

The symmetric Enable side already handles this correctly: `EnableGloballyAction` uses `isDisabledGlobally()` which correctly identifies extensions that need global re-enablement.