### PR TITLE
fix: prevent forced markdown preview refresh from being dropped by throttle

### DIFF
--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -213,6 +213,11 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			} else {
 				this.#throttleTimer = setTimeout(() => this.#updatePreview(forceUpdate), this.#delay);
 			}
+		} else if (forceUpdate) {
+			// A forced update (e.g. security settings change) must not be
+			// silently dropped by a pending throttled update.
+			clearTimeout(this.#throttleTimer);
+			this.#throttleTimer = setTimeout(() => this.#updatePreview(true), this.#delay);
 		}
 
 		this.#firstUpdate = false;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After changing the markdown preview security setting (e.g. from "Strict" to "Disable"), the preview may fail to reload with the updated Content Security Policy. This happens when a text-change-triggered update is already pending in the throttle timer — the forced refresh from the security change is silently dropped.

Closes #280270

## What is the new behavior?

When `refresh(forceUpdate=true)` is called (e.g. from the security selector) while a throttle timer is already pending, the pending timer is cleared and replaced with a forced update. This ensures the preview always performs a full page reload after security settings change, applying the new CSP.

## Additional context

The `refresh()` method in `MarkdownPreview` uses a throttle mechanism to batch rapid updates (e.g. from typing). Previously, if a throttled update was pending and a forced update arrived, the forced update was silently ignored because the `if (!this.#throttleTimer)` check failed. The fix adds an `else if (forceUpdate)` branch that replaces the pending timer with a forced update.

The maintainer noted: "It doesn't work if you open it and then change the setting without a reload. We don't have good support for updating scripts after the preview had been loaded." This fix ensures the full page reload always happens, which generates a new CSP meta tag matching the updated security level.