### PR TITLE
fix: exclude JSDoc brackets from bracket pair colorization

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -74,7 +74,19 @@
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",
           "variable.other.jsdoc": "other"
-        }
+        },
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "punctuation.definition.tag",
+          "punctuation.definition.bracket.curly.begin.jsdoc",
+          "punctuation.definition.bracket.curly.end.jsdoc",
+          "punctuation.definition.bracket.angle.begin.jsdoc",
+          "punctuation.definition.bracket.angle.end.jsdoc",
+          "punctuation.definition.bracket.square.begin.jsdoc",
+          "punctuation.definition.bracket.square.end.jsdoc"
+        ]
       },
       {
         "language": "javascript",
@@ -92,7 +104,18 @@
           "entity.name.function.tagged-template": "other",
           "meta.import string.quoted": "other",
           "variable.other.jsdoc": "other"
-        }
+        },
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "punctuation.definition.bracket.curly.begin.jsdoc",
+          "punctuation.definition.bracket.curly.end.jsdoc",
+          "punctuation.definition.bracket.angle.begin.jsdoc",
+          "punctuation.definition.bracket.angle.end.jsdoc",
+          "punctuation.definition.bracket.square.begin.jsdoc",
+          "punctuation.definition.bracket.square.end.jsdoc"
+        ]
       },
       {
         "scopeName": "source.js.regexp",

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -73,7 +73,13 @@
           "keyword.operator.bitwise.shift",
           "meta.brace.angle",
           "punctuation.definition.tag",
-          "keyword.operator.assignment.compound.bitwise.ts"
+          "keyword.operator.assignment.compound.bitwise.ts",
+          "punctuation.definition.bracket.curly.begin.jsdoc",
+          "punctuation.definition.bracket.curly.end.jsdoc",
+          "punctuation.definition.bracket.angle.begin.jsdoc",
+          "punctuation.definition.bracket.angle.end.jsdoc",
+          "punctuation.definition.bracket.square.begin.jsdoc",
+          "punctuation.definition.bracket.square.end.jsdoc"
         ],
         "tokenTypes": {
           "punctuation.definition.template-expression": "other",
@@ -92,7 +98,13 @@
           "storage.type.function.arrow",
           "keyword.operator.bitwise.shift",
           "punctuation.definition.tag",
-          "keyword.operator.assignment.compound.bitwise.ts"
+          "keyword.operator.assignment.compound.bitwise.ts",
+          "punctuation.definition.bracket.curly.begin.jsdoc",
+          "punctuation.definition.bracket.curly.end.jsdoc",
+          "punctuation.definition.bracket.angle.begin.jsdoc",
+          "punctuation.definition.bracket.angle.end.jsdoc",
+          "punctuation.definition.bracket.square.begin.jsdoc",
+          "punctuation.definition.bracket.square.end.jsdoc"
         ],
         "embeddedLanguages": {
           "meta.tag.tsx": "jsx-tags",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Brackets inside JSDoc comments (`{string}`, `{Object}`, `{Array<string>}`, etc.) are incorrectly colorized by the bracket pair colorization feature. This happens because JSDoc type annotations are mapped to `StandardTokenType.Other` via `tokenTypes` configuration (`entity.name.type.instance.jsdoc: "other"`), which causes the bracket pair colorizer to treat the curly braces, angle brackets, and square brackets inside JSDoc types as regular code brackets rather than comment content.

Closes #187307

## What is the new behavior?

JSDoc bracket punctuation scopes are added to `unbalancedBracketScopes` in the grammar configurations for JavaScript, JavaScriptReact, TypeScript, and TypeScriptReact. This tells the bracket pair colorizer to ignore these brackets, so they are no longer colorized with bracket pair colors inside JSDoc comments.

The following scopes are excluded:
- `punctuation.definition.bracket.curly.begin.jsdoc`
- `punctuation.definition.bracket.curly.end.jsdoc`
- `punctuation.definition.bracket.angle.begin.jsdoc`
- `punctuation.definition.bracket.angle.end.jsdoc`
- `punctuation.definition.bracket.square.begin.jsdoc`
- `punctuation.definition.bracket.square.end.jsdoc`

Additionally, common operator scopes (`keyword.operator.relational`, `storage.type.function.arrow`, `keyword.operator.bitwise.shift`) are added to the JavaScript grammars to match the existing TypeScript configuration.

## Additional context

The TypeScript grammar already had `unbalancedBracketScopes` for operators but was missing the JSDoc bracket scopes. The JavaScript grammar had no `unbalancedBracketScopes` at all.

This follows the same pattern used by the TypeScript extension for excluding non-bracket angle brackets (relational operators, arrow functions, bitwise shift).