### PR TITLE
fix: strip null characters when copying text to clipboard

### DIFF
--- a/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/clipboardUtils.ts
@@ -151,7 +151,11 @@ const ClipboardEventUtils = {
 	},
 
 	setTextData(clipboardData: IWritableClipboardData, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
-		clipboardData.setData(Mimes.text, text);
+		// Strip null characters (U+0000) before writing to clipboard.
+		// On Windows, the clipboard uses null-terminated strings, so any
+		// null character would truncate the remaining text.
+		// eslint-disable-next-line no-control-regex
+		clipboardData.setData(Mimes.text, text.replace(/\x00/g, ''));
 		if (typeof html === 'string') {
 			clipboardData.setData('text/html', html);
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When copying a line that contains null characters (U+0000), the clipboard content is truncated at the first null character. All text after the null character is lost. This affects Windows primarily because the Windows clipboard uses null-terminated strings (CF_TEXT format).

For example, copying `szDisposeFlag=NUL szProperty=value` (where NUL is U+0000) would only paste `szDisposeFlag=`.

Closes #249508

## What is the new behavior?

Null characters are stripped from the text before writing to the clipboard via `clipboardData.setData()`. The null characters remain visible in the editor (via control character rendering), but they are removed from clipboard data to ensure the full line content is preserved when pasting.

## Additional context

The fix is in `ClipboardEventUtils.setTextData()` which is the single point where editor text is written to the clipboard. The regex `/\x00/g` matches all null characters and replaces them with empty strings.

This is a minimal change that follows the same approach used by other text editors (e.g., Notepad strips null characters on copy).