### PR TITLE
feat: honor git.autoStash when switching branches

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2958,6 +2958,16 @@ export class CommandCenter {
 					return false;
 				}
 
+				const config = workspace.getConfiguration('git', Uri.file(repository.root));
+				const autoStash = config.get<boolean>('autoStash');
+
+				if (autoStash) {
+					await repository.createStash(undefined, true);
+					await item.run(repository, opts);
+					await repository.popStash();
+					return true;
+				}
+
 				const stash = l10n.t('Stash & Checkout');
 				const migrate = l10n.t('Migrate Changes');
 				const force = l10n.t('Force Checkout');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / Enhancement

## What is the current behavior?

When `git.autoStash` is enabled and there are uncommitted changes in the working tree, switching branches still shows a modal dialog asking the user to choose between "Stash & Checkout", "Migrate Changes", or "Force Checkout". The `git.autoStash` setting is not consulted during branch checkout.

Closes #240571

## What is the new behavior?

When `git.autoStash` is enabled and the checkout fails due to a dirty work tree, the changes are automatically stashed (including untracked files), the checkout proceeds, and the stash is popped — all without showing a dialog. This matches the behavior users expect from the `git.autoStash` setting, which already works for pull/rebase operations.

If `git.autoStash` is not enabled, the existing dialog behavior is preserved.

## Additional context

The implementation follows the same pattern as `maybeAutoStash` in `repository.ts`, which uses `createStash(undefined, true)` / `popStash()` to perform automatic stash-and-pop around operations.