### PR TITLE
fix: improve banner visibility in Modern themes

### DIFF
--- a/extensions/theme-defaults/themes/dark_modern.json
+++ b/extensions/theme-defaults/themes/dark_modern.json
@@ -130,6 +130,7 @@
 		"welcomePage.progress.foreground": "#0078D4",
 		"banner.background": "#0078D4",
 		"banner.foreground": "#FFFFFF",
+		"banner.iconForeground": "#FFFFFF",
 		"widget.border": "#313131",
 	},
 }

--- a/extensions/theme-defaults/themes/dark_modern.json
+++ b/extensions/theme-defaults/themes/dark_modern.json
@@ -128,6 +128,8 @@
 		"titleBar.inactiveForeground": "#9D9D9D",
 		"welcomePage.tileBackground": "#2B2B2B",
 		"welcomePage.progress.foreground": "#0078D4",
+		"banner.background": "#0078D4",
+		"banner.foreground": "#FFFFFF",
 		"widget.border": "#313131",
 	},
 }

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -9,7 +9,6 @@
 		"editorIndentGuide.background1": "#404040",
 		"editorIndentGuide.activeBackground1": "#707070",
 		"editor.selectionHighlightBackground": "#ADD6FF26",
-		"editor.wordHighlightBackground": "#7C5C3E80",
 		"list.dropBackground": "#383B3D",
 		"activityBarBadge.background": "#007ACC",
 		"sideBarTitle.foreground": "#BBBBBB",

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -9,6 +9,7 @@
 		"editorIndentGuide.background1": "#404040",
 		"editorIndentGuide.activeBackground1": "#707070",
 		"editor.selectionHighlightBackground": "#ADD6FF26",
+		"editor.wordHighlightBackground": "#7C5C3E80",
 		"list.dropBackground": "#383B3D",
 		"activityBarBadge.background": "#007ACC",
 		"sideBarTitle.foreground": "#BBBBBB",

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -149,6 +149,7 @@
 		"welcomePage.tileBackground": "#F3F3F3",
 		"banner.background": "#005FB8",
 		"banner.foreground": "#FFFFFF",
+		"banner.iconForeground": "#FFFFFF",
 		"widget.border": "#E5E5E5"
 	},
 }

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -147,6 +147,8 @@
 		"titleBar.inactiveBackground": "#F8F8F8",
 		"titleBar.inactiveForeground": "#8B949E",
 		"welcomePage.tileBackground": "#F3F3F3",
+		"banner.background": "#005FB8",
+		"banner.foreground": "#FFFFFF",
 		"widget.border": "#E5E5E5"
 	},
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (theme color improvement)

## What is the current behavior?

In Dark Modern and Light Modern themes, banners (shown under the title bar for important notifications) have very low contrast against the surrounding UI. This is because banners inherit their background from `list.activeSelectionBackground`, which produces:

- **Dark Modern**: `#04395E` banner on `#1F1F1F` background -- only **1.38:1** contrast ratio
- **Light Modern**: `~#A2A2A2` banner (darkened `#E8E8E8`) on `#F8F8F8` background -- only **2.40:1** contrast ratio

Banners are designed to be attention-grabbing (warnings, info alerts, trust prompts), but they blend into the background and are easy to miss.

Closes #174970

## What is the new behavior?

Added explicit `banner.background` and `banner.foreground` to both Modern themes using their respective accent colors with white foreground:

| Theme | Old Background | New Background | Old Contrast | New Contrast |
|-------|---------------|---------------|-------------|-------------|
| Dark Modern | `#04395E` | `#0078D4` | 1.38:1 | **3.64:1** |
| Light Modern | `~#A2A2A2` | `#005FB8` | 2.40:1 | **5.94:1** |

White text on the new backgrounds also has good readability:
- White on `#0078D4`: **4.53:1** (meets WCAG AA)
- White on `#005FB8`: **6.31:1** (meets WCAG AA)

The accent colors (`#0078D4` / `#005FB8`) are consistent with how these themes use color for other prominent UI elements (progress bars, status bar debugging mode, badges, activity bar badges).

## Additional context

- Changed files: `dark_modern.json`, `light_modern.json`
- Added `banner.background` and `banner.foreground` keys to each theme
- No impact on other themes; they continue to use the platform defaults