### PR TITLE
feat: add command to show dirty diff at current cursor line

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
+++ b/src/vs/workbench/contrib/scm/browser/quickDiffWidget.ts
@@ -605,6 +605,44 @@ export class QuickDiffEditorController extends Disposable implements IEditorCont
 		this.session = Disposable.None;
 	}
 
+	showAtLine(lineNumber?: number): void {
+		if (!this.editor.hasModel()) {
+			return;
+		}
+
+		const line = typeof lineNumber === 'number' ? lineNumber : this.editor.getPosition().lineNumber;
+		const editorModel = this.editor.getModel();
+
+		if (!editorModel) {
+			return;
+		}
+
+		const modelRef = this.quickDiffModelService.createQuickDiffModelReference(editorModel.uri);
+
+		if (!modelRef) {
+			return;
+		}
+
+		try {
+			const index = modelRef.object.changes
+				.findIndex(change => lineIntersectsChange(line, change.change));
+
+			if (index < 0) {
+				return;
+			}
+
+			if (!this.assertWidget()) {
+				return;
+			}
+
+			if (this.widget) {
+				this.widget.showChange(index);
+			}
+		} finally {
+			modelRef.dispose();
+		}
+	}
+
 	private assertWidget(): boolean {
 		if (!this.enabled) {
 			return false;
@@ -970,6 +1008,26 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 
 		controller.toggleFocus();
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'editor.action.dirtydiff.showAtLine',
+	weight: KeybindingWeight.EditorContrib,
+	primary: 0,
+	when: EditorContextKeys.editorTextFocus,
+	handler: (accessor: ServicesAccessor) => {
+		const outerEditor = getOuterEditorFromDiffEditor(accessor);
+		if (!outerEditor) {
+			return;
+		}
+
+		const controller = QuickDiffEditorController.get(outerEditor);
+		if (!controller) {
+			return;
+		}
+
+		controller.showAtLine();
 	}
 });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Users can navigate to the next/previous dirty diff using `editor.action.dirtydiff.next` (Alt+F3) and `editor.action.dirtydiff.previous` (Shift+Alt+F3), or click on a gutter decoration. However, there is no keyboard command to show the dirty diff inline view at the current cursor position.

This means keyboard-only users must navigate away from their current position to view a change's diff, which is disorienting during code review workflows.

Closes #265297

## What is the new behavior?

Adds a new command `editor.action.dirtydiff.showAtLine` that opens the quick diff inline widget at the current cursor line, if there is a change at that line. This mirrors the behavior of clicking the gutter decoration, but via a keyboard-accessible command.

Users can assign a keybinding to this command and combine it with:
- `toggleQuickDiffWidgetFocus` (Ctrl+K, F2) to focus into the diff widget for keyboard scrolling
- `closeQuickDiff` (Escape) to close the widget

This provides a complete keyboard-driven workflow for reviewing dirty diffs.

## Additional context

The `dirtyDiffVisible` context key and `closeQuickDiff` / `toggleQuickDiffWidgetFocus` commands already existed. This PR adds the missing piece: opening the diff at the cursor position.

The new `showAtLine()` method on `QuickDiffEditorController` uses the same `lineIntersectsChange` check that the gutter click handler uses, ensuring consistent behavior.