### PR TITLE
feat: add zen mode indicator to window title for accessibility

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -123,7 +123,7 @@ export class WindowTitle extends Disposable {
 			}
 		}));
 		this._register(this.contextKeyService.onDidChangeContext(e => {
-			if (e.affectsSome(this.variables)) {
+			if (e.affectsSome(this.variables) || e.affectsSome(new Set(['inZenMode']))) {
 				this.titleUpdater.schedule();
 			}
 		}));
@@ -302,6 +302,7 @@ export class WindowTitle extends Disposable {
 	 * {focusedView}: e.g. Terminal
 	 * {separator}: conditional separator
 	 * {activeEditorState}: e.g. Modified
+	 * {zenMode}: Zen Mode indicator
 	 */
 	getWindowTitle(): string {
 		const editor = this.editorService.activeEditor;
@@ -363,6 +364,7 @@ export class WindowTitle extends Disposable {
 		const focusedView: string = this.viewsService.getFocusedViewName();
 		const activeEditorState = editorResource ? this.decorationsService.getDecoration(editorResource, false)?.tooltip : undefined;
 		const activeEditorLanguageId = this.editorService.activeTextEditorLanguageId;
+		const zenMode = this.contextKeyService.getContextKeyValue<boolean>('inZenMode') ? localize('zenMode', "Zen Mode") : '';
 
 		const variables: Record<string, string> = {};
 		for (const [contextKey, name] of this.variables) {
@@ -375,7 +377,7 @@ export class WindowTitle extends Disposable {
 		}
 
 		if (!this.titleIncludesEditorState && this.accessibilityService.isScreenReaderOptimized() && this.configurationService.getValue('accessibility.windowTitleOptimized')) {
-			titleTemplate += '${separator}${activeEditorState}';
+			titleTemplate += '${separator}${activeEditorState}${separator}${zenMode}';
 		}
 
 		let separator = this.configurationService.getValue<string>(WindowSettingNames.titleSeparator);
@@ -403,6 +405,7 @@ export class WindowTitle extends Disposable {
 			profileName,
 			focusedView,
 			activeEditorState,
+			zenMode,
 			separator: { label: separator }
 		});
 	}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -819,6 +819,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 		localize('activeRepositoryName', "`${activeRepositoryName}`: the name of the active repository (e.g. vscode)."),
 		localize('activeRepositoryBranchName', "`${activeRepositoryBranchName}`: the name of the active branch in the active repository (e.g. main)."),
 		localize('activeEditorState', "`${activeEditorState}`: provides information about the state of the active editor (e.g. modified). This will be appended by default when in screen reader mode with {0} enabled.", '`accessibility.windowTitleOptimized`'),
+		localize('zenMode', "`${zenMode}`: an indicator when Zen Mode is active. Automatically appended in screen reader mode with {0} enabled.", '`accessibility.windowTitleOptimized`'),
 		localize('separator', "`${separator}`: a conditional separator (\" - \") that only shows when surrounded by variables with values or static text.")
 	].join('\n- '); // intentionally concatenated to not produce a string that is too long for translations
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Accessibility feature

## What is the current behavior?

Screen reader users have no way to tell when zen mode is active. The window title does not contain any indication of the current zen mode state, and since zen mode hides the status bar by default, there is no accessible element to communicate this state.

Closes #180056

## What is the new behavior?

Adds a `${zenMode}` template variable to the window title system:
- Shows "Zen Mode" when zen mode is active, empty string otherwise
- Automatically appended to the window title when screen reader optimization is enabled (`accessibility.windowTitleOptimized`)
- Can be manually added to the `window.title` setting by any user
- Title updates immediately when zen mode is toggled

This follows the same pattern as `${activeEditorState}` which is also automatically appended for screen reader users.

## Additional context

The implementation:
1. Adds `zenMode` variable to `getWindowTitle()` in `windowTitle.ts`
2. Reads the existing `inZenMode` context key to determine state
3. Appends `${separator}${zenMode}` to the accessibility-optimized title template
4. Listens for `inZenMode` context key changes to trigger title updates
5. Documents the new variable in the `window.title` setting description